### PR TITLE
Package install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,12 @@ before_install:
   - sudo apt-get install -y nodejs
   - cd ermrestjs
   - sudo npm install
-  - sudo bower install
+  - bower install
 
 install:
   - sudo make build
   - sudo service apache2 restart
+  - sudo ls -lR /var/www/html/ermrestjs
 
 before_script:
   - sudo -H -u webauthn webauthn2-manage adduser test1

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ before_install:
   - sudo apt-get install -y nodejs
   - cd ermrestjs
   - sudo npm install
+  - sudo bower install
 
 install:
   - sudo make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,6 @@ before_install:
 install:
   - sudo make build
   - sudo service apache2 restart
-  - sudo ls -lR 
 
 before_script:
   - sudo -H -u webauthn webauthn2-manage adduser test1

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
 install:
   - sudo make build
   - sudo service apache2 restart
-  - sudo ls -lR /var/www/html/ermrestjs
+  - sudo ls -lR 
 
 before_script:
   - sudo -H -u webauthn webauthn2-manage adduser test1

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,10 @@ BOWER=bower_components
 # JavaScript source and test specs
 JS=js
 
+BOWERCOMPONENTS=bower_components
+
 # Pure ERMrest API
-SOURCE=markdown-it/markdown-it.min.js \
-	   markdown-it/markdown-it-sub.min.js \
-	   markdown-it/markdown-it-sup.min.js \
-	   $(JS)/core.js \
+SOURCE=$(JS)/core.js \
 	   $(JS)/datapath.js \
 	   $(JS)/filters.js \
 	   $(JS)/utilities.js \
@@ -148,6 +147,7 @@ install: $(PKG)
 	test -d $(ERMRESTJSDIR) || mkdir -p $(ERMRESTJSDIR)
 	cp $(PKG) $(ERMRESTJSDIR)/$(notdir $(PKG))
 	cp $(MIN) $(ERMRESTJSDIR)/$(notdir $(MIN)) || true
+	cp -R $(BOWERCOMPONENTS) $(ERMRESTJSDIR)
 
 # Rule to install the package
 .PHONY: installTravis

--- a/bower.json
+++ b/bower.json
@@ -1,23 +1,19 @@
 {
   "name": "ermrestjs",
-  "version": "0.0.0",
-  "private": true,
   "description": "ERMrest client library in JavaScript",
-  "main": "ermrest.js",
-  "moduleType": [
-    "globals"
+  "main": "build/ermrest.js",
+  "authors": [
+    "ISI"
   ],
+  "license": "Apache-2.0",
   "keywords": [
     "database",
     "rest",
     "postgresql",
     "library"
   ],
-  "authors": [
-    "ermrestjs authors"
-  ],
-  "license": "Apache-2.0",
-  "homepage": "www.isi.edu",
+  "homepage": "https://github.com/informatics-isi-edu/ermrestjs",
+  "private": true,
   "ignore": [
     "**/.*",
     "node_modules",
@@ -25,11 +21,12 @@
     "test",
     "tests",
     "dist",
-    "doc"
+    "doc",
+    "build"
   ],
   "dependencies": {
-      "angular": "x",
-      "angular-mocks": "x",
-      "jquery": "x"
+    "markdown-it": "x",
+    "markdown-it-sub": "x",
+    "markdown-it-sup" :"x"
   }
 }

--- a/js/node.js
+++ b/js/node.js
@@ -1,18 +1,87 @@
+// Check for whether the environment is Node.js or Browser
 if (typeof module === 'object' && module.exports && typeof require === 'function') {
+    
+    /*
+     *  Call configure with node.js request-q package for Http and
+     *  q library for promise
+     */
     ERMrest.configure(require('request-q'), require('q'));
+    
+
+    /*
+     * Expose authCookie function, to set ermrest cookie
+     */
     ERMrest.setUserCookie = function(authCookie) {
     	ERMrest._http.setDefaults({
 		    headers: { 'Cookie': authCookie || '' },
 		    json: true
 		});
     };
+
+    /*
+     * Inject _markdownIt module in ERMrest
+     */
     ERMrest._markdownIt = require('markdown-it')()
     						.use(require('markdown-it-sub')) // add subscript support
         					.use(require('markdown-it-sup')); // add superscript support;
+    
+    /*
+     * Set ERMrest as a module 
+     */
     module.exports = ERMrest;
 } else {
+    /*
+     * Set ERMrest in window scope
+     */
     window.ERMrest = ERMrest;
-    ERMrest._markdownIt = window.markdownit()
-    			.use(window.markdownitSub)
-    			.use(window.markdownitSup);
+
+    /*
+     * Utility function to load a script in the page, which invokes the callback once the script has loaded
+     * after a 20ms timeout to allow it to load
+     */
+    var loadScript = function (url, callback) {
+      /* Load script from url and calls callback once it's loaded */
+      var scriptTag = document.createElement('script');
+      scriptTag.setAttribute("type", "text/javascript");
+      scriptTag.setAttribute("src", url);
+      if (typeof callback !== "undefined") {
+        if (scriptTag.readyState) {
+          /* For old versions of IE */
+          scriptTag.onreadystatechange = function () { 
+            if (this.readyState === 'complete' || this.readyState === 'loaded') {
+              setTimeout(callback, 20);
+            }
+          };
+        } else {
+          scriptTag.onload = callback;
+        }
+      }
+      (document.getElementsByTagName("head")[0] || document.documentElement).appendChild(scriptTag);
+    };
+
+    /*
+     * Utility function to include multiple scripts in the page, and then invoke the callback
+     */
+    var loadScripts = function(urls, callback) {
+        var count = 0;
+        urls.forEach(function(url) {
+            loadScript(url, function() {
+              if (++count == urls.length) callback();
+            });
+        });
+    };    
+
+    /*
+     * Call this function to load all dependent scripts in order
+     */
+    loadScripts([
+        "/ermrestjs/bower_components/markdown-it/dist/markdown-it.min.js", 
+        "/ermrestjs/bower_components/markdown-it-sub/dist/markdown-it-sub.min.js", 
+        "/ermrestjs/bower_components/markdown-it-sup/dist/markdown-it-sup.min.js"], 
+        function() {
+            ERMrest._markdownIt = window.markdownit()
+                    .use(window.markdownitSub)
+                    .use(window.markdownitSup);
+    });
+
 }

--- a/js/node.js
+++ b/js/node.js
@@ -71,13 +71,15 @@ if (typeof module === 'object' && module.exports && typeof require === 'function
         });
     };    
 
