### PR TITLE
Fixed lint error in reference.js

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -515,10 +515,15 @@ var ERMrest = (function(module) {
                         newRef._tableName = fkr.colset.columns[0].table.name;
                         newRef._context = undefined; // NOTE: related reference is not contextualized
                         
-                        newRef._columns = newRef._table.columns.all().filter(function(col){
+                        newRef._columns = [];
+                        var refTableColumnlength = newRef._table.columns.all().length;
+
+                        for (var j=0; j < refTableColumnlength; j++) {
+                            var col = newRef._table.columns.all()[j];
+
                             // remove the columns that are involved in the FKR
-                            return fkr.colset.columns.indexOf(col) == -1;
-                        });
+                            if (fkr.colset.columns.indexOf(col) == -1) newRef.columns.push(col);
+                        }
                         
                         if (fkr.from_name) {
                             newRef._displayname = fkr.from_name;


### PR DESCRIPTION
Fixed lint error **line 518, col 78, Don't make functions within a loop** in [reference.js](https://github.com/informatics-isi-edu/ermrestjs/blob/master/js/reference.js#L518).
