### PR TITLE
Use all columns as key (for sorting) when table has no key defined. #154

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -378,10 +378,16 @@ var ERMrest = (function(module) {
 
                 // add sorting
                 // get a list of columns in key
-                var keys = this._table.keys.all().sort( function(a, b) {
-                    return a.colset.length() - b.colset.length();
-                });
-                var keycols = keys[0].colset.columns;
+                // if table has no key, use all columns as key
+                var keycols;
+                if (this._table.keys.length() === 0) {
+                    keycols = this._table.columns.all();
+                } else {
+                    var keys = this._table.keys.all().sort( function(a, b) {
+                        return a.colset.length() - b.colset.length();
+                    });
+                    keycols = keys[0].colset.columns;
+                }
 
                 // append @sort(..) to uri
                 var sortby;


### PR DESCRIPTION
Sorting requires a key. In case that a table has not defined a key, use all columns as the key.