### PR TITLE
Contextualize

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -139,7 +139,6 @@ var ERMrest = (function(module) {
         this._tableName  = context.tableName;
         this._filter     = context.filter;
 
-        this._parsedContext = context;
         this.contextualize._reference = this;
     }
 
@@ -263,7 +262,7 @@ var ERMrest = (function(module) {
                 newRef._columns = [];
                 for (var i = 0; i < columnOrders.length; i++) {
                     var column = columnOrders[i];
-                    if (source._columns.indexOf(column)) {
+                    if (source._columns.indexOf(column) != -1) {
                         newRef._columns.push(column);
                     }
                 }
@@ -509,7 +508,10 @@ var ERMrest = (function(module) {
      * @returns {ERMrest.Reference} The copy of the reference object.
      */
     function _referenceCopy(source) {
-        return Object.assign(Object.create(Reference.prototype), source);
+        var referenceCopy = Object.create(Reference.prototype);
+        // referenceCopy must be defined before _clone can copy values from source to referenceCopy
+        module._clone(referenceCopy, source);
+        return referenceCopy;
     }
 
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -138,6 +138,8 @@ var ERMrest = (function(module) {
         this._schemaName = context.schemaName;
         this._tableName  = context.tableName;
         this._filter     = context.filter;
+
+        this.contextualize._reference = this;
     }
 
     Reference.prototype = {
@@ -253,8 +255,18 @@ var ERMrest = (function(module) {
              * @type {ERMrest.Reference}
              */
             get record() {
-                // TODO: remember these are copies of this reference.
-                return undefined;
+                var source = this._reference;
+                var newRef = _referenceCopy(source);
+                var columnOrders = source._table.columns._contextualize('record').all();
+
+                newRef._columns = [];
+                for (var i = 0; i < columnOrders.length; i++) {
+                    var column = columnOrders[i];
+                    if (source._columns.indexOf(column)) {
+                        newRef._columns.push(column);
+                    }
+                }
+                return newRef;
             },
 
             /**
@@ -496,8 +508,7 @@ var ERMrest = (function(module) {
      * @returns {ERMrest.Reference} The copy of the reference object.
      */
     function _referenceCopy(source) {
-        // TODO: make a (copy-on-write) copy of the source reference
-        return source; // TODO
+        return Object.assign({}, source);
     }
 
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -139,6 +139,7 @@ var ERMrest = (function(module) {
         this._tableName  = context.tableName;
         this._filter     = context.filter;
 
+        this._parsedContext = context;
         this.contextualize._reference = this;
     }
 
@@ -375,7 +376,7 @@ var ERMrest = (function(module) {
                 var ownReference = this;
                 var limitedUri = this._uri + "?limit=" + limit;
                 module._http.get(limitedUri).then(function readReference(response) {
-                    
+
                     var page = new Page(ownReference, response.data);
 
                     defer.resolve(page);
@@ -508,7 +509,7 @@ var ERMrest = (function(module) {
      * @returns {ERMrest.Reference} The copy of the reference object.
      */
     function _referenceCopy(source) {
-        return Object.assign({}, source);
+        return Object.assign(Object.create(Reference.prototype), source);
     }
 
 

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -1,48 +1,52 @@
 {
-  "schema_name": "reference_schema",
-  "tables": {
-    "reference_table": {
-      "comment": "Table to represent a testable reference object",
-      "kind": "table",
-      "keys": [
-          {
-              "comment": null,
-              "annotations": {},
-              "unique_columns": [
-                  "id"
-              ]
-          }
-      ],
-      "entityCount": 0,
-      "foreign_keys": [],
-      "table_name": "reference_table",
-      "schema_name": "reference_schema",
-      "column_definitions": [
-        {
-          "name": "id",
-          "type": {
-            "typename": "text"
-          }
-        },
-        {
-          "name": "name",
-          "type": {
-            "typename": "text"
-          }
-        },
-        {
-          "name": "value",
-          "type": {
-            "typename": "integer"
-          }
+    "schema_name": "reference_schema",
+    "tables": {
+        "reference_table": {
+            "comment": "Table to represent a testable reference object",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id"
+                    ]
+                }
+            ],
+            "entityCount": 0,
+            "foreign_keys": [],
+            "table_name": "reference_table",
+            "schema_name": "reference_schema",
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "name",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "value",
+                    "type": {
+                        "typename": "integer"
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2016:visible-columns": {
+                    "record": ["name", "value"]
+                }
+            }
         }
-      ],
-      "annotations": {}
-    }
-  },
-  "table_names": [
-      "reference_table"
-  ],
-  "comment": null,
-  "annotations": {}
+    },
+    "table_names": [
+        "reference_table"
+    ],
+    "comment": null,
+    "annotations": {}
 }

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -40,6 +40,8 @@ exports.execute = function (options) {
                 expect(reference._schemaName).toBe(schemaName);
                 expect(reference._tableName).toBe(tableName);
                 expect(reference._filter instanceof options.ermRest.ParsedFilter).toBeDefined();
+
+                expect(reference.contextualize._reference).toBe(reference);
             });
 
             // Methods that are currently implemented
@@ -59,9 +61,25 @@ exports.execute = function (options) {
             it('contextualize.record should return a contextualized reference object.', function() {
                 var recordReference = reference.contextualize.record;
 
+                // Make sure Reference prototype is available
+                expect(recordReference.uri).toBeDefined();
+                expect(recordReference.columns).toBeDefined();
+                expect(recordReference.read).toBeDefined();
+
+                // The only difference should be the set of columns returned
                 expect(recordReference).not.toBe(reference);
                 expect(recordReference.columns.length).not.toBe(reference.columns.length);
                 expect(recordReference.columns.length).toBe(2);
+
+                var columns = Array.prototype.map.call(recordReference.columns, function(column){
+                    return column.name;
+                });
+                expect(columns).toEqual(["name", "value"]);
+
+                expect(recordReference.uri).toBe(reference.uri);
+                expect(recordReference._serviceUrl).toBe(reference._serviceUrl);
+                // If catalog is the same, so will be the schema and table
+                expect(recordReference._catalog).toBe(reference._catalog);
             });
 
             // Single Entity specific tests

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -56,6 +56,14 @@ exports.execute = function (options) {
                 expect(reference._columns).toBeDefined();
             });
 
+            it('contextualize.record should return a contextualized reference object.', function() {
+                var recordReference = reference.contextualize.record;
+
+                expect(recordReference).not.toBe(reference);
+                expect(recordReference.columns.length).not.toBe(reference.columns.length);
+                expect(recordReference.columns.length).toBe(2);
+            });
+
             // Single Entity specific tests
             it('read should return a Page object that is defined.', function(done) {
                 reference.read(limit).then(function (response) {


### PR DESCRIPTION
Contextualize.record function written with unit tests. _referenceCopy also written. Interesting way I found to create an Obj without using it's constructor and then copy all of the data to it.

Assigning to @chiragsanghvi, @RFSH, @howdyjessie for review.