+    var ermrestJsPath = "../ermrestjs/";
+
     /*
      * Call this function to load all dependent scripts in order
      */
     loadScripts([
-        "/ermrestjs/bower_components/markdown-it/dist/markdown-it.min.js", 
-        "/ermrestjs/bower_components/markdown-it-sub/dist/markdown-it-sub.min.js", 
-        "/ermrestjs/bower_components/markdown-it-sup/dist/markdown-it-sup.min.js"], 
+        ermrestJsPath + "bower_components/markdown-it/dist/markdown-it.min.js", 
+        ermrestJsPath + "bower_components/markdown-it-sub/dist/markdown-it-sub.min.js", 
+        ermrestJsPath + "bower_components/markdown-it-sup/dist/markdown-it-sup.min.js"], 
         function() {
             ERMrest._markdownIt = window.markdownit()
                     .use(window.markdownitSub)

--- a/js/node.js
+++ b/js/node.js
@@ -71,7 +71,7 @@ if (typeof module === 'object' && module.exports && typeof require === 'function
         });
     };    
 
-    var ermrestJsPath = "../ermrestjs/";
+    var ermrestJsPath = "../../ermrestjs/";
 
     /*
      * Call this function to load all dependent scripts in order

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "make build",
     "pretest": "make build",
     "test": "make test",
-    "docs": "make doc"
+    "docs": "make doc",
+    "postinstall": "bower cache clean && bower install"
   },
   "repository": {
     "type": "git",

--- a/test/specs/sample/tests/02.http_retries.js
+++ b/test/specs/sample/tests/02.http_retries.js
@@ -19,7 +19,7 @@ exports.execute = function (options) {
 	        
 	        var id = "jhgjhgjhg",  ops = {allowUnmocked: true};;
 	        nock(options.url.replace('ermrest', ''), ops)
-	          .get("/ermrest/catalog/" + id + "/schema")
+	          .get("/ermrest/catalog/" + id + "/schema?cid=null")
 	          .reply(500, 'Error message');
 
 	        var startTime = (new Date()).getTime();


### PR DESCRIPTION
This **PR** addresses the issue #135 - Packaging of third party dependencies.

Implemented a way to install dependencies using **bower**. In the file [node.js](https://github.com/informatics-isi-edu/ermrestjs/blob/ff8386bac5002bb67d7e9affe4401f818d57a223/js/node.js) if browser is detected then all the dependencies are injected in the head of the page where `ermrest.js` is included. 

You can have a look at the **network** tab of [this](https://dev.isrd.isi.edu/~chirag/chaise/recordedit/#2985/error_schema:valid_table_name/id=4) page to determine whether the scripts `markdown-it.min.js`, `markdown-it-sup.min.js` and `markdown-it-sub.min.js` are loaded or not.

I need to come up with a way of accepting different value for the [ermrestjs path](https://github.com/informatics-isi-edu/ermrestjs/blob/ff8386bac5002bb67d7e9affe4401f818d57a223/js/node.js#L74) variable.