### PR TITLE
Add 'location' property to 'Reference' #141

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -192,7 +192,7 @@ to use for ERMrest JavaScript agents.
         * [.setFilters(filters)](#ERMrest.ParsedFilter+setFilters)
         * [.setBinaryPredicate(colname, operator, value)](#ERMrest.ParsedFilter+setBinaryPredicate)
     * [.Reference](#ERMrest.Reference)
-        * [new Reference(context)](#new_ERMrest.Reference_new)
+        * [new Reference(location)](#new_ERMrest.Reference_new)
         * [.displayname](#ERMrest.Reference+displayname) : <code>string</code>
         * [.uri](#ERMrest.Reference+uri) : <code>string</code>
         * [.columns](#ERMrest.Reference+columns) : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
@@ -219,6 +219,7 @@ to use for ERMrest JavaScript agents.
         * [.next](#ERMrest.Page+next) : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
     * [.Tuple](#ERMrest.Tuple)
         * [new Tuple(reference, data)](#new_ERMrest.Tuple_new)
+        * [.reference](#ERMrest.Tuple+reference) ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
         * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
         * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
         * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
@@ -1719,7 +1720,7 @@ Constructor for a ParsedFilter.
 **Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Reference](#ERMrest.Reference)
-    * [new Reference(context)](#new_ERMrest.Reference_new)
+    * [new Reference(location)](#new_ERMrest.Reference_new)
     * [.displayname](#ERMrest.Reference+displayname) : <code>string</code>
     * [.uri](#ERMrest.Reference+uri) : <code>string</code>
     * [.columns](#ERMrest.Reference+columns) : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
@@ -1740,7 +1741,7 @@ Constructor for a ParsedFilter.
 
 <a name="new_ERMrest.Reference_new"></a>
 
-#### new Reference(context)
+#### new Reference(location)
 Constructs a Reference object.
 
 For most uses, maybe all, of the `ermrestjs` library, the Reference
@@ -1756,7 +1757,7 @@ Usage:
 
 | Param | Type | Description |
 | --- | --- | --- |
-| context | <code>Object</code> | The context object generated from parsing the URI |
+| location | <code>ERMrest.Location</code> | The location object generated from parsing the URI |
 
 <a name="ERMrest.Reference+displayname"></a>
 
@@ -2077,6 +2078,7 @@ if (reference.next) {
 
 * [.Tuple](#ERMrest.Tuple)
     * [new Tuple(reference, data)](#new_ERMrest.Tuple_new)
+    * [.reference](#ERMrest.Tuple+reference) ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
     * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
     * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
     * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
@@ -2100,6 +2102,13 @@ Usage:
 | reference | <code>[Reference](#ERMrest.Reference)</code> | The reference object from which this data was acquired. |
 | data | <code>Object</code> | The unprocessed tuple of data returned from ERMrest. |
 
+<a name="ERMrest.Tuple+reference"></a>
+
+#### tuple.reference ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
+This is the reference of the Tuple
+
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Returns**: <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code> - reference of the Tuple  
 <a name="ERMrest.Tuple+canUpdate"></a>
 
 #### tuple.canUpdate : <code>boolean</code> &#124; <code>undefined</code>

--- a/js/parser.js
+++ b/js/parser.js
@@ -17,6 +17,7 @@
 var ERMrest = (function(module) {
 
     module.ParsedFilter = ParsedFilter;
+    module.Location = Location;
 
     /**
      * The ERMrest service name. Internal use only.
@@ -49,105 +50,109 @@ var ERMrest = (function(module) {
             throw new module.InvalidInputError('The URI does not contain the expected service name: ' + _service_name);
         }
 
-        var context = {
-            uri: uri, // full uri without modifiers
-            baseUri: uri.slice(0,svc_idx+_service_name_len), // ermrest service url
-            path: uri.slice(svc_idx+_service_name_len) // full path without service
-        };
+        return new Location(uri);
 
-        // remove modifiers from uri
+    };
+
+    /**
+     *
+     * uri = <service>/catalog/<catalog>/<api>/<path><sort><paging>?<limit>
+     * service: the ERMrest service endpoint such as https://www.example.com/ermrest.
+     * catalog: the catalog identifier for one dataset such as 42.
+     * api: the API or data resource space identifier such as entity, attribute, attributegroup, or aggregate.
+     * path: the data path which identifies one filtered entity set with optional joined context.
+     * sort: optional @sort
+     * paging: optional @before/@after
+     * limit: optional ?limit
+     *
+     * @param {String} uri full path
+     * @constructor
+     */
+    function Location(uri) {
+
+        // full uri
+        this._uri = uri;
+
+        // compactUri is the full uri without modifiers
         if (uri.indexOf("@sort(") !== -1) {
-            context.uri = uri.split("@sort(")[0]; // remove modifiers from uri
+            this._compactUri = uri.split("@sort(")[0];
         } else if (uri.indexOf("@before(") !== -1) {
-            context.uri = uri.split("@before(")[0]; // remove modifiers from uri
+            this._compactUri = uri.split("@before(")[0];
         } else if (uri.indexOf("@after(") !== -1) {
-            context.uri = uri.split("@after(")[0]; // remove modifiers from uri
+            this._compactUri = uri.split("@after(")[0];
         } else if (uri.indexOf("?limit=") !== -1) {
-            context.uri = uri.split("?limit=")[0]; // remove modifiers from uri
+            this._compactUri = uri.split("?limit=")[0];
+        } else {
+            this._compactUri = uri;
         }
 
-        var modifierPath = uri.split(context.uri)[1]; // modifiers string
-        var shortPath = (modifierPath === "" ? context.path : context.path.split(modifierPath)[0]); // path without modifiers
+        // service
+        var parts = uri.match(/(.*)\/catalog\/([^\/]*)\/(entity|attribute|aggregate|attributegroup)\/(.*)/);
+        this._service = parts[1];
 
-        // Parse out @sort(...) parameter and assign to context
-        // Expected format:
-        //  ".../catalog/catalog_id/entity/[schema_name:]table_name[/{attribute::op::value}{&attribute::op::value}*][@sort(column[::desc::])]"
-        if (modifierPath) {
-            if (modifierPath.indexOf("@sort(") !== -1) {
+        // catalog id
+        this._catalog = parts[2];
 
-                var sorts = modifierPath.match(/@sort\(([^\)]*)\)/)[1].split(",");
+        // api
+        this._api = parts[3];
 
-                context.sort = [];
-                for (var s = 0; s < sorts.length; s++) {
-                    var sort = sorts[s];
-                    var column = (sort.endsWith("::desc::") ?
-                        decodeURIComponent(sort.match(/(.*)::desc::/)[1]) : decodeURIComponent(sort));
-                    context.sort.push({"column": column, "descending": sort.endsWith("::desc::")});
-                }
+        // path is everything after catalog id
+        this._path = parts[4];
+
+        var modifiers = uri.split(this._compactUri)[1]; // emtpy string if no modifiers
+
+        // compactPath is path without modifiers
+        this._compactPath = (modifiers === "" ? this._path : this._path.split(modifiers)[0]);
+
+        // sort and paging
+        if (modifiers) {
+            if (modifiers.indexOf("@sort(") !== -1) {
+                this._sort = modifiers.match(/(@sort\([^\)]*\))/)[1];
             }
-
             // sort must specified to use @before and @after
-            if (modifierPath.indexOf("@before(") !== -1) {
-                if (context.sort) {
-                    context.paging = {};
-                    context.paging.before = true;
-                    context.paging.row = {};
-                    var row = modifierPath.match(/@before\(([^\)]*)\)/)[1].split(",");
-                    for (var i = 0; i < context.sort.length; i++) {
-                        // ::null:: to null, empty string to "", otherwise decode value
-                        var value = (row[i] === "::null::" ? null : decodeURIComponent(row[i]));
-                        context.paging.row[context.sort[i].column] = value;
-                    }
+            if (modifiers.indexOf("@before(") !== -1) {
+                if (this._sort) {
+                    this._paging = modifiers.match(/(@before\([^\)]*\))/)[1];
+                } else {
+                    throw new Error("Invalid uri: " + this._uri + ". Sort modifier required with paging");
                 }
-
-            } else if (modifierPath.indexOf("@after(") !== -1) {
-                if (context.sort) {
-                    context.paging = {};
-                    context.paging.before = false;
-                    context.paging.row = {};
-                    var row = modifierPath.match(/@after\(([^\)]*)\)/)[1].split(",");
-                    for (var i = 0; i < context.sort.length; i++) {
-                        // ::null:: to null, empty string to "", otherwise decode value
-                        var value = (row[i] === "::null::" ? null : decodeURIComponent(row[i]));
-                        context.paging.row[context.sort[i].column] = value;
-                    }
+            } else if (modifiers.indexOf("@after(") !== -1) {
+                if (this._sort) {
+                    this._paging = modifiers.match(/(@after\([^\)]*\))/)[1];
+                } else {
+                    throw new Error("Invalid uri: " + this._uri + ". Sort modifier required with paging");
                 }
             }
         }
 
-        // Split the URI on '/'
-        // Expected format:
-        //  ".../catalog/catalog_id/entity/[schema_name:]table_name[/{attribute::op::value}{&attribute::op::value}*]"
-        var parts = shortPath.split('/');
+        // Split compact path on '/'
+        // Expected format: "[schema_name:]table_name[/{attribute::op::value}{&attribute::op::value}*]"
+        parts = this._compactPath.split('/');
 
-        if (parts.length < 3) {
-            throw new module.MalformedURIError("Uri does not have enough qualifying information");
-        }
-
-        // parts[5] should be the catalog id only
-        context.catalogId = parts[2];
-
-        // parts[7] should be <schema-name>:<table-name>
-        if (parts[4]) {
-            var params = parts[4].split(':');
+        // first schema name and first table name
+        // we can't handle complex path right now, only knows the first schema and table
+        // so after doing a Reference.relate() and generate a new uri/location, we don't have schema/table information here
+        if (parts[0]) {
+            var params = parts[0].split(':');
             if (params.length > 1) {
-                context.schemaName = decodeURIComponent(params[0]);
-                context.tableName = decodeURIComponent(params[1]);
+                this._firstSchemaName = decodeURIComponent(params[0]);
+                this._firstTableName = decodeURIComponent(params[1]);
             } else {
-                context.schemaName = '';
-                context.tableName = decodeURIComponent(params[0]);
+                this._firstSchemaName = '';
+                this._firstTableName = decodeURIComponent(params[0]);
             }
         }
 
-        // If there are filters appended to the URL, add them to context.js
-        if (parts[5]) {
+        // If there are filters appended to the URL
+        // this is not used right now, but keep it in parsing
+        if (parts[1]) {
             // split by ';' and '&'
             var regExp = new RegExp('(;|&|[^;&]+)', 'g');
-            var items = parts[5].match(regExp);
+            var items = parts[1].match(regExp);
 
             // if a single filter
             if (items.length === 1) {
-                context.filter = _processSingleFilterString(items[0]);
+                this._firstFilter = _processSingleFilterString(items[0]);
 
             } else {
                 var filters = [];
@@ -191,11 +196,181 @@ var ERMrest = (function(module) {
                     }
                 }
 
-                context.filter = new ParsedFilter(type);
-                context.filter.setFilters(filters);
+                this._firstFilter = new ParsedFilter(type);
+                this._firstFilter.setFilters(filters);
             }
         }
-        return context;
+
+    }
+
+    Location.prototype = {
+
+        get uri() {
+            return this._uri;
+        },
+
+        get compactUri() {
+            return this._compactUri;
+        },
+
+        get service() {
+            return this._service;
+        },
+
+        get catalog() {
+            return this._catalog;
+        },
+
+        get api() {
+            return this._api;
+        },
+
+        get path() {
+            return this._path;
+        },
+
+        get compactPath() {
+            return this._compactPath;
+        },
+
+        get firstSchemaName() {
+            return this._firstSchemaName;
+        },
+
+        get firstTableName() {
+            return this._firstTableName;
+        },
+
+        get sort() {
+            return this._sort;
+        },
+
+        /**
+         * get the sorting object, null if no sorting
+         * @returns {Object[]} in this format [{"column":colname, "descending":true},...]
+         */
+        get sortObject() {
+            if (this._sortObject === undefined) {
+                if (this._sort !== undefined) {
+                    var sorts = this._sort.match(/@sort\(([^\)]*)\)/)[1].split(",");
+
+                    this._sortObject = [];
+                    for (var s = 0; s < sorts.length; s++) {
+                        var sort = sorts[s];
+                        var column = (sort.endsWith("::desc::") ?
+                            decodeURIComponent(sort.match(/(.*)::desc::/)[1]) : decodeURIComponent(sort));
+                        this._sortObject.push({"column": column, "descending": sort.endsWith("::desc::")});
+                    }
+                } else {
+                    this._sortObject = null;
+                }
+            }
+            return this._sortObject;
+        },
+
+        /**
+         * change sort with new sort Object
+         * @param {Object[]} so in this format [{"column":colname, "descending":true},...]
+         */
+        set sortObject(so) {
+            if ((!so && !this._sort) || (so === this._sort))
+                return;
+
+            // null or undefined = remove sort
+            var oldSortString = (this._sort? this._sort : "");
+            if (!so || so.length === 0) {
+                delete this._sort;
+                this._sortObject = null;
+            } else {
+                this._sortObject = so;
+                this._sort = module._getSortModifier(so);
+            }
+
+            // update uri/path
+            var newSortString = (this._sort? this._sort : "");
+            if (oldSortString !== "") {
+                this._uri = this._uri.replace(oldSortString, newSortString);
+                this._path = this._path.replace(oldSortString, newSortString);
+            } else { // add sort
+                // since there was no sort, there isn't paging, and we are totally ignoring ?limit in the uri
+                this._uri = this._compactUri + newSortString;
+                this._path = this._compactPath + newSortString;
+            }
+        },
+
+        get paging() {
+            return this._paging;
+        },
+
+        /**
+         * get paging object, null if no paging
+         * @returns {Object} in this format {"before":boolean, "row":[v1, v2, v3...]} where v is in same column order as in sort
+         */
+        get pagingObject() {
+            if (this._pagingObject === undefined) {
+                if (this._paging) {
+                    this.sortObject; // create this._sortObject if it hasn't
+                    if (this._paging.indexOf("@before") !== -1) {
+                        this._pagingObject = {};
+                        this._pagingObject.before = true;
+                        this._pagingObject.row = [];
+                        var row = this._paging.match(/@before\(([^\)]*)\)/)[1].split(",");
+                        for (var i = 0; i < this._sortObject.length; i++) {
+                            // ::null:: to null, empty string to "", otherwise decode value
+                            var value = (row[i] === "::null::" ? null : decodeURIComponent(row[i]));
+                            this._pagingObject.row.push(value);
+                        }
+                    } else if (this._paging.indexOf("@after(") !== -1) {
+                        this._pagingObject = {};
+                        this._pagingObject.before = false;
+                        this._pagingObject.row = [];
+                        var row = this._paging.match(/@after\(([^\)]*)\)/)[1].split(",");
+                        for (var i = 0; i < this._sortObject.length; i++) {
+                            // ::null:: to null, empty string to "", otherwise decode value
+                            var value = (row[i] === "::null::" ? null : decodeURIComponent(row[i]));
+                            this._pagingObject.row.push(value);
+                        }
+                    }
+                } else {
+                    this._pagingObject = null;
+                }
+            }
+            return this._pagingObject;
+        },
+
+        /**
+         * change the paging with new pagingObject
+         * @param {Object} po in this format {"before":boolean, "row":[v1, v2, v3...]} where v is in same column order as in sort
+         */
+        set pagingObject(po) {
+            if ((!po && !this._paging) || (po === this._paging))
+                return;
+
+            // null or undefined = remove paing
+            if (!po || po === {}) {
+                delete this._paging;
+                this._sortObject = null;
+            }
+
+            var oldPagingString = (this._paging? this._paging : "");
+            if (this._sort) {
+                this._pagingObject = po;
+                this._paging = module._getPagingModifier(po);
+            } else {
+                throw Error("Error setPagingObject: Paging not allowed without sort");
+            }
+
+            //  update uri/path
+            var newPagingString = (this._paging? this._paging : "");
+            if (oldPagingString !== "") {
+                this._uri = this._uri.replace(oldPagingString, newPagingString);
+                this._path = this._path.replace(oldPagingString, newPagingString);
+            } else { // add paging
+                // append to the end, we are totally ignoring ?limit in the uri
+                this._uri = this._compactUri + this._sort + newPagingString;
+                this._path = this._compactPath + this._sort + newPagingString;
+            }
+        }
     };
 
     /**

--- a/js/parser.js
+++ b/js/parser.js
@@ -205,42 +205,84 @@ var ERMrest = (function(module) {
 
     Location.prototype = {
 
+        /**
+         *
+         * @returns {String} The full URI of the location
+         */
         get uri() {
             return this._uri;
         },
 
+        /**
+         *
+         * @returns {String} The URI without modifiers or queries
+         */
         get compactUri() {
             return this._compactUri;
         },
 
+        /**
+         *
+         * @returns {String} The URI of ermrest service
+         */
         get service() {
             return this._service;
         },
 
+        /**
+         *
+         * @returns {String} catalog id
+         */
         get catalog() {
             return this._catalog;
         },
 
+        /**
+         *
+         * @returns {String} API of the ermrest service.
+         * API includes entity, attribute, aggregate, attributegroup
+         */
         get api() {
             return this._api;
         },
 
+        /**
+         *
+         * @returns {String} Path portion of the URI
+         * This is everything after the catalog id
+         */
         get path() {
             return this._path;
         },
 
+        /**
+         *
+         * @returns {String} Path without modifiers or queries
+         */
         get compactPath() {
             return this._compactPath;
         },
 
+        /**
+         *
+         * @returns {string} The first schema in <schema:table> found in the URI
+         */
         get firstSchemaName() {
             return this._firstSchemaName;
         },
 
+        /**
+         *
+          * @returns {string} The first table in <schema:table> found in the URI
+         */
         get firstTableName() {
             return this._firstTableName;
         },
 
+        /**
+         *
+         * @returns {String} The sort modifier in the string format of @sort(...)
+         */
         get sort() {
             return this._sort;
         },
@@ -298,6 +340,10 @@ var ERMrest = (function(module) {
             }
         },
 
+        /**
+         *
+         * @returns {String} The string format of the paging modifier in the form of @before(..) or @after(...)
+         */
         get paging() {
             return this._paging;
         },

--- a/js/parser.js
+++ b/js/parser.js
@@ -39,7 +39,7 @@ var ERMrest = (function(module) {
      * @memberof ERMrest
      * @function _parse
      * @param {String} uri An ERMrest resource URI to be parsed.
-     * @returns {Object} An object containing the parsed components of the URI.
+     * @returns {ERMrest.Location} Location object created from the URI.
      * @throws {ERMrest.InvalidInputError} If the URI does not contain the
      * service name.
      * @private
@@ -265,22 +265,22 @@ var ERMrest = (function(module) {
 
         /**
          *
-         * @returns {string} The first schema in <schema:table> found in the URI
+         * @returns {string} The schema name in the projection table
          */
         get firstSchemaName() {
             return this._firstSchemaName;
         },
 
         /**
-         *
-          * @returns {string} The first table in <schema:table> found in the URI
+         * Subject to change soon
+         * @returns {string} The table name in the projection table
          */
         get firstTableName() {
             return this._firstTableName;
         },
 
         /**
-         *
+         * Subject to change soon
          * @returns {String} The sort modifier in the string format of @sort(...)
          */
         get sort() {

--- a/js/parser.js
+++ b/js/parser.js
@@ -357,13 +357,12 @@ var ERMrest = (function(module) {
             var row, i, value;
             if (this._pagingObject === undefined) {
                 if (this._paging) {
-                    this.sortObject; // create this._sortObject if it hasn't
                     if (this._paging.indexOf("@before") !== -1) {
                         this._pagingObject = {};
                         this._pagingObject.before = true;
                         this._pagingObject.row = [];
                         row = this._paging.match(/@before\(([^\)]*)\)/)[1].split(",");
-                        for (i = 0; i < this._sortObject.length; i++) {
+                        for (i = 0; i < this.sortObject.length; i++) { // use getting to force sortobject to be created, it could be undefined
                             // ::null:: to null, empty string to "", otherwise decode value
                             value = (row[i] === "::null::" ? null : decodeURIComponent(row[i]));
                             this._pagingObject.row.push(value);
@@ -373,7 +372,7 @@ var ERMrest = (function(module) {
                         this._pagingObject.before = false;
                         this._pagingObject.row = [];
                         row = this._paging.match(/@after\(([^\)]*)\)/)[1].split(",");
-                        for (i = 0; i < this._sortObject.length; i++) {
+                        for (i = 0; i < this.sortObject.length; i++) { // use getter to force sortobject to be created, it could be undefined
                             // ::null:: to null, empty string to "", otherwise decode value
                             value = (row[i] === "::null::" ? null : decodeURIComponent(row[i]));
                             this._pagingObject.row.push(value);

--- a/js/reference.js
+++ b/js/reference.js
@@ -779,7 +779,8 @@ var ERMrest = (function(module) {
 
                 // update its location by adding the tuple’s key filter to the URI
                 // don't keep any modifiers
-                var uri = this._pageRef._location.compactUri + "/";
+                var uri = this._pageRef._location.service + "/catalog/" + this._pageRef._location.catalog + "/" +
+                    this._pageRef._location.api + "/" + this._pageRef._table.schema.name + ":" + this._pageRef._table.name + "/";
                 for (var k = 0; k < this._pageRef._shortestKey.length; k++) {
                     var col = this._pageRef._shortestKey[k].name;
                     if (k === 0) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -62,15 +62,13 @@ var ERMrest = (function(module) {
             var defer = module._q.defer();
 
             // build reference
-            var context = module._parse(uri);
-            var reference = new Reference(context);
+            var location = module._parse(uri);
+            var reference = new Reference(location);
 
-            var server = module.ermrestFactory.getServer(reference._serviceUrl, params);
-            server.catalogs.get(reference._catalogId).then(function (catalog) {
+            var server = module.ermrestFactory.getServer(reference._location.service, params);
+            server.catalogs.get(reference._location.catalog).then(function (catalog) {
 
-                reference._catalog = catalog;
-                reference._schema  = catalog.schemas.get(reference._schemaName);
-                reference._table   = reference._schema.tables.get(reference._tableName);
+                reference._table   = catalog.schemas.get(reference._location.firstSchemaName).tables.get(reference._location.firstTableName);
                 reference._columns = reference._table.columns.all();
                 reference._shortestKey = reference._table.shortestKey;
 
@@ -130,17 +128,10 @@ var ERMrest = (function(module) {
      *  See {@link ERMrest.resolve}.
      * @memberof ERMrest
      * @class
-     * @param {Object} context - The context object generated from parsing the URI
+     * @param {ERMrest.Location} location - The location object generated from parsing the URI
      */
-    function Reference(context) {
-        this._uri        = context.uri;
-        this._serviceUrl = context.baseUri;
-        this._catalogId  = context.catalogId;
-        this._schemaName = context.schemaName;
-        this._tableName  = context.tableName;
-        this._sort       = context.sort;
-        this._paging     = context.paging;
-
+    function Reference(location) {
+        this._location   = location;
         this.contextualize._reference = this;
     }
 
@@ -171,7 +162,7 @@ var ERMrest = (function(module) {
          * @type {string}
          */
         get uri() {
-            return this._uri;
+            return this._location.compactUri;
         },
 
         /**
@@ -196,6 +187,10 @@ var ERMrest = (function(module) {
          get columns() {
              return this._columns;
          },
+
+        get location() {
+            return this._location;
+        },
 
         /**
          * A Boolean value that indicates whether this Reference is _inherently_
@@ -377,70 +372,52 @@ var ERMrest = (function(module) {
 
                 var defer = module._q.defer();
 
-                var uri = this._uri;
+                var uri = this._location.compactUri;
 
                 // if no sorting provided, use schema defined sort if that's present
                 // If neither one present, use shortestkey
-                if (!this._sort || (this._sort.length === 0)) {
+                var addkey = true;
+                if (!this._location.sortObject || (this._location.sortObject.length === 0)) {
                     if (this._table.annotations.contains(module._annotations.TABLE_DISPLAY) &&
                         this._table.annotations.get(module._annotations.TABLE_DISPLAY).contains("row_order")) {
-                        this._sort = this._table.annotations.get(module._annotations.TABLE_DISPLAY).get("row_order");
+                        this._location.sortObject = this._table.annotations.get(module._annotations.TABLE_DISPLAY).get("row_order");
+                        addkey = true;
                     } else {
                         // use shortest key as sort
-                        this._sort = [];
+                        var sortObject = [];
                         for (var sk = 0; sk < this._shortestKey.length; sk++) {
                             var col = this._shortestKey[sk].name;
-                            this._sort.push({"column":col, "descending":false});
+                            sortObject.push({"column":col, "descending":false});
                         }
+                        this._location.sortObject = sortObject; // this will update location.sort and all the uri and path
+                        addkey = false;
                     }
-                }
 
-                // insert @sort()
-                // get a list of columns in this._sort
-                var sortCols = this._sort.map(function(sort) {
-                    return sort.column;});
-
-                for (var d = 0; d < this._sort.length; d++) {
-                    // column name
-                    var sortCol = this._sort[d].column;
-                    var order = (this._sort[d].descending ? "::desc::" : "");
-                    if (d === 0)
-                        uri = uri + "@sort(" + module._fixedEncodeURIComponent(sortCol) + order;
-                    else
-                        uri = uri + "," + module._fixedEncodeURIComponent(sortCol) + order;
                 }
 
                 // ermrest requires key columns to be in sort param
                 // add them if they are missing
-                for (var i = 0; i < this._shortestKey.length; i++) { // all the key columns
-                    var col = this._shortestKey[i].name;
-                    // add if key col is not in the sortby list
-                    if (!sortCols.includes(col)) {
-                        this._sort.push({"column":module._fixedEncodeURIComponent(col), "descending":false}); // add key to sort
-                        uri = uri + "," + module._fixedEncodeURIComponent(col);
+                if (addkey) {
+                    var sortCols = this._location.sortObject.map(function(sort) {
+                        return sort.column;});
+                    var sortObject = this._location.sortObject;
+                    for (var i = 0; i < this._shortestKey.length; i++) { // all the key columns
+                        var col = this._shortestKey[i].name;
+                        // add if key col is not in the sortby list
+                        if (!sortCols.includes(col)) {
+                            sortObject.push({"column":module._fixedEncodeURIComponent(col), "descending":false}); // add key to sort
+                        }
                     }
+                    this._location.sortObject = sortObject;
                 }
-                uri = uri + ")";
+
+                // insert @sort()
+                if (this._location.sort)
+                    uri = uri + this._location.sort;
 
                 // insert paging
-                if (this._paging) {
-                    uri = uri + (this._paging.before? "@before(" : "@after(");
-
-                    for (var s = 0; s < this._sort.length; s++) {
-                        var col = this._sort[s].column;
-                        var value = this._paging.row[col];
-                        if (value === null)
-                            value = "::null::";
-                        else
-                            value = module._fixedEncodeURIComponent(value);
-                        if (s === 0)
-                            uri = uri + value;
-                        else
-                            uri = uri + "," + value;
-                    }
-
-                    uri = uri + ")";
-                }
+                if (this._location.paging)
+                    uri = uri + this._location.paging;
 
 
                 // add limit
@@ -452,10 +429,10 @@ var ERMrest = (function(module) {
                 module._http.get(uri).then(function readReference(response) {
 
                     var hasPrevious, hasNext = false;
-                    if (!ownReference._paging) { // first page
+                    if (!ownReference._location.paging) { // first page
                         hasPrevious = false;
                         hasNext = (response.data.length > limit);
-                    } else if (ownReference._paging.before) { // has @before()
+                    } else if (ownReference._location.pagingObject.before) { // has @before()
                         hasPrevious = (response.data.length > limit);
                         hasNext = true;
                     } else { // has @after()
@@ -467,7 +444,7 @@ var ERMrest = (function(module) {
                     // We need to remove those extra row of data from the result
                     if (response.data.length > limit) {
                         // if no paging or @after, remove last row
-                        if (!ownReference._paging || !ownReference._paging.before)
+                        if (!ownReference._location.pagingObject || !ownReference._location.pagingObject.before)
                             response.data.splice(response.data.length-1);
                        else // @before, remove first row
                             response.data.splice(0, 1);
@@ -500,17 +477,19 @@ var ERMrest = (function(module) {
 
             // make a Reference copy
             var newReference = _referenceCopy(this);
-            delete newReference._paging;
 
-            // change ._sort
-            if (!sort || sort.length === 0) {
-                delete newReference._sort;
-            }
-            else {
+            // change by updating location
+            var uri = this._location.compactUri;
+            if (sort) {
                 verify((sort instanceof Array), "input should be an array");
                 verify(sort.every(module._isValidSortElement), "invalid arguments in array");
-                newReference._sort = sort;
+
+                // create new ._location using the new sort
+                // any paging is removed at resort
+                uri = uri + module._getSortModifier(sort);
             }
+
+            newReference._location = new module.Location(uri);
 
             return newReference;
         },
@@ -573,11 +552,7 @@ var ERMrest = (function(module) {
                         var newRef = _referenceCopy(this);
                         newRef.contextualize._reference = newRef;
                         delete newRef._context; // NOTE: related reference is not contextualized
-                        delete newRef._sort;
-                        delete newRef._paging;
 
-                        newRef._shortestKey = newRef._table.shortestKey;
-                        
                         var fkrTable = fkr.colset.columns[0].table;
                         if (fkrTable._isPureBinaryAssociation()) { // Association Table
                             var otherFK;
@@ -588,19 +563,15 @@ var ERMrest = (function(module) {
                                 }
                             }
 
-                            newRef._schema = otherFK.key.table.schema;
-                            newRef._schemaName = otherFK.key.table.schema.name;
                             newRef._table = otherFK.key.table;
-                            newRef._tableName = otherFK.key.table.name;
+                            newRef._shortestKey = newRef._table.shortestKey;
                             newRef._columns = otherFK.key.table.columns.all();
                             newRef._displayname = otherFK.to_name ? otherFK.to_name : otherFK.key.table.displayname;
-                            newRef._uri = this._uri + "/" + fkr.toString() + "/" + otherFK.toString(true);
+                            newRef._location = new module.Location(this._location.compactUri + "/" + fkr.toString() + "/" + otherFK.toString(true));
 
                         } else { // Simple inbound Table
-                            newRef._schema = fkrTable.schema;
-                            newRef._schemaName = fkrTable.schema.name;
                             newRef._table = fkrTable;
-                            newRef._tableName = fkrTable.name;
+                            newRef._shortestKey = newRef._table.shortestKey;
 
                             newRef._columns = [];
                             for (var l = 0, col; l < newRef._table.columns.all().length; l++) {
@@ -612,7 +583,7 @@ var ERMrest = (function(module) {
                             }
 
                             newRef._displayname = fkr.from_name ? fkr.from_name : newRef._table.displayname;
-                            newRef._uri = this._uri + "/" + fkr.toString();
+                            newRef._location = new module.Location(this._location.compactUri + "/" + fkr.toString());
                         }
 
                         this._related.push(newRef);
@@ -717,14 +688,17 @@ var ERMrest = (function(module) {
         get previous() {
             if (this._hasPrevious) {
                 var newReference = _referenceCopy(this._ref);
-                newReference._paging = {};
-                newReference._paging.before = true;
-                newReference._paging.row = {};
-                for (var i = 0; i < newReference._sort.length; i++) {
-                    var col = newReference._sort[i].column;
-                    newReference._paging.row[col] = this._data[0][col]; // first row
-                }
 
+                // update paging by creating a new location
+                var paging = {};
+                paging.before = true;
+                paging.row = [];
+                for (var i = 0; i < newReference._location.sortObject.length; i++) {
+                    var col = newReference._location.sortObject[i].column;
+                    paging.row.push(this._data[0][col]); // first row
+                }
+                // create new _location
+                newReference._location = new module.Location(newReference._location.compactUri + newReference._location.sort + module._getPagingModifier(paging));
                 return newReference;
             }
             return null;
@@ -755,14 +729,17 @@ var ERMrest = (function(module) {
         get next() {
             if (this._hasNext) {
                 var newReference = _referenceCopy(this._ref);
-                newReference._paging = {};
-                newReference._paging.before = false;
-                newReference._paging.row = {};
-                for (var i = 0; i < newReference._sort.length; i++) {
-                    var col = newReference._sort[i].column;
-                    newReference._paging.row[col] = this._data[this._data.length - 1][col]; // last row
-                }
 
+                // update paging by creating a new location
+                var paging = {};
+                paging.before = false;
+                paging.row = [];
+                for (var i = 0; i < newReference._location.sortObject.length; i++) {
+                    var col = newReference._location.sortObject[i].column;
+                    paging.row.push(this._data[this._data.length-1][col]); // last row
+                }
+                // create new _location
+                newReference._location = new module.Location(newReference._location.compactUri + newReference._location.sort + module._getPagingModifier(paging));
                 return newReference;
             }
             return null;
@@ -783,13 +760,38 @@ var ERMrest = (function(module) {
      * this data was acquired.
      * @param {!Object} data The unprocessed tuple of data returned from ERMrest.
      */
-    function Tuple(reference, data) {
-        this._ref = reference;
+    function Tuple(pageReference, data) {
+        this._pageRef = pageReference;
         this._data = data;
     }
 
     Tuple.prototype = {
         constructor: Tuple,
+
+        /**
+         * This is the reference of the Tuple
+         * @returns {ERMrest.Reference|*} reference of the Tuple
+         */
+        get reference() {
+
+            if (this._ref === undefined) {
+                this._ref = _referenceCopy(this._pageRef);
+
+                // update its location by adding the tuple’s key filter to the URI
+                // don't keep any modifiers
+                var uri = this._pageRef._location.compactUri + "/";
+                for (var k = 0; k < this._pageRef._shortestKey.length; k++) {
+                    var col = this._pageRef._shortestKey[k].name;
+                    if (k === 0) {
+                        uri = uri + module._fixedEncodeURIComponent(col) + "=" + module._fixedEncodeURIComponent(this._data[col]);
+                    } else {
+                        uri = uri + "&" + module._fixedEncodeURIComponent(col) + "=" + module._fixedEncodeURIComponent(this._data[col]);
+                    }
+                }
+                this._ref._location = new module.Location(uri);
+            }
+            return this._ref;
+        },
 
         /**
          * Indicates whether the client can update this tuple. Because
@@ -892,9 +894,9 @@ var ERMrest = (function(module) {
         get values() {
             if (this._values === undefined) {
                 this._values = [];
-                for (var i = 0; i < this._ref.columns.length; i++) {
-                    var col = this._ref.columns[i];
-                    this._values[i] = col.formatvalue(this._data[col.name], {context:this._ref._context});
+                for (var i = 0; i < this._pageRef.columns.length; i++) {
+                    var col = this._pageRef.columns[i];
+                    this._values[i] = col.formatvalue(this._data[col.name], {context:this._pageRef._context});
                 }
             }
             return this._values;
@@ -915,7 +917,7 @@ var ERMrest = (function(module) {
          */
         get displayname() {
             if (!this._displayname) {
-                var table = this._ref._table;
+                var table = this._pageRef._table;
                 // if table has display row_name annotation
                 if (table.annotations.contains(module._annotations.TABLE_DISPLAY) &&
                     table.annotations.get(module._annotations.TABLE_DISPLAY).contains("row_name")) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -374,6 +374,8 @@ var ERMrest = (function(module) {
 
                 var uri = this._location.compactUri;
 
+                var sortObject, col;
+
                 // if no sorting provided, use schema defined sort if that's present
                 // If neither one present, use shortestkey
                 var addkey = true;
@@ -384,9 +386,9 @@ var ERMrest = (function(module) {
                         addkey = true;
                     } else {
                         // use shortest key as sort
-                        var sortObject = [];
+                        sortObject = [];
                         for (var sk = 0; sk < this._shortestKey.length; sk++) {
-                            var col = this._shortestKey[sk].name;
+                            col = this._shortestKey[sk].name;
                             sortObject.push({"column":col, "descending":false});
                         }
                         this._location.sortObject = sortObject; // this will update location.sort and all the uri and path
@@ -400,9 +402,9 @@ var ERMrest = (function(module) {
                 if (addkey) {
                     var sortCols = this._location.sortObject.map(function(sort) {
                         return sort.column;});
-                    var sortObject = this._location.sortObject;
+                    sortObject = this._location.sortObject;
                     for (var i = 0; i < this._shortestKey.length; i++) { // all the key columns
-                        var col = this._shortestKey[i].name;
+                        col = this._shortestKey[i].name;
                         // add if key col is not in the sortby list
                         if (!sortCols.includes(col)) {
                             sortObject.push({"column":module._fixedEncodeURIComponent(col), "descending":false}); // add key to sort

--- a/js/reference.js
+++ b/js/reference.js
@@ -478,18 +478,15 @@ var ERMrest = (function(module) {
             // make a Reference copy
             var newReference = _referenceCopy(this);
 
-            // change by updating location
-            var uri = this._location.compactUri;
             if (sort) {
                 verify((sort instanceof Array), "input should be an array");
                 verify(sort.every(module._isValidSortElement), "invalid arguments in array");
 
-                // create new ._location using the new sort
-                // any paging is removed at resort
-                uri = uri + module._getSortModifier(sort);
             }
 
-            newReference._location = new module.Location(uri);
+            newReference._location = this._location._clone();
+            newReference._location.pagingObject = null;
+            newReference._location.sortObject = sort;
 
             return newReference;
         },
@@ -567,7 +564,7 @@ var ERMrest = (function(module) {
                             newRef._shortestKey = newRef._table.shortestKey;
                             newRef._columns = otherFK.key.table.columns.all();
                             newRef._displayname = otherFK.to_name ? otherFK.to_name : otherFK.key.table.displayname;
-                            newRef._location = new module.Location(this._location.compactUri + "/" + fkr.toString() + "/" + otherFK.toString(true));
+                            newRef._location = module._parse(this._location.compactUri + "/" + fkr.toString() + "/" + otherFK.toString(true));
 
                         } else { // Simple inbound Table
                             newRef._table = fkrTable;
@@ -583,7 +580,7 @@ var ERMrest = (function(module) {
                             }
 
                             newRef._displayname = fkr.from_name ? fkr.from_name : newRef._table.displayname;
-                            newRef._location = new module.Location(this._location.compactUri + "/" + fkr.toString());
+                            newRef._location = module._parse(this._location.compactUri + "/" + fkr.toString());
                         }
 
                         this._related.push(newRef);
@@ -697,8 +694,9 @@ var ERMrest = (function(module) {
                     var col = newReference._location.sortObject[i].column;
                     paging.row.push(this._data[0][col]); // first row
                 }
-                // create new _location
-                newReference._location = new module.Location(newReference._location.compactUri + newReference._location.sort + module._getPagingModifier(paging));
+
+                newReference._location = this._ref._location._clone();
+                newReference._location.pagingObject = paging;
                 return newReference;
             }
             return null;
@@ -738,8 +736,9 @@ var ERMrest = (function(module) {
                     var col = newReference._location.sortObject[i].column;
                     paging.row.push(this._data[this._data.length-1][col]); // last row
                 }
-                // create new _location
-                newReference._location = new module.Location(newReference._location.compactUri + newReference._location.sort + module._getPagingModifier(paging));
+
+                newReference._location = this._ref._location._clone();
+                newReference._location.pagingObject = paging;
                 return newReference;
             }
             return null;
@@ -789,7 +788,7 @@ var ERMrest = (function(module) {
                         uri = uri + "&" + module._fixedEncodeURIComponent(col) + "=" + module._fixedEncodeURIComponent(this._data[col]);
                     }
                 }
-                this._ref._location = new module.Location(uri);
+                this._ref._location = module._parse(uri);
             }
             return this._ref;
         },

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -437,50 +437,6 @@ var ERMrest = (function(module) {
     };
 
     /**
-     * given sort object, get the string modifier
-     * @param {Object[]} sort [{"column":colname, "descending":boolean}, ...]
-     * @return {string} string modifier @sort(...)
-     * @private
-     */
-    module._getSortModifier = function(sort) {
-
-        // if no sorting
-        if (!sort || sort.length === 0) {
-            return "";
-        }
-
-        var modifier = "@sort(";
-        for (var i = 0; i < sort.length; i++) {
-            if (i !== 0) modifier = modifier + ",";
-            modifier = modifier + module._fixedEncodeURIComponent(sort[i].column) + (sort[i].descending ? "::desc::" : "");
-        }
-        modifier = modifier + ")";
-        return modifier;
-    };
-
-    /**
-     * given paging object, get the paging modifier
-     * @param {Object} paging {"before":boolean, "row":[c1,c2,c3..]}
-     * @return {string} string modifier @paging(...)
-     * @private
-     */
-    module._getPagingModifier = function(paging) {
-
-        // no paging
-        if (!paging) {
-            return "";
-        }
-
-        var modifier = (paging.before ? "@before(" : "@after(");
-        for (var i = 0; i < paging.row.length; i++) {
-            if (i !== 0) modifier = modifier + ",";
-            modifier = modifier + (paging.row[i] === "null" ? "::null::" : module._fixedEncodeURIComponent(paging.row[i]));
-        }
-        modifier = modifier + ")";
-        return modifier;
-    };
-
-    /**
      * @desc List of annotations that ermrestjs supports.
      * @private
      */

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -437,6 +437,50 @@ var ERMrest = (function(module) {
     };
 
     /**
+     * given sort object, get the string modifier
+     * @param {Object[]} sort [{"column":colname, "descending":boolean}, ...]
+     * @return {string} string modifier @sort(...)
+     * @private
+     */
+    module._getSortModifier = function(sort) {
+
+        // if no sorting
+        if (!sort || sort.length === 0) {
+            return "";
+        }
+
+        var modifier = "@sort(";
+        for (var i = 0; i < sort.length; i++) {
+            if (i !== 0) modifier = modifier + ",";
+            modifier = modifier + module._fixedEncodeURIComponent(sort[i].column) + (sort[i].descending ? "::desc::" : "");
+        }
+        modifier = modifier + ")";
+        return modifier;
+    };
+
+    /**
+     * given paging object, get the paging modifier
+     * @param {Object} paging {"before":boolean, "row":[c1,c2,c3..]}
+     * @return {string} string modifier @paging(...)
+     * @private
+     */
+    module._getPagingModifier = function(paging) {
+
+        // no paging
+        if (!paging) {
+            return "";
+        }
+
+        var modifier = (paging.before ? "@before(" : "@after(");
+        for (var i = 0; i < paging.row.length; i++) {
+            if (i !== 0) modifier = modifier + ",";
+            modifier = modifier + (paging.row[i] === "null" ? "::null::" : module._fixedEncodeURIComponent(paging.row[i]));
+        }
+        modifier = modifier + ")";
+        return modifier;
+    };
+
+    /**
      * @desc List of annotations that ermrestjs supports.
      * @private
      */

--- a/test/specs/parser/tests/01.parser.js
+++ b/test/specs/parser/tests/01.parser.js
@@ -11,16 +11,24 @@ exports.execute = function (options) {
             var singleFilterPath = "/catalog/" + catalogId + "/entity/"
                 + schemaName + ":" + tableName + "/id=" + entityId;
 
-            it('_parse should take a uri with a single filter and return a context object.', function() {
-                var context = options.ermRest._parse(options.url + singleFilterPath);
-                parsedFilter = context.filter;
+            it('_parse should take a uri with a single filter and return a location object.', function() {
+                var location = options.ermRest._parse(options.url + singleFilterPath);
+                parsedFilter = location._firstFilter;
 
-                expect(context).toBeDefined();
-                expect(context.path).toBe(singleFilterPath);
-                expect(context.catalogId).toBe(catalogId.toString());
-                expect(context.schemaName).toBe(schemaName);
-                expect(context.tableName).toBe(tableName);
-                expect(context.filter instanceof options.ermRest.ParsedFilter).toBe(true);
+                expect(location).toBeDefined();
+                expect(location.uri).toBe(options.url + singleFilterPath);
+                expect(location.compactUri).toBe(options.url + singleFilterPath);
+                expect(location.api).toBe("entity");
+                expect(location.path).toBe(schemaName + ":" + tableName + "/id=" + entityId);
+                expect(location.compactPath).toBe(schemaName + ":" + tableName + "/id=" + entityId);
+                expect(location.catalog).toBe(catalogId.toString());
+                expect(location.sort).toBeUndefined();
+                expect(location.sortObject).toBe(null);
+                expect(location.paging).toBeUndefined();
+                expect(location.pagingObject).toBe(null);
+                expect(location.firstSchemaName).toBe(schemaName);
+                expect(location.firstTableName).toBe(tableName);
+                expect(location._firstFilter instanceof options.ermRest.ParsedFilter).toBe(true);
             });
 
             it('parsedFilter should have methods and values properly defined.', function() {
@@ -40,22 +48,35 @@ exports.execute = function (options) {
             var parsedFilter;
             var lowerLimit = 1,
                 upperLimit = 10,
-                sort = "summary";
+                sort = "summary",
+                text = "some%20random%20text"
             var multipleFilterPath = "/catalog/" + catalogId + "/entity/" + schemaName + ":"
-                + tableName + "/id::gt::" + lowerLimit + "&id::lt::" + upperLimit + "@sort(" + sort + ")";
+                + tableName + "/id::gt::" + lowerLimit + "&id::lt::" + upperLimit + "@sort(" + sort + ")" + "@after(" + text + ")";
 
-            it('_parse should take a uri with multiple filters and return a context object.', function() {
-                var context = options.ermRest._parse(options.url + multipleFilterPath);
-                parsedFilter = context.filter;
+            it('_parse should take a uri with multiple filters and return a location object.', function() {
+                var location = options.ermRest._parse(options.url + multipleFilterPath);
+                parsedFilter = location._firstFilter;
 
-                expect(context).toBeDefined();
-                expect(context.path).toBe(multipleFilterPath);
-                expect(context.sort[0].column).toBe("summary");
-                expect(context.sort[0].descending).toBe(false);
-                expect(context.catalogId).toBe(catalogId.toString());
-                expect(context.schemaName).toBe(schemaName);
-                expect(context.tableName).toBe(tableName);
-                expect(context.filter instanceof options.ermRest.ParsedFilter).toBe(true);
+                expect(location).toBeDefined();
+                expect(location.uri).toBe(options.url + multipleFilterPath);
+                expect(location.compactUri).toBe(options.url + "/catalog/" + catalogId + "/entity/" + schemaName + ":"
+                    + tableName + "/id::gt::" + lowerLimit + "&id::lt::" + upperLimit);
+                expect(location.api).toBe("entity");
+                expect(location.path).toBe(schemaName + ":"
+                    + tableName + "/id::gt::" + lowerLimit + "&id::lt::" + upperLimit + "@sort(" + sort + ")"  + "@after(" + text + ")");
+                expect(location.compactPath).toBe(schemaName + ":"
+                    + tableName + "/id::gt::" + lowerLimit + "&id::lt::" + upperLimit);
+                expect(location.sort).toBe("@sort(" + sort + ")");
+                expect(location.sortObject[0].column).toBe("summary");
+                expect(location.sortObject[0].descending).toBe(false);
+                expect(location.paging).toBe("@after(" + text + ")");
+                expect(location.pagingObject.before).toBe(false);
+                expect(location.pagingObject.row.length).toBe(1);
+                expect(location.pagingObject.row[0]).toBe("some random text");
+                expect(location.catalog).toBe(catalogId.toString());
+                expect(location.firstSchemaName).toBe(schemaName);
+                expect(location.firstTableName).toBe(tableName);
+                expect(location._firstFilter instanceof options.ermRest.ParsedFilter).toBe(true);
             });
 
             it('parsedFilter should have methods and values properly defined.', function() {
@@ -85,16 +106,26 @@ exports.execute = function (options) {
             var multipleFilterPath = "/catalog/" + catalogId + "/entity/" + schemaName + ":"
                 + tableName + "/id=" + firstEntityId + ";id=" + secondEntityId;
 
-            it('_parse should take a uri with multiple filters and return a context object.', function() {
-                var context = options.ermRest._parse(options.url + multipleFilterPath);
-                parsedFilter = context.filter;
+            it('_parse should take a uri with multiple filters and return a location object.', function() {
+                var location = options.ermRest._parse(options.url + multipleFilterPath);
+                parsedFilter = location._firstFilter;
 
-                expect(context).toBeDefined();
-                expect(context.path).toBe(multipleFilterPath);
-                expect(context.catalogId).toBe(catalogId.toString());
-                expect(context.schemaName).toBe(schemaName);
-                expect(context.tableName).toBe(tableName);
-                expect(context.filter instanceof options.ermRest.ParsedFilter).toBe(true);
+                expect(location).toBeDefined();
+                expect(location.uri).toBe(options.url + multipleFilterPath);
+                expect(location.compactUri).toBe(options.url + multipleFilterPath);
+                expect(location.api).toBe("entity");
+                expect(location.path).toBe(schemaName + ":"
+                    + tableName + "/id=" + firstEntityId + ";id=" + secondEntityId);
+                expect(location.compactPath).toBe(schemaName + ":"
+                    + tableName + "/id=" + firstEntityId + ";id=" + secondEntityId);
+                expect(location.catalog).toBe(catalogId.toString());
+                expect(location.sort).toBeUndefined();
+                expect(location.sortObject).toBe(null);
+                expect(location.paging).toBeUndefined();
+                expect(location.pagingObject).toBe(null);
+                expect(location.firstSchemaName).toBe(schemaName);
+                expect(location.firstTableName).toBe(tableName);
+                expect(location._firstFilter instanceof options.ermRest.ParsedFilter).toBe(true);
             });
 
             it('parsedFilter should have methods and values properly defined.', function() {

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -34,29 +34,25 @@ exports.execute = function (options) {
             });
 
             it('reference should be properly defined based on the constructor.', function() {
-                expect(reference._uri).toBe(singleEnitityUri);
-                expect(reference._serviceUrl).toBe(options.url);
-                expect(reference._catalogId).toBe(catalog_id.toString());
-                expect(reference._schemaName).toBe(schemaName);
-                expect(reference._tableName).toBe(tableName);
-                expect(reference._filter instanceof options.ermRest.ParsedFilter).toBeDefined();
+                expect(reference._location.uri).toBe(singleEnitityUri);
+                expect(reference._location.service).toBe(options.url);
+                expect(reference._location.catalog).toBe(catalog_id.toString());
+                expect(reference._location.firstSchemaName).toBe(schemaName);
+                expect(reference._location.firstTableName).toBe(tableName);
 
                 expect(reference.contextualize._reference).toBe(reference);
             });
 
             // Methods that are currently implemented
             it('reference should have methods properly defined.', function() {
-                expect(reference.uri).toBe(reference._uri);
+                expect(reference.uri).toBe(reference._location.uri);
                 expect(reference.columns).toBe(reference._columns);
                 expect(reference.displayname).toBe(reference._table.name);
                 expect(reference.read()).toBeDefined();
             });
 
             it('reference should be properly defined after the callback is resolved.', function() {
-                expect(reference._catalog).toBeDefined();
-                expect(reference._schema).toBeDefined();
                 expect(reference._table).toBeDefined();
-                expect(reference._columns).toBeDefined();
             });
 
             it('contextualize.record should return a contextualized reference object.', function() {
@@ -78,9 +74,9 @@ exports.execute = function (options) {
                 expect(columns).toEqual(["name", "value"]);
 
                 expect(recordReference.uri).toBe(reference.uri);
-                expect(recordReference._serviceUrl).toBe(reference._serviceUrl);
+                expect(recordReference._location.service).toBe(reference._location.service);
                 // If catalog is the same, so will be the schema and table
-                expect(recordReference._catalog).toBe(reference._catalog);
+                expect(recordReference._location.catalog).toBe(reference._location.catalog);
             });
 
             // Single Entity specific tests
@@ -111,7 +107,7 @@ exports.execute = function (options) {
                 tuple = page.tuples[0];
                 expect(page._tuples).toBeDefined();
                 expect(tuple._data).toBe(page._data[0]);
-                expect(tuple._ref).toBe(reference);
+                expect(tuple._pageRef).toBe(reference);
             });
 
             it('tuples should have methods properly defined.', function() {

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -93,9 +93,9 @@ exports.execute = function(options) {
 
         describe('for pure and binray association foreign keys, ', function() {
             it('should have the correct catalog, schema, and table.', function (){
-                expect(related[2]._catalogId).toBe(catalog_id.toString());
-                expect(related[2]._schemaName).toBe(schemaName);
-                expect(related[2]._tableName).toBe(inboudTableName);
+                expect(related[2]._location.catalog).toBe(catalog_id.toString());
+                expect(related[2]._table.schema.name).toBe(schemaName);
+                expect(related[2]._table.name).toBe(inboudTableName);
             });
 
             describe('.displayname, ', function (){

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -39,9 +39,9 @@ exports.execute = function(options) {
 
         describe('for inbound foreign keys, ', function() {
             it('should have the correct catalog, schema, and table.', function() {
-                expect(related[0]._catalogId).toBe(catalog_id.toString());
-                expect(related[0]._schemaName).toBe(schemaName);
-                expect(related[0]._tableName).toBe(inboudTableName);
+                expect(related[0]._location.catalog).toBe(catalog_id.toString());
+                expect(related[0]._table.schema.name).toBe(schemaName);
+                expect(related[0]._table.name).toBe(inboudTableName);
             });
 
             describe('.displayname, ', function() {

--- a/test/specs/reference/tests/03.reference_sort.js
+++ b/test/specs/reference/tests/03.reference_sort.js
@@ -27,9 +27,9 @@ exports.execute = function (options) {
 
             it('sort should return a new Reference with new sort. ', function() {
                 reference2 = reference1.sort([{"column":"name", "descending":false}]);
-                expect(reference2._sort.length).toEqual(1);
-                expect(reference2._sort[0].column).toEqual("name");
-                expect(reference2._sort[0].descending).toEqual(false);
+                expect(reference2._location.sortObject.length).toEqual(1);
+                expect(reference2._location.sortObject[0].column).toEqual("name");
+                expect(reference2._location.sortObject[0].descending).toEqual(false);
             });
 
             it('read should return a Page object that is defined.', function(done) {

--- a/test/specs/reference/tests/04.paging.js
+++ b/test/specs/reference/tests/04.paging.js
@@ -54,7 +54,11 @@ exports.execute = function (options) {
             it('tuples should be sorted by ascending value by default. ', function() {
                 tuples = page1.tuples;
                 expect(tuples.length).toBe(10);
+                var shortestkey = tuples[0].reference._shortestKey[0].name; // only 1 column
                 for(var i = 0; i < tuples.length - 1; i++) {
+                    expect(tuples[i].reference._location.uri).toBe(
+                        options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+                        + tableNameNoSort + "/" + shortestkey + "=" + tuples[i]._data[shortestkey]);
                     expect(tuples[i]._data.value).toBeLessThan(tuples[i+1]._data.value);
                 }
             });
@@ -83,7 +87,11 @@ exports.execute = function (options) {
                 it('tuples should be sorted by ascending id by default. ', function() {
                     tuples = page2.tuples;
                     expect(tuples.length).toBe(6);
+                    var shortestkey = tuples[0].reference._shortestKey[0].name; // only 1 column
                     for(var i = 0; i < tuples.length - 1; i++) {
+                        expect(tuples[i].reference._location.uri).toBe(
+                            options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+                            + tableNameNoSort + "/" + shortestkey + "=" + tuples[i]._data[shortestkey]);
                         expect(tuples[i]._data.value).toBeLessThan(tuples[i+1]._data.value);
                     }
                 });
@@ -123,7 +131,11 @@ exports.execute = function (options) {
                 it('tuples should be sorted by ascending id by default. ', function() {
                     tuples = page2.tuples;
                     expect(tuples.length === 10);
+                    var shortestkey = tuples[0].reference._shortestKey[0].name; // only 1 column
                     for(var i = 0; i < tuples.length - 1; i++) {
+                        expect(tuples[i].reference._location.uri).toBe(
+                            options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+                            + tableNameNoSort + "/" + shortestkey + "=" + tuples[i]._data[shortestkey]);
                         expect(tuples[i]._data.value).toBeLessThan(tuples[i+1]._data.value);
                     }
                 });
@@ -177,7 +189,11 @@ exports.execute = function (options) {
             it('tuples should be sorted by name. ', function() {
                 tuples = page1.tuples;
                 expect(tuples.length).toBe(10);
+                var shortestkey = tuples[0].reference._shortestKey[0].name; // only 1 column
                 for(var i = 0; i < tuples.length - 1; i++) {
+                    expect(tuples[i].reference._location.uri).toBe(
+                        options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+                        + tableNameWSort + "/" + shortestkey + "=" + tuples[i]._data[shortestkey]);
                     expect(tuples[i]._data.name).toBeLessThan(tuples[i+1]._data.name);
                 }
             });
@@ -206,7 +222,11 @@ exports.execute = function (options) {
                 it('tuples should be sorted by name. ', function() {
                     tuples = page2.tuples;
                     expect(tuples.length).toBe(6);
+                    var shortestkey = tuples[0].reference._shortestKey[0].name; // only 1 column
                     for(var i = 0; i < tuples.length - 1; i++) {
+                        expect(tuples[i].reference._location.uri).toBe(
+                            options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+                            + tableNameWSort + "/" + shortestkey + "=" + tuples[i]._data[shortestkey]);
                         expect(tuples[i]._data.name).toBeLessThan(tuples[i+1]._data.name);
                     }
                 });
@@ -246,7 +266,11 @@ exports.execute = function (options) {
                 it('tuples should be sorted by ascending id by default. ', function() {
                     tuples = page2.tuples;
                     expect(tuples.length === 10);
+                    var shortestkey = tuples[0].reference._shortestKey[0].name; // only 1 column
                     for(var i = 0; i < tuples.length - 1; i++) {
+                        expect(tuples[i].reference._location.uri).toBe(
+                            options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+                            + tableNameWSort + "/" + shortestkey + "=" + tuples[i]._data[shortestkey]);
                         expect(tuples[i]._data.name).toBeLessThan(tuples[i+1]._data.name);
                     }
                 });
@@ -265,7 +289,7 @@ exports.execute = function (options) {
 
         describe("Paging with with url specified sort", function() {
             var uri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
-                + tableNameNoSort + "@sort(value)";
+                + tableNameNoSort + "/value::lt::1000@sort(value)";
 
             var reference1, reference2, reference3, tuples;
             var page1, page2, page3;
@@ -300,7 +324,11 @@ exports.execute = function (options) {
             it('tuples should be sorted by ascending id by default. ', function() {
                 tuples = page1.tuples;
                 expect(tuples.length).toBe(10);
+                var shortestkey = tuples[0].reference._shortestKey[0].name; // only 1 column
                 for(var i = 0; i < tuples.length - 1; i++) {
+                    expect(tuples[i].reference._location.uri).toBe(
+                        options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+                        + tableNameNoSort + "/" + shortestkey + "=" + tuples[i]._data[shortestkey]);
                     expect(tuples[i]._data.value).toBeLessThan(tuples[i+1]._data.value);
                 }
             });
@@ -329,7 +357,11 @@ exports.execute = function (options) {
                 it('tuples should be sorted by ascending id by default. ', function() {
                     tuples = page2.tuples;
                     expect(tuples.length).toBe(6);
+                    var shortestkey = tuples[0].reference._shortestKey[0].name; // only 1 column
                     for(var i = 0; i < tuples.length - 1; i++) {
+                        expect(tuples[i].reference._location.uri).toBe(
+                            options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+                            + tableNameNoSort + "/" + shortestkey + "=" + tuples[i]._data[shortestkey]);
                         expect(tuples[i]._data.value).toBeLessThan(tuples[i+1]._data.value);
                     }
                 });
@@ -369,7 +401,11 @@ exports.execute = function (options) {
                 it('tuples should be sorted by ascending id by default. ', function() {
                     tuples = page2.tuples;
                     expect(tuples.length === 10);
+                    var shortestkey = tuples[0].reference._shortestKey[0].name; // only 1 column
                     for(var i = 0; i < tuples.length - 1; i++) {
+                        expect(tuples[i].reference._location.uri).toBe(
+                            options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
+                            + tableNameNoSort + "/" + shortestkey + "=" + tuples[i]._data[shortestkey]);
                         expect(tuples[i]._data.value).toBeLessThan(tuples[i+1]._data.value);
                     }
                 });


### PR DESCRIPTION
* cleaned up the Reference fields that are not needed: _tableName, _schemaName and _schema.
* parser function returns the (new) Location instance rather than the context object
* Reference(...) constructor will take the location instead of the context
* the Location include the parsed sort object