### PR TITLE
Added jasmine matcher "toHaveSameItems" to compare arrays

### DIFF
--- a/test/specs/sample/conf/product/schema.json
+++ b/test/specs/sample/conf/product/schema.json
@@ -6,7 +6,7 @@
       "entityCount": 0,
       "keys": [
         {
-          "comment": null,
+          "comment": "some comment",
           "annotations": {},
           "unique_columns": [
             "title"
@@ -22,7 +22,7 @@
       ],
       "foreign_keys": [
         {
-          "comment": null,
+          "comment": "some comment",
           "foreign_key_columns": [
             {
               "table_name": "accommodation",

--- a/test/specs/sample/tests/01.sample.js
+++ b/test/specs/sample/tests/01.sample.js
@@ -34,5 +34,13 @@ exports.execute = function (options) {
         it('should have catalog id', function () {
             expect(catalog.id).toBe(catalogId);
         });
+
+        it("should test custom matcher toHaveSameItems", function() {
+            // second argument to the toHaveSameItems function takes a boolean value
+            // It determines ignore sorting or not, default is false
+            expect([1,2,3]).toHaveSameItems([1,3,2], true);
+            expect([1,2,3]).toHaveSameItems([1,2,3]);
+            expect([schema,catalogId, schemaName, server]).toHaveSameItems([ schema, catalogId, server, schemaName], true);
+        });
     });
 }

--- a/test/utils/jasmine-matchers.js
+++ b/test/utils/jasmine-matchers.js
@@ -1,0 +1,102 @@
+exports.execute = function() {
+
+    beforeAll(function() {
+        'use strict';
+        function stringify(entity) {
+            return jasmine.pp(entity);
+        }
+        jasmine.addMatchers({
+            toHaveSameItems: function(util, customEqualityTesters) {
+                function isObject(obj) {
+                    return Object.prototype.toString.apply(obj) === '[object Object]';
+                }
+                function craftMessage(actual, expected, mismatches) {
+                    if(mismatches.length === 0) {
+                        return 'The collections do not match in length or objects. \n Expected collection:' + stringify(actual) + ' is not equal to ' + stringify(expected);
+                    }
+                    return ['The collections have equal length, but do not match.'].concat(mismatches.map(function(m) {
+                        return 'At ' + m.index + ': expected ' + stringify(m.expected) + ', actual ' + stringify(m.actual);
+                    })).join('\n    ');
+                }
+                function compareArraysSorted(actual, expected) {
+                    var mismatches = [];
+                    actual.forEach(function(item, i) {
+                        if(!util.equals(item, expected[i], customEqualityTesters)) {
+                            mismatches.push({index: i, actual: item, expected: expected[i]});
+                        }
+                    });
+                    return mismatches;
+                }
+                function compareArraysIgnoreSort(actual, expected) {
+                    expected = expected.slice(0);
+                    var mismatches = [];
+                    actual.forEach(function(item, i) {
+                        var foundIndex = -1;
+                        expected.some(function(expectedItem, i) {
+                            if(util.equals(item, expectedItem, customEqualityTesters)) {
+                                foundIndex = i;
+                                return true;
+                            }
+                        });
+                        if(foundIndex > -1) {
+                            expected.splice(foundIndex, 1)
+                        } else {
+                            mismatches.push({index: i, actual: item, expected: null});
+                        }
+                    });
+                    mismatches = mismatches.concat(expected.map(function(val, i) {
+                        return {index: actual.length+i, actual: null, expected: val};
+                    }));
+                    return mismatches;
+                }
+                function compareHashes(actual, expected) {
+                    var mismatches = {};
+                    Object.keys(actual).forEach(function(key) {
+                        if(!util.equals(actual[key], expected[key], customEqualityTesters)) {
+                            mismatches[key] = {index: key, actual: actual[key], expected: expected[key]};
+                        }
+                    });
+                    Object.keys(expected).forEach(function(key) {
+                        if(!util.equals(actual[key], expected[key], customEqualityTesters) && !mismatches[key]) {
+                            mismatches[key] = {index: key, actual: actual[key], expected: expected[key]};
+                        }
+                    });
+                    return Object.keys(mismatches).map(function(key) {
+                        return mismatches[key];
+                    });
+                }
+                return {
+                    compare: function(actual, expected, ignoreOrder) {
+                        if(!Array.isArray(actual) && !isObject(actual)) {
+                            throw new Error('Actual must be an Array or Object. Is type: ' + typeof actual);
+                        }
+                        if(!Array.isArray(expected) && !isObject(expected)) {
+                            throw new Error('Expectation must be an Array or Object. Is type: ' + typeof expected);
+                        }
+                        var mismatches;
+                        if(Array.isArray(actual) && Array.isArray(expected)) {
+                            if(actual.length !== expected.length) {
+                                return {
+                                    pass: false,
+                                    message: 'Array length differs! Actual length: ' + actual.length + ', expected length: ' + expected.length
+                                };
+                            }
+                            if(ignoreOrder) {
+                                mismatches = compareArraysIgnoreSort(actual, expected);
+                            } else {
+                                mismatches = compareArraysSorted(actual, expected);
+                            }
+                        }
+                        else {
+                            mismatches = compareHashes(actual, expected);
+                        }
+                        return {
+                            pass: mismatches.length === 0,
+                            message: craftMessage(actual, expected, mismatches)
+                        };
+                    }
+                };
+            }
+        });
+    });
+};

--- a/test/utils/starter.spec.js
+++ b/test/utils/starter.spec.js
@@ -20,6 +20,8 @@ exports.runTests = function (options) {
 
     describe(description, function () {
 
+        require('./jasmine-matchers.js').execute();
+
         // Import the schemas
         beforeAll(function (done) {
             importUtils.importSchemas(schemaConfs, process.env.DEFAULT_CATALOG)


### PR DESCRIPTION
@jrchudy @RFSH @howdyjessie 

This matcher can be used to match arrays irrespective of their order. We should replace all `toEqual` functions that match arrays to this one.

### expect(&lt;Array, Object&gt;).toHaveSameItems(&lt;Array, Object&gt;, [&lt;boolean&gt; ignoreSort])

Validates that passed arrays or objects are identical. If not, prints the difference.

`ignoreSort` &mdash; ignore items order while comparing arrays. Default to `false`.

```javascript
expect([1,2,3]).toHaveSameItems([1,3,2], true);   // match arrays without ordering
expect([1,2,3]).toHaveSameItems([1,2,3]);            // match arrays with ordering

// Match array of objects without ordering
expect([schema, catalog, 213]).toHaveSameItems([schema, 213, catalog], true);
```