### PR TITLE
Pretty print gene sequences

### DIFF
--- a/js/utilities.js
+++ b/js/utilities.js
@@ -400,6 +400,69 @@ var ERMrest = (function(module) {
                 return '';
             }
             return module._markdownIt.renderInline(value);
+        },
+
+        /**
+         * @function
+         * @param {string} value The gene sequence to transform
+         * @param {Object} [options] Configuration options. Accepted parameters
+         * are "increment" (desired number of characters in each segment) and
+         * "separator" (desired separator between segments).
+         * @return {string} A string representation of value
+         * @desc Formats a gene sequence into a string for display. By default,
+         * it will split gene sequence into an increment of 10 characters and
+         * insert an empty space in between each increment.
+         */
+
+        printGeneSeq: function printGeneSeq(value, options) {
+            options = (typeof options === 'undefined') ? {} : options;
+
+            if (value === null) {
+                return '';
+            }
+            // Default separator is a space.
+            if (!options.separator) {
+                options.separator = ' ';
+            }
+            // Default increment is 10
+            if (!options.increment) {
+                options.increment = 10;
+            }
+            var inc = parseInt(options.increment, 10);
+
+            if (inc === 0) {
+                return value.toString();
+            }
+
+            // Reset the increment if it's negative
+            if (inc <= -1) {
+                inc = 1;
+            }
+
+            var formattedSeq = '`';
+            var separator = options.separator;
+            while (value.length >= inc) {
+                // Get the first inc number of chars
+                var chunk = value.slice(0, inc);
+                // Append the chunk and separator
+                formattedSeq += chunk + separator;
+                // Remove this chunk from value
+                value = value.slice(inc);
+            }
+
+            // Append any remaining chars from value that was too small to form an increment
+            formattedSeq += value;
+
+            // Slice off separator at the end
+            if (formattedSeq.slice(-1) == separator) {
+                formattedSeq = formattedSeq.slice(0, -1);
+            }
+
+            // Add the ending backtick at the end
+            formattedSeq += '`';
+
+            // Run it through printMarkdown to get the sequence in a fixed-width font
+            return module._formatUtils.printMarkdown(formattedSeq);
         }
     };
 
@@ -461,7 +524,6 @@ var ERMrest = (function(module) {
         EDIT: 'entry/edit',
         ENTRY: 'entry',
         FILTER: 'filter',
-        RECORD: 'record',
         DEFAULT: '*'
     });
 

--- a/test/single-test-runner.js
+++ b/test/single-test-runner.js
@@ -7,17 +7,17 @@ var config = {
   "random": false
 };
 
-// Specify the spec file to be run here 
+// Specify the spec file to be run here
 // or leave it same to execute the spec in /support folder
 // Make changes to the tests and schema configuration values in spec.js in /support folder
 // to execute specific test cases only
 config["spec_files"] = ["support/*.spec.js"];
 
 // function to run all test specs
-var runSpecs = function() {		
+var runSpecs = function() {
 	// Load the configuration file
 	jasmineUtils.run(config);
-}; 
+};
 
 runSpecs();
 
@@ -28,5 +28,3 @@ process.on('uncaughtException', function(e) {
 	console.log(e.stack);
 	jasmineUtils.deleteCatalog();
 });
-
-

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -74,6 +74,10 @@
                             }
                         }
                     }
+                },
+                {
+                    "name": "table_1_gene_sequence",
+                    "type": { "typename": "gene_sequence" }
                 }
             ],
             "foreign_keys": [],

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -215,6 +215,18 @@ exports.execute = function(options) {
                         expect(formattedValue).toBe('<em>taylor <sup>swift</sup></em>');
                     });
                 });
+
+                describe('should call printGeneSeq() to format,', function() {
+                    it('gene_sequence columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printGeneSeq').and.callThrough();
+                        var testVal = 'GATCGATCGCGTATT';
+                        var col = table1_schema2.columns.get('table_1_gene_sequence');
+                        var formattedValue = col.formatvalue(testVal);
+                        expect(spy).toHaveBeenCalledWith(testVal, undefined);
+                        expect(formattedValue).toEqual(jasmine.any(String));
+                        expect(formattedValue).toBe('<code>GATCGATCGC GTATT</code>');
+                    });
+                });
             });
         });
     });

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -76,5 +76,33 @@ exports.execute = function (options) {
             expect(printMarkdown('H~2~0')).toBe('H<sub>2</sub>0');
             expect(printMarkdown('13^th^')).toBe('13<sup>th</sup>');
         });
+
+        it('printGeneSeq() should format gene sequences correctly.', function() {
+            var printGeneSeq = formatUtils.printGeneSeq;
+            expect(printGeneSeq(null)).toBe('');
+            expect(printGeneSeq('sample', {increment: 0})).toBe('<code>sample</code>');
+            
+            var testCases = [
+                {
+                    input: 'as',
+                    defaultFormat: '<code>as</code>',
+                    negativeIncrement: '<code>a s</code>',
+                    incrementOf5WithDashes: '<code>as</code>',
+                },
+                {
+                    input: 'GATCTCGATGACTGAGAGGTA',
+                    defaultFormat: '<code>GATCTCGATG ACTGAGAGGT A</code>',
+                    negativeIncrement: '<code>G A T C T C G A T G A C T G A G A G G T A</code>',
+                    incrementOf5WithDashes: '<code>GATCT-CGATG-ACTGA-GAGGT-A</code>',
+                }
+            ];
+
+            for (var i = 0, len = testCases.length; i < len; i++) {
+                var testCase = testCases[i];
+                expect(printGeneSeq(testCase.input)).toBe(testCase.defaultFormat);
+                expect(printGeneSeq(testCase.input, {increment: -34})).toBe(testCase.negativeIncrement);
+                expect(printGeneSeq(testCase.input, {separator: '-', increment: 5})).toBe(testCase.incrementOf5WithDashes);
+            }
+        });
     });
 };


### PR DESCRIPTION
This PR addresses #157, "support gene_sequence use case".

By default, sequences are segmented into groups of 10 characters with a space between each group.

This PR introduces a new pretty pretty utility function (`printGeneSeq`)for columns of `gene_sequence` type, which depends on the `printMarkdown` utility function in order to return the gene sequence in a fixed-width font.