### PR TITLE
Updates to Angular bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ SOURCE=$(JS)/core.js \
 	   $(JS)/filters.js \
 	   $(JS)/utilities.js \
 	   $(JS)/errors.js \
-	   $(JS)/node.js \
 	   $(JS)/parser.js \
 	   $(JS)/http.js \
-	   $(JS)/ng.js \
-	   $(JS)/reference.js
+	   $(JS)/reference.js \
+	   $(JS)/node.js \
+	   $(JS)/ng.js
 
 # Build target
 BUILD=build

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The library consists of the following scripts:
 
 See the [API reference](doc/api.md).
 
+See the [Angular Bindings](doc/angular.md).
+
 ## Development dependencies
 
 We use a combination of [nodejs](https://www.nodejs.org), npm, and good old

--- a/doc/angular.md
+++ b/doc/angular.md
@@ -1,0 +1,21 @@
+# Angular Binding
+
+To use ermrestjs and the `ERMrest` object in Angular applications, first your
+modules will need to inject the `ermrestjs` module.
+
+```
+angular.module("myapp", ['ermrestjs'])
+```
+
+Then you can inject the `ERMrest` service and use its public APIs.
+
+```
+.run(['ERMrest', function(ERMrest) {
+    var uri = 'http://example.org/ermrest/catalog/1/entity/s:t/k=1232';
+    ERMrest.resolve(uri).then(...);
+});
+```
+
+Note that you do not need to configure the ERMrest service by calling its
+`ERMrest.configure(http, q)` function, because the service will handle the
+configuration itself.

--- a/doc/angular.md
+++ b/doc/angular.md
@@ -13,7 +13,7 @@ Then you can inject the `ERMrest` service and use its public APIs.
 .run(['ERMrest', function(ERMrest) {
     var uri = 'http://example.org/ermrest/catalog/1/entity/s:t/k=1232';
     ERMrest.resolve(uri).then(...);
-});
+}]);
 ```
 
 Note that you do not need to configure the ERMrest service by calling its

--- a/js/ng.js
+++ b/js/ng.js
@@ -15,8 +15,35 @@
  */
 if (typeof angular === 'object' && angular.module) {
 
-    angular.module('ERMrest', [])
+    /* This is the current way to use ERMrest in an Angular application.
+     * First, your application or module should depend on 'ermrestjs' then
+     * when you need ERMrest services, use a dependency on 'ERMrest'.
+     */
+    angular.module('ermrestjs', [])
+    .factory('ERMrest', ['$window', '$http', '$q', function ($window, $http, $q) {
+        if ($window.ERMrest) {
+            // we assume that http and q have not been passed yet
+            $window.ERMrest.configure($http, $q);
+            // now save a copy in _thirdParty for future reference
+            $window._thirdParty = $window._thirdParty || {};
+            $window._thirdParty.ERMrest = $window.ERMrest;
+            // delete or undefine the global var
+            try {
+                delete $window.ERMrest;
+            }
+            catch (e) {
+                // <IE8 does not permit delete of window vars
+                // see http://jameshill.io/articles/angular-third-party-injection-pattern/
+                $window.ERMrest = undefined;
+            }
+        }
+        return $window._thirdParty.ERMrest;
+    }]);
 
+    /* The following style of Angular module is deprecated. We will leave it for
+     * now until we have removed its usage from the UI applications.
+     */
+    angular.module('ERMrest', [])
     .factory('ermrestServerFactory', ['$http', '$q', function ($http, $q) {
         ERMrest.configure($http, $q);
         return ERMrest.ermrestFactory;


### PR DESCRIPTION
My tests of this branch indicate that it is backward compatible. I have tested against chaise recordset.

I have not been able to test the new injectors and I would like @jrchudy (if possible) to give it a try in his app. What this does is eliminate the need for the ermrestFactory (for our new apps) and cleans up the global variable ERMrest (sort of) but continues to configure the ermrestjs library.

This (if it works) resolves issue #104 .