### PR TITLE
Keys

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -106,6 +106,7 @@ to use for ERMrest JavaScript agents.
         * [new Key(table, jsonKey)](#new_ERMrest.Key_new)
         * [.colset](#ERMrest.Key+colset) : <code>[ColSet](#ERMrest.ColSet)</code>
         * [.annotations](#ERMrest.Key+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+        * [.simple](#ERMrest.Key+simple) : <code>Boolean</code>
     * [.ColSet](#ERMrest.ColSet)
         * [new ColSet(columns)](#new_ERMrest.ColSet_new)
         * [.columns](#ERMrest.ColSet+columns) : <code>Array</code>
@@ -127,6 +128,7 @@ to use for ERMrest JavaScript agents.
         * [.key](#ERMrest.ForeignKeyRef+key) : <code>[Key](#ERMrest.Key)</code>
         * [.mapping](#ERMrest.ForeignKeyRef+mapping) : <code>[Mapping](#ERMrest.Mapping)</code>
         * [.annotations](#ERMrest.ForeignKeyRef+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+        * [.simple](#ERMrest.ForeignKeyRef+simple) : <code>Boolean</code>
         * [.getDomainValues(limit)](#ERMrest.ForeignKeyRef+getDomainValues) ⇒ <code>Promise</code>
     * [.Type](#ERMrest.Type)
         * [new Type(name)](#new_ERMrest.Type_new)
@@ -781,6 +783,7 @@ Constructor for Keys.
     * [new Key(table, jsonKey)](#new_ERMrest.Key_new)
     * [.colset](#ERMrest.Key+colset) : <code>[ColSet](#ERMrest.ColSet)</code>
     * [.annotations](#ERMrest.Key+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+    * [.simple](#ERMrest.Key+simple) : <code>Boolean</code>
 
 <a name="new_ERMrest.Key_new"></a>
 #### new Key(table, jsonKey)
@@ -797,6 +800,11 @@ Constructor for Key.
 **Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.Key+annotations"></a>
 #### key.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
+**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
+<a name="ERMrest.Key+simple"></a>
+#### key.simple : <code>Boolean</code>
+Indicates if the key is simple (not composite)
+
 **Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.ColSet"></a>
 ### ERMrest.ColSet
@@ -904,6 +912,7 @@ Constructor for ColSet, a set of Column objects.
     * [.key](#ERMrest.ForeignKeyRef+key) : <code>[Key](#ERMrest.Key)</code>
     * [.mapping](#ERMrest.ForeignKeyRef+mapping) : <code>[Mapping](#ERMrest.Mapping)</code>
     * [.annotations](#ERMrest.ForeignKeyRef+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+    * [.simple](#ERMrest.ForeignKeyRef+simple) : <code>Boolean</code>
     * [.getDomainValues(limit)](#ERMrest.ForeignKeyRef+getDomainValues) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.ForeignKeyRef_new"></a>
@@ -928,6 +937,11 @@ use index 0 since all refCols should be of the same schema:table
 **Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+annotations"></a>
 #### foreignKeyRef.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+<a name="ERMrest.ForeignKeyRef+simple"></a>
+#### foreignKeyRef.simple : <code>Boolean</code>
+Indicates if the foreign key is simple (not composite)
+
 **Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+getDomainValues"></a>
 #### foreignKeyRef.getDomainValues(limit) ⇒ <code>Promise</code>

--- a/doc/api.md
+++ b/doc/api.md
@@ -84,6 +84,8 @@ to use for ERMrest JavaScript agents.
         * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
         * [.default](#ERMrest.Column+default) : <code>String</code>
         * [.annotations](#ERMrest.Column+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+        * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : <code>Array</code>
+        * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : <code>Array</code>
     * [.Annotations](#ERMrest.Annotations)
         * [new Annotations()](#new_ERMrest.Annotations_new)
         * [.all()](#ERMrest.Annotations+all) ⇒ <code>Array</code>
@@ -628,6 +630,8 @@ Constructor for Columns.
     * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
     * [.default](#ERMrest.Column+default) : <code>String</code>
     * [.annotations](#ERMrest.Column+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+    * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : <code>Array</code>
+    * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : <code>Array</code>
 
 <a name="new_ERMrest.Column_new"></a>
 #### new Column(table, jsonColumn)
@@ -656,6 +660,16 @@ Constructor for Column.
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+annotations"></a>
 #### column.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+<a name="ERMrest.Column+memberOfKeys"></a>
+#### column.memberOfKeys : <code>Array</code>
+Member of Keys
+
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+<a name="ERMrest.Column+memberOfForeignKeys"></a>
+#### column.memberOfForeignKeys : <code>Array</code>
+Member of ForeignKeys
+
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Annotations"></a>
 ### ERMrest.Annotations

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -1427,9 +1427,9 @@ var ERMrest = (function (module) {
         var fkCols = jsonFKR.foreign_key_columns;
         var foreignKeyCols = [];
         for (var i = 0; i < fkCols.length; i++) {
-            var col = table.columns.get(fkCols[i].column_name); // "Column" object
-            foreignKeyCols.push(col);
-            col.memberOfForeignKeys.push(this);
+            var fkcol = table.columns.get(fkCols[i].column_name); // "Column" object
+            foreignKeyCols.push(fkcol);
+            fkcol.memberOfForeignKeys.push(this);
         }
 
         /**

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -611,15 +611,15 @@ var ERMrest = (function (module) {
 
             if (sortby !== undefined && sortby !== null) {
                 for (var d = 0; d < sortby.length; d++) {
-                    var col1 = sortby[d].column; // if string
+                    var sortCol = sortby[d].column; // if string
                     if (sortby[d] instanceof Column) { // if Column object
-                        col1 = sortby[d].name;
+                        sortCol = sortby[d].name;
                     }
                     var order = (sortby[d].order === 'desc' ? "::desc::" : "");
                     if (d === 0)
-                        uri = uri + "@sort(" + module._fixedEncodeURIComponent(col1) + order;
+                        uri = uri + "@sort(" + module._fixedEncodeURIComponent(sortCol) + order;
                     else
-                        uri = uri + "," + module._fixedEncodeURIComponent(col1) + order;
+                        uri = uri + "," + module._fixedEncodeURIComponent(sortCol) + order;
                 }
                 uri = uri + ")";
 
@@ -632,11 +632,11 @@ var ERMrest = (function (module) {
                     }
 
                     for (d = 0; d < sortby.length; d++) {
-                        var col1 = sortby[d].column; // if string
+                        var pageCol = sortby[d].column; // if string
                         if (sortby[d] instanceof Column) { // if Column object
-                            col1 = sortby[d].name;
+                            pageCol = sortby[d].name;
                         }
-                        var value = row[col1];
+                        var value = row[pageCol];
                         if (value === null)
                             value = "::null::";
                         else

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -1452,9 +1452,10 @@ var ERMrest = (function (module) {
         // find corresponding Key from referenced columns
         // ** all the tables in the catalog must have been created at this point
         var refCols = jsonFKR.referenced_columns;
+        var refTable = catalog.schemas.get(refCols[0].schema_name).tables.get(refCols[0].table_name);
         var referencedCols = [];
         for (var j = 0; j < refCols.length; j++) {
-            var col = catalog.schemas.get(refCols[j].schema_name).tables.get(refCols[j].table_name).columns.get(refCols[j].column_name);
+            var col = refTable.columns.get(refCols[j].column_name);
             referencedCols.push(col);
         }
 
@@ -1464,7 +1465,7 @@ var ERMrest = (function (module) {
          * use index 0 since all refCols should be of the same schema:table
          * @type {ERMrest.Key}
          */
-        this.key = catalog.schemas.get(refCols[0].schema_name).tables.get(refCols[0].table_name).keys.get(new ColSet(referencedCols));
+        this.key = refTable.keys.get(new ColSet(referencedCols));
 
         /**
          *

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -1226,6 +1226,17 @@ var ERMrest = (function (module) {
         }
     }
 
+    Key.prototype = {
+        constructor: Key,
+
+        /**
+         * Indicates if the key is simple (not composite)
+         * @type {Boolean}
+         */
+        get simple() {
+            return this.colset.length() == 1;
+        }
+    };
 
 
     /**
@@ -1490,8 +1501,15 @@ var ERMrest = (function (module) {
             if (limit === undefined)
                 limit = null;
             return this.key._table.entity.get(null, limit, this.key.colset.columns);
-        }
+        },
 
+        /**
+         * Indicates if the foreign key is simple (not composite)
+         * @type {Boolean}
+         */
+        get simple() {
+            return this.key.simple;
+        }
     };
 
 

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -994,6 +994,18 @@ var ERMrest = (function (module) {
             var jsonAnnotation = jsonColumn.annotations[uri];
             this.annotations._push(new Annotation("column", uri, jsonAnnotation));
         }
+
+        /**
+         * Member of Keys
+         * @type {Array}
+         */
+        this.memberOfKeys = [];
+
+        /**
+         * Member of ForeignKeys
+         * @type {Array}
+         */
+        this.memberOfForeignKeys = [];
     }
 
     Column.prototype = {
@@ -1192,7 +1204,9 @@ var ERMrest = (function (module) {
         var uniqueColumns = [];
         for (var i = 0; i < jsonKey.unique_columns.length; i++) {
             // find corresponding column objects
-            uniqueColumns.push(table.columns.get(jsonKey.unique_columns[i]));
+            var col = table.columns.get(jsonKey.unique_columns[i]);
+            uniqueColumns.push(col);
+            col.memberOfKeys.push(this);
         }
 
         /**
@@ -1413,7 +1427,9 @@ var ERMrest = (function (module) {
         var fkCols = jsonFKR.foreign_key_columns;
         var foreignKeyCols = [];
         for (var i = 0; i < fkCols.length; i++) {
-            foreignKeyCols.push(table.columns.get(fkCols[i].column_name)); // "Column" object
+            var col = table.columns.get(fkCols[i].column_name); // "Column" object
+            foreignKeyCols.push(col);
+            col.memberOfForeignKeys.push(this);
         }
 
         /**


### PR DESCRIPTION
Summary:
- Adds `memberOf[Foreign]Keys` arrays to `Column` class to make it easier for a client to see what keys or foriegnkey references a column participates in.
- Adds a boolean flag `simple` to `Key` and `ForeignKeyRef` classes so that clients can immediately see that the key contains only a single column. It is actually implemented as a getter that computes the property on demand.
- And then some minor changes to make one introspection function a little more efficient and another to clean up some lint warnings.

I'm going to assign to @karlcz for review from the perspective of whether these seem like good API changes. I would also suggest that @jrchudy or @howdyjessie weigh in on whether it helps the client processing steps they have to do in the data entry app. Finally, a mention for @shinyichen to be aware of the changes.

Additional changes to the API that might help could be:
- add a `referencedBy` array of `ForeignKeyRefs` to the `Table` class as a sort of reverse lookup of any FKs that point to the table.
- add a boolean flag called `association` to the `Table` class to indicate that if it is an association table.
- add an `associations` array of (not sure what?) either `Table`s or `ForeignKeyRef`s to the `Table` class so that clients can easily tell what other tables it is associated with via a many-to-many relationship.

These last few ideas I didn't implement because I'm not as certain about them.