### PR TITLE
Made failing test-suite to use process.exit(1) for error failure indication

### DIFF
--- a/test/jasmine-runner.js
+++ b/test/jasmine-runner.js
@@ -1,6 +1,5 @@
 var jasmineUtils = require('./utils/jasmine-runner-utils.js');
 
-
 // function to run all test specs
 var runSpecs = function() {
 	// Load the configuration file
@@ -20,11 +19,11 @@ if (process.env.TRAVIS) {
 	      if (c.name == "webauthn") process.env['AUTH_COOKIE'] = c.name + "=" + c.value + ";";
 	    });
 	    if (process.env.AUTH_COOKIE) runSpecs();
-	    else console.log("Unable to retreive authcoooie");
-
+	    else {
+	      throw new Error("Unable to retreive authcookie : " + error.message);
+		}
 	  } else {
-	  	console.log("Unable to retreive authcoooie");
-	    console.dir(error);
+	  	throw new Error("Unable to retreive authcookie ");
 	  }
 	});
 } else {
@@ -34,7 +33,14 @@ if (process.env.TRAVIS) {
 // Catch unhandled exceptions and show the stack trace. This is most
 // useful when running the jasmine specs.
 process.on('uncaughtException', function(e) {
-	console.log('Caught unhandled exception: ' + e.toString());
-	console.log(e.stack);
-	jasmineUtils.deleteCatalog();
+	if (e) {
+		console.log('Caught unhandled exception: ' + e.toString());
+		console.log(e.stack);
+	}
+	jasmineUtils.deleteCatalog().done(function() {
+		process.exit(1);
+	});
+	setTimeout(function() {
+		process.exit(1);
+	}, 3000);
 });

--- a/test/utils/ermrest-import.js
+++ b/test/utils/ermrest-import.js
@@ -24,9 +24,10 @@ var importSchemas = function(configFilePaths, defer, catalogId) {
     	process.env.catalogId = data.catalogId;
     	importSchemas(configFilePaths, defer, data.catalogId);
     }, function (err) {
-        console.log("Unable to import data");
-        console.dir(err);
         defer.reject(err);
+    }).catch(function(err) {
+    	console.log(err);
+    	defer.reject(err);
     });
 };
 
@@ -66,9 +67,10 @@ var cleanup = function(configFilePaths, defer, catalogId, deleteCatalog) {
     }).then(function(data) {
     	cleanup(configFilePaths, defer, catalogId, deleteCatalog);
     }, function(err) {
-        console.log("Unable to delete data");
-        console.dir(err);
         defer.reject(err);
+    }).catch(function(err) {
+    	console.log(err);
+    	defer.reject(err);
     });
 };
 

--- a/test/utils/jasmine-runner-utils.js
+++ b/test/utils/jasmine-runner-utils.js
@@ -18,8 +18,7 @@ var createCatalog = function() {
     	process.env.DEFAULT_CATALOG = data.catalogId;
 	    defer.resolve(data.catalogId);
     }, function (err) {
-        console.log("Unable to create catalog");
-	    defer.reject(error);
+	    defer.reject(err);
     });
 
 	return defer.promise;
@@ -41,7 +40,7 @@ var deleteCatalog = function(catalogId) {
 		  	defer.resolve();
 	    }, function(err) {
 	        console.log("Unable to delete catalog");
-		    defer.reject(error);
+		    defer.reject(err);
 	    });
 	} else {
 		defer.resolve("no catalogId found");
@@ -68,10 +67,13 @@ exports.run = function(config) {
 	jrunner.addReporter(new SpecReporter());   
 
 	// Set timeout to a large value 
-	jrunner.jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+	jrunner.jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
 
 	jrunner.onComplete(function(passed) {
-		deleteCatalog();
+		console.log("Test suite " + passed ? "passed" : "failed");
+		deleteCatalog().done(function() {
+			if (!passed) process.exit(1);
+		});
 	});
 
 	// Create a catalog and then
@@ -80,8 +82,8 @@ exports.run = function(config) {
 		jrunner.execute();
 	}, function(err) {
 		console.log("Unable to create default catalog");
-		console.dir(err);
+		process.exit(1);
 	}).catch(function(err) {
-		console.dir(err);
+		process.exit(1);
 	});
 };

--- a/test/utils/starter.spec.js
+++ b/test/utils/starter.spec.js
@@ -1,7 +1,7 @@
 exports.runTests = function (options) {
     var description = options.description;
-    var schemaConfs = options.schemaConfigurations;
-    var testCases = options.testCases;
+    var schemaConfs = options.schemaConfigurations || [];
+    var testCases = options.testCases || [];
 
 
     var includes = require('./ermrest-init.js').init();
@@ -51,10 +51,12 @@ exports.runTests = function (options) {
             importUtils.tear(schemaConfs, process.env.DEFAULT_CATALOG).then(function () {
                 done();
             }, function (err) {
-                done.fail(err);
+                if (options.considerTearError) done.fail(err);
+                else done();
             }).catch(function(err) {
                 console.log(err);
-                done.fail(err);
+                if (options.considerTearError) done.fail(err);
+                else done();
             });
         })
     });


### PR DESCRIPTION
This **PR** adds `process.exit(1)` to all error handlers and rejected promises which are point of exits for the test-suite to indicate failure of tests and mark build as **failed**.