### PR TITLE
Implement Tuple.displayname #49

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1411,6 +1411,14 @@ var ERMrest = (function (module) {
     Annotation.prototype = {
         constructor: Annotation,
 
+        contains: function(name) {
+            return (name in this.content);
+        },
+
+        get: function(name) {
+            return this.content[name];
+        },
+
         _delete: function () {
 
         }

--- a/js/reference.js
+++ b/js/reference.js
@@ -750,9 +750,9 @@ var ERMrest = (function(module) {
             if (!this._displayname) {
                 var table = this._ref._table;
                 // if table has display row_name annotation
-                if (table.annotations.contains("tag:isrd.isi.edu,2016:table-display") &&
-                    table.annotations.get("tag:isrd.isi.edu,2016:table-display").contains("row_name")) {
-                    this._displayname = table.annotations.get("tag:isrd.isi.edu,2016:table-display").get("row_name"); // pattern
+                if (table.annotations.contains(module._annotations.TABLE_DISPLAY) &&
+                    table.annotations.get(module._annotations.TABLE_DISPLAY).contains("row_name")) {
+                    this._displayname = table.annotations.get(module._annotations.TABLE_DISPLAY).get("row_name"); // pattern
 
                     // replace patterns with values
                     var colnames = table.columns.names();

--- a/js/reference.js
+++ b/js/reference.js
@@ -747,21 +747,36 @@ var ERMrest = (function(module) {
          * @type {string}
          */
         get displayname() {
-            // TODO: what is row name if no annotation?
-            // if (this._displayname === undefined) {
-            //     var tableDisplayAnnotation = "tag:isrd.isi.edu,2016:table-display";
-            //     if(this._ref.table.annotations.contains(tableDisplayAnnotation)) {
-            //         var annotation = this._ref.table.annotations.get(tableDisplayAnnotation);
-            //         if (annotation.row_name) {
-            //             var pattern = annotation.row_name;
-            //             // TODO: parse the pattern to get all `{***}` tokens
-            //             //    -  implement pattern expansion funcion?
-            //         }
-            //     }
-            // }
-            //
-            // return this._displayname;
+            if (!this._displayname) {
+                var table = this._ref._table;
+                // if table has display row_name annotation
+                if (table.annotations.contains("tag:isrd.isi.edu,2016:table-display") &&
+                    table.annotations.get("tag:isrd.isi.edu,2016:table-display").contains("row_name")) {
+                    this._displayname = table.annotations.get("tag:isrd.isi.edu,2016:table-display").get("row_name"); // pattern
+
+                    // replace patterns with values
+                    var colnames = table.columns.names();
+                    for (var c = 0; c < colnames.length; c++) {
+                        var cname = colnames[c];
+                        var search = "{" + cname + "}";
+                        this._displayname = this._displayname.replace(new RegExp(search, 'g'), this._data[cname]);
+                    }
+
+                }
+                // no row_name annotation, use column with title, name, or label
+                else if (this._data.name) // TODO case insensitive
+                    this._displayname = this._data.name;
+                else if (this._data.title)
+                    this._displayname = this._data.title;
+                else if (this._data.label)
+                    this._displayname = this._data.label;
+                else
+                    this._displayname = "";
+            }
+
+            return this._displayname;
         }
+
     };
 
 

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -331,7 +331,8 @@ var ERMrest = (function(module) {
         HIDDEN: "tag:misd.isi.edu,2015:hidden", //TODO deprecated and should be deleted.
         IGNORE: "tag:isrd.isi.edu,2016:ignore", //TODO should not be used in column and foreign key
         VISIBLE_COLUMNS: "tag:isrd.isi.edu,2016:visible-columns",
-        FOREIGN_KEY: "tag:isrd.isi.edu,2016:foreign-key"
+        FOREIGN_KEY: "tag:isrd.isi.edu,2016:foreign-key",
+        TABLE_DISPLAY: "tag:isrd.isi.edu,2016:table-display"
     });
 
     /**

--- a/test/specs/annotation/conf/table_display.conf.json
+++ b/test/specs/annotation/conf/table_display.conf.json
@@ -1,7 +1,7 @@
 {
   "catalog": {},
   "schema": {
-    "name": "library",
+    "name": "schema_table_display",
     "createNew": true,
     "path": "test/specs/annotation/conf/table_display/schema.json"
   },

--- a/test/specs/annotation/conf/table_display.conf.json
+++ b/test/specs/annotation/conf/table_display.conf.json
@@ -1,0 +1,15 @@
+{
+  "catalog": {},
+  "schema": {
+    "name": "library",
+    "createNew": true,
+    "path": "test/specs/annotation/conf/table_display/schema.json"
+  },
+  "tables": {
+    "createNew": true
+  },
+  "entities": {
+    "createNew": true,
+    "path": "test/specs/annotation/conf/table_display/data"
+  }
+}

--- a/test/specs/annotation/conf/table_display/data/table_w_table_display_annotation.json
+++ b/test/specs/annotation/conf/table_display/data/table_w_table_display_annotation.json
@@ -1,0 +1,5 @@
+[{"id":10001, "firstname":"William", "lastname":"Shakespeare"},
+  {"id":10002, "firstname":"Mark", "lastname":"Twain"},
+  {"id":10003, "firstname":"Lewis", "lastname":"Carroll"},
+  {"id":10004, "firstname":"Jane", "lastname":"Austen"},
+  {"id":10005, "firstname":"Charles", "lastname":"Dickens"}]

--- a/test/specs/annotation/conf/table_display/data/table_w_title_wo_annotation.json
+++ b/test/specs/annotation/conf/table_display/data/table_w_title_wo_annotation.json
@@ -1,0 +1,10 @@
+[{"id":20001,"title":"Hamlet"},
+  {"id":20002,"title":"The Adventures of Huckleberry Finn"},
+  {"id":20003,"title":"Alice's Adventures in Wonderland"},
+  {"id":20004,"title":"Pride and Prejudice"},
+  {"id":20005,"title":"Great Expectations"},
+  {"id":20006,"title":"David Copperfield"},
+  {"id":20007,"title":"Emma"},
+  {"id":20008,"title":"As You Like It"},
+  {"id":20009,"title":"The Adventures of Tom Sawyer"},
+  {"id":20010,"title":"Through the Looking Glass"}]

--- a/test/specs/annotation/conf/table_display/data/table_wo_title_wo_annotation.json
+++ b/test/specs/annotation/conf/table_display/data/table_wo_title_wo_annotation.json
@@ -1,0 +1,10 @@
+[{"id":20001,"description":"Hamlet"},
+  {"id":20002,"description":"The Adventures of Huckleberry Finn"},
+  {"id":20003,"description":"Alice's Adventures in Wonderland"},
+  {"id":20004,"description":"Pride and Prejudice"},
+  {"id":20005,"description":"Great Expectations"},
+  {"id":20006,"description":"David Copperfield"},
+  {"id":20007,"description":"Emma"},
+  {"id":20008,"description":"As You Like It"},
+  {"id":20009,"description":"The Adventures of Tom Sawyer"},
+  {"id":20010,"description":"Through the Looking Glass"}]

--- a/test/specs/annotation/conf/table_display/schema.json
+++ b/test/specs/annotation/conf/table_display/schema.json
@@ -1,0 +1,106 @@
+{
+  "tables": {
+    "table_wo_title_wo_annotation": {
+      "kind": "table",
+      "keys": [
+        {
+          "comment": null,
+          "annotations": {},
+          "unique_columns": [
+            "id"
+          ]
+        }
+      ],
+      "entityCount": 0,
+      "foreign_keys": [],
+      "table_name": "table_wo_title_wo_annotation",
+      "schema_name": "schema_table_display",
+      "column_definitions": [
+        {
+          "name": "id",
+          "type": {
+            "typename": "integer"
+          }
+        },
+        {
+          "name": "description",
+          "type": {
+            "typename": "text"
+          }
+        }
+      ]
+    },
+    "table_w_title_wo_annotation": {
+      "kind": "table",
+      "keys": [
+        {
+          "comment": null,
+          "annotations": {},
+          "unique_columns": [
+            "id"
+          ]
+        }
+      ],
+      "entityCount": 0,
+      "foreign_keys": [],
+      "table_name": "table_w_title_wo_annotation",
+      "schema_name": "schema_table_display",
+      "column_definitions": [
+        {
+          "name": "id",
+          "type": {
+            "typename": "integer"
+          }
+        },
+        {
+          "name": "title",
+          "type": {
+            "typename": "text"
+          }
+        }
+      ]
+    },
+    "table_w_table_display_annotation": {
+      "kind": "table",
+      "keys": [
+        {
+          "comment": null,
+          "annotations": {},
+          "unique_columns": [
+            "id"
+          ]
+        }
+      ],
+      "entityCount": 0,
+      "foreign_keys": [],
+      "table_name": "table_w_table_display_annotation",
+      "schema_name": "schema_table_display",
+      "column_definitions": [
+        {
+          "name": "id",
+          "type": {
+            "typename": "integer"
+          }
+        },
+        {
+          "name": "firstname",
+          "type": {
+            "typename": "text"
+          }
+        },
+        {
+          "name": "lastname",
+          "type": {
+            "typename": "text"
+          }
+        }
+      ],
+      "annotations": {
+        "tag:isrd.isi.edu,2016:table-display": {
+          "row_name": "{firstname} {lastname}"
+        }
+      }
+    }
+  },
+  "schema_name": "schema_table_display"
+}

--- a/test/specs/annotation/spec.js
+++ b/test/specs/annotation/spec.js
@@ -2,10 +2,12 @@ require('./../../utils/starter.spec.js').runTests({
     description: 'In annotations, ',
     testCases: [
         "/annotation/tests/01.displayname.js",
-        '/annotation/tests/02.visible_columns.js'
+        '/annotation/tests/02.visible_columns.js',
+        "/annotation/tests/03.table_display.js"
     ],
     schemaConfigurations: [
         "/annotation/conf/displayname.conf.json",
-        "/annotation/conf/visible_columns.conf.json"
+        "/annotation/conf/visible_columns.conf.json",
+        "/annotation/conf/table_display.conf.json"
     ]
 });

--- a/test/specs/annotation/tests/03.table_display.js
+++ b/test/specs/annotation/tests/03.table_display.js
@@ -1,0 +1,140 @@
+exports.execute = function (options) {
+
+    describe("2016:table-display annotation test", function () {
+        var catalog_id = process.env.DEFAULT_CATALOG,
+            schemaName = "schema_table_display",
+            tableName1 = "table_wo_title_wo_annotation",
+            tableName2 = "table_w_title_wo_annotation",
+            tableName3 = "table_w_table_display_annotation";
+
+        var table1EntityUri = options.url + "/catalog/" + catalog_id + "/entity/"
+            + schemaName + ":" + tableName1;
+
+        var table2EntityUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+            + tableName2;
+
+        var table3EntityUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+            + tableName3;
+
+        describe('table entities without lable/name/title nor table-display:row_name annotation, ', function() {
+            var reference, page, tuple;
+            var limit = 10;
+
+            it('resolve should return a Reference object that is defined.', function(done) {
+                options.ermRest.resolve(table1EntityUri, {cid: "test"}).then(function (response) {
+                    reference = response;
+
+                    expect(reference).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('read should return a Page object that is defined.', function(done) {
+                reference.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('tuple displayname should return empty string.', function() {
+                var tuples = page.tuples;
+                for(var i = 0; i < limit; i++) {
+                    var tuple = tuples[i];
+                    var displayname = tuple.displayname;
+                    expect(displayname).toBe("");
+                }
+            });
+        });
+
+        describe('table entities with lable/name/title without table-display:row_name annotation, ', function() {
+            var reference, page, tuple;
+            var limit = 10;
+
+            it('resolve should return a Reference object that is defined.', function(done) {
+                options.ermRest.resolve(table2EntityUri, {cid: "test"}).then(function (response) {
+                    reference = response;
+
+                    expect(reference).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('read should return a Page object that is defined.', function(done) {
+                reference.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('tuple displayname should return title column.', function() {
+                var tuples = page.tuples;
+                for(var i = 0; i < limit; i++) {
+                    var tuple = tuples[i];
+                    var displayname = tuple.displayname;
+                    expect(displayname).toBe(tuple._data.title);
+                }
+            });
+        });
+
+        describe('table entities with table-display.row-name annotation', function() {
+            var reference, page, tuple;
+            var limit = 5;
+
+            it('resolve should return a Reference object that is defined.', function(done) {
+                options.ermRest.resolve(table3EntityUri, {cid: "test"}).then(function (response) {
+                    reference = response;
+
+                    expect(reference).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('read should return a Page object that is defined.', function(done) {
+                reference.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('tuple displayname should return string: firstname lastname', function() {
+                var tuples = page.tuples;
+                for(var i = 0; i < limit; i++) {
+                    var tuple = tuples[i];
+                    var displayname = tuple.displayname;
+                    expect(displayname).toBe(tuple._data.firstname + " " + tuple._data.lastname);
+                }
+            });
+        });
+
+    });
+};

--- a/test/utils/jasmine-runner-utils.js
+++ b/test/utils/jasmine-runner-utils.js
@@ -67,7 +67,7 @@ exports.run = function(config) {
 	jrunner.addReporter(new SpecReporter());   
 
 	// Set timeout to a large value 
-	jrunner.jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
+	jrunner.jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
 
 	jrunner.onComplete(function(passed) {
 		console.log("Test suite " + (passed ? "passed" : "failed"));


### PR DESCRIPTION
The changes correspond to issue #49 to implement Tuple.displayname method. The displayname is derived from:
* 2016:table-display.row_name annotation
* Otherwise, look for a column with title, name, or label