### PR TITLE
Show null

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -207,6 +207,7 @@ to use for ERMrest JavaScript agents.
         * [.related](#ERMrest.Reference+related) : <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
         * [.create(tbd)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
         * [.read(limit)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
+        * [.sort(sort)](#ERMrest.Reference+sort)
         * [.update(tbd)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
         * [.delete()](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
     * [.Page](#ERMrest.Page)
@@ -1726,6 +1727,7 @@ Constructor for a ParsedFilter.
     * [.related](#ERMrest.Reference+related) : <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
     * [.create(tbd)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
     * [.read(limit)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
+    * [.sort(sort)](#ERMrest.Reference+sort)
     * [.update(tbd)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
     * [.delete()](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
 
@@ -1936,6 +1938,17 @@ other errors TBD (TODO document other errors here).
 | Param | Type | Description |
 | --- | --- | --- |
 | limit | <code>number</code> | The limit of results to be returned by the read request. __required__ |
+
+<a name="ERMrest.Reference+sort"></a>
+
+#### reference.sort(sort)
+Return a new Reference with the new sorting
+
+**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| sort | <code>Array.&lt;Object&gt;</code> | an array of objects in the format {"column":columname, "descending":true|false} in order of priority. Undfined, null or Empty array to use default sorting. |
 
 <a name="ERMrest.Reference+update"></a>
 
@@ -2594,7 +2607,7 @@ ERMrest.resolve('https://example.org/catalog/42/entity/s:t/k=123').then(
 [InternalServerError](#ERMrest.InternalServerError),
 [ConflictError](#ERMrest.ConflictError),
 [ForbiddenError](#ERMrest.ForbiddenError),
-[ERMrest.Unauthorized](ERMrest.Unauthorized),
+[UnauthorizedError](#ERMrest.UnauthorizedError),
 [NotFoundError](#ERMrest.NotFoundError),  
 
 | Param | Type | Description |

--- a/js/core.js
+++ b/js/core.js
@@ -1401,9 +1401,9 @@ var ERMrest = (function (module) {
                 value = "";
             } else if (typeof value !== "string") { // default
                 if (context === module._contexts.DETAILED) {
-                    value = null;
+                    value = null; // default null value for DETAILED context
                 } else {
-                    value = "";
+                    value = ""; //default null value
                 }
             }
 

--- a/js/core.js
+++ b/js/core.js
@@ -273,7 +273,7 @@ var ERMrest = (function (module) {
          * @throws {ERMrest.NotFoundError} constraint not found
          * @returns {Object} the constrant object
          */
-        constraintByNamePair: function (pair) { 
+        constraintByNamePair: function (pair) {
             if ((pair[0] in this._constraintNames) && (pair[1] in this._constraintNames[pair[0]]) ){
                 return this._constraintNames[pair[0]][pair[1]];
             }
@@ -642,7 +642,7 @@ var ERMrest = (function (module) {
         _visibleForeignKeys: function (context) {
             var orders = -1;
             if (this.annotations.contains(module._annotations.VISIBLE_FOREIGN_KEYS)) {
-                orders = module._getAnnotationValueByContext(context, this.annotations.get(module._annotations.VISIBLE_FOREIGN_KEYS).content);
+                orders = module._getAnnotationArrayValue(context, this.annotations.get(module._annotations.VISIBLE_FOREIGN_KEYS).content);
             }
 
             // no annoation, return all outbound and inbound fks
@@ -1181,7 +1181,7 @@ var ERMrest = (function (module) {
             // get column orders from annotation
             var orders = -1;
             if (this._table.annotations.contains(module._annotations.VISIBLE_COLUMNS)) {
-                orders = module._getAnnotationValueByContext(context, this._table.annotations.get(module._annotations.VISIBLE_COLUMNS).content);
+                orders = module._getAnnotationArrayValue(context, this._table.annotations.get(module._annotations.VISIBLE_COLUMNS).content);
             }
 
             // no annotation
@@ -1236,7 +1236,7 @@ var ERMrest = (function (module) {
          */
         this.formatvalue = function (data, options) {
             if (data === undefined || data === null) {
-                return '';
+                return this._getNullValue(options ? options.context : undefined);
             }
             /* TODO format the raw value based on the column definition
              * type, heuristics, annotations, etc.
@@ -1330,6 +1330,7 @@ var ERMrest = (function (module) {
         }
 
         this._nameStyle = {}; // Used in the displayname to store the name styles.
+        this._nullValue = {}; // used to avoid recomputation of null value for different contexts.
 
         /**
          * @type {string}
@@ -1371,6 +1372,43 @@ var ERMrest = (function (module) {
             return (column.table.schema.name === this.table.schema.name &&
             column.table.name === this.table.name &&
             column.name === this.name);
+        },
+
+        // find the null value for the column based on context and annotation
+        _getNullValue: function (context) {
+            if (context in this._nullValue) { // use the cached value
+                return this._nullValue[context];
+            }
+
+            var value = -1,
+                displayAnnot = module._annotations.DISPLAY,
+                elements = [this, this.table, this.table.schema];
+
+            // first look at the column, then table, and at last schema for annotation.
+            for (var i=0; i < elements.length; i++) {
+                if (elements[i].annotations.contains(displayAnnot)) {
+                    var annotation = elements[i].annotations.get(displayAnnot);
+                    if(annotation.content.show_nulls){
+                        value = module._getAnnotationValueByContext(context, annotation.content.show_nulls);
+                        if (value !== -1) break; //found the value
+                    }
+                }
+            }
+
+            if (value === false) { //eliminate the field
+                value = null;
+            } else if (value === true) { //empty field
+                value = "";
+            } else if (typeof value !== "string") { // default
+                if (context === module._contexts.DETAILED) {
+                    value = null;
+                } else {
+                    value = "";
+                }
+            }
+
+            this._nullValue[context] = value; // cache the value
+            return value;
         }
 
     };

--- a/js/reference.js
+++ b/js/reference.js
@@ -571,12 +571,12 @@ var ERMrest = (function(module) {
                  * This annotation should be consulted for determining whether
                  * to hide some references and how to order them.
                  */
-                
+
                 var visibleFKs = this._table._visibleForeignKeys(this._context);
 
                 for(var i = 0, fkr; i < visibleFKs.length; i++) {
                     fkr = visibleFKs[i];
-                    
+
                     // inbound FKRs
                     if (this._table.referredBy.all().indexOf(fkr) != -1) {
                         var newRef = _referenceCopy(this);
@@ -587,7 +587,7 @@ var ERMrest = (function(module) {
                         newRef._tableName = fkr.colset.columns[0].table.name;
                         newRef._context = undefined; // NOTE: related reference is not contextualized
                         delete newRef._sort;
-                        
+
                         newRef._columns = [];
                         var refTableColumnlength = newRef._table.columns.all().length;
 
@@ -597,7 +597,7 @@ var ERMrest = (function(module) {
                             // remove the columns that are involved in the FKR
                             if (fkr.colset.columns.indexOf(col) == -1) newRef.columns.push(col);
                         }
-                        
+
                         if (fkr.from_name) {
                             newRef._displayname = fkr.from_name;
                         } else {
@@ -842,7 +842,7 @@ var ERMrest = (function(module) {
                 this._values = [];
                 for (var i = 0; i < this._ref.columns.length; i++) {
                     var col = this._ref.columns[i];
-                    this._values[i] = col.formatvalue(this._data[col.name]);
+                    this._values[i] = col.formatvalue(this._data[col.name], {context:this._ref._context});
                 }
             }
             return this._values;

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -170,6 +170,10 @@ var ERMrest = (function(module) {
     * @desc returns the annotation value based on the given context.
     */
     module._getAnnotationValueByContext = function (context, annotation) {
+        if (typeof context !== "string") {
+            return -1; // if context is undefined or not an string.
+        }
+
         // NOTE: We assume that context names are seperated with `/`
         var partial = context,
             parts = context.split("/");

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -121,7 +121,7 @@ var ERMrest = (function(module) {
         }
 
         // if name styles are undefined, get them from the parent element
-        // Note: underline_space and title_case might be null.
+        // NOTE: underline_space and title_case might be null.
         if(parentElement){
             if(!("underline_space" in element._nameStyle)){
                element._nameStyle.underline_space = parentElement._nameStyle.underline_space;
@@ -171,7 +171,7 @@ var ERMrest = (function(module) {
     */
     module._getAnnotationValueByContext = function (context, annotation) {
         if (typeof context !== "string") {
-            return -1; // if context is undefined or not an string.
+            return -1; // context must be a string;
         }
 
         // NOTE: We assume that context names are seperated with `/`
@@ -184,12 +184,12 @@ var ERMrest = (function(module) {
           parts.splice(-1,1); // remove the last part
           partial = parts.join("/");
         }
-        //if context wasn't in the annotations but there is a default context
+        // if context wasn't in the annotations but there is a default context
         if (module._contexts.DEFAULT in annotation) {
             return annotation[module._contexts.DEFAULT];
         }
-        // there was no annotation
-        return -1;
+
+        return -1; // there was no annotation
     };
 
     /**

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -170,20 +170,19 @@ var ERMrest = (function(module) {
     * @desc returns the annotation value based on the given context.
     */
     module._getAnnotationValueByContext = function (context, annotation) {
-        if (typeof context !== "string") {
-            return -1; // context must be a string;
+        if (typeof context === "string") {
+            // NOTE: We assume that context names are seperated with `/`
+            var partial = context,
+                parts = context.split("/");
+            while (partial !== "") {
+              if (partial in annotation) { // found the context
+                return annotation[partial];
+              }
+              parts.splice(-1,1); // remove the last part
+              partial = parts.join("/");
+            }
         }
 
-        // NOTE: We assume that context names are seperated with `/`
-        var partial = context,
-            parts = context.split("/");
-        while (partial !== "") {
-          if (partial in annotation) { // found the context
-            return annotation[partial];
-          }
-          parts.splice(-1,1); // remove the last part
-          partial = parts.join("/");
-        }
         // if context wasn't in the annotations but there is a default context
         if (module._contexts.DEFAULT in annotation) {
             return annotation[module._contexts.DEFAULT];

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -151,32 +151,44 @@ var ERMrest = (function(module) {
      * @desc This function returns the list that should be used for the given context.
      * Used for visible columns and visible foreign keys.
      */
-    module._getAnnotationValueByContext = function (context, annotation) {
-        var contextedAnnot;
-        if (context in annotation) { // exact context
-            contextedAnnot = annotation[context];
-        } else {
-            for (var key in annotation) { // partial context
-                if (annotation.hasOwnProperty(key) && context.indexOf(key) != -1) {
-                    contextedAnnot = annotation[key];
-                    break;
-                }
-            }
-        }
-        if (contextedAnnot) { // found the context
+    module._getAnnotationArrayValue = function (context, annotation) {
+        var contextedAnnot = module._getAnnotationValueByContext(context, annotation);
+        if (contextedAnnot !== -1) { // found the context
             if (Array.isArray(contextedAnnot)) {
                 return contextedAnnot;
             } else {
-                return module._getAnnotationValueByContext(contextedAnnot, annotation); // go to next level
+                return module._getAnnotationArrayValue(contextedAnnot, annotation); // go to next level
+            }
+        }
+
+        return -1; // there was no annotation
+    };
+
+    /**
+    * @param {string} context the context that we want the value of.
+    * @param {ERMrest.Annotation} annotation the annotation object.
+    * @desc returns the annotation value based on the given context.
+    */
+    module._getAnnotationValueByContext = function (context, annotation) {
+        // exact context
+        if (context in annotation) {
+            return annotation[context];
+        }
+
+        // partial context
+        for (var key in annotation) {
+            if (annotation.hasOwnProperty(key) && context.indexOf(key) != -1) {
+                return annotation[key];
             }
         }
 
         //if context wasn't in the annotations but there is a default context
-        if (Array.isArray(annotation[module._contexts.DEFAULT])) {
+        if (module._contexts.DEFAULT in annotation) {
             return annotation[module._contexts.DEFAULT];
         }
+
         return -1; // there was no annotation
-    };
+    }
 
     /**
      * @function

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -170,25 +170,23 @@ var ERMrest = (function(module) {
     * @desc returns the annotation value based on the given context.
     */
     module._getAnnotationValueByContext = function (context, annotation) {
-        // exact context
-        if (context in annotation) {
-            return annotation[context];
+        // NOTE: We assume that context names are seperated with `/`
+        var partial = context,
+            parts = context.split("/");
+        while (partial !== "") {
+          if (partial in annotation) { // found the context
+            return annotation[partial];
+          }
+          parts.splice(-1,1); // remove the last part
+          partial = parts.join("/");
         }
-
-        // partial context
-        for (var key in annotation) {
-            if (annotation.hasOwnProperty(key) && context.indexOf(key) != -1) {
-                return annotation[key];
-            }
-        }
-
         //if context wasn't in the annotations but there is a default context
         if (module._contexts.DEFAULT in annotation) {
             return annotation[module._contexts.DEFAULT];
         }
-
-        return -1; // there was no annotation
-    }
+        // there was no annotation
+        return -1;
+    };
 
     /**
      * @function

--- a/test/specs/annotation/conf/visible_columns/schema.json
+++ b/test/specs/annotation/conf/visible_columns/schema.json
@@ -52,8 +52,8 @@
       "annotations": {
         "tag:isrd.isi.edu,2016:visible-columns": {
           "entry": ["column_1", "column_2"],
-          "edit": ["column_1", "column_3"],
-          "create": ["column_2", "column_3"],
+          "entry/edit": ["column_1", "column_3"],
+          "entry/create": ["column_2", "column_3"],
           "record": ["column_1"],
           "filter": ["column_2"],
           "compact": ["column_3"],

--- a/test/specs/annotation/conf/visible_foreign_keys/schema.json
+++ b/test/specs/annotation/conf/visible_foreign_keys/schema.json
@@ -82,7 +82,7 @@
           "entry": [
             ["visible_foregin_keys_schema", "fk_with_annotation_to_outbound"]
           ],
-          "edit": [
+          "entry/edit": [
             ["visible_foregin_keys_schema", "fk_inbound_to_with_annotation"]
           ],
           "record": [

--- a/test/specs/annotation/tests/02.visible_columns.js
+++ b/test/specs/annotation/tests/02.visible_columns.js
@@ -23,8 +23,8 @@ exports.execute = function (options) {
         it('should use the defined order in annotations based on its context.', function () {
             runTestCases('table_with_all_contexts', {
                 "entry": ['column_1', 'column_2'],
-                "edit": ['column_1', 'column_3'],
-                "create": ['column_2', 'column_3'],
+                "entry/edit": ['column_1', 'column_3'],
+                "entry/create": ['column_2', 'column_3'],
                 "record": ['column_1'],
                 "filter": ['column_2'],
                 "compact": ['column_3'],
@@ -32,9 +32,9 @@ exports.execute = function (options) {
             });
         });
 
-        it('should use `entry` context when context is `edit` or `create` and they are not present in annotation.', function () {
+        it('should use `entry` context when context is `entry/edit` or `entry/create` and they are not present in annotation.', function () {
             runTestCases('table_with_entry_filter_compact_star', {
-                "edit": ['column_1'], 'create': ['column_1']
+                "entry/edit": ['column_1'], 'entry/create': ['column_1']
             });
         });
 
@@ -48,7 +48,7 @@ exports.execute = function (options) {
             var expected = ['column_1', 'column_2'];
             runTestCases('table_without_annotation', {
                 "entry": expected,
-                "edit": expected,
+                "entry/edit": expected,
                 "create": expected,
                 "record": expected,
                 "filter": expected,

--- a/test/specs/annotation/tests/04.visible_foreign_keys.js
+++ b/test/specs/annotation/tests/04.visible_foreign_keys.js
@@ -26,17 +26,17 @@ exports.execute = function (options) {
         it('should use the defined order in anntoations based on its context.', function(){
             runTestCases(tableWithAnnotation, {
                 "entry": ["fk_with_annotation_to_outbound"],
-                "edit": ["fk_inbound_to_with_annotation"],
+                "entry/edit": ["fk_inbound_to_with_annotation"],
                 "*": []
             }, true);
         });
 
-        it('should use `entry` context when context is `edit` or `create` and they are not present in annotation.', function () {
+        it('should use `entry` context when context is `entry/edit` or `entry/create` and they are not present in annotation.', function () {
             runTestCases(tableWithAnnotation, {
-                "create": ["fk_with_annotation_to_outbound"]
+                "entry/create": ["fk_with_annotation_to_outbound"]
             }, true);
-        }); 
-        
+        });
+
         it('should use default (`*`) context for any context not matched by a more specific context name.', function () {
             runTestCases(tableWithAnnotation, {
                 "filter": []
@@ -45,7 +45,7 @@ exports.execute = function (options) {
 
         it('should ignore the constraint names that do not correspond to any inbound or outbound foreign key of the table.', function () {
             runTestCases(tableWithAnnotation, {
-                "record": ["fk_inbound_to_with_annotation"] 
+                "record": ["fk_inbound_to_with_annotation"]
             }, true);
         });
 
@@ -54,7 +54,7 @@ exports.execute = function (options) {
                 "compact": [
                     "fk_inbound_to_with_annotation",
                     "fk_with_annotation_to_outbound"
-                ] 
+                ]
             }, true);
         });
 
@@ -63,7 +63,7 @@ exports.execute = function (options) {
                 "filter": [
                     "fk_inbound_to_without_annotation",
                     "fk_without_annotation_to_outbound"
-                ] 
+                ]
             }, false);
         });
 

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -59,10 +59,39 @@
                 {
                     "name": "table_1_markdown",
                     "type": { "typename": "markdown" }
+                },
+                {
+                    "name": "table_1_show_nulls_annotation",
+                    "type": {"typename": "text"},
+                    "annotations": {
+                        "tag:misd.isi.edu,2015:display": {
+                            "show_nulls": {
+                                "record": "empty",
+                                "detailed": true,
+                                "compact": "",
+                                "entry/edit": false,
+                                "*": "default"
+                            }
+                        }
+                    }
                 }
             ],
-            "foreign_keys": []
+            "foreign_keys": [],
+            "annotations": {
+                "tag:misd.isi.edu,2015:display": {
+                    "show_nulls": {
+                        "entry/create": "table"
+                    }
+                }
+            }
         }
     },
-    "schema_name": "common_schema_2"
+    "schema_name": "common_schema_2",
+    "annotations": {
+        "tag:misd.isi.edu,2015:display": {
+            "show_nulls": {
+                "entry": "schema"
+            }
+        }
+    }
 }

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -49,22 +49,25 @@ exports.execute = function(options) {
                     it('when the specified context is not defined in its `show_nulls` display annotation should return the value that is defined in default context .', function() {
                         runShowNullTestCases(columnWithAnnotation,{"filter": "default"});
                     });
-                    it('when the specfied context and default context are not defined in column, should return the value that is defined in its table `show_nulls` display annotation based on context.', function() {
+                    it('when `show_nulls` annotation is not defined in column, should return the value that is defined in its table `show_nulls` display annotation based on context.', function() {
                         runShowNullTestCases(columnWithoutAnnotation, {"entry/create": "table"});
                     });
-                    it('when the specfied context and default context are not defined in column and table, should return the value that is defined in its schema `show_nulls` display annotation based on context.', function() {
+                    it('when `show_nulls` annotation is not defined in column or table, should return the value that is defined in its schema `show_nulls` display annotation based on context.', function() {
                         runShowNullTestCases(columnWithoutAnnotation, {"entry": "schema"});
                     });
-                    it('should return null when `show_nulls` annotation is not defined for `detailed` context.', function() {
+                    it('when `show_nulls` annotation is not defined and context is `detailed`, should return null.', function() {
                         runShowNullTestCases(columnWithoutAnnotation, {"detailed": null});
                     });
-                    it('should return empty string when `show_nulls` annotation is not defined for any context other than `detailed`.', function() {
+                    it('when `show_nulls` annotation is not defined and context is not `detailed`, should return empty string.', function() {
                         runShowNullTestCases(columnWithoutAnnotation,{"filter": ""});
                     });
-                    it('should return empty string if context is not specified in options.', function() {
-                        expect(columnWithAnnotation.formatvalue(null)).toBe("");
+                    it('when context is not specified in options and default context is defined in annotation, should use the default context.', function() {
+                        expect(columnWithAnnotation.formatvalue(null)).toBe("default");
+                    });
+
+                    it('when context is not specified in options and default context it not defined in annotation, should return an empty string.', function() {
                         expect(columnWithoutAnnotation.formatvalue(null)).toBe("");
-                    })
+                    });
                 })
 
 

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -26,11 +26,43 @@ exports.execute = function(options) {
             describe('the .formatvalue property, ', function() {
                 var formatUtils = options.includes.ermRest._formatUtils;
 
-                it('should be empty string if column value is null.', function() {
-                    var column = table1_schema2.columns.get('table_1_text');
-                    expect(column.formatvalue(null)).toEqual(jasmine.any(String));
-                    expect(column.formatvalue(null)).toBe('');
-                });
+                describe('when column value is null, ', function() {
+                    var columnWithAnnotation, columnWithoutAnnotation;
+
+                    beforeAll(function(done){
+                        columnWithAnnotation = table1_schema2.columns.get('table_1_show_nulls_annotation');
+                        columnWithoutAnnotation = table1_schema2.columns.get('table_1_text');
+                        done();
+                    });
+
+                    function runShowNullTestCases (column, testCases){
+                        for(key in testCases){
+                            expect(column.formatvalue(null, {context:key})).toBe(testCases[key]);
+                        }
+                    }
+                    it('should return the value that is defined in its `show_nulls` display annotation based on context.', function() {
+                        runShowNullTestCases(
+                            columnWithAnnotation,
+                            {"record": "empty", "detailed": "", "compact": "", "entry/edit": null, "*": "default"}
+                        );
+                    });
+                    it('when the specified context is not defined in its `show_nulls` display annotation should return the value that is defined in default context .', function() {
+                        runShowNullTestCases(columnWithAnnotation,{"filter": "default"});
+                    });
+                    it('when the specfied context and default context are not defined in column, should return the value that is defined in its table `show_nulls` display annotation based on context.', function() {
+                        runShowNullTestCases(columnWithoutAnnotation, {"entry/create": "table"});
+                    });
+                    it('when the specfied context and default context are not defined in column and table, should return the value that is defined in its schema `show_nulls` display annotation based on context.', function() {
+                        runShowNullTestCases(columnWithoutAnnotation, {"entry": "schema"});
+                    });
+                    it('should return null when `show_nulls` annotation is not defined for `detailed` context.', function() {
+                        runShowNullTestCases(columnWithoutAnnotation, {"detailed": null});
+                    });
+                    it('should return empty string when `show_nulls` annotation is not defined for any context other than `detailed`.', function() {
+                        runShowNullTestCases(columnWithoutAnnotation,{"filter": ""});
+                    });
+                })
+
 
                 describe('should call printText() to format,', function() {
                     var formattedValue = undefined;

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -61,6 +61,10 @@ exports.execute = function(options) {
                     it('should return empty string when `show_nulls` annotation is not defined for any context other than `detailed`.', function() {
                         runShowNullTestCases(columnWithoutAnnotation,{"filter": ""});
                     });
+                    it('should return empty string if context is not specified in options.', function() {
+                        expect(columnWithAnnotation.formatvalue(null)).toBe("");
+                        expect(columnWithoutAnnotation.formatvalue(null)).toBe("");
+                    })
                 })
 
 


### PR DESCRIPTION
This PR

- adds support for `show_nulls` display annotations.
- Updates the `_getAnnotationValueByContext` function to support multi level sub-contexts. e.g. lookup `entry/create`.  if not found, lookup `entry`.  if not found, lookup `*`. (This function assumes that application contexts are separated by "/").

Related Issue: #152 