### PR TITLE
Added support to run single testcase if needed

### DIFF
--- a/test/jasmine-runner.js
+++ b/test/jasmine-runner.js
@@ -1,93 +1,10 @@
-var Jasmine = require('jasmine');
-var SpecReporter = require('jasmine-spec-reporter');
-var q = require('q');
-var jrunner = new Jasmine();
+var jasmineUtils = require('./utils/jasmine-runner-utils.js');
 
-
-// Util function to create a catalog
-// Returns a promise
-var createCatalog = function() {
-	var defer = q.defer();
-
-	require('request')({
-	  url:  process.env.ERMREST_URL + "/catalog",
-	  method: 'POST',
-	  headers: {
-	    'Cookie': process.env.AUTH_COOKIE
-	  }
-	}, function(error, response, body) {
-	  if (!error && response.statusCode >= 200 && response.statusCode < 300) {
-	  	var catalog = JSON.parse(body);
-	  	process.env.DEFAULT_CATALOG = catalog.id;
-	    console.log("Catalog created with id " + catalog.id);
-	    defer.resolve(catalog.id);
-	  } else {
-	  	console.log("Unable to create catalog");
-	    defer.reject(error);
-	  }
-	})
-
-	return defer.promise;
-};
-
-// Util function to delete a catalog if provided or uses process.env.DEFAULT_CATALOG
-// Returns a promise
-var deleteCatalog = function(catalogId) {
-	var defer = q.defer();
-	catalogId = catalogId || process.env.DEFAULT_CATALOG;
-	if (catalogId) {
-		require('request')({
-		  url:  process.env.ERMREST_URL + "/catalog/" + catalogId,
-		  method: 'DELETE',
-		  headers: {
-		    'Cookie': process.env.AUTH_COOKIE
-		  }
-		}, function(error, response, body) {
-		  if (!error && response.statusCode >= 200 && response.statusCode < 300) {
-		  	console.log("Catalog deleted with id " + catalogId);
-		  	defer.resolve();
-		  } else {
-		  	console.log("Unable to delete catalog");
-		    defer.reject(error);
-		  }
-		});
-	} else {
-		defer.resolve("no catalogId found");
-	}
-
-	return defer.promise;
-};
 
 // function to run all test specs
 var runSpecs = function() {		
-
 	// Load the configuration file
-	jrunner.loadConfigFile(__dirname + '/support/jasmine.json');
-
-	// Remove default reporter logs
-	jrunner.configureDefaultReporter({ print: function() { } });
-
-	// Add Jasmine  specReporter
-	jrunner.addReporter(new SpecReporter());   
-
-	// Set timeout to a large value 
-	jrunner.jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
-
-	jrunner.onComplete(function(passed) {
-		deleteCatalog();
-	});
-
-	// Create a catalog and then
-	// Execute the specs mentioned in the config file jasmine.json in /support folder
-	createCatalog().then(function() {
-		jrunner.execute();
-	}, function(err) {
-		console.log("Unable to create default catalog");
-		console.dir(err);
-	}).catch(function(err) {
-		console.dir(err);
-	});
-
+	jasmineUtils.run(require('./support/jasmine.json'));
 }; 
 
 if (process.env.TRAVIS) {
@@ -109,7 +26,7 @@ if (process.env.TRAVIS) {
 	  	console.log("Unable to retreive authcoooie");
 	    console.dir(error);
 	  }
-	})
+	});
 } else {
     runSpecs();
 }
