### PR TITLE
Implement Column.formatvalue

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1194,14 +1194,46 @@ var ERMrest = (function (module) {
          * @param {Object} data The 'raw' data value.
          * @returns {string} The formatted value.
          */
-        this.formatvalue = function (data) {
+        this.formatvalue = function (data, options) {
             if (data) {
                 /* TODO format the raw value based on the column definition
                  * type, heuristics, annotations, etc.
                  */
+                var type = this.type.name;
+                var utils = module._formatUtils;
+                switch(type) {
+                    // case 'serial4': ??
+                    case 'timestamptz':
+                        data = utils.printTimestamp(data, options);
+                    case 'date':
+                        data = utils.printDate(data, options);
+                        break;
+                    case 'float4':
+                    case 'float8':
+                        data = utils.printFloat(data, options);
+                        break;
+                    case 'numeric':
+                    case 'int2':
+                    case 'int4':
+                    case 'int8':
+                        data = utils.printInteger(data, options);
+                        break;
+                    case 'boolean':
+                        data = utils.printBoolean(data, options);
+                        break;
+                    case 'markdown':
+                        data = utils.printMarkdown(data, options);
+                        break;
+                    case 'text':
+                    case 'longtext':
+                    case 'shorttext':
+                    default:
+                        data = utils.printText(data, options);
+                        break;
+                }
                 return data.toString();
             } else {
-                return 'undefined';
+                return '';
             }
         };
 

--- a/js/core.js
+++ b/js/core.js
@@ -1195,46 +1195,43 @@ var ERMrest = (function (module) {
          * @returns {string} The formatted value.
          */
         this.formatvalue = function (data, options) {
-            if (data) {
-                /* TODO format the raw value based on the column definition
-                 * type, heuristics, annotations, etc.
-                 */
-                var type = this.type.name;
-                var utils = module._formatUtils;
-                switch(type) {
-                    // case 'serial4': ??
-                    case 'timestamptz':
-                        data = utils.printTimestamp(data, options);
-                    case 'date':
-                        data = utils.printDate(data, options);
-                        break;
-                    case 'float4':
-                    case 'float8':
-                        data = utils.printFloat(data, options);
-                        break;
-                    case 'numeric':
-                    case 'int2':
-                    case 'int4':
-                    case 'int8':
-                        data = utils.printInteger(data, options);
-                        break;
-                    case 'boolean':
-                        data = utils.printBoolean(data, options);
-                        break;
-                    case 'markdown':
-                        data = utils.printMarkdown(data, options);
-                        break;
-                    case 'text':
-                    case 'longtext':
-                    case 'shorttext':
-                    default:
-                        data = utils.printText(data, options);
-                        break;
-                }
-                return data.toString();
-            } else {
+            if (data === undefined || data === null) {
                 return '';
             }
+            /* TODO format the raw value based on the column definition
+             * type, heuristics, annotations, etc.
+             */
+            var type = this.type.name;
+            var utils = module._formatUtils;
+            switch(type) {
+                // case 'serial4': ??
+                case 'timestamptz':
+                    data = utils.printTimestamp(data, options);
+                    break;
+                case 'date':
+                    data = utils.printDate(data, options);
+                    break;
+                case 'float4':
+                case 'float8':
+                    data = utils.printFloat(data, options);
+                    break;
+                case 'numeric':
+                case 'int2':
+                case 'int4':
+                case 'int8':
+                    data = utils.printInteger(data, options);
+                    break;
+                case 'boolean':
+                    data = utils.printBoolean(data, options);
+                    break;
+                case 'markdown':
+                    data = utils.printMarkdown(data, options);
+                    break;
+                default: // includes 'text' and 'longtext' cases
+                    data = utils.printText(data, options);
+                    break;
+            }
+            return data.toString();
         };
 
         /**

--- a/js/core.js
+++ b/js/core.js
@@ -1204,7 +1204,6 @@ var ERMrest = (function (module) {
             var type = this.type.name;
             var utils = module._formatUtils;
             switch(type) {
-                // case 'serial4': ??
                 case 'timestamptz':
                     data = utils.printTimestamp(data, options);
                     break;

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -157,7 +157,6 @@ var ERMrest = (function(module) {
             if (value === null) {
                 return '';
             }
-            // TODO: What kinds of options are we supporting?
             return Boolean(value).toString();
         },
 

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -43,6 +43,22 @@
                 {
                     "name": "table_1_float8",
                     "type": { "typename": "float8" }
+                },
+                {
+                    "name": "table_1_int2",
+                    "type": { "typename": "int2" }
+                },
+                {
+                    "name": "table_1_int4",
+                    "type": { "typename": "int4" }
+                },
+                {
+                    "name": "table_1_int8",
+                    "type": { "typename": "int8" }
+                },
+                {
+                    "name": "table_1_markdown",
+                    "type": { "typename": "markdown" }
                 }
             ],
             "foreign_keys": []

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -15,6 +15,22 @@
                 {
                     "name": "table_1_second_key",
                     "type": { "typename": "text" }
+                },
+                {
+                    "name": "table_1_text",
+                    "type": { "typename": "text" }
+                },
+                {
+                    "name": "table_1_longtext",
+                    "type": { "typename": "longtext" }
+                },
+                {
+                    "name": "table_1_shorttext",
+                    "type": { "typename": "text" }
+                },
+                {
+                    "name": "table_1_boolean",
+                    "type": { "typename": "boolean" }
                 }
             ],
             "foreign_keys": []

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -25,12 +25,16 @@
                     "type": { "typename": "longtext" }
                 },
                 {
-                    "name": "table_1_shorttext",
-                    "type": { "typename": "text" }
+                    "name": "table_1_date",
+                    "type": { "typename": "date" }
                 },
                 {
                     "name": "table_1_boolean",
                     "type": { "typename": "boolean" }
+                },
+                {
+                    "name": "table_1_timestamp",
+                    "type": { "typename": "timestamptz" }
                 }
             ],
             "foreign_keys": []

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -35,6 +35,14 @@
                 {
                     "name": "table_1_timestamp",
                     "type": { "typename": "timestamptz" }
+                },
+                {
+                    "name": "table_1_float4",
+                    "type": { "typename": "float4" }
+                },
+                {
+                    "name": "table_1_float8",
+                    "type": { "typename": "float8" }
                 }
             ],
             "foreign_keys": []

--- a/test/specs/common/spec.js
+++ b/test/specs/common/spec.js
@@ -2,6 +2,7 @@ require('./../../utils/starter.spec.js').runTests({
     description: 'After introspection, ',
     testCases: [
         "/common/tests/01.foreignkey.js",
+        "/common/tests/02.column.js"
     ],
     schemaConfigurations: [
         "/common/conf/common_schema_2.conf.json", //this should come first since schema_1 has fk to it.

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -113,6 +113,32 @@ exports.execute = function(options) {
                         expect(formattedValue).toBe(new Date(testVal).toLocaleString());
                     });
                 });
+
+                describe('should call printFloat() to format,', function() {
+                    var formattedValue = undefined;
+
+                    it('float4 columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printFloat').and.callThrough();
+                        var col = table1_schema2.columns.getByPosition(7);
+                        formattedValue = col.formatvalue('11.1');
+                        expect(spy).toHaveBeenCalledWith('11.1', undefined);
+                        expect(formattedValue).toBe('11.10');
+                    });
+
+                    it('float8 columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printFloat').and.callThrough();
+                        var col = table1_schema2.columns.getByPosition(8);
+                        var options = {numDecDigits: 7};
+                        formattedValue = col.formatvalue('234523523.023045230450245', options);
+                        expect(spy).toHaveBeenCalledWith('234523523.023045230450245', options);
+                        expect(formattedValue).toBe('234,523,523.0230452');
+                    });
+
+                    afterEach(function() {
+                        expect(formattedValue).toEqual(jasmine.any(String));
+                        formattedValue = undefined;
+                    });
+                });
             });
         });
     });

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -24,7 +24,7 @@ exports.execute = function(options) {
         describe('a column in Table class, ', function() {
             var column;
             beforeAll(function() {
-                column = table1_schema2.columns.getByPosition(2);
+                column = table1_schema2.columns.get('table_1_text');
             });
 
             it('should be defined.', function() {
@@ -39,7 +39,7 @@ exports.execute = function(options) {
                 var formatUtils = options.includes.ermRest._formatUtils;
 
                 it('should be empty string if column value is null.', function() {
-                    var column = table1_schema2.columns.getByPosition(2);
+                    var column = table1_schema2.columns.get('table_1_text');
                     expect(column.formatvalue(null)).toEqual(jasmine.any(String));
                     expect(column.formatvalue(null)).toBe('');
                 });
@@ -49,7 +49,7 @@ exports.execute = function(options) {
 
                     it('text columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printText').and.callThrough();
-                        var textCol = table1_schema2.columns.getByPosition(2);
+                        var textCol = table1_schema2.columns.get('table_1_text');
                         formattedValue = textCol.formatvalue('text value');
                         expect(spy).toHaveBeenCalledWith('text value', undefined);
                         expect(formattedValue).toBe('text value');
@@ -57,7 +57,7 @@ exports.execute = function(options) {
 
                     it('longtext columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printText').and.callThrough();
-                        var longtextCol = table1_schema2.columns.getByPosition(3);
+                        var longtextCol = table1_schema2.columns.get('table_1_longtext');
                         var longtext = 'asjdf;laksjdf;laj ;lkajsd;f lkajsdf;lakjs f;lakjs df;lasjd f;ladsjf;alskdjfa ;lskdjf a;lsdkjf a;lskdfjal;sdkfj as;ldfkj as;dlf kjasl;fkaj;lfkjasl;fjas;ldfkjals;dfkjas;dlkfja;sldkfjasl;dkfjas;dlfkjasl;dfkja; lsdjfk a;lskdjf a;lsdfj as;ldfja;sldkfja;lskjdfa;lskdjfa;lsdkfja;sldkfjas;ldfkjas;dlfkjas;lfkja;sldkjf a;lsjf ;laskj fa;slk jfa;sld fjas;l js;lfkajs;lfkasjf;alsja;lk ;l kja';
                         formattedValue = longtextCol.formatvalue(longtext);
                         expect(spy).toHaveBeenCalledWith(longtext, undefined);
@@ -74,7 +74,7 @@ exports.execute = function(options) {
                     it('date columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printDate').and.callThrough();
                         var testVal = '2016-05-02 13:00:00.00 PST';
-                        var col = table1_schema2.columns.getByPosition(4);
+                        var col = table1_schema2.columns.get('table_1_date');
                         var options = {separator: '.', leadingZero: false};
                         var formattedValue = col.formatvalue(testVal, options);
                         expect(spy).toHaveBeenCalledWith(testVal, options);
@@ -86,7 +86,7 @@ exports.execute = function(options) {
                 describe('should call printBoolean() to format,', function() {
                     it('boolean columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printBoolean').and.callThrough();
-                        var col = table1_schema2.columns.getByPosition(5);
+                        var col = table1_schema2.columns.get('table_1_boolean');
 
                         var trueBoolean = col.formatvalue(true);
                         expect(spy).toHaveBeenCalledWith(true, undefined);
@@ -106,7 +106,7 @@ exports.execute = function(options) {
                     it('timestamptz columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printTimestamp').and.callThrough();
                         var testVal = '2011-05-06T08:25:25-07:00';
-                        var col = table1_schema2.columns.getByPosition(6);
+                        var col = table1_schema2.columns.get('table_1_timestamp');
                         var formattedValue = col.formatvalue(testVal);
                         expect(spy).toHaveBeenCalledWith(testVal, undefined);
                         expect(formattedValue).toEqual(jasmine.any(String));
@@ -119,7 +119,7 @@ exports.execute = function(options) {
 
                     it('float4 columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printFloat').and.callThrough();
-                        var col = table1_schema2.columns.getByPosition(7);
+                        var col = table1_schema2.columns.get('table_1_float4');
                         formattedValue = col.formatvalue(11.1);
                         expect(spy).toHaveBeenCalledWith(11.1, undefined);
                         expect(formattedValue).toBe('11.10');
@@ -127,7 +127,7 @@ exports.execute = function(options) {
 
                     it('float8 columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printFloat').and.callThrough();
-                        var col = table1_schema2.columns.getByPosition(8);
+                        var col = table1_schema2.columns.get('table_1_float8');
                         var options = {numDecDigits: 7};
                         formattedValue = col.formatvalue(234523523.023045230450245, options);
                         expect(spy).toHaveBeenCalledWith(234523523.023045230450245, options);
@@ -145,7 +145,7 @@ exports.execute = function(options) {
 
                     it('int2 columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printInteger').and.callThrough();
-                        var col = table1_schema2.columns.getByPosition(9);
+                        var col = table1_schema2.columns.get('table_1_int2');
                         var int2 = 32768;
                         formattedValue = col.formatvalue(int2);
                         expect(spy).toHaveBeenCalledWith(int2, undefined);
@@ -154,7 +154,7 @@ exports.execute = function(options) {
 
                     it('int4 columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printInteger').and.callThrough();
-                        var col = table1_schema2.columns.getByPosition(10);
+                        var col = table1_schema2.columns.get('table_1_int4');
                         var int4 = -2147483648;
                         formattedValue = col.formatvalue(int4);
                         expect(spy).toHaveBeenCalledWith(int4, undefined);
@@ -163,7 +163,7 @@ exports.execute = function(options) {
 
                     it('int8 columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printInteger').and.callThrough();
-                        var col = table1_schema2.columns.getByPosition(11);
+                        var col = table1_schema2.columns.get('table_1_int8');
                         var int8 = 9007199254740991; // Max safe integer in JS
                         var options = {numDecDigits: 7};
                         formattedValue = col.formatvalue(int8);
@@ -181,7 +181,7 @@ exports.execute = function(options) {
                     it('Markdown columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printMarkdown').and.callThrough();
                         var testVal = '*taylor ^swift^*';
-                        var col = table1_schema2.columns.getByPosition(12);
+                        var col = table1_schema2.columns.get('table_1_markdown');
                         var formattedValue = col.formatvalue(testVal);
                         expect(spy).toHaveBeenCalledWith(testVal, undefined);
                         expect(formattedValue).toEqual(jasmine.any(String));

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -47,7 +47,7 @@ exports.execute = function(options) {
                         var spy = spyOn(formatUtils, 'printText').and.callThrough();
                         var textCol = table1_schema2.columns.getByPosition(2);
                         formattedValue = textCol.formatvalue('text value');
-                        expect(spy).toHaveBeenCalled();
+                        expect(spy).toHaveBeenCalledWith('text value', undefined);
                         expect(formattedValue).toBe('text value');
                     });
 
@@ -56,16 +56,8 @@ exports.execute = function(options) {
                         var longtextCol = table1_schema2.columns.getByPosition(3);
                         var longtext = 'asjdf;laksjdf;laj ;lkajsd;f lkajsdf;lakjs f;lakjs df;lasjd f;ladsjf;alskdjfa ;lskdjf a;lsdkjf a;lskdfjal;sdkfj as;ldfkj as;dlf kjasl;fkaj;lfkjasl;fjas;ldfkjals;dfkjas;dlkfja;sldkfjasl;dkfjas;dlfkjasl;dfkja; lsdjfk a;lskdjf a;lsdfj as;ldfja;sldkfja;lskjdfa;lskdjfa;lsdkfja;sldkfjas;ldfkjas;dlfkjas;lfkja;sldkjf a;lsjf ;laskj fa;slk jfa;sld fjas;l js;lfkajs;lfkasjf;alsja;lk ;l kja';
                         formattedValue = longtextCol.formatvalue(longtext);
-                        expect(spy).toHaveBeenCalled();
+                        expect(spy).toHaveBeenCalledWith(longtext, undefined);
                         expect(formattedValue).toBe(longtext);
-                    });
-
-                    it('shorttext columns correctly.', function() {
-                        var spy = spyOn(formatUtils, 'printText').and.callThrough();
-                        var shorttextCol = table1_schema2.columns.getByPosition(4);
-                        formattedValue = shorttextCol.formatvalue('sja;lk ;l kja');
-                        expect(spy).toHaveBeenCalled();
-                        expect(formattedValue).toBe('sja;lk ;l kja');
                     });
 
                     afterEach(function() {
@@ -78,12 +70,33 @@ exports.execute = function(options) {
                     it('boolean columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printBoolean').and.callThrough();
                         var col = table1_schema2.columns.getByPosition(5);
+
+                        var trueBoolean = col.formatvalue(true);
+                        expect(spy).toHaveBeenCalledWith(true, undefined);
+                        expect(trueBoolean).toEqual(jasmine.any(String));
+                        expect(trueBoolean).toBe('true');
+
+                        var falseBoolean = col.formatvalue(false);
+                        expect(spy).toHaveBeenCalledWith(false, undefined);
+                        expect(falseBoolean).toEqual(jasmine.any(String));
+                        expect(falseBoolean).toBe('false');
+
+                        expect(spy.calls.count()).toBe(2);
+                    });
+                });
+
+                xdescribe('should call printTimestamp() to format,', function() {
+                    it('timestamptz columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printTimestamp').and.callThrough();
+                        var col = table1_schema2.columns.getByPosition(6);
                         var formattedValue = col.formatvalue(true);
                         expect(spy).toHaveBeenCalled();
                         expect(formattedValue).toEqual(jasmine.any(String));
                         expect(formattedValue).toBe('true');
                     });
                 });
+
+                // describe('should call printDate()')
             });
         });
     });

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -9,7 +9,7 @@ exports.execute = function(options) {
             schemaName2 = "common_schema_2";
         var table1_schema1, // has two outbound fks to table2_schema1. with foreign-key annotation.
             table2_schema1, // has outbound fk to table1_schema2.
-            table1_schema2, // doesn't have any outbound foreignkeys. in different schema.
+            table1_schema2, // has all the column types we support
             catalog;
 
         beforeAll(function(done) {
@@ -120,8 +120,8 @@ exports.execute = function(options) {
                     it('float4 columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printFloat').and.callThrough();
                         var col = table1_schema2.columns.getByPosition(7);
-                        formattedValue = col.formatvalue('11.1');
-                        expect(spy).toHaveBeenCalledWith('11.1', undefined);
+                        formattedValue = col.formatvalue(11.1);
+                        expect(spy).toHaveBeenCalledWith(11.1, undefined);
                         expect(formattedValue).toBe('11.10');
                     });
 
@@ -129,14 +129,63 @@ exports.execute = function(options) {
                         var spy = spyOn(formatUtils, 'printFloat').and.callThrough();
                         var col = table1_schema2.columns.getByPosition(8);
                         var options = {numDecDigits: 7};
-                        formattedValue = col.formatvalue('234523523.023045230450245', options);
-                        expect(spy).toHaveBeenCalledWith('234523523.023045230450245', options);
+                        formattedValue = col.formatvalue(234523523.023045230450245, options);
+                        expect(spy).toHaveBeenCalledWith(234523523.023045230450245, options);
                         expect(formattedValue).toBe('234,523,523.0230452');
                     });
 
                     afterEach(function() {
                         expect(formattedValue).toEqual(jasmine.any(String));
                         formattedValue = undefined;
+                    });
+                });
+
+                describe('should call printInteger() to format,', function() {
+                    var formattedValue = undefined;
+
+                    it('int2 columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printInteger').and.callThrough();
+                        var col = table1_schema2.columns.getByPosition(9);
+                        var int2 = 32768;
+                        formattedValue = col.formatvalue(int2);
+                        expect(spy).toHaveBeenCalledWith(int2, undefined);
+                        expect(formattedValue).toBe('32,768');
+                    });
+
+                    it('int4 columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printInteger').and.callThrough();
+                        var col = table1_schema2.columns.getByPosition(10);
+                        var int4 = -2147483648;
+                        formattedValue = col.formatvalue(int4);
+                        expect(spy).toHaveBeenCalledWith(int4, undefined);
+                        expect(formattedValue).toBe('-2,147,483,648');
+                    });
+
+                    it('int8 columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printInteger').and.callThrough();
+                        var col = table1_schema2.columns.getByPosition(11);
+                        var int8 = 9007199254740991; // Max safe integer in JS
+                        var options = {numDecDigits: 7};
+                        formattedValue = col.formatvalue(int8);
+                        expect(spy).toHaveBeenCalledWith(int8, undefined);
+                        expect(formattedValue).toBe('9,007,199,254,740,991');
+                    });
+
+                    afterEach(function() {
+                        expect(formattedValue).toEqual(jasmine.any(String));
+                        formattedValue = undefined;
+                    });
+                });
+
+                describe('should call printMarkdown() to format,', function() {
+                    it('Markdown columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printMarkdown').and.callThrough();
+                        var testVal = '*taylor ^swift^*';
+                        var col = table1_schema2.columns.getByPosition(12);
+                        var formattedValue = col.formatvalue(testVal);
+                        expect(spy).toHaveBeenCalledWith(testVal, undefined);
+                        expect(formattedValue).toEqual(jasmine.any(String));
+                        expect(formattedValue).toBe('<em>taylor <sup>swift</sup></em>');
                     });
                 });
             });

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -1,4 +1,8 @@
 exports.execute = function(options) {
+    var sampleValues = {
+        date: '2016-05-02',
+        timestamptz: '2011-05-06T08:25:25-07:00'
+    };
 
     describe('About the Column class, ', function() {
         var schemaName1 = "common_schema_1",
@@ -66,6 +70,19 @@ exports.execute = function(options) {
                     });
                 });
 
+                describe('should call printDate() to format,', function() {
+                    it('date columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printDate').and.callThrough();
+                        var testVal = '2016-05-02 13:00:00.00 PST';
+                        var col = table1_schema2.columns.getByPosition(4);
+                        var options = {separator: '.', leadingZero: false};
+                        var formattedValue = col.formatvalue(testVal, options);
+                        expect(spy).toHaveBeenCalledWith(testVal, options);
+                        expect(formattedValue).toEqual(jasmine.any(String));
+                        expect(formattedValue).toBe('2016.5.2');
+                    });
+                });
+
                 describe('should call printBoolean() to format,', function() {
                     it('boolean columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printBoolean').and.callThrough();
@@ -85,18 +102,17 @@ exports.execute = function(options) {
                     });
                 });
 
-                xdescribe('should call printTimestamp() to format,', function() {
+                describe('should call printTimestamp() to format,', function() {
                     it('timestamptz columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printTimestamp').and.callThrough();
+                        var testVal = '2011-05-06T08:25:25-07:00';
                         var col = table1_schema2.columns.getByPosition(6);
-                        var formattedValue = col.formatvalue(true);
-                        expect(spy).toHaveBeenCalled();
+                        var formattedValue = col.formatvalue(testVal);
+                        expect(spy).toHaveBeenCalledWith(testVal, undefined);
                         expect(formattedValue).toEqual(jasmine.any(String));
-                        expect(formattedValue).toBe('true');
+                        expect(formattedValue).toBe(new Date(testVal).toLocaleString());
                     });
                 });
-
-                // describe('should call printDate()')
             });
         });
     });

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -1,22 +1,10 @@
 exports.execute = function(options) {
-    var sampleValues = {
-        date: '2016-05-02',
-        timestamptz: '2011-05-06T08:25:25-07:00'
-    };
 
     describe('About the Column class, ', function() {
-        var schemaName1 = "common_schema_1",
-            schemaName2 = "common_schema_2";
-        var table1_schema1, // has two outbound fks to table2_schema1. with foreign-key annotation.
-            table2_schema1, // has outbound fk to table1_schema2.
-            table1_schema2, // has all the column types we support
-            catalog;
+        var schemaName2 = 'common_schema_2', table1_schema2;
 
         beforeAll(function(done) {
-            catalog = options.catalog;
-            table1_schema1 = catalog.schemas.get(schemaName1).tables.get('table_1_schema_1');
-            table2_schema1 = catalog.schemas.get(schemaName1).tables.get('table_2_schema_1');
-            table1_schema2 = catalog.schemas.get(schemaName2).tables.get('table_1_schema_2');
+            table1_schema2 = options.catalog.schemas.get(schemaName2).tables.get('table_1_schema_2');
             done();
         });
 

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -1,0 +1,90 @@
+exports.execute = function(options) {
+
+    describe('About the Column class, ', function() {
+        var schemaName1 = "common_schema_1",
+            schemaName2 = "common_schema_2";
+        var table1_schema1, // has two outbound fks to table2_schema1. with foreign-key annotation.
+            table2_schema1, // has outbound fk to table1_schema2.
+            table1_schema2, // doesn't have any outbound foreignkeys. in different schema.
+            catalog;
+
+        beforeAll(function(done) {
+            catalog = options.catalog;
+            table1_schema1 = catalog.schemas.get(schemaName1).tables.get('table_1_schema_1');
+            table2_schema1 = catalog.schemas.get(schemaName1).tables.get('table_2_schema_1');
+            table1_schema2 = catalog.schemas.get(schemaName2).tables.get('table_1_schema_2');
+            done();
+        });
+
+        // Test Cases:
+        describe('a column in Table class, ', function() {
+            var column;
+            beforeAll(function() {
+                column = table1_schema2.columns.getByPosition(2);
+            });
+
+            it('should be defined.', function() {
+                expect(column).toBeDefined();
+            });
+
+            it('should have a .formatvalue property.', function() {
+                expect(column.formatvalue).toBeDefined();
+            });
+
+            describe('the .formatvalue property, ', function() {
+                var formatUtils = options.includes.ermRest._formatUtils;
+
+                it('should be empty string if column value is null.', function() {
+                    var column = table1_schema2.columns.getByPosition(2);
+                    expect(column.formatvalue(null)).toEqual(jasmine.any(String));
+                    expect(column.formatvalue(null)).toBe('');
+                });
+
+                describe('should call printText() to format,', function() {
+                    var formattedValue = undefined;
+
+                    it('text columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printText').and.callThrough();
+                        var textCol = table1_schema2.columns.getByPosition(2);
+                        formattedValue = textCol.formatvalue('text value');
+                        expect(spy).toHaveBeenCalled();
+                        expect(formattedValue).toBe('text value');
+                    });
+
+                    it('longtext columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printText').and.callThrough();
+                        var longtextCol = table1_schema2.columns.getByPosition(3);
+                        var longtext = 'asjdf;laksjdf;laj ;lkajsd;f lkajsdf;lakjs f;lakjs df;lasjd f;ladsjf;alskdjfa ;lskdjf a;lsdkjf a;lskdfjal;sdkfj as;ldfkj as;dlf kjasl;fkaj;lfkjasl;fjas;ldfkjals;dfkjas;dlkfja;sldkfjasl;dkfjas;dlfkjasl;dfkja; lsdjfk a;lskdjf a;lsdfj as;ldfja;sldkfja;lskjdfa;lskdjfa;lsdkfja;sldkfjas;ldfkjas;dlfkjas;lfkja;sldkjf a;lsjf ;laskj fa;slk jfa;sld fjas;l js;lfkajs;lfkasjf;alsja;lk ;l kja';
+                        formattedValue = longtextCol.formatvalue(longtext);
+                        expect(spy).toHaveBeenCalled();
+                        expect(formattedValue).toBe(longtext);
+                    });
+
+                    it('shorttext columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printText').and.callThrough();
+                        var shorttextCol = table1_schema2.columns.getByPosition(4);
+                        formattedValue = shorttextCol.formatvalue('sja;lk ;l kja');
+                        expect(spy).toHaveBeenCalled();
+                        expect(formattedValue).toBe('sja;lk ;l kja');
+                    });
+
+                    afterEach(function() {
+                        expect(formattedValue).toEqual(jasmine.any(String));
+                        formattedValue = undefined;
+                    });
+                });
+
+                describe('should call printBoolean() to format,', function() {
+                    it('boolean columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printBoolean').and.callThrough();
+                        var col = table1_schema2.columns.getByPosition(5);
+                        var formattedValue = col.formatvalue(true);
+                        expect(spy).toHaveBeenCalled();
+                        expect(formattedValue).toEqual(jasmine.any(String));
+                        expect(formattedValue).toBe('true');
+                    });
+                });
+            });
+        });
+    });
+};

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -46,12 +46,12 @@ exports.execute = function (options) {
 
         it('printTimestamp() should format timestamps correctly.', function () {
             var printTimestamp = formatUtils.printTimestamp;
-            var testTime = new Date();
+            var testTime = '2011-05-06T08:25:25-07:00';
             expect(printTimestamp(null)).toBe('');
             /* Default behavior w/o options parameter = transform time via toLocaleString().
             Cannot use a static timestamp because toLocaleString() will return
             different values in different test environments. */
-            expect(printTimestamp(testTime)).toBe(testTime.toLocaleString());
+            expect(printTimestamp(testTime)).toBe(new Date(testTime).toLocaleString());
             expect(function() {
                 printTimestamp()
             }).toThrowError(module.InvalidInputError);

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -30,6 +30,8 @@ exports.execute = function (options) {
             expect(printInteger(.0000)).toBe('0');
             expect(printInteger(23.101)).toBe('23');
             expect(printInteger(.1)).toBe('0');
+            expect(printInteger(-435.00)).toBe('-435');
+            expect(printInteger(-1435.00)).toBe('-1,435');
         });
 
         it('printDate() should format dates correctly.', function () {

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -30,6 +30,7 @@ exports.execute = function (options) {
             expect(printInteger(.0000)).toBe('0');
             expect(printInteger(23.101)).toBe('23');
             expect(printInteger(.1)).toBe('0');
+            expect(printInteger(.5)).toBe('1');
             expect(printInteger(-435.00)).toBe('-435');
             expect(printInteger(-1435.00)).toBe('-1,435');
         });


### PR DESCRIPTION
This PR fleshes out the calculation of the `formatvalue` property in the Column class. In Column instance, the instance's formatvalue property is determined by checking the instance's type and then running the appropriate pretty-print function to return a value in string format.

Since `Column.formatvalue` is basically just a switch statement that calls various pretty-print functions, this PR's tests primarily test that `formatvalue` will route to the correct pretty-print function based on the column's type. Each of the pretty-print functions have tests that should more thoroughly test all the range of potential inputs; they can be found [here](https://github.com/informatics-isi-edu/ermrestjs/blob/master/test/specs/print_utils/tests/01.print_utils.js).