### PR TITLE
Update Columns to return visible ordered column list

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -80,7 +80,6 @@ to use for ERMrest JavaScript agents.
         * [.get(name)](#ERMrest.Row+get) ⇒ <code>Object</code>
     * [.Columns](#ERMrest.Columns)
         * [new Columns(table)](#new_ERMrest.Columns_new)
-        * [.table](#ERMrest.Columns+table) : <code>Table</code>
         * [.all()](#ERMrest.Columns+all) ⇒ <code>Array</code>
         * [.length()](#ERMrest.Columns+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Columns+names) ⇒ <code>Array</code>
@@ -822,7 +821,6 @@ The row returned from the ith result in the Rows.data.
 
 * [.Columns](#ERMrest.Columns)
     * [new Columns(table)](#new_ERMrest.Columns_new)
-    * [.table](#ERMrest.Columns+table) : <code>Table</code>
     * [.all()](#ERMrest.Columns+all) ⇒ <code>Array</code>
     * [.length()](#ERMrest.Columns+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Columns+names) ⇒ <code>Array</code>
@@ -840,12 +838,6 @@ Constructor for Columns.
 | --- | --- | --- |
 | table | <code>Table</code> | Required |
 
-<a name="ERMrest.Columns+table"></a>
-
-#### columns.table : <code>Table</code>
-The table that these columns belong to.
-
-**Kind**: instance property of <code>[Columns](#ERMrest.Columns)</code>  
 <a name="ERMrest.Columns+all"></a>
 
 #### columns.all() ⇒ <code>Array</code>

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,4 +1,5 @@
 <a name="ERMrest"></a>
+
 ## ERMrest : <code>object</code>
 The ERMrest module is a JavaScript client library for the ERMrest
 service. Most clients should begin with [resolve](#ERMrest.resolve).
@@ -79,11 +80,14 @@ to use for ERMrest JavaScript agents.
         * [.names()](#ERMrest.Row+names) ⇒ <code>Array</code>
         * [.get(name)](#ERMrest.Row+get) ⇒ <code>Object</code>
     * [.Columns](#ERMrest.Columns)
-        * [new Columns()](#new_ERMrest.Columns_new)
+        * [new Columns(table)](#new_ERMrest.Columns_new)
+        * [.table](#ERMrest.Columns+table) : <code>Table</code>
         * [.all()](#ERMrest.Columns+all) ⇒ <code>Array</code>
         * [.length()](#ERMrest.Columns+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Columns+names) ⇒ <code>Array</code>
+        * [.has(name)](#ERMrest.Columns+has) ⇒ <code>boolean</code>
         * [.get(name)](#ERMrest.Columns+get) ⇒ <code>[Column](#ERMrest.Column)</code>
+        * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ <code>[Column](#ERMrest.Column)</code>
     * [.Column](#ERMrest.Column)
         * [new Column(table, jsonColumn)](#new_ERMrest.Column_new)
         * [.position](#ERMrest.Column+position) : <code>number</code>
@@ -248,6 +252,7 @@ to use for ERMrest JavaScript agents.
     * [.resolve(uri)](#ERMrest.resolve) ⇒ <code>Promise</code>
 
 <a name="ERMrest.Server"></a>
+
 ### ERMrest.Server
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -257,6 +262,7 @@ to use for ERMrest JavaScript agents.
     * [.catalogs](#ERMrest.Server+catalogs) : <code>[Catalogs](#ERMrest.Catalogs)</code>
 
 <a name="new_ERMrest.Server_new"></a>
+
 #### new Server(uri)
 
 | Param | Type | Description |
@@ -264,12 +270,15 @@ to use for ERMrest JavaScript agents.
 | uri | <code>string</code> | URI of the ERMrest service. |
 
 <a name="ERMrest.Server+uri"></a>
+
 #### server.uri : <code>string</code>
 **Kind**: instance property of <code>[Server](#ERMrest.Server)</code>  
 <a name="ERMrest.Server+catalogs"></a>
+
 #### server.catalogs : <code>[Catalogs](#ERMrest.Catalogs)</code>
 **Kind**: instance property of <code>[Server](#ERMrest.Server)</code>  
 <a name="ERMrest.Catalogs"></a>
+
 ### ERMrest.Catalogs
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -280,6 +289,7 @@ to use for ERMrest JavaScript agents.
     * [.get(id)](#ERMrest.Catalogs+get) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.Catalogs_new"></a>
+
 #### new Catalogs(server)
 Constructor for the Catalogs.
 
@@ -289,14 +299,17 @@ Constructor for the Catalogs.
 | server | <code>[Server](#ERMrest.Server)</code> | the server object. |
 
 <a name="ERMrest.Catalogs+length"></a>
+
 #### catalogs.length() ⇒ <code>Number</code>
 **Kind**: instance method of <code>[Catalogs](#ERMrest.Catalogs)</code>  
 **Returns**: <code>Number</code> - Returns the length of the catalogs.  
 <a name="ERMrest.Catalogs+names"></a>
+
 #### catalogs.names() ⇒ <code>Array</code>
 **Kind**: instance method of <code>[Catalogs](#ERMrest.Catalogs)</code>  
 **Returns**: <code>Array</code> - Returns an array of names of catalogs.  
 <a name="ERMrest.Catalogs+get"></a>
+
 #### catalogs.get(id) ⇒ <code>Promise</code>
 Get a catalog by id. This call does catalog introspection.
 
@@ -310,6 +323,7 @@ Get a catalog by id. This call does catalog introspection.
 | id | <code>string</code> | Catalog ID. |
 
 <a name="ERMrest.Catalog"></a>
+
 ### ERMrest.Catalog
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -320,6 +334,7 @@ Get a catalog by id. This call does catalog introspection.
     * [.schemas](#ERMrest.Catalog+schemas) : <code>[Schemas](#ERMrest.Schemas)</code>
 
 <a name="new_ERMrest.Catalog_new"></a>
+
 #### new Catalog(server, id)
 Constructor for the Catalog.
 
@@ -330,15 +345,19 @@ Constructor for the Catalog.
 | id | <code>string</code> | the catalog id. |
 
 <a name="ERMrest.Catalog+server"></a>
+
 #### catalog.server : <code>[Server](#ERMrest.Server)</code>
 **Kind**: instance property of <code>[Catalog](#ERMrest.Catalog)</code>  
 <a name="ERMrest.Catalog+id"></a>
+
 #### catalog.id : <code>string</code>
 **Kind**: instance property of <code>[Catalog](#ERMrest.Catalog)</code>  
 <a name="ERMrest.Catalog+schemas"></a>
+
 #### catalog.schemas : <code>[Schemas](#ERMrest.Schemas)</code>
 **Kind**: instance property of <code>[Catalog](#ERMrest.Catalog)</code>  
 <a name="ERMrest.Schemas"></a>
+
 ### ERMrest.Schemas
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -350,22 +369,27 @@ Constructor for the Catalog.
     * [.get(name)](#ERMrest.Schemas+get) ⇒ <code>[Schema](#ERMrest.Schema)</code>
 
 <a name="new_ERMrest.Schemas_new"></a>
+
 #### new Schemas()
 Constructor for the Schemas.
 
 <a name="ERMrest.Schemas+length"></a>
+
 #### schemas.length() ⇒ <code>Number</code>
 **Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
 **Returns**: <code>Number</code> - number of schemas  
 <a name="ERMrest.Schemas+all"></a>
+
 #### schemas.all() ⇒ <code>Array</code>
 **Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
 **Returns**: <code>Array</code> - Array of all schemas in the catalog  
 <a name="ERMrest.Schemas+names"></a>
+
 #### schemas.names() ⇒ <code>Array</code>
 **Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
 **Returns**: <code>Array</code> - Array of schema names  
 <a name="ERMrest.Schemas+get"></a>
+
 #### schemas.get(name) ⇒ <code>[Schema](#ERMrest.Schema)</code>
 get schema by schema name
 
@@ -381,6 +405,7 @@ get schema by schema name
 | name | <code>string</code> | schema name |
 
 <a name="ERMrest.Schema"></a>
+
 ### ERMrest.Schema
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -394,6 +419,7 @@ get schema by schema name
     * [.tables](#ERMrest.Schema+tables) : <code>[Tables](#ERMrest.Tables)</code>
 
 <a name="new_ERMrest.Schema_new"></a>
+
 #### new Schema(catalog, jsonSchema)
 Constructor for the Catalog.
 
@@ -404,26 +430,33 @@ Constructor for the Catalog.
 | jsonSchema | <code>string</code> | json of the schema. |
 
 <a name="ERMrest.Schema+catalog"></a>
+
 #### schema.catalog : <code>[Catalog](#ERMrest.Catalog)</code>
 **Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+name"></a>
+
 #### schema.name
 **Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+ignore"></a>
+
 #### schema.ignore : <code>boolean</code>
 **Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+annotations"></a>
+
 #### schema.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
 **Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+displayname"></a>
+
 #### schema.displayname : <code>string</code>
 Preferred display name for user presentation only.
 
 **Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+tables"></a>
+
 #### schema.tables : <code>[Tables](#ERMrest.Tables)</code>
 **Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Tables"></a>
+
 ### ERMrest.Tables
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -435,22 +468,27 @@ Preferred display name for user presentation only.
     * [.get(name)](#ERMrest.Tables+get) ⇒ <code>[Table](#ERMrest.Table)</code>
 
 <a name="new_ERMrest.Tables_new"></a>
+
 #### new Tables()
 Constructor for the Tables.
 
 <a name="ERMrest.Tables+all"></a>
+
 #### tables.all() ⇒ <code>Array</code>
 **Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
 **Returns**: <code>Array</code> - array of tables  
 <a name="ERMrest.Tables+length"></a>
+
 #### tables.length() ⇒ <code>Number</code>
 **Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
 **Returns**: <code>Number</code> - number of tables  
 <a name="ERMrest.Tables+names"></a>
+
 #### tables.names() ⇒ <code>Array</code>
 **Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
 **Returns**: <code>Array</code> - Array of table names  
 <a name="ERMrest.Tables+get"></a>
+
 #### tables.get(name) ⇒ <code>[Table](#ERMrest.Table)</code>
 get table by table name
 
@@ -466,6 +504,7 @@ get table by table name
 | name | <code>string</code> | name of table |
 
 <a name="ERMrest.Table"></a>
+
 ### ERMrest.Table
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -493,6 +532,7 @@ get table by table name
             * [.post(rows, defaults)](#ERMrest.Table.Entity+post) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.Table_new"></a>
+
 #### new Table(schema, jsonTable)
 Constructor for Table.
 
@@ -503,35 +543,45 @@ Constructor for Table.
 | jsonTable | <code>string</code> | the json of the table. |
 
 <a name="ERMrest.Table+schema"></a>
+
 #### table.schema : <code>[Schema](#ERMrest.Schema)</code>
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+name"></a>
+
 #### table.name
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+entity"></a>
+
 #### table.entity : <code>[Entity](#ERMrest.Table.Entity)</code>
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+ignore"></a>
+
 #### table.ignore : <code>boolean</code>
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+annotations"></a>
+
 #### table.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+displayname"></a>
+
 #### table.displayname : <code>string</code>
 Preferred display name for user presentation only.
 
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+columns"></a>
+
 #### table.columns : <code>[Columns](#ERMrest.Columns)</code>
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+keys"></a>
+
 #### table.keys : <code>[Keys](#ERMrest.Keys)</code>
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+foreignKeys"></a>
+
 #### table.foreignKeys : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table.Entity"></a>
+
 #### Table.Entity
 **Kind**: static class of <code>[Table](#ERMrest.Table)</code>  
 
@@ -546,6 +596,7 @@ Preferred display name for user presentation only.
     * [.post(rows, defaults)](#ERMrest.Table.Entity+post) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.Table.Entity_new"></a>
+
 ##### new Entity(table)
 Constructor for Entity. This is a container in Table
 
@@ -555,6 +606,7 @@ Constructor for Entity. This is a container in Table
 | table | <code>[Table](#ERMrest.Table)</code> | 
 
 <a name="ERMrest.Table.Entity+count"></a>
+
 ##### entity.count([filter]) ⇒ <code>Promise</code>
 get the number of rows
 
@@ -568,6 +620,7 @@ get the number of rows
 | [filter] | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
 
 <a name="ERMrest.Table.Entity+get"></a>
+
 ##### entity.get([filter], [limit], [columns], [sortby]) ⇒ <code>Promise</code>
 get table rows with option filter, row limit and selected columns (in this order).
 
@@ -587,6 +640,7 @@ output columns and sortby needs to have columns of a key
 | [sortby] | <code>Array.&lt;Object&gt;</code> | An ordered array of {column, order} where column is column name or Column object, order is null (default), 'asc' or 'desc' |
 
 <a name="ERMrest.Table.Entity+getBefore"></a>
+
 ##### entity.getBefore(filter, limit, [columns], [sortby], row) ⇒ <code>Promise</code>
 get a page of rows before a specific row
 
@@ -604,6 +658,7 @@ get a page of rows before a specific row
 | row | <code>Object</code> | json row data used to getBefore |
 
 <a name="ERMrest.Table.Entity+getAfter"></a>
+
 ##### entity.getAfter(filter, limit, [columns], [sortby], row) ⇒ <code>Promise</code>
 get a page of rows after a specific row
 
@@ -621,6 +676,7 @@ get a page of rows after a specific row
 | row | <code>Object</code> | json row data used to getAfter |
 
 <a name="ERMrest.Table.Entity+delete"></a>
+
 ##### entity.delete(filter) ⇒ <code>Promise</code>
 Delete rows from table based on the filter
 
@@ -634,6 +690,7 @@ Delete rows from table based on the filter
 | filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
 
 <a name="ERMrest.Table.Entity+put"></a>
+
 ##### entity.put(rows) ⇒ <code>Promise</code>
 **Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
 **Returns**: <code>Promise</code> - Promise that returns the rows updated if resolved or
@@ -646,6 +703,7 @@ Update rows in the table
 | rows | <code>Object</code> | jSON representation of the updated rows |
 
 <a name="ERMrest.Table.Entity+post"></a>
+
 ##### entity.post(rows, defaults) ⇒ <code>Promise</code>
 Create new entities
 
@@ -660,6 +718,7 @@ Create new entities
 | defaults | <code>Array.&lt;String&gt;</code> | Array of string column names to be defaults |
 
 <a name="ERMrest.Rows"></a>
+
 ### ERMrest.Rows
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -672,6 +731,7 @@ Create new entities
     * [.before()](#ERMrest.Rows+before) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.Rows_new"></a>
+
 #### new Rows(table, jsonRows, filter, limit, columns, [sortby])
 
 | Param | Type | Description |
@@ -684,6 +744,7 @@ Create new entities
 | [sortby] | <code>Array.&lt;Object&gt;</code> | An ordered array of {column, order} where column is column name or Column object, order is null/'' (default), 'asc' or 'desc' |
 
 <a name="ERMrest.Rows+data"></a>
+
 #### rows.data : <code>Array</code>
 The set of rows returns from the server. It is an Array of
 Objects that has keys and values based on the query that produced
@@ -691,12 +752,15 @@ the Rows.
 
 **Kind**: instance property of <code>[Rows](#ERMrest.Rows)</code>  
 <a name="ERMrest.Rows+length"></a>
+
 #### rows.length() ⇒ <code>number</code>
 **Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
 <a name="ERMrest.Rows+get"></a>
+
 #### rows.get() ⇒ <code>Row</code>
 **Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
 <a name="ERMrest.Rows+after"></a>
+
 #### rows.after() ⇒ <code>Promise</code>
 get the rows of the next page
 
@@ -705,6 +769,7 @@ get the rows of the next page
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
 <a name="ERMrest.Rows+before"></a>
+
 #### rows.before() ⇒ <code>Promise</code>
 get the rowset of the previous page
 
@@ -713,6 +778,7 @@ get the rowset of the previous page
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
 <a name="ERMrest.Row"></a>
+
 ### ERMrest.Row
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -723,6 +789,7 @@ get the rowset of the previous page
     * [.get(name)](#ERMrest.Row+get) ⇒ <code>Object</code>
 
 <a name="new_ERMrest.Row_new"></a>
+
 #### new Row(jsonRow)
 
 | Param | Type | Description |
@@ -730,15 +797,18 @@ get the rowset of the previous page
 | jsonRow | <code>Object</code> | Required. |
 
 <a name="ERMrest.Row+data"></a>
+
 #### row.data : <code>Object</code>
 The row returned from the ith result in the Rows.data.
 
 **Kind**: instance property of <code>[Row](#ERMrest.Row)</code>  
 <a name="ERMrest.Row+names"></a>
+
 #### row.names() ⇒ <code>Array</code>
 **Kind**: instance method of <code>[Row](#ERMrest.Row)</code>  
 **Returns**: <code>Array</code> - Array of column names  
 <a name="ERMrest.Row+get"></a>
+
 #### row.get(name) ⇒ <code>Object</code>
 **Kind**: instance method of <code>[Row](#ERMrest.Row)</code>  
 **Returns**: <code>Object</code> - column value  
@@ -748,33 +818,63 @@ The row returned from the ith result in the Rows.data.
 | name | <code>string</code> | name of column |
 
 <a name="ERMrest.Columns"></a>
+
 ### ERMrest.Columns
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Columns](#ERMrest.Columns)
-    * [new Columns()](#new_ERMrest.Columns_new)
+    * [new Columns(table)](#new_ERMrest.Columns_new)
+    * [.table](#ERMrest.Columns+table) : <code>Table</code>
     * [.all()](#ERMrest.Columns+all) ⇒ <code>Array</code>
     * [.length()](#ERMrest.Columns+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Columns+names) ⇒ <code>Array</code>
+    * [.has(name)](#ERMrest.Columns+has) ⇒ <code>boolean</code>
     * [.get(name)](#ERMrest.Columns+get) ⇒ <code>[Column](#ERMrest.Column)</code>
+    * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ <code>[Column](#ERMrest.Column)</code>
 
 <a name="new_ERMrest.Columns_new"></a>
-#### new Columns()
+
+#### new Columns(table)
 Constructor for Columns.
 
+
+| Param | Type | Description |
+| --- | --- | --- |
+| table | <code>Table</code> | Required |
+
+<a name="ERMrest.Columns+table"></a>
+
+#### columns.table : <code>Table</code>
+The table that these columns belong to.
+
+**Kind**: instance property of <code>[Columns](#ERMrest.Columns)</code>  
 <a name="ERMrest.Columns+all"></a>
+
 #### columns.all() ⇒ <code>Array</code>
 **Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
 **Returns**: <code>Array</code> - array of all columns  
 <a name="ERMrest.Columns+length"></a>
+
 #### columns.length() ⇒ <code>Number</code>
 **Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
 **Returns**: <code>Number</code> - number of columns  
 <a name="ERMrest.Columns+names"></a>
+
 #### columns.names() ⇒ <code>Array</code>
 **Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
 **Returns**: <code>Array</code> - names of columns  
+<a name="ERMrest.Columns+has"></a>
+
+#### columns.has(name) ⇒ <code>boolean</code>
+**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
+**Returns**: <code>boolean</code> - whether Columns has this column or not  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>string</code> | name of the column |
+
 <a name="ERMrest.Columns+get"></a>
+
 #### columns.get(name) ⇒ <code>[Column](#ERMrest.Column)</code>
 **Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
 **Returns**: <code>[Column](#ERMrest.Column)</code> - column  
@@ -783,7 +883,17 @@ Constructor for Columns.
 | --- | --- | --- |
 | name | <code>string</code> | name of column |
 
+<a name="ERMrest.Columns+getByPosition"></a>
+
+#### columns.getByPosition(pos) ⇒ <code>[Column](#ERMrest.Column)</code>
+**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
+
+| Param | Type |
+| --- | --- |
+| pos | <code>int</code> | 
+
 <a name="ERMrest.Column"></a>
+
 ### ERMrest.Column
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -804,6 +914,7 @@ Constructor for Columns.
     * [.formatvalue(data)](#ERMrest.Column+formatvalue) ⇒ <code>string</code>
 
 <a name="new_ERMrest.Column_new"></a>
+
 #### new Column(table, jsonColumn)
 Constructs a Column.
 
@@ -818,6 +929,7 @@ a Column _may not_ be a part of a Table.
 | jsonColumn | <code>string</code> | the json column. |
 
 <a name="ERMrest.Column+position"></a>
+
 #### column.position : <code>number</code>
 The ordinal number or position of this column relative to other
 columns within the same scope.
@@ -825,45 +937,57 @@ TODO: to be implemented
 
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+table"></a>
+
 #### column.table : <code>[Table](#ERMrest.Table)</code>
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+name"></a>
+
 #### column.name : <code>string</code>
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+type"></a>
+
 #### column.type : <code>[Type](#ERMrest.Type)</code>
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+nullok"></a>
+
 #### column.nullok : <code>Boolean</code>
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+default"></a>
+
 #### column.default : <code>string</code>
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+comment"></a>
+
 #### column.comment : <code>string</code>
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+ignore"></a>
+
 #### column.ignore : <code>boolean</code>
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+annotations"></a>
+
 #### column.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+displayname"></a>
+
 #### column.displayname : <code>string</code>
 Preferred display name for user presentation only.
 
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+memberOfKeys"></a>
+
 #### column.memberOfKeys : <code>[Array.&lt;Key&gt;](#ERMrest.Key)</code>
 keys that this column is a member of
 
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+memberOfForeignKeys"></a>
+
 #### column.memberOfForeignKeys : <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
 foreign key that this column is a member of
 
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+formatvalue"></a>
+
 #### column.formatvalue(data) ⇒ <code>string</code>
 Formats a value corresponding to this column definition.
 
@@ -875,6 +999,7 @@ Formats a value corresponding to this column definition.
 | data | <code>Object</code> | The 'raw' data value. |
 
 <a name="ERMrest.Annotations"></a>
+
 ### ERMrest.Annotations
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -887,22 +1012,27 @@ Formats a value corresponding to this column definition.
     * [.contains(uri)](#ERMrest.Annotations+contains) ⇒ <code>boolean</code>
 
 <a name="new_ERMrest.Annotations_new"></a>
+
 #### new Annotations()
 Constructor for Annotations.
 
 <a name="ERMrest.Annotations+all"></a>
+
 #### annotations.all() ⇒ <code>[Array.&lt;Annotation&gt;](#ERMrest.Annotation)</code>
 **Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
 **Returns**: <code>[Array.&lt;Annotation&gt;](#ERMrest.Annotation)</code> - list of all annotations  
 <a name="ERMrest.Annotations+length"></a>
+
 #### annotations.length() ⇒ <code>Number</code>
 **Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
 **Returns**: <code>Number</code> - number of annotations  
 <a name="ERMrest.Annotations+names"></a>
+
 #### annotations.names() ⇒ <code>Array</code>
 **Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
 **Returns**: <code>Array</code> - array of annotation names  
 <a name="ERMrest.Annotations+get"></a>
+
 #### annotations.get(uri) ⇒ <code>[Annotation](#ERMrest.Annotation)</code>
 get annotation by URI
 
@@ -918,6 +1048,7 @@ get annotation by URI
 | uri | <code>string</code> | uri of annotation |
 
 <a name="ERMrest.Annotations+contains"></a>
+
 #### annotations.contains(uri) ⇒ <code>boolean</code>
 **Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
 **Returns**: <code>boolean</code> - whether or not annotation exists  
@@ -927,6 +1058,7 @@ get annotation by URI
 | uri | <code>string</code> | uri of annotation |
 
 <a name="ERMrest.Annotation"></a>
+
 ### ERMrest.Annotation
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -936,6 +1068,7 @@ get annotation by URI
     * [.content](#ERMrest.Annotation+content) : <code>string</code>
 
 <a name="new_ERMrest.Annotation_new"></a>
+
 #### new Annotation(subject, uri, jsonAnnotation)
 Constructor for Annotation.
 
@@ -947,16 +1080,19 @@ Constructor for Annotation.
 | jsonAnnotation | <code>string</code> | json of annotation. |
 
 <a name="ERMrest.Annotation+subject"></a>
+
 #### annotation.subject : <code>string</code>
 One of schema,table,column,key,foreignkeyref
 
 **Kind**: instance property of <code>[Annotation](#ERMrest.Annotation)</code>  
 <a name="ERMrest.Annotation+content"></a>
+
 #### annotation.content : <code>string</code>
 json content
 
 **Kind**: instance property of <code>[Annotation](#ERMrest.Annotation)</code>  
 <a name="ERMrest.Keys"></a>
+
 ### ERMrest.Keys
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -968,22 +1104,27 @@ json content
     * [.get(colset)](#ERMrest.Keys+get) ⇒ <code>[Key](#ERMrest.Key)</code>
 
 <a name="new_ERMrest.Keys_new"></a>
+
 #### new Keys()
 Constructor for Keys.
 
 <a name="ERMrest.Keys+all"></a>
+
 #### keys.all() ⇒ <code>Array.&lt;Key&gt;</code>
 **Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
 **Returns**: <code>Array.&lt;Key&gt;</code> - a list of all Keys  
 <a name="ERMrest.Keys+length"></a>
+
 #### keys.length() ⇒ <code>Number</code>
 **Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
 **Returns**: <code>Number</code> - number of keys  
 <a name="ERMrest.Keys+colsets"></a>
+
 #### keys.colsets() ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
 **Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
 **Returns**: <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code> - array of colsets  
 <a name="ERMrest.Keys+get"></a>
+
 #### keys.get(colset) ⇒ <code>[Key](#ERMrest.Key)</code>
 get the key by the column set
 
@@ -999,6 +1140,7 @@ get the key by the column set
 | colset | <code>[ColSet](#ERMrest.ColSet)</code> | 
 
 <a name="ERMrest.Key"></a>
+
 ### ERMrest.Key
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1010,6 +1152,7 @@ get the key by the column set
     * [.simple](#ERMrest.Key+simple) : <code>boolean</code>
 
 <a name="new_ERMrest.Key_new"></a>
+
 #### new Key(table, jsonKey)
 Constructor for Key.
 
@@ -1020,22 +1163,27 @@ Constructor for Key.
 | jsonKey | <code>string</code> | json key. |
 
 <a name="ERMrest.Key+table"></a>
+
 #### key.table : <code>Table</code>
 Reference to the table that this Key belongs to.
 
 **Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.Key+colset"></a>
+
 #### key.colset : <code>[ColSet](#ERMrest.ColSet)</code>
 **Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.Key+annotations"></a>
+
 #### key.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
 **Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.Key+simple"></a>
+
 #### key.simple : <code>boolean</code>
 Indicates if the key is simple (not composite)
 
 **Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.ColSet"></a>
+
 ### ERMrest.ColSet
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1045,6 +1193,7 @@ Indicates if the key is simple (not composite)
     * [.length()](#ERMrest.ColSet+length) ⇒ <code>Number</code>
 
 <a name="new_ERMrest.ColSet_new"></a>
+
 #### new ColSet(columns)
 Constructor for ColSet, a set of Column objects.
 
@@ -1054,13 +1203,16 @@ Constructor for ColSet, a set of Column objects.
 | columns | <code>Array</code> | an array of Column objects. |
 
 <a name="ERMrest.ColSet+columns"></a>
+
 #### colSet.columns : <code>Array</code>
 **Kind**: instance property of <code>[ColSet](#ERMrest.ColSet)</code>  
 <a name="ERMrest.ColSet+length"></a>
+
 #### colSet.length() ⇒ <code>Number</code>
 **Kind**: instance method of <code>[ColSet](#ERMrest.ColSet)</code>  
 **Returns**: <code>Number</code> - number of columns  
 <a name="ERMrest.Mapping"></a>
+
 ### ERMrest.Mapping
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1071,6 +1223,7 @@ Constructor for ColSet, a set of Column objects.
     * [.get(fromCol)](#ERMrest.Mapping+get) ⇒ <code>[Column](#ERMrest.Column)</code>
 
 <a name="new_ERMrest.Mapping_new"></a>
+
 #### new Mapping(from, to)
 
 | Param | Type | Description |
@@ -1079,14 +1232,17 @@ Constructor for ColSet, a set of Column objects.
 | to | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> | array of to Columns |
 
 <a name="ERMrest.Mapping+length"></a>
+
 #### mapping.length() ⇒ <code>Number</code>
 **Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
 **Returns**: <code>Number</code> - number of mapping columns  
 <a name="ERMrest.Mapping+domain"></a>
+
 #### mapping.domain() ⇒ <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
 **Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
 **Returns**: <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> - the from columns  
 <a name="ERMrest.Mapping+get"></a>
+
 #### mapping.get(fromCol) ⇒ <code>[Column](#ERMrest.Column)</code>
 get the mapping column given the from column
 
@@ -1102,6 +1258,7 @@ get the mapping column given the from column
 | fromCol | <code>[Column](#ERMrest.Column)</code> | 
 
 <a name="ERMrest.ForeignKeys"></a>
+
 ### ERMrest.ForeignKeys
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1113,22 +1270,27 @@ get the mapping column given the from column
     * [.get(colset)](#ERMrest.ForeignKeys+get) ⇒ <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
 
 <a name="ERMrest.ForeignKeys+all"></a>
+
 #### foreignKeys.all() ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
 **Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
 **Returns**: <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code> - an array of all foreign key references  
 <a name="ERMrest.ForeignKeys+colsets"></a>
+
 #### foreignKeys.colsets() ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
 **Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
 **Returns**: <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code> - an array of the foreign keys' colsets  
 <a name="ERMrest.ForeignKeys+length"></a>
+
 #### foreignKeys.length() ⇒ <code>Number</code>
 **Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
 **Returns**: <code>Number</code> - number of foreign keys  
 <a name="ERMrest.ForeignKeys+mappings"></a>
+
 #### foreignKeys.mappings() ⇒ <code>[Array.&lt;Mapping&gt;](#ERMrest.Mapping)</code>
 **Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
 **Returns**: <code>[Array.&lt;Mapping&gt;](#ERMrest.Mapping)</code> - mappings  
 <a name="ERMrest.ForeignKeys+get"></a>
+
 #### foreignKeys.get(colset) ⇒ <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
 get the foreign key of the given column set
 
@@ -1144,6 +1306,7 @@ get the foreign key of the given column set
 | colset | <code>[ColSet](#ERMrest.ColSet)</code> | 
 
 <a name="ERMrest.ForeignKeyRef"></a>
+
 ### ERMrest.ForeignKeyRef
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1158,6 +1321,7 @@ get the foreign key of the given column set
     * [.getDomainValues(limit)](#ERMrest.ForeignKeyRef+getDomainValues) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.ForeignKeyRef_new"></a>
+
 #### new ForeignKeyRef(table, jsonFKR)
 
 | Param | Type |
@@ -1166,29 +1330,36 @@ get the foreign key of the given column set
 | jsonFKR | <code>Object</code> | 
 
 <a name="ERMrest.ForeignKeyRef+colset"></a>
+
 #### foreignKeyRef.colset : <code>[ColSet](#ERMrest.ColSet)</code>
 **Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+key"></a>
+
 #### foreignKeyRef.key : <code>[Key](#ERMrest.Key)</code>
 find key from referencedCols
 use index 0 since all refCols should be of the same schema:table
 
 **Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+mapping"></a>
+
 #### foreignKeyRef.mapping : <code>[Mapping](#ERMrest.Mapping)</code>
 **Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+ignore"></a>
+
 #### foreignKeyRef.ignore : <code>boolean</code>
 **Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+annotations"></a>
+
 #### foreignKeyRef.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
 **Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+simple"></a>
+
 #### foreignKeyRef.simple : <code>Boolean</code>
 Indicates if the foreign key is simple (not composite)
 
 **Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+getDomainValues"></a>
+
 #### foreignKeyRef.getDomainValues(limit) ⇒ <code>Promise</code>
 **Kind**: instance method of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 **Returns**: <code>Promise</code> - promise that returns a rowset of the referenced key's table if resolved or
@@ -1200,6 +1371,7 @@ Indicates if the foreign key is simple (not composite)
 | limit | <code>Number</code> | 
 
 <a name="ERMrest.Type"></a>
+
 ### ERMrest.Type
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1208,6 +1380,7 @@ Indicates if the foreign key is simple (not composite)
     * [.name](#ERMrest.Type+name)
 
 <a name="new_ERMrest.Type_new"></a>
+
 #### new Type(name)
 
 | Param |
@@ -1215,12 +1388,15 @@ Indicates if the foreign key is simple (not composite)
 | name | 
 
 <a name="ERMrest.Type+name"></a>
+
 #### type.name
 **Kind**: instance property of <code>[Type](#ERMrest.Type)</code>  
 <a name="ERMrest.TimedOutError"></a>
+
 ### ERMrest.TimedOutError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.TimedOutError_new"></a>
+
 #### new TimedOutError(status, message)
 
 | Param | Type | Description |
@@ -1229,9 +1405,11 @@ Indicates if the foreign key is simple (not composite)
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.BadRequestError"></a>
+
 ### ERMrest.BadRequestError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.BadRequestError_new"></a>
+
 #### new BadRequestError(status, message)
 
 | Param | Type | Description |
@@ -1240,9 +1418,11 @@ Indicates if the foreign key is simple (not composite)
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.UnauthorizedError"></a>
+
 ### ERMrest.UnauthorizedError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.UnauthorizedError_new"></a>
+
 #### new UnauthorizedError(status, message)
 
 | Param | Type | Description |
@@ -1251,9 +1431,11 @@ Indicates if the foreign key is simple (not composite)
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.ForbiddenError"></a>
+
 ### ERMrest.ForbiddenError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.ForbiddenError_new"></a>
+
 #### new ForbiddenError(status, message)
 
 | Param | Type | Description |
@@ -1262,9 +1444,11 @@ Indicates if the foreign key is simple (not composite)
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.NotFoundError"></a>
+
 ### ERMrest.NotFoundError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.NotFoundError_new"></a>
+
 #### new NotFoundError(status, message)
 
 | Param | Type | Description |
@@ -1273,9 +1457,11 @@ Indicates if the foreign key is simple (not composite)
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.ConflictError"></a>
+
 ### ERMrest.ConflictError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.ConflictError_new"></a>
+
 #### new ConflictError(status, message)
 
 | Param | Type | Description |
@@ -1284,9 +1470,11 @@ Indicates if the foreign key is simple (not composite)
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.InternalServerError"></a>
+
 ### ERMrest.InternalServerError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.InternalServerError_new"></a>
+
 #### new InternalServerError(status, message)
 
 | Param | Type | Description |
@@ -1295,9 +1483,11 @@ Indicates if the foreign key is simple (not composite)
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.ServiceUnavailableError"></a>
+
 ### ERMrest.ServiceUnavailableError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.ServiceUnavailableError_new"></a>
+
 #### new ServiceUnavailableError(status, message)
 
 | Param | Type | Description |
@@ -1306,9 +1496,11 @@ Indicates if the foreign key is simple (not composite)
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.InvalidFilterOperatorError"></a>
+
 ### ERMrest.InvalidFilterOperatorError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.InvalidFilterOperatorError_new"></a>
+
 #### new InvalidFilterOperatorError(message)
 An invalid filter operator
 
@@ -1318,9 +1510,11 @@ An invalid filter operator
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.InvalidInputError"></a>
+
 ### ERMrest.InvalidInputError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.InvalidInputError_new"></a>
+
 #### new InvalidInputError(message)
 An invalid input
 
@@ -1330,9 +1524,11 @@ An invalid input
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.MalformedURIError"></a>
+
 ### ERMrest.MalformedURIError
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.MalformedURIError_new"></a>
+
 #### new MalformedURIError(message)
 A malformed URI was passed to the API.
 
@@ -1342,6 +1538,7 @@ A malformed URI was passed to the API.
 | message | <code>string</code> | error message |
 
 <a name="ERMrest.Reference"></a>
+
 ### ERMrest.Reference
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1364,6 +1561,7 @@ A malformed URI was passed to the API.
     * [.delete()](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.Reference_new"></a>
+
 #### new Reference(uri)
 Constructs a Reference object.
 
@@ -1383,11 +1581,13 @@ Usage:
 | uri | <code>string</code> | The `URI` for this reference. |
 
 <a name="ERMrest.Reference+uri"></a>
+
 #### reference.uri : <code>string</code>
 The string form of the `URI` for this reference.
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+columns"></a>
+
 #### reference.columns : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
 The array of column definitions which represent the model of
 the resources accessible via this reference.
@@ -1408,6 +1608,7 @@ for (var i=0, len=reference.columns.length; i<len; i++) {
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+isUnique"></a>
+
 #### reference.isUnique : <code>boolean</code>
 A Boolean value that indicates whether this Reference is _inherently_
 unique. Meaning, that it can only refere to a single data element, 
@@ -1434,6 +1635,7 @@ console.log("This reference is unique?", (reference.isUnique ? 'yes' : 'no'));
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+contextualize"></a>
+
 #### reference.contextualize
 The members of this object are _contextualized references_.
 
@@ -1456,16 +1658,19 @@ different compared to `reference.columns`.
     * [.edit](#ERMrest.Reference+contextualize.edit) : <code>[Reference](#ERMrest.Reference)</code>
 
 <a name="ERMrest.Reference+contextualize.view"></a>
+
 ##### contextualize.view : <code>[Reference](#ERMrest.Reference)</code>
 The _view_ context of this reference.
 
 **Kind**: static property of <code>[contextualize](#ERMrest.Reference+contextualize)</code>  
 <a name="ERMrest.Reference+contextualize.edit"></a>
+
 ##### contextualize.edit : <code>[Reference](#ERMrest.Reference)</code>
 The _edit_ context of this reference.
 
 **Kind**: static property of <code>[contextualize](#ERMrest.Reference+contextualize)</code>  
 <a name="ERMrest.Reference+canCreate"></a>
+
 #### reference.canCreate : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client has the permission to _create_
 the referenced resource(s). In some cases, this permission cannot
@@ -1473,6 +1678,7 @@ be determined and the value will be `undefined`.
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+canRead"></a>
+
 #### reference.canRead : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client has the permission to _read_
 the referenced resource(s). In some cases, this permission cannot
@@ -1480,6 +1686,7 @@ be determined and the value will be `undefined`.
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+canUpdate"></a>
+
 #### reference.canUpdate : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client has the permission to _update_
 the referenced resource(s). In some cases, this permission cannot
@@ -1487,6 +1694,7 @@ be determined and the value will be `undefined`.
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+canDelete"></a>
+
 #### reference.canDelete : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client has the permission to _delete_
 the referenced resource(s). In some cases, this permission cannot
@@ -1494,6 +1702,7 @@ be determined and the value will be `undefined`.
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+relatedReferences"></a>
+
 #### reference.relatedReferences : <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
 The "related" references. Relationships are defined by foreign key
 references between [Table](#ERMrest.Table)s. Those references can be
@@ -1513,6 +1722,7 @@ _Note_: Initially, this will only reflect relationships based on
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+create"></a>
+
 #### reference.create(tbd) ⇒ <code>Promise</code>
 Creates a set of resources.
 
@@ -1524,6 +1734,7 @@ Creates a set of resources.
 | tbd | <code>Array</code> | TBD parameters. Probably an array of tuples [ {tuple},... ] for all entities to be created. |
 
 <a name="ERMrest.Reference+read"></a>
+
 #### reference.read(limit) ⇒ <code>Promise</code>
 Reads the referenced resources and returns a promise for a page of 
 tuples. The `limit` parameter is required and must be a positive 
@@ -1554,6 +1765,7 @@ other errors TBD (TODO document other errors here).
 | limit | <code>number</code> | The limit of results to be returned by the read request. __required__ |
 
 <a name="ERMrest.Reference+update"></a>
+
 #### reference.update(tbd) ⇒ <code>Promise</code>
 Updates a set of resources.
 
@@ -1565,12 +1777,14 @@ Updates a set of resources.
 | tbd | <code>Array</code> | TBD parameters. Probably an array of pairs of [ (keys+values, allvalues)]+ ] for all entities to be updated. |
 
 <a name="ERMrest.Reference+delete"></a>
+
 #### reference.delete() ⇒ <code>Promise</code>
 Deletes the referenced resources.
 
 **Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
 **Returns**: <code>Promise</code> - A promise for a TBD result or errors.  
 <a name="ERMrest.Page"></a>
+
 ### ERMrest.Page
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1581,6 +1795,7 @@ Deletes the referenced resources.
     * [.next](#ERMrest.Page+next) : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
 
 <a name="new_ERMrest.Page_new"></a>
+
 #### new Page(reference, data)
 Constructs a new Page. A _page_ represents a set of results returned from
 ERMrest. It may not represent the complete set of results. There is an
@@ -1600,6 +1815,7 @@ Usage:
 | data | <code>Array.&lt;Object&gt;</code> | The data returned from ERMrest. |
 
 <a name="ERMrest.Page+tuples"></a>
+
 #### page.tuples : <code>[Array.&lt;Tuple&gt;](#ERMrest.Tuple)</code>
 An array of processed tuples. The results will be processed
 according to the contextualized scheme (model) of this reference.
@@ -1614,6 +1830,7 @@ for (var i=0, len=page.tuples.length; i<len; i++) {
 
 **Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
 <a name="ERMrest.Page+previous"></a>
+
 #### page.previous : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
 A reference to the previous set of results.
 
@@ -1629,6 +1846,7 @@ if (reference.previous) {
 
 **Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
 <a name="ERMrest.Page+next"></a>
+
 #### page.next : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
 A reference to the next set of results.
 
@@ -1644,6 +1862,7 @@ if (reference.next) {
 
 **Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
 <a name="ERMrest.Tuple"></a>
+
 ### ERMrest.Tuple
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1657,6 +1876,7 @@ if (reference.next) {
     * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.Tuple_new"></a>
+
 #### new Tuple(reference, data)
 Constructs a new Tuple. In database jargon, a tuple is a row in a 
 relation. This object represents a row returned by a query to ERMrest.
@@ -1672,6 +1892,7 @@ Usage:
 | data | <code>Object</code> | The unprocessed tuple of data returned from ERMrest. |
 
 <a name="ERMrest.Tuple+canUpdate"></a>
+
 #### tuple.canUpdate : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client can update this tuple. Because
 some policies may be undecidable until query execution, this
@@ -1692,6 +1913,7 @@ else {
 
 **Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+canDelete"></a>
+
 #### tuple.canDelete : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client can delete this tuple. Because
 some policies may be undecidable until query execution, this
@@ -1701,6 +1923,7 @@ See [canUpdate](#ERMrest.Tuple+canUpdate) for a usage example.
 
 **Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+values"></a>
+
 #### tuple.values : <code>Array.&lt;string&gt;</code>
 The array of formatted values of this tuple. The ordering of the 
 values in the array matches the ordering of the columns in the 
@@ -1723,6 +1946,7 @@ console.log(tuple.displayname, "has a", column.displayname,
 
 **Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+displayname"></a>
+
 #### tuple.displayname : <code>string</code>
 The _disaply name_ of this tuple. For example, if this tuple is a
 row from a table, then the display name is defined by the heuristic
@@ -1737,6 +1961,7 @@ console.log("This tuple has a displayable name of", tuple.displayname);
 
 **Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+update"></a>
+
 #### tuple.update() ⇒ <code>Promise</code>
 Attempts to update this tuple. This is a server side transaction,
 and therefore an asynchronous operation that returns a promise.
@@ -1744,6 +1969,7 @@ and therefore an asynchronous operation that returns a promise.
 **Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
 **Returns**: <code>Promise</code> - a promise (TBD the result object)  
 <a name="ERMrest.Tuple+delete"></a>
+
 #### tuple.delete() ⇒ <code>Promise</code>
 Attempts to delete this tuple. This is a server side transaction,
 and therefore an asynchronous operation that returns a promise.
@@ -1751,6 +1977,7 @@ and therefore an asynchronous operation that returns a promise.
 **Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
 **Returns**: <code>Promise</code> - a promise (TBD the result object)  
 <a name="ERMrest.Datapath"></a>
+
 ### ERMrest.Datapath : <code>object</code>
 **Kind**: static namespace of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1782,6 +2009,7 @@ and therefore an asynchronous operation that returns a promise.
     * [.Operators()](#ERMrest.Datapath.Operators)
 
 <a name="ERMrest.Datapath.DataPath"></a>
+
 #### Datapath.DataPath
 **Kind**: static class of <code>[Datapath](#ERMrest.Datapath)</code>  
 
@@ -1796,6 +2024,7 @@ and therefore an asynchronous operation that returns a promise.
     * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
 
 <a name="new_ERMrest.Datapath.DataPath_new"></a>
+
 ##### new DataPath(table)
 
 | Param | Type |
@@ -1803,12 +2032,15 @@ and therefore an asynchronous operation that returns a promise.
 | table | <code>[Table](#ERMrest.Table)</code> | 
 
 <a name="ERMrest.Datapath.DataPath+catalog"></a>
+
 ##### dataPath.catalog : <code>[Catalog](#ERMrest.Catalog)</code>
 **Kind**: instance property of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
 <a name="ERMrest.Datapath.DataPath+context"></a>
+
 ##### dataPath.context : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
 **Kind**: instance property of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
 <a name="ERMrest.Datapath.DataPath+entity"></a>
+
 ##### dataPath.entity
 entity container
 
@@ -1819,12 +2051,14 @@ entity container
     * [.delete(filter)](#ERMrest.Datapath.DataPath+entity.delete) ⇒ <code>Promise</code>
 
 <a name="ERMrest.Datapath.DataPath+entity.get"></a>
+
 ###### entity.get() ⇒ <code>Promise</code>
 **Kind**: static method of <code>[entity](#ERMrest.Datapath.DataPath+entity)</code>  
 **Returns**: <code>Promise</code> - promise that returns a row data if resolved or
     [ERMrest.Errors.TimedOutError](ERMrest.Errors.TimedOutError), [ERMrest.Errors.InternalServerError](ERMrest.Errors.InternalServerError), [ERMrest.Errors.ServiceUnavailableError](ERMrest.Errors.ServiceUnavailableError),
     [ERMrest.Errors.ConflictError](ERMrest.Errors.ConflictError), [ERMrest.Errors.ForbiddenError](ERMrest.Errors.ForbiddenError) or [ERMrest.Errors.UnauthorizedError](ERMrest.Errors.UnauthorizedError) if rejected  
 <a name="ERMrest.Datapath.DataPath+entity.delete"></a>
+
 ###### entity.delete(filter) ⇒ <code>Promise</code>
 delete entities
 
@@ -1838,6 +2072,7 @@ delete entities
 | filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
 
 <a name="ERMrest.Datapath.DataPath+filter"></a>
+
 ##### dataPath.filter(filter) ⇒ <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
 this datapath is not modified
 
@@ -1849,6 +2084,7 @@ this datapath is not modified
 | filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
 
 <a name="ERMrest.Datapath.DataPath+extend"></a>
+
 ##### dataPath.extend(table, context, link) ⇒ <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
 extend the Datapath with table
 
@@ -1861,6 +2097,7 @@ extend the Datapath with table
 | link |  | 
 
 <a name="ERMrest.Datapath.PathTable"></a>
+
 #### Datapath.PathTable
 **Kind**: static class of <code>[Datapath](#ERMrest.Datapath)</code>  
 
@@ -1873,6 +2110,7 @@ extend the Datapath with table
     * [.toString()](#ERMrest.Datapath.PathTable+toString) ⇒ <code>string</code>
 
 <a name="new_ERMrest.Datapath.PathTable_new"></a>
+
 ##### new PathTable(table, datapath, alias)
 
 | Param | Type |
@@ -1882,22 +2120,28 @@ extend the Datapath with table
 | alias | <code>string</code> | 
 
 <a name="ERMrest.Datapath.PathTable+datapath"></a>
+
 ##### pathTable.datapath : <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
 **Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
 <a name="ERMrest.Datapath.PathTable+table"></a>
+
 ##### pathTable.table : <code>[Table](#ERMrest.Table)</code>
 **Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
 <a name="ERMrest.Datapath.PathTable+alias"></a>
+
 ##### pathTable.alias : <code>string</code>
 **Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
 <a name="ERMrest.Datapath.PathTable+columns"></a>
+
 ##### pathTable.columns : <code>[Columns](#ERMrest.Datapath.Columns)</code>
 **Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
 <a name="ERMrest.Datapath.PathTable+toString"></a>
+
 ##### pathTable.toString() ⇒ <code>string</code>
 **Kind**: instance method of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
 **Returns**: <code>string</code> - uri of the PathTable  
 <a name="ERMrest.Datapath.PathColumn"></a>
+
 #### Datapath.PathColumn
 **Kind**: static class of <code>[Datapath](#ERMrest.Datapath)</code>  
 
@@ -1907,6 +2151,7 @@ extend the Datapath with table
     * [.column](#ERMrest.Datapath.PathColumn+column) : <code>[Column](#ERMrest.Column)</code>
 
 <a name="new_ERMrest.Datapath.PathColumn_new"></a>
+
 ##### new PathColumn(column, pathtable)
 
 | Param | Type |
@@ -1915,12 +2160,15 @@ extend the Datapath with table
 | pathtable | <code>[PathTable](#ERMrest.Datapath.PathTable)</code> | 
 
 <a name="ERMrest.Datapath.PathColumn+pathtable"></a>
+
 ##### pathColumn.pathtable : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
 **Kind**: instance property of <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>  
 <a name="ERMrest.Datapath.PathColumn+column"></a>
+
 ##### pathColumn.column : <code>[Column](#ERMrest.Column)</code>
 **Kind**: instance property of <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>  
 <a name="ERMrest.Datapath.Columns"></a>
+
 #### Datapath.Columns(table, pathtable)
 **Kind**: static method of <code>[Datapath](#ERMrest.Datapath)</code>  
 
@@ -1936,14 +2184,17 @@ extend the Datapath with table
     * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>
 
 <a name="ERMrest.Datapath.Columns+length"></a>
+
 ##### columns.length() ⇒ <code>Number</code>
 **Kind**: instance method of <code>[Columns](#ERMrest.Datapath.Columns)</code>  
 **Returns**: <code>Number</code> - number of path columns  
 <a name="ERMrest.Datapath.Columns+names"></a>
+
 ##### columns.names() ⇒ <code>Array.&lt;String&gt;</code>
 **Kind**: instance method of <code>[Columns](#ERMrest.Datapath.Columns)</code>  
 **Returns**: <code>Array.&lt;String&gt;</code> - a list of pathcolumn names  
 <a name="ERMrest.Datapath.Columns+get"></a>
+
 ##### columns.get(colName) ⇒ <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>
 get PathColumn object by column name
 
@@ -1959,9 +2210,11 @@ get PathColumn object by column name
 | colName | <code>string</code> | column name |
 
 <a name="ERMrest.Datapath.Operators"></a>
+
 #### Datapath.Operators()
 **Kind**: static method of <code>[Datapath](#ERMrest.Datapath)</code>  
 <a name="ERMrest.Filters"></a>
+
 ### ERMrest.Filters : <code>object</code>
 **Kind**: static namespace of <code>[ERMrest](#ERMrest)</code>  
 
@@ -1983,6 +2236,7 @@ get PathColumn object by column name
         * [.toUri()](#ERMrest.Filters.BinaryPredicate+toUri) ⇒ <code>string</code>
 
 <a name="ERMrest.Filters.Negation"></a>
+
 #### Filters.Negation
 **Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
 
@@ -1991,6 +2245,7 @@ get PathColumn object by column name
     * [.toUri()](#ERMrest.Filters.Negation+toUri) ⇒ <code>string</code>
 
 <a name="new_ERMrest.Filters.Negation_new"></a>
+
 ##### new Negation(filter)
 
 | Param |
@@ -1998,10 +2253,12 @@ get PathColumn object by column name
 | filter | 
 
 <a name="ERMrest.Filters.Negation+toUri"></a>
+
 ##### negation.toUri() ⇒ <code>string</code>
 **Kind**: instance method of <code>[Negation](#ERMrest.Filters.Negation)</code>  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.Conjunction"></a>
+
 #### Filters.Conjunction
 **Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
 
@@ -2010,6 +2267,7 @@ get PathColumn object by column name
     * [.toUri()](#ERMrest.Filters.Conjunction+toUri) ⇒ <code>string</code>
 
 <a name="new_ERMrest.Filters.Conjunction_new"></a>
+
 ##### new Conjunction(filters)
 
 | Param |
@@ -2017,10 +2275,12 @@ get PathColumn object by column name
 | filters | 
 
 <a name="ERMrest.Filters.Conjunction+toUri"></a>
+
 ##### conjunction.toUri() ⇒ <code>string</code>
 **Kind**: instance method of <code>[Conjunction](#ERMrest.Filters.Conjunction)</code>  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.Disjunction"></a>
+
 #### Filters.Disjunction
 **Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
 
@@ -2029,6 +2289,7 @@ get PathColumn object by column name
     * [.toUri()](#ERMrest.Filters.Disjunction+toUri) ⇒ <code>string</code>
 
 <a name="new_ERMrest.Filters.Disjunction_new"></a>
+
 ##### new Disjunction(filters)
 
 | Param |
@@ -2036,10 +2297,12 @@ get PathColumn object by column name
 | filters | 
 
 <a name="ERMrest.Filters.Disjunction+toUri"></a>
+
 ##### disjunction.toUri() ⇒ <code>string</code>
 **Kind**: instance method of <code>[Disjunction](#ERMrest.Filters.Disjunction)</code>  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.UnaryPredicate"></a>
+
 #### Filters.UnaryPredicate
 **Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
 
@@ -2048,6 +2311,7 @@ get PathColumn object by column name
     * [.toUri()](#ERMrest.Filters.UnaryPredicate+toUri) ⇒ <code>string</code>
 
 <a name="new_ERMrest.Filters.UnaryPredicate_new"></a>
+
 ##### new UnaryPredicate(column, operator)
 **Throws**:
 
@@ -2060,10 +2324,12 @@ get PathColumn object by column name
 | operator | <code>ERMrest.Filters.OPERATOR</code> | 
 
 <a name="ERMrest.Filters.UnaryPredicate+toUri"></a>
+
 ##### unaryPredicate.toUri() ⇒ <code>string</code>
 **Kind**: instance method of <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code>  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.BinaryPredicate"></a>
+
 #### Filters.BinaryPredicate
 **Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
 
@@ -2072,6 +2338,7 @@ get PathColumn object by column name
     * [.toUri()](#ERMrest.Filters.BinaryPredicate+toUri) ⇒ <code>string</code>
 
 <a name="new_ERMrest.Filters.BinaryPredicate_new"></a>
+
 ##### new BinaryPredicate(column, operator, rvalue)
 **Throws**:
 
@@ -2085,10 +2352,12 @@ get PathColumn object by column name
 | rvalue | <code>String</code> &#124; <code>Number</code> | 
 
 <a name="ERMrest.Filters.BinaryPredicate+toUri"></a>
+
 ##### binaryPredicate.toUri() ⇒ <code>string</code>
 **Kind**: instance method of <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code>  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.configure"></a>
+
 ### ERMrest.configure(http, q)
 This function is used to configure the module
 
@@ -2100,6 +2369,7 @@ This function is used to configure the module
 | q | <code>Object</code> | Angular $q service object |
 
 <a name="ERMrest.getServer"></a>
+
 ### ERMrest.getServer(uri) ⇒ <code>[Server](#ERMrest.Server)</code>
 ERMrest server factory creates or reuses ERMrest.Server instances. The
 URI should be to the ERMrest _service_. For example,
@@ -2117,6 +2387,7 @@ URI should be to the ERMrest _service_. For example,
 | uri | <code>string</code> | URI of the ERMrest service. |
 
 <a name="ERMrest.resolve"></a>
+
 ### ERMrest.resolve(uri) ⇒ <code>Promise</code>
 This function resolves a URI reference to a [Reference](#ERMrest.Reference) 
 object. It validates the syntax of the URI and validates that the 

--- a/doc/api.md
+++ b/doc/api.md
@@ -593,6 +593,7 @@ Preferred display name for user presentation only.
     * [.post(rows, defaults)](#ERMrest.Table.Entity+post) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.Table.Entity_new"></a>
+
 ##### new Entity(server, table)
 Constructor for Entity. This is a container in Table
 

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -273,7 +273,7 @@ var ERMrest = (function (module) {
     Schemas.prototype = {
         constructor: Schemas,
 
-        _push: function(schema) {
+        _push: function (schema) {
             this._schemas[schema.name] = schema;
         },
 
@@ -293,7 +293,7 @@ var ERMrest = (function (module) {
          *
          * @returns {Array} Array of all schemas in the catalog
          */
-        all: function() {
+        all: function () {
             var array = [];
             for (var key in this._schemas) {
                 array.push(this._schemas[key]);
@@ -414,7 +414,7 @@ var ERMrest = (function (module) {
     Tables.prototype = {
         constructor: Tables,
 
-        _push: function(table) {
+        _push: function (table) {
             this._tables[table.name] = table;
         },
 
@@ -422,7 +422,7 @@ var ERMrest = (function (module) {
          *
          * @returns {Array} array of tables
          */
-        all: function() {
+        all: function () {
             var array = [];
             for (var key in this._tables) {
                 array.push(this._tables[key]);
@@ -533,7 +533,7 @@ var ERMrest = (function (module) {
          *
          * @type {ERMrest.Columns}
          */
-        this.columns = new Columns();
+        this.columns = new Columns(this);
         for (var i = 0; i < jsonTable.column_definitions.length; i++) {
             var jsonColumn = jsonTable.column_definitions[i];
             this.columns._push(new Column(this, jsonColumn));
@@ -564,7 +564,7 @@ var ERMrest = (function (module) {
 
         },
 
-        _buildForeignKeys: function() {
+        _buildForeignKeys: function () {
             // this should be built on the second pass after introspection
             // so we already have all the keys and columns for all tables
             this.foreignKeys = new ForeignKeys();
@@ -598,7 +598,7 @@ var ERMrest = (function (module) {
          * @private
          * @desc <service>/catalog/<cid>/<api>/<schema>:<table>
          */
-        _getBaseURI: function(api) {
+        _getBaseURI: function (api) {
             return this._table.schema.catalog._uri + "/" + api + "/" +
                 module._fixedEncodeURIComponent(this._table.schema.name) + ":" +
                 module._fixedEncodeURIComponent(this._table.name);
@@ -616,7 +616,7 @@ var ERMrest = (function (module) {
          * @private
          * @desc get ermrest URI
          */
-        _toURI: function(filter, output, sortby, paging, row, limit) {
+        _toURI: function (filter, output, sortby, paging, row, limit) {
 
             var api = (output === null || output === undefined) ? "entity" : "attribute";
 
@@ -655,7 +655,7 @@ var ERMrest = (function (module) {
                 uri = uri + ")";
 
                 // paging requires sortby
-                if (paging  !== undefined && paging !== null && row !== undefined && row !== null) {
+                if (paging !== undefined && paging !== null && row !== undefined && row !== null) {
                     if (paging === "before") {
                         uri = uri + "@before(";
                     } else {
@@ -700,7 +700,7 @@ var ERMrest = (function (module) {
          * @desc get the number of rows
          *
          */
-        count: function(filter) {
+        count: function (filter) {
 
             var uri = this._getBaseURI("aggregate");
 
@@ -710,9 +710,9 @@ var ERMrest = (function (module) {
 
             uri = uri + "/row_count:=cnt(*)";
 
-            return module._http.get(uri).then(function(response) {
+            return module._http.get(uri).then(function (response) {
                 return response.data[0].row_count;
-            }, function(response) {
+            }, function (response) {
                 var error = module._responseToError(response);
                 return module._q.reject(error);
             });
@@ -733,14 +733,14 @@ var ERMrest = (function (module) {
          * In order to use before & after on a rowset, limit must be speficied,
          * output columns and sortby needs to have columns of a key
          */
-        get: function(filter, limit, columns, sortby) {
+        get: function (filter, limit, columns, sortby) {
 
             var uri = this._toURI(filter, columns, sortby, null, null, limit);
 
             var self = this;
-            return module._http.get(uri).then(function(response) {
+            return module._http.get(uri).then(function (response) {
                 return new Rows(self._table, response.data, filter, limit, columns, sortby);
-            }, function(response) {
+            }, function (response) {
                 var error = module._responseToError(response);
                 return module._q.reject(error);
             });
@@ -760,14 +760,14 @@ var ERMrest = (function (module) {
          * get a page of rows before a specific row
          *
          */
-        getBefore: function(filter, limit, columns, sortby, row) {
+        getBefore: function (filter, limit, columns, sortby, row) {
             var uri =
                 this._toURI(filter, columns, sortby, "before", row, limit);
 
             var self = this;
-            return module._http.get(uri).then(function(response) {
+            return module._http.get(uri).then(function (response) {
                 return new Rows(self._table, response.data, filter, limit, columns, sortby);
-            }, function(response) {
+            }, function (response) {
                 var error = module._responseToError(response);
                 return module._q.reject(error);
             });
@@ -787,14 +787,14 @@ var ERMrest = (function (module) {
          * get a page of rows after a specific row
          *
          */
-        getAfter: function(filter, limit, columns, sortby, row) {
+        getAfter: function (filter, limit, columns, sortby, row) {
             var uri =
                 this._toURI(filter, columns, sortby, "after", row, limit);
 
             var self = this;
-            return module._http.get(uri).then(function(response) {
+            return module._http.get(uri).then(function (response) {
                 return new Rows(self._table, response.data, filter, limit, columns, sortby);
-            }, function(response) {
+            }, function (response) {
                 var error = module._responseToError(response);
                 return module._q.reject(error);
             });
@@ -812,9 +812,9 @@ var ERMrest = (function (module) {
         delete: function (filter) {
             var uri = this._toURI(filter);
 
-            return module._http.delete(uri).then(function(response) {
+            return module._http.delete(uri).then(function (response) {
                 return response.data;
-            }, function(response) {
+            }, function (response) {
                 var error = module._responseToError(response);
                 return module._q.reject(error);
             });
@@ -832,9 +832,9 @@ var ERMrest = (function (module) {
 
             var uri = this._toURI();
 
-            return module._http.put(uri, rows).then(function(response) {
+            return module._http.put(uri, rows).then(function (response) {
                 return response.data;
-            }, function(response) {
+            }, function (response) {
                 var error = module._responseToError(response);
                 return module._q.reject(error);
             });
@@ -865,9 +865,9 @@ var ERMrest = (function (module) {
                 }
             }
 
-            return module._http.post(uri, rows).then(function(response) {
-               return response.data;
-            }, function(response) {
+            return module._http.post(uri, rows).then(function (response) {
+                return response.data;
+            }, function (response) {
                 var error = module._responseToError(response);
                 return module._q.reject(error);
             });
@@ -910,7 +910,7 @@ var ERMrest = (function (module) {
          *
          * @returns {number}
          */
-        length: function() {
+        length: function () {
             return this.data.length;
         },
 
@@ -918,7 +918,7 @@ var ERMrest = (function (module) {
          *
          * @returns {Row}
          */
-        get: function(index) {
+        get: function (index) {
             return new Row(this.data[index]);
         },
 
@@ -929,7 +929,7 @@ var ERMrest = (function (module) {
          * @desc get the rows of the next page
          *
          */
-        after: function() {
+        after: function () {
 
             return this._table.entity.getAfter(this._filter, this._limit, this._output, this._sortby, this.data[this.data.length - 1]);
         },
@@ -942,7 +942,7 @@ var ERMrest = (function (module) {
          * @desc get the rowset of the previous page
          *
          */
-        before: function() {
+        before: function () {
 
             return this._table.entity.getBefore(this._filter, this._limit, this._output, this._sortby, this.data[0]);
         }
@@ -969,7 +969,7 @@ var ERMrest = (function (module) {
          *
          * @returns {Array} Array of column names
          */
-        names: function() {
+        names: function () {
             return Object.keys(this.data);
         },
 
@@ -978,7 +978,7 @@ var ERMrest = (function (module) {
          * @param {string} name name of column
          * @returns {Object} column value
          */
-        get: function(name) {
+        get: function (name) {
             if (!(name in this.data)) {
                 throw new module.NotFoundError("", "Column " + name + " not found in row.");
             }
@@ -988,31 +988,58 @@ var ERMrest = (function (module) {
 
     /**
      * @memberof ERMrest
+     * @param {Table} table Required
      * @constructor
      * @desc
      * Constructor for Columns.
      */
-    function Columns() {
-        this._columns = {};
+    function Columns(table) {
+        this._columns = [];
+
+        /**
+         * @type {Table}
+         * @desc The table that these columns belong to.
+         */
+        this.table = table;
     }
 
     Columns.prototype = {
         constructor: Columns,
 
-        _push: function(column) {
-            this._columns[column.name] = column;
+        _push: function (column) {
+            this._columns.push(column);
+        },
+
+        // Returns column orders that are specified in annotations.
+        _getColumnOrders: function (context, annotation) {
+
+            if (context in annotation) {
+                if (Array.isArray(annotation[context])) {
+                    return annotation[context]; // found the context
+                } else {
+                    return this._getColumnOrders(annotation[context], annotation); // go to next level
+                }
+            }
+
+            // if context is edit or create, but there's no annotation for those
+            if (["edit", "create"].indexOf(context) != -1 && Array.isArray(annotation.entry)) {
+                return annotation.entry;
+            }
+
+            //if context wasn't in the annotations but there is a default context
+            if (Array.isArray(annotation["*"])) {
+                return annotation["*"];
+            }
+
+            return -1; // there was no annotation, return all
         },
 
         /**
          *
          * @returns {Array} array of all columns
          */
-        all: function() {
-            var array = [];
-            for (var key in this._columns) {
-                array.push(this._columns[key]);
-            }
-            return array;
+        all: function () {
+            return this._columns;
         },
 
         create: function () {
@@ -1024,7 +1051,7 @@ var ERMrest = (function (module) {
          * @returns {Number} number of columns
          */
         length: function () {
-            return Object.keys(this._columns).length;
+            return this._columns.length;
         },
 
         /**
@@ -1032,7 +1059,20 @@ var ERMrest = (function (module) {
          * @returns {Array} names of columns
          */
         names: function () {
-            return Object.keys(this._columns);
+            return Array.prototype.map.call(this._columns, function (column) {
+                return column.name;
+            });
+        },
+
+        /**
+         *
+         * @param {string} name name of the column
+         * @returns {boolean} whether Columns has this column or not
+         */
+        has: function (name) {
+            return this._columns.filter(function (column) {
+                    return column.name == name;
+                }).length > 0;
         },
 
         /**
@@ -1041,15 +1081,64 @@ var ERMrest = (function (module) {
          * @returns {ERMrest.Column} column
          */
         get: function (name) {
-            if (!(name in this._columns)) {
-                throw new module.NotFoundError("", "Column " + name + " not found in table.");
+            var result = this._columns.filter(function (column) {
+                return column.name == name;
+            });
+
+            if (result.length) {
+                return result[0];
             }
-            return this._columns[name];
+            throw new module.NotFoundError("", "Column " + name + " not found in table.");
         },
 
+        /**
+         *
+         * @param {int} pos
+         * @returns {ERMrest.Column}
+         */
         getByPosition: function (pos) {
+            return this._columns[pos];
+        },
 
+        /***
+         * Get columns based on the context.
+         *
+         * @param {string} context
+         * @returns {ERMrest.Columns} columns with predefined order based on the context.
+         */
+        contextualize: function (context) {
+
+            // get column orders from annotation
+            var orders = -1;
+            try {
+                var annot = this.table.annotations.get("tag:isrd.isi.edu,2016:visible-columns");
+                if (annot && annot.content) {
+                    orders = this._getColumnOrders(context, annot.content);
+                }
+            } catch (exception) {
+            }
+
+            // no annotation
+            if (orders == -1) {
+                return this;
+            }
+
+            // build the columns
+            var columns = new Columns(this._table);
+            for (var i = 0; i < orders.length; i++) {
+                try {
+                    var c = this.get(orders[i]);
+
+                    if (!columns.has(c.name)) { // not already in the columns.
+                        columns._push(c);
+                    }
+                } catch (exception) {
+                    //do nothing, go to the next column
+                }
+            }
+            return columns;
         }
+
     };
 
 
@@ -1079,7 +1168,7 @@ var ERMrest = (function (module) {
          * @param {Object} data The 'raw' data value.
          * @returns {string} The formatted value.
          */
-        this.formatvalue = function(data) {
+        this.formatvalue = function (data) {
             if (data) {
                 /* TODO format the raw value based on the column definition
                  * type, heuristics, annotations, etc.
@@ -1175,10 +1264,10 @@ var ERMrest = (function (module) {
 
         },
 
-        _equals: function(column) {
+        _equals: function (column) {
             return (column.table.schema.name === this.table.schema.name &&
-                column.table.name === this.table.name &&
-                column.name === this.name);
+            column.table.name === this.table.name &&
+            column.name === this.name);
         }
 
     };
@@ -1197,7 +1286,7 @@ var ERMrest = (function (module) {
     Annotations.prototype = {
         constructor: Annotations,
 
-        _push: function(annotation) {
+        _push: function (annotation) {
             this._annotations[annotation._uri] = annotation;
         },
 
@@ -1205,7 +1294,7 @@ var ERMrest = (function (module) {
          *
          * @returns {ERMrest.Annotation[]} list of all annotations
          */
-        all: function() {
+        all: function () {
             var array = [];
             for (var key in this._annotations) {
                 array.push(this._annotations[key]);
@@ -1253,9 +1342,9 @@ var ERMrest = (function (module) {
          * @param {string} uri uri of annotation
          * @returns {boolean} whether or not annotation exists
          */
-         contains: function (uri) {
-             return (uri in this._annotations);
-         }
+        contains: function (uri) {
+            return (uri in this._annotations);
+        }
     };
 
 
@@ -1306,7 +1395,7 @@ var ERMrest = (function (module) {
     Keys.prototype = {
         constructor: Keys,
 
-        _push: function(key) {
+        _push: function (key) {
             this._keys.push(key);
         },
 
@@ -1314,7 +1403,7 @@ var ERMrest = (function (module) {
          *
          * @returns {Key[]} a list of all Keys
          */
-        all: function() {
+        all: function () {
             return this._keys;
         },
 
@@ -1463,7 +1552,7 @@ var ERMrest = (function (module) {
                     var foundMatchingCol = false;
                     for (var b = 0; b < colsB.length; b++) {
                         var colB = colsB[b];
-                        if (colA._equals(colB)){
+                        if (colA._equals(colB)) {
                             foundMatchingCol = true;
                             break;
                         }
@@ -1543,7 +1632,7 @@ var ERMrest = (function (module) {
     ForeignKeys.prototype = {
         constructor: ForeignKeys,
 
-        _push: function(foreignKeyRef) {
+        _push: function (foreignKeyRef) {
             this._foreignKeys.push(foreignKeyRef);
             this._mappings.push(foreignKeyRef.mapping);
         },
@@ -1552,7 +1641,7 @@ var ERMrest = (function (module) {
          *
          * @returns {ERMrest.ForeignKeyRef[]} an array of all foreign key references
          */
-        all: function() {
+        all: function () {
             return this._foreignKeys;
         },
 

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -1102,13 +1102,8 @@ var ERMrest = (function (module) {
             return this._columns[pos];
         },
 
-        /***
-         * Get columns based on the context.
-         *
-         * @param {string} context
-         * @returns {ERMrest.Columns} columns with predefined order based on the context.
-         */
-        contextualize: function (context) {
+        // Get columns based on the context.
+        _contextualize: function (context) {
 
             // get column orders from annotation
             var orders = -1;

--- a/js/ermrest.js
+++ b/js/ermrest.js
@@ -1000,11 +1000,7 @@ var ERMrest = (function (module) {
     function Columns(table) {
         this._columns = [];
 
-        /**
-         * @type {Table}
-         * @desc The table that these columns belong to.
-         */
-        this.table = table;
+        this._table = table;
     }
 
     Columns.prototype = {
@@ -1115,7 +1111,7 @@ var ERMrest = (function (module) {
             // get column orders from annotation
             var orders = -1;
             try {
-                var annot = this.table.annotations.get("tag:isrd.isi.edu,2016:visible-columns");
+                var annot = this._table.annotations.get("tag:isrd.isi.edu,2016:visible-columns");
                 if (annot && annot.content) {
                     orders = this._getColumnOrders(context, annot.content);
                 }

--- a/test/configuration/visible_columns.spec.conf.json
+++ b/test/configuration/visible_columns.spec.conf.json
@@ -1,0 +1,11 @@
+{
+  "catalog": {},
+  "schema": {
+    "name": "visible_columns_schema",
+    "createNew": true,
+    "path": "test/configuration/visible_columns.spec.conf/visible_columns_schema.json"
+  },
+  "tables": {
+    "createNew": true
+  }
+}

--- a/test/configuration/visible_columns.spec.conf/visible_columns_schema.json
+++ b/test/configuration/visible_columns.spec.conf/visible_columns_schema.json
@@ -1,0 +1,96 @@
+{
+  "tables": {
+    "table_without_annotation": {
+      "kind": "table",
+      "keys": [],
+      "entityCount": 0,
+      "foreign_keys": [],
+      "table_name": "table_without_annotation",
+      "schema_name": "visible_columns_schemas",
+      "column_definitions": [
+        {
+          "name": "column_1",
+          "type": {
+            "typename": "text"
+          }
+        },
+        {
+          "name": "column_2",
+          "type": {
+            "typename": "text"
+          }
+        }
+      ]
+    },
+    "table_with_all_contexts": {
+      "kind": "table",
+      "keys": [],
+      "entityCount": 0,
+      "foreign_keys": [],
+      "table_name": "table_with_all_contexts",
+      "schema_name": "visible_columns_schemas",
+      "column_definitions": [
+        {
+          "name": "column_1",
+          "type": {
+            "typename": "text"
+          }
+        },
+        {
+          "name": "column_2",
+          "type": {
+            "typename": "text"
+          }
+        },
+        {
+          "name": "column_3",
+          "type": {
+            "typename": "text"
+          }
+        }
+      ],
+      "annotations": {
+        "tag:isrd.isi.edu,2016:visible-columns": {
+          "entry": ["column_1", "column_2"],
+          "edit": ["column_1", "column_3"],
+          "create": ["column_2", "column_3"],
+          "record": ["column_1"],
+          "filter": ["column_2"],
+          "compact": ["column_3"],
+          "*": []
+        }
+      }
+    },
+    "table_with_entry_filter_star": {
+      "kind": "table",
+      "keys": [],
+      "entityCount": 0,
+      "foreign_keys": [],
+      "table_name": "table_with_entry_filter_compact_star",
+      "schema_name": "visible_columns_schemas",
+      "column_definitions": [
+        {
+          "name": "column_1",
+          "type": {
+            "typename": "text"
+          }
+        },
+        {
+          "name": "column_2",
+          "type": {
+            "typename": "text"
+          }
+        }
+      ],
+      "annotations": {
+        "tag:isrd.isi.edu,2016:visible-columns": {
+          "entry": ["column_1"],
+          "filter": ["no_a_column", "not_a_column_2", "column_2", "not_a_column_3"],
+          "compact": ["column_2", "column_1", "column_2", "column_1"],
+          "*": ["column_2"]
+        }
+      }
+    }
+  },
+  "schema_name": "visible_columns_schema"
+}

--- a/test/specs/02.visible_columns.spec.js
+++ b/test/specs/02.visible_columns.spec.js
@@ -37,7 +37,7 @@ describe('For determining order of visible columns, ', function () {
         var columns = schema.tables.get(table).columns;
 
         Object.keys(cases).forEach(function (key) {
-            expect(columns.contextualize(key).names()).toEqual(cases[key]);
+            expect(columns._contextualize(key).names()).toEqual(cases[key]);
         });
     }
 

--- a/test/specs/02.visible_columns.spec.js
+++ b/test/specs/02.visible_columns.spec.js
@@ -1,0 +1,110 @@
+// Unit Test that are related to annotations should be here
+
+var includes = require(__dirname + '/../utils/ermrest-init.js').init();
+
+var server = includes.server;
+var ermrestUtils = includes.ermrestUtils;
+
+describe('For determining order of visible columns, ', function () {
+    var catalog_id, schemaName, schema, catalog;
+
+    // This function should be present in all spec files. It will add sample database and configurations.
+    beforeAll(function (done) {
+        ermrestUtils.importData({
+            setup: require('../configuration/visible_columns.spec.conf.json'),
+            url: includes.url,
+            authCookie: includes.authCookie
+        }).then(function (data) {
+            catalog_id = data.catalogId;
+            schemaName = data.schema.name;
+            console.log("Data imported with catalogId " + data.catalogId);
+            server.catalogs.get(catalog_id).then(function (response) {
+                schema = response.schemas.get(schemaName);
+                done();
+            }, function (err) {
+                console.dir(err);
+                done.fail();
+            });
+        }, function (err) {
+            console.log("Unable to import data");
+            console.dir(err);
+            done.fail();
+        });
+    });
+
+    // Helper function to add 'expect' based on test cases and the specified table
+    function runTestCases(table, cases) {
+        var columns = schema.tables.get(table).columns;
+
+        Object.keys(cases).forEach(function (key) {
+            expect(columns.contextualize(key).names()).toEqual(cases[key]);
+        });
+    }
+
+    // Test Cases:
+
+    it('should use the defined order in annotations based on its context.', function () {
+        runTestCases('table_with_all_contexts', {
+            "entry": ['column_1', 'column_2'],
+            "edit": ['column_1', 'column_3'],
+            "create": ['column_2', 'column_3'],
+            "record": ['column_1'],
+            "filter": ['column_2'],
+            "compact": ['column_3'],
+            "*": []
+        });
+    });
+
+    it('should use `entry` context when context is `edit` or `create` and they are not present in annotation.', function () {
+        runTestCases('table_with_entry_filter_compact_star', {
+            "edit": ['column_1'], 'create': ['column_1']
+        });
+    });
+
+    it('should use default (`*`) context for any context not matched by a more specific context name.', function () {
+        runTestCases('table_with_entry_filter_compact_star', {
+            "record": ['column_2'], 'not_a_context': ['column_2']
+        });
+    });
+
+    it('should use the default order when context not matched by a more specific context name and default (`*`) context is not present.', function () {
+        var expected = ['column_1', 'column_2'];
+        runTestCases('table_without_annotation', {
+            "entry": expected,
+            "edit": expected,
+            "create": expected,
+            "record": expected,
+            "filter": expected,
+            "compact": expected,
+            "*": expected
+        });
+    });
+
+    it('should ignore the column names that do not correspond to any column in the table.', function () {
+        runTestCases('table_with_entry_filter_compact_star', {
+            "filter": ["column_2"]
+        });
+    });
+
+    it('should ignore repetitive column names and just consider the first one.', function () {
+        runTestCases('table_with_entry_filter_compact_star', {
+            "compact": ["column_2", "column_1"]
+        });
+    });
+
+    // This function should be present in all spec files. It will remove the newly created catalog
+    afterAll(function (done) {
+        ermrestUtils.tear({
+            setup: require('../configuration/visible_columns.spec.conf.json'),
+            catalogId: catalog_id,
+            url: includes.url,
+            authCookie: includes.authCookie
+        }).then(function (data) {
+            done();
+        }, function (err) {
+            console.log("Unable to import data");
+            console.dir(err);
+            done.fail();
+        });
+    })
+});


### PR DESCRIPTION
Related Issue: #51 

This PR,
- Changes `._columns` in `Columns` class from Object to Array.
- Adds a `.table` to `Columns` class since it is only used to store columns of a single table.
- Adds `.contextualize(context)` to `Columns` class, which contextualizes the object and returns a new `Columns` object based on [its annotation](https://github.com/informatics-isi-edu/ermrest/blob/master/user-doc/annotation.md#2016-visible-columns).
- Adds the following unit tests:

   For determining order of visible columns, 
      - should use the defined order in annotations based on its context.
      - should use `entry` context when context is `edit` or `create` and they are not present in annotation.
      - should use default (`*`) context for any context not matched by a more specific context name.
      - should use the default order when context not matched by a more specific context name and default (`*`) context is not present.
      - should ignore the column names that do not correspond to any column in the table.
      - should ignore repetitive column names and just consider the first one.