@@ -119,7 +36,7 @@ if (process.env.TRAVIS) {
 process.on('uncaughtException', function(e) {
 	console.log('Caught unhandled exception: ' + e.toString());
 	console.log(e.stack);
-	deleteCatalog();
+	jUtils.deleteCatalog();
 });
 
 

--- a/test/single-test-runner.js
+++ b/test/single-test-runner.js
@@ -1,0 +1,32 @@
+var jasmineUtils = require('./utils/jasmine-runner-utils.js');
+
+var config = {
+  "spec_dir": "test",
+  "helpers": [],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+};
+
+// Specify the spec file to be run here 
+// or leave it same to execute the spec in /support folder
+// Make changes to the tests and schema configuration values in spec.js in /support folder
+// to execute specific test cases only
+config["spec_files"] = ["support/*.spec.js"];
+
+// function to run all test specs
+var runSpecs = function() {		
+	// Load the configuration file
+	jasmineUtils.run(config);
+}; 
+
+runSpecs();
+
+// Catch unhandled exceptions and show the stack trace. This is most
+// useful when running the jasmine specs.
+process.on('uncaughtException', function(e) {
+	console.log('Caught unhandled exception: ' + e.toString());
+	console.log(e.stack);
+	jUtils.deleteCatalog();
+});
+
+

--- a/test/specs/sample/tests/02.http_retries.js
+++ b/test/specs/sample/tests/02.http_retries.js
@@ -16,7 +16,6 @@ exports.execute = function (options) {
         });
 
         it("should make 1 http retry", function(done) {
-	        nock.disableNetConnect();
 	        
 	        var id = "jhgjhgjhg",  ops = {allowUnmocked: true};;
 	        nock(options.url.replace('ermrest', ''), ops)

--- a/test/support/single.spec.js
+++ b/test/support/single.spec.js
@@ -1,0 +1,9 @@
+require('./../utils/starter.spec.js').runTests({
+    description: 'In single spec, ',
+    testCases: [
+        "/sample/tests/01.sample.js",
+    ],
+    schemaConfigurations: [
+        "/sample/conf/product.conf.json"
+    ]
+});

--- a/test/utils/jasmine-runner-utils.js
+++ b/test/utils/jasmine-runner-utils.js
@@ -1,0 +1,96 @@
+var q = require('q');
+var Jasmine = require('jasmine');
+var SpecReporter = require('jasmine-spec-reporter');
+var jrunner = new Jasmine();
+
+// Util function to create a catalog before running all specs
+// Returns a promise
+var createCatalog = function() {
+	var defer = q.defer();
+
+	// make http request to create a catalog to be used across all specs
+	require('request')({
+	  url:  process.env.ERMREST_URL + "/catalog",
+	  method: 'POST',
+	  headers: {
+	    'Cookie': process.env.AUTH_COOKIE
+	  }
+	}, function(error, response, body) {
+	  if (!error && response.statusCode >= 200 && response.statusCode < 300) {
+	  	var catalog = JSON.parse(body);
+	  	process.env.DEFAULT_CATALOG = catalog.id;
+	    console.log("Catalog created with id " + catalog.id);
+	    defer.resolve(catalog.id);
+	  } else {
+	  	console.log("Unable to create catalog");
+	    defer.reject(error);
+	  }
+	})
+
+	return defer.promise;
+};
+exports.createCatalog = createCatalog;
+
+// Util function to delete a catalog if provided or uses process.env.DEFAULT_CATALOG after running all specs
+// Returns a promise
+var deleteCatalog = function(catalogId) {
+	var defer = q.defer();
+	catalogId = catalogId || process.env.DEFAULT_CATALOG;
+	if (catalogId) {
+		require('request')({
+		  url:  process.env.ERMREST_URL + "/catalog/" + catalogId,
+		  method: 'DELETE',
+		  headers: {
+		    'Cookie': process.env.AUTH_COOKIE
+		  }
+		}, function(error, response, body) {
+		  if (!error && response.statusCode >= 200 && response.statusCode < 300) {
+		  	console.log("Catalog deleted with id " + catalogId);
+		  	defer.resolve();
+		  } else {
+		  	console.log("Unable to delete catalog");
+		    defer.reject(error);
+		  }
+		});
+	} else {
+		defer.resolve("no catalogId found");
+	}
+
+	return defer.promise;
+};
+exports.deleteCatalog = deleteCatalog
+
+
+// Start running the test specs
+// Accepts a config json
+// Creates a catalog and then runs the specs as mentioned in the config file
+// Deletes the created catalog once all specs have been executed
+exports.run = function(config) {
+
+	// Load the configuration
+	jrunner.loadConfig(config);
+
+	// Remove default reporter logs
+	jrunner.configureDefaultReporter({ print: function() { } });
+
+	// Add Jasmine  specReporter
+	jrunner.addReporter(new SpecReporter());   
+
+	// Set timeout to a large value 
+	jrunner.jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+
+	jrunner.onComplete(function(passed) {
+		deleteCatalog();
+	});
+
+	// Create a catalog and then
+	// Execute the specs mentioned in the config file jasmine.json in /support folder
+	createCatalog().then(function() {
+		jrunner.execute();
+	}, function(err) {
+		console.log("Unable to create default catalog");
+		console.dir(err);
+	}).catch(function(err) {
+		console.dir(err);
+	});
+};


### PR DESCRIPTION
@hongsudt @karlcz @RFSH @howdyjessie @jrchudy 
This PR adds the ability to run one test spec specifically without changing `support/jasmine.json`.

You need to change the `testCases` and `schemaConfigurations` parameter values in `test/support/single.spec.js` file, to run your spec only.

To run execute following command in your terminal
```sh
node test/single-test-runner.js
```

This is useful and can be executed only while writing the test-cases. **Travis** will execute all the specs mentioned in the `support/jasmine.json`.

Please refer this [link](https://github.com/informatics-isi-edu/ermrestjs/wiki/Unit-Testing-In-ermrestjs#test-single-spec-file) for more information.