### PR TITLE
Reference.read default page size

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -417,9 +417,20 @@ var ERMrest = (function(module) {
          */
         read: function(limit) {
             try {
-                verify(limit, "'limit' must be specified");
-                verify(typeof(limit) == 'number', "'limit' must be a number");
-                verify(limit > 0, "'limit' must be greater than 0");
+                if (typeof(limit) != 'number' || limit <= 0) {
+                    var content = -1;
+                    // get default page size from annotation
+                    if (this._table.annotations.contains(module._annotations.TABLE_DISPLAY)) {
+                        content = module._getRecursiveAnnotationValue(this._context, this._table.annotations.get(module._annotations.TABLE_DISPLAY).content);
+                    }
+
+                    if (content != -1 && typeof(content.page_size) == 'number') {
+                        limit = content.page_size; // default page_size is defined
+                    } else {
+                        limit = 1; // fixed default limit
+                    }
+                }
+
 
                 var defer = module._q.defer();
 

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -377,7 +377,10 @@
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:table-display": {
-                    "row_order": [{"column":"name", "descending":false}]
+                    "row_order": [{"column":"name", "descending":false}],
+                    "detailed": {
+                        "page_size" : 6
+                    }
                 }
             }
         },

--- a/test/specs/reference/tests/04.paging.js
+++ b/test/specs/reference/tests/04.paging.js
@@ -9,12 +9,62 @@ exports.execute = function (options) {
     //   2. Next with no more data
     //   3. Previous with more data
     //   4. Previous with no more data
-    
+
     describe("For paging with previous and next,", function () {
         var catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "reference_schema",
             tableNameNoSort = "paging_table_no_sort",
             tableNameWSort = "paging_table_w_sort";
+
+        describe('page size, ', function() {
+            var limit = 5,
+                detailedLimit = 6,
+                defaultLimit = 1,
+                uri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":" + tableNameWSort;
+
+            var reference, contextualizedReference;
+
+            beforeAll(function (done) {
+                options.ermRest.resolve(uri, {cid: "test"}).then(function(response) {
+                    reference = response;
+                    contextualizedReference = response.contextualize.detailed;
+                    done();
+                }, function(err) {
+                    console.dir(err);
+                    done.fail();
+                })
+            });
+
+            it('should be the value that is defined in read() function', function(done) {
+                contextualizedReference.read(limit).then(function(response){
+                    expect(response._data.length).toBe(limit);
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('should use the value defined in `page_size` in Table Display annotation when `limit` in read() is not defined.', function() {
+                contextualizedReference.read().then(function(response){
+                    expect(response._data.length).toBe(detailedLimit);
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('should use default value(1) when `limit` in read() and `page_size` in Table Display annotation are not defined.', function() {
+                reference.read().then(function(response){
+                    expect(response._data.length).toBe(defaultLimit);
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+        });
 
 
         describe("Paging table with no sort", function() {


### PR DESCRIPTION
This PR, adds default value for page size in read function.

If the limit is not defined, it will look for `page_size` in Table Display annotation, using the current context. Otherwise, it will use "1" as a default page size.

Related Issue: #177 