### PR TITLE
Add Row API; rename RowSet class to Rows (#61)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -66,12 +66,12 @@ to use for ERMrest JavaScript agents.
                 * [.delete(filter)](#ERMrest.Table.Entity+delete) ⇒ <code>Promise</code>
                 * [.put(rows)](#ERMrest.Table.Entity+put) ⇒ <code>Promise</code>
                 * [.post(rows, defaults)](#ERMrest.Table.Entity+post) ⇒ <code>Promise</code>
-    * [.RowSet](#ERMrest.RowSet)
-        * [new RowSet(table, jsonRows, filter, limit, columns, sortby)](#new_ERMrest.RowSet_new)
-        * [.data](#ERMrest.RowSet+data) : <code>Array</code>
-        * [.length()](#ERMrest.RowSet+length) ⇒ <code>number</code>
-        * [.after()](#ERMrest.RowSet+after) ⇒ <code>Promise</code>
-        * [.before()](#ERMrest.RowSet+before) ⇒ <code>Promise</code>
+    * [.Rows](#ERMrest.Rows)
+        * [new Rows(table, jsonRows, filter, limit, columns, sortby)](#new_ERMrest.Rows_new)
+        * [.data](#ERMrest.Rows+data) : <code>Array</code>
+        * [.length()](#ERMrest.Rows+length) ⇒ <code>number</code>
+        * [.after()](#ERMrest.Rows+after) ⇒ <code>Promise</code>
+        * [.before()](#ERMrest.Rows+before) ⇒ <code>Promise</code>
     * [.Columns](#ERMrest.Columns)
         * [new Columns()](#new_ERMrest.Columns_new)
         * [.all()](#ERMrest.Columns+all) ⇒ <code>Array</code>
@@ -601,19 +601,19 @@ Create new entities
 | rows | <code>Object</code> | Array of jSON representation of rows |
 | defaults | <code>Array</code> | Array of string column names to be defaults |
 
-<a name="ERMrest.RowSet"></a>
-### ERMrest.RowSet
+<a name="ERMrest.Rows"></a>
+### ERMrest.Rows
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
-* [.RowSet](#ERMrest.RowSet)
-    * [new RowSet(table, jsonRows, filter, limit, columns, sortby)](#new_ERMrest.RowSet_new)
-    * [.data](#ERMrest.RowSet+data) : <code>Array</code>
-    * [.length()](#ERMrest.RowSet+length) ⇒ <code>number</code>
-    * [.after()](#ERMrest.RowSet+after) ⇒ <code>Promise</code>
-    * [.before()](#ERMrest.RowSet+before) ⇒ <code>Promise</code>
+* [.Rows](#ERMrest.Rows)
+    * [new Rows(table, jsonRows, filter, limit, columns, sortby)](#new_ERMrest.Rows_new)
+    * [.data](#ERMrest.Rows+data) : <code>Array</code>
+    * [.length()](#ERMrest.Rows+length) ⇒ <code>number</code>
+    * [.after()](#ERMrest.Rows+after) ⇒ <code>Promise</code>
+    * [.before()](#ERMrest.Rows+before) ⇒ <code>Promise</code>
 
-<a name="new_ERMrest.RowSet_new"></a>
-#### new RowSet(table, jsonRows, filter, limit, columns, sortby)
+<a name="new_ERMrest.Rows_new"></a>
+#### new Rows(table, jsonRows, filter, limit, columns, sortby)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -624,26 +624,26 @@ Create new entities
 | columns | <code>Array</code> | Optional. Array of column names or Column objects output |
 | sortby | <code>Array</code> | Optional. An ordered array of {column, order} where column is column name or Column object, order is null/'' (default), 'asc' or 'desc' |
 
-<a name="ERMrest.RowSet+data"></a>
+<a name="ERMrest.Rows+data"></a>
 #### rowSet.data : <code>Array</code>
 The set of rows returns from the server. It is an Array of
 Objects that has keys and values based on the query that produced
-the RowSet.
+the Rows.
 
-**Kind**: instance property of <code>[RowSet](#ERMrest.RowSet)</code>  
-<a name="ERMrest.RowSet+length"></a>
+**Kind**: instance property of <code>[Rows](#ERMrest.Rows)</code>  
+<a name="ERMrest.Rows+length"></a>
 #### rowSet.length() ⇒ <code>number</code>
-**Kind**: instance method of <code>[RowSet](#ERMrest.RowSet)</code>  
-<a name="ERMrest.RowSet+after"></a>
+**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
+<a name="ERMrest.Rows+after"></a>
 #### rowSet.after() ⇒ <code>Promise</code>
 get the rowset of the next page
 
-**Kind**: instance method of <code>[RowSet](#ERMrest.RowSet)</code>  
-<a name="ERMrest.RowSet+before"></a>
+**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
+<a name="ERMrest.Rows+before"></a>
 #### rowSet.before() ⇒ <code>Promise</code>
 get the rowset of the previous page
 
-**Kind**: instance method of <code>[RowSet](#ERMrest.RowSet)</code>  
+**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
 <a name="ERMrest.Columns"></a>
 ### ERMrest.Columns
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  

--- a/doc/api.md
+++ b/doc/api.md
@@ -69,9 +69,15 @@ to use for ERMrest JavaScript agents.
     * [.Rows](#ERMrest.Rows)
         * [new Rows(table, jsonRows, filter, limit, columns, sortby)](#new_ERMrest.Rows_new)
         * [.data](#ERMrest.Rows+data) : <code>Array</code>
+        * [.get(index)](#ERMrest.Rows+get) : <code>[Row](#ERMrest.Row)</code>
         * [.length()](#ERMrest.Rows+length) ⇒ <code>number</code>
         * [.after()](#ERMrest.Rows+after) ⇒ <code>Promise</code>
         * [.before()](#ERMrest.Rows+before) ⇒ <code>Promise</code>
+    * [.Row](#ERMrest.Row)
+        * [new Row(jsonRow)](#new_ERMrest.Row_new)
+        * [.data](#ERMrest.Row+data) : <code>Object</code>
+        * [.names()](#ERMrest.Row+names) ⇒ <code>Array</code>
+        * [.get(name)](#ERMrest.Row+get) ⇒ <code>String</code>
     * [.Columns](#ERMrest.Columns)
         * [new Columns()](#new_ERMrest.Columns_new)
         * [.all()](#ERMrest.Columns+all) ⇒ <code>Array</code>
@@ -528,7 +534,7 @@ get the number of rows
 ##### entity.get(filter, limit, columns, sortby) ⇒ <code>Promise</code>
 get table rows with option filter, row limit and selected columns (in this order).
 
-In order to use before & after on a rowset, limit must be speficied,
+In order to use before & after on a rows, limit must be speficied,
 output columns and sortby needs to have columns of a key
 
 **Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
@@ -608,6 +614,7 @@ Create new entities
 * [.Rows](#ERMrest.Rows)
     * [new Rows(table, jsonRows, filter, limit, columns, sortby)](#new_ERMrest.Rows_new)
     * [.data](#ERMrest.Rows+data) : <code>Array</code>
+    * [.get(index)](#ERMrest.Rows+get) : <code>[Row](#ERMrest.Row)</code>
     * [.length()](#ERMrest.Rows+length) ⇒ <code>number</code>
     * [.after()](#ERMrest.Rows+after) ⇒ <code>Promise</code>
     * [.before()](#ERMrest.Rows+before) ⇒ <code>Promise</code>
@@ -625,28 +632,67 @@ Create new entities
 | sortby | <code>Array</code> | Optional. An ordered array of {column, order} where column is column name or Column object, order is null/'' (default), 'asc' or 'desc' |
 
 <a name="ERMrest.Rows+data"></a>
-#### rowSet.data : <code>Array</code>
+#### rows.data : <code>Array</code>
 The set of rows returns from the server. It is an Array of
 Objects that has keys and values based on the query that produced
 the Rows.
-
 **Kind**: instance property of <code>[Rows](#ERMrest.Rows)</code>  
 <a name="ERMrest.Rows+length"></a>
-#### rowSet.length() ⇒ <code>number</code>
+#### rows.length() ⇒ <code>number</code>
 **Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
+<a name="ERMrest.Rows+get"></a>
+#### rows.get(index) ⇒ <code>[Row](#ERMrest.Row)</code>
+**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
+**Returns**: <code>[Row](#ERMrest.Row)</code>
+| Param | Type | Description |
+| --- | --- | --- |
+| index | <code>Number</code> | Index of a Row from Rows.data |
 <a name="ERMrest.Rows+after"></a>
-#### rowSet.after() ⇒ <code>Promise</code>
-get the rowset of the next page
-
+#### rows.after() ⇒ <code>Promise</code>
+get the rows of the next page
 **Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
 <a name="ERMrest.Rows+before"></a>
-#### rowSet.before() ⇒ <code>Promise</code>
-get the rowset of the previous page
-
+#### rows.before() ⇒ <code>Promise</code>
+get the rows of the previous page
 **Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
+
+<a name="ERMrest.Row"></a>
+### ERMrest.Row
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>
+
+* [.Row](#ERMrest.Row)
+    * [new Row(jsonRow)](#new_ERMrest.Row_new)
+    * [.data](#ERMrest.Row+data) : <code>Object</code>
+    * [.names()](#ERMrest.Row+names) ⇒ <code>Array</code>
+    * [.get(name)](#ERMrest.Row+get) ⇒ <code>Object</code>
+
+<a name="new_ERMrest.Row_new"></a>
+### new Row(jsonRow)
+Constructor for Row.
+
+| Param | Type | Description |
+| --- | --- | --- |
+| jsonRow | <code>Object</code> | Required. |
+
+<a name="ERMrest.Row+data"></a>
+#### row.data : <code>Object</code>
+The row returned from the ith result in the Rows.data.
+**Kind**: instance property of <code>[Rows](#ERMrest.Row)</code>  
+<a name="ERMrest.Row+get"></a>
+#### row.get(name) ⇒ <code>[Row](#ERMrest.Row)</code>
+**Kind**: instance method of <code>[Row](#ERMrest.Row)</code>  
+**Returns**: <code>Object</code>
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>String</code> | name of a column |
+<a name="ERMrest.Row+names"></a>
+#### row.names() : <code>Array</code>
+**Kind**: instance property of <code>[Row](#ERMrest.Row)</code>
+**Returns**: <code>Array</code>
+
 <a name="ERMrest.Columns"></a>
 ### ERMrest.Columns
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>
 
 * [.Columns](#ERMrest.Columns)
     * [new Columns()](#new_ERMrest.Columns_new)
@@ -1129,7 +1175,7 @@ entity container
 <a name="ERMrest.Datapath.DataPath+entity.get"></a>
 ###### entity.get() ⇒ <code>Promise</code>
 **Kind**: static method of <code>[entity](#ERMrest.Datapath.DataPath+entity)</code>  
-**Returns**: <code>Promise</code> - promise with rowset data  
+**Returns**: <code>Promise</code> - promise with rows data  
 <a name="ERMrest.Datapath.DataPath+entity.delete"></a>
 ###### entity.delete(filter) ⇒ <code>Promise</code>
 delete entities

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8">
         <title>ERMrest API Test</title>
         <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.js"></script>
-        <script src="../chaise/error-handling/networkerrors.js"></script>
         <script src="js/filters.js"></script>
         <script src="js/datapath.js"></script>
         <script src="js/utilities.js"></script>

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -891,15 +891,13 @@ var ERMrest = (function (module) {
     /**
      *
      * @memberof ERMrest
-     * @param {ERMrest.Table} table Required.
      * @param {Object} jsonRow Required.
      * @constructor
      */
     function Row(jsonRow) {
         /**
          * @type {Object}
-         * @desc The row returned from the ith result in the Rows.data. It is an
-         * Object that has keys and values ....
+         * @desc The row returned from the ith result in the Rows.data.
          */
         this.data = jsonRow;
     }
@@ -917,8 +915,8 @@ var ERMrest = (function (module) {
 
         /**
          *
-         * @returns {String} name name of column
-         * @returns {ERMrest.Column} column
+         * @param {String} name name of column
+         * @returns {Object} column value
          */
         get: function(name) {
             if (!(name in this.data)) {

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -862,7 +862,7 @@ var ERMrest = (function (module) {
          * @returns {Row}
          */
         get: function(index) {
-            return new Row(this._table, this.data[index]);
+            return new Row(this.data[index]);
         },
 
         /**
@@ -895,9 +895,7 @@ var ERMrest = (function (module) {
      * @param {Object} jsonRow Required.
      * @constructor
      */
-    function Row(table, jsonRow) {
-        this._table = table;
-
+    function Row(jsonRow) {
         /**
          * @type {Object}
          * @desc The row returned from the ith result in the Rows.data. It is an

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -690,7 +690,7 @@ var ERMrest = (function (module) {
 
             var self = this;
             return module._http.get(uri).then(function(response) {
-                return new RowSet(self._table, response.data, filter, limit, columns, sortby);
+                return new Rows(self._table, response.data, filter, limit, columns, sortby);
             }, function(response) {
                 var error = responseToError(response);
                 return module._q.reject(error);
@@ -716,7 +716,7 @@ var ERMrest = (function (module) {
 
             var self = this;
             return module._http.get(uri).then(function(response) {
-                return new RowSet(self._table, response.data, filter, limit, columns, sortby);
+                return new Rows(self._table, response.data, filter, limit, columns, sortby);
             }, function(response) {
                 var error = responseToError(response);
                 return module._q.reject(error);
@@ -742,7 +742,7 @@ var ERMrest = (function (module) {
 
             var self = this;
             return module._http.get(uri).then(function(response) {
-                return new RowSet(self._table, response.data, filter, limit, columns, sortby);
+                return new Rows(self._table, response.data, filter, limit, columns, sortby);
             }, function(response) {
                 var error = responseToError(response);
                 return module._q.reject(error);
@@ -830,7 +830,7 @@ var ERMrest = (function (module) {
      * @param {Array} sortby Optional. An ordered array of {column, order} where column is column name or Column object, order is null/'' (default), 'asc' or 'desc'
      * @constructor
      */
-    function RowSet(table, jsonRows, filter, limit, columns, sortby) {
+    function Rows(table, jsonRows, filter, limit, columns, sortby) {
         this._table = table;
         this._filter = filter;
         this._limit = limit;
@@ -841,13 +841,13 @@ var ERMrest = (function (module) {
          * @type {Array}
          * @desc The set of rows returns from the server. It is an Array of
          * Objects that has keys and values based on the query that produced
-         * the RowSet.
+         * the Rows.
          */
         this.data = jsonRows;
     }
 
-    RowSet.prototype = {
-        constructor: RowSet,
+    Rows.prototype = {
+        constructor: Rows,
 
         /**
          *
@@ -855,6 +855,14 @@ var ERMrest = (function (module) {
          */
         length: function() {
             return this.data.length;
+        },
+
+        /**
+         *
+         * @returns {Row}
+         */
+        get: function(index) {
+            return new Row(this._table, this.data[index]);
         },
 
         /**
@@ -877,6 +885,48 @@ var ERMrest = (function (module) {
         before: function() {
 
             return this._table.entity.getBefore(this._filter, this._limit, this._output, this._sortby, this.data[0]);
+        }
+    };
+
+    /**
+     *
+     * @memberof ERMrest
+     * @param {ERMrest.Table} table Required.
+     * @param {Object} jsonRow Required.
+     * @constructor
+     */
+    function Row(table, jsonRow) {
+        this._table = table;
+
+        /**
+         * @type {Object}
+         * @desc The row returned from the ith result in the Rows.data. It is an
+         * Object that has keys and values ....
+         */
+        this.data = jsonRow;
+    }
+
+    Row.prototype = {
+        constructor: Row,
+
+        /**
+         *
+         * @returns {Array} Array of column names
+         */
+        names: function() {
+            return Object.keys(this.data);
+        },
+
+        /**
+         *
+         * @returns {String} name name of column
+         * @returns {ERMrest.Column} column
+         */
+        get: function(name) {
+            if (!(name in this.data)) {
+                throw new module.NotFoundError("", "Column " + name + " not found in row.");
+            }
+            return this.data[name];
         }
     };
 

--- a/js/ngtest.js
+++ b/js/ngtest.js
@@ -52,6 +52,8 @@ angular.module("testApp", ['ERMrest'])
             t1.entity.get().then(function(rows) {
                 console.log("Get all rows from dataset_chromosome using Table.entity.get()");
                 console.log(rows);
+                // get a Row from Rows
+                console.log(rows.get(0));
             }, function(error) {
                 console.log("Error getting entities from table " + t1.name + ":");
                 console.log(error);
@@ -119,8 +121,6 @@ angular.module("testApp", ['ERMrest'])
             }, function(response) {
                 console.log(response);
             });
-
-
 
 
 


### PR DESCRIPTION
This PR:
- Renames the `RowSet` class to `Rows`
- Adds a `Rows.get(index)` method, which returns the ith `Row` from `Rows.data`.
- Adds a `Row` class, which has:
 - `.data` => raw json object for the ith result in `Rows.data`
 - `.names()` => an array of column names in the row
 - `.get(name)` => the value of the column in this row