### PR TITLE
Resolve Issue #184 (Extract Contextualize class)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -194,16 +194,12 @@ to use for ERMrest JavaScript agents.
         * [.setBinaryPredicate(colname, operator, value)](#ERMrest.ParsedFilter+setBinaryPredicate)
     * [.Reference](#ERMrest.Reference)
         * [new Reference(location)](#new_ERMrest.Reference_new)
+        * [.contextualize](#ERMrest.Reference+contextualize)
         * [.displayname](#ERMrest.Reference+displayname) : <code>string</code>
         * [.uri](#ERMrest.Reference+uri) : <code>string</code>
         * [.session](#ERMrest.Reference+session)
         * [.columns](#ERMrest.Reference+columns) : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
         * [.isUnique](#ERMrest.Reference+isUnique) : <code>boolean</code>
-        * [.contextualize](#ERMrest.Reference+contextualize)
-            * [.detailed](#ERMrest.Reference+contextualize.detailed) : <code>[Reference](#ERMrest.Reference)</code>
-            * [.compact](#ERMrest.Reference+contextualize.compact) : <code>[Reference](#ERMrest.Reference)</code>
-            * [.compactBrief](#ERMrest.Reference+contextualize.compactBrief) : <code>[Reference](#ERMrest.Reference)</code>
-            * [.entry](#ERMrest.Reference+contextualize.entry) : <code>[Reference](#ERMrest.Reference)</code>
         * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> &#124; <code>undefined</code>
         * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> &#124; <code>undefined</code>
         * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
@@ -1742,16 +1738,12 @@ Constructor for a ParsedFilter.
 
 * [.Reference](#ERMrest.Reference)
     * [new Reference(location)](#new_ERMrest.Reference_new)
+    * [.contextualize](#ERMrest.Reference+contextualize)
     * [.displayname](#ERMrest.Reference+displayname) : <code>string</code>
     * [.uri](#ERMrest.Reference+uri) : <code>string</code>
     * [.session](#ERMrest.Reference+session)
     * [.columns](#ERMrest.Reference+columns) : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
     * [.isUnique](#ERMrest.Reference+isUnique) : <code>boolean</code>
-    * [.contextualize](#ERMrest.Reference+contextualize)
-        * [.detailed](#ERMrest.Reference+contextualize.detailed) : <code>[Reference](#ERMrest.Reference)</code>
-        * [.compact](#ERMrest.Reference+contextualize.compact) : <code>[Reference](#ERMrest.Reference)</code>
-        * [.compactBrief](#ERMrest.Reference+contextualize.compactBrief) : <code>[Reference](#ERMrest.Reference)</code>
-        * [.entry](#ERMrest.Reference+contextualize.entry) : <code>[Reference](#ERMrest.Reference)</code>
     * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> &#124; <code>undefined</code>
     * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> &#124; <code>undefined</code>
     * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
@@ -1784,6 +1776,25 @@ Usage:
 | --- | --- | --- |
 | location | <code>ERMrest.Location</code> | The location object generated from parsing the URI |
 
+<a name="ERMrest.Reference+contextualize"></a>
+
+#### reference.contextualize
+The members of this object are _contextualized references_.
+
+These references will behave and reflect state according to the mode.
+For instance, in a `record` mode on a table some columns may be
+hidden.
+
+Usage:
+```
+// assumes we have an uncontextualized `Reference` object
+var recordref = reference.contextualize.detailed;
+```
+The `reference` is unchanged, while `recordref` now represents a
+reconfigured reference. For instance, `recordref.columns` may be
+different compared to `reference.columns`.
+
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+displayname"></a>
 
 #### reference.displayname : <code>string</code>
@@ -1855,56 +1866,6 @@ console.log("This reference is unique?", (reference.isUnique ? 'yes' : 'no'));
 ```
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
-<a name="ERMrest.Reference+contextualize"></a>
-
-#### reference.contextualize
-The members of this object are _contextualized references_.
-
-These references will behave and reflect state according to the mode.
-For instance, in a `record` mode on a table some columns may be
-hidden.
-
-Usage:
-```
-// assumes we have an uncontextualized `Reference` object
-var recordref = reference.contextualize.detailed;
-```
-The `reference` is unchanged, while `recordref` now represents a
-reconfigured reference. For instance, `recordref.columns` may be
-different compared to `reference.columns`.
-
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
-
-* [.contextualize](#ERMrest.Reference+contextualize)
-    * [.detailed](#ERMrest.Reference+contextualize.detailed) : <code>[Reference](#ERMrest.Reference)</code>
-    * [.compact](#ERMrest.Reference+contextualize.compact) : <code>[Reference](#ERMrest.Reference)</code>
-    * [.compactBrief](#ERMrest.Reference+contextualize.compactBrief) : <code>[Reference](#ERMrest.Reference)</code>
-    * [.entry](#ERMrest.Reference+contextualize.entry) : <code>[Reference](#ERMrest.Reference)</code>
-
-<a name="ERMrest.Reference+contextualize.detailed"></a>
-
-##### contextualize.detailed : <code>[Reference](#ERMrest.Reference)</code>
-The _record_ context of this reference.
-
-**Kind**: static property of <code>[contextualize](#ERMrest.Reference+contextualize)</code>  
-<a name="ERMrest.Reference+contextualize.compact"></a>
-
-##### contextualize.compact : <code>[Reference](#ERMrest.Reference)</code>
-The _compact_ context of this reference.
-
-**Kind**: static property of <code>[contextualize](#ERMrest.Reference+contextualize)</code>  
-<a name="ERMrest.Reference+contextualize.compactBrief"></a>
-
-##### contextualize.compactBrief : <code>[Reference](#ERMrest.Reference)</code>
-The _compact/brief_ context of this reference.
-
-**Kind**: static property of <code>[contextualize](#ERMrest.Reference+contextualize)</code>  
-<a name="ERMrest.Reference+contextualize.entry"></a>
-
-##### contextualize.entry : <code>[Reference](#ERMrest.Reference)</code>
-The _entry_ context of this reference.
-
-**Kind**: static property of <code>[contextualize](#ERMrest.Reference+contextualize)</code>  
 <a name="ERMrest.Reference+canCreate"></a>
 
 #### reference.canCreate : <code>boolean</code> &#124; <code>undefined</code>

--- a/js/reference.js
+++ b/js/reference.js
@@ -133,7 +133,24 @@ var ERMrest = (function(module) {
      */
     function Reference(location) {
         this._location   = location;
-        this.contextualize._reference = this;
+
+        /**
+         * The members of this object are _contextualized references_.
+         *
+         * These references will behave and reflect state according to the mode.
+         * For instance, in a `record` mode on a table some columns may be
+         * hidden.
+         *
+         * Usage:
+         * ```
+         * // assumes we have an uncontextualized `Reference` object
+         * var recordref = reference.contextualize.detailed;
+         * ```
+         * The `reference` is unchanged, while `recordref` now represents a
+         * reconfigured reference. For instance, `recordref.columns` may be
+         * different compared to `reference.columns`.
+         */
+        this.contextualize = new Contextualize(this);
     }
 
     Reference.prototype = {
@@ -233,83 +250,6 @@ var ERMrest = (function(module) {
              * on-demand.
              */
             return undefined; // TODO
-        },
-
-        /**
-         * The members of this object are _contextualized references_.
-         *
-         * These references will behave and reflect state according to the mode.
-         * For instance, in a `record` mode on a table some columns may be
-         * hidden.
-         *
-         * Usage:
-         * ```
-         * // assumes we have an uncontextualized `Reference` object
-         * var recordref = reference.contextualize.detailed;
-         * ```
-         * The `reference` is unchanged, while `recordref` now represents a
-         * reconfigured reference. For instance, `recordref.columns` may be
-         * different compared to `reference.columns`.
-         */
-        contextualize: {
-            /* TODO: you'll need to figure out how to allow the following
-             * getters to have access to `this` with respect to the Refernece
-             * object not the nested contextualize object. A simple test can be
-             * done. The brute force way would be to introduce a `Contextualize`
-             * class that gets instantiated. Or a better less brute force way
-             * would be to have another lazy getter for the contextualize
-             * property.
-             */
-
-            /**
-             * The _record_ context of this reference.
-             * @type {ERMrest.Reference}
-             */
-            get detailed() {
-                return this._contextualize(module._contexts.DETAILED);
-            },
-
-            /**
-             * The _compact_ context of this reference.
-             * @type {ERMrest.Reference}
-             */
-            get compact() {
-                return this._contextualize(module._contexts.COMPACT);
-            },
-
-            /**
-             * The _compact/brief_ context of this reference.
-             * @type {ERMrest.Reference}
-             */
-            get compactBrief() {
-                return this._contextualize(module._contexts.COMPACT_BRIEF);
-            },
-
-            _contextualize: function(context) {
-                var source = this._reference;
-                var newRef = _referenceCopy(source);
-                delete newRef._related;
-                var columnOrders = source._table.columns._contextualize(context).all();
-
-                newRef._context = context;
-                newRef._columns = [];
-                for (var i = 0; i < columnOrders.length; i++) {
-                    var column = columnOrders[i];
-                    if (source._columns.indexOf(column) != -1) {
-                        newRef._columns.push(column);
-                    }
-                }
-                return newRef;
-            },
-
-            /**
-             * The _entry_ context of this reference.
-             * @type {ERMrest.Reference}
-             */
-            get entry() {
-                // TODO: remember these are copies of this reference.
-                return undefined;
-            }
         },
 
         /**
@@ -709,13 +649,13 @@ var ERMrest = (function(module) {
                     visibleFKs = this._table.referredBy.all();
                 }
 
-                var i, j, col, fkr;
+                var i, j, col, fkr, newRef;
                 for(i = 0; i < visibleFKs.length; i++) {
                     fkr = visibleFKs[i];
 
-                    var newRef = _referenceCopy(this);
-                    newRef.contextualize._reference = newRef;
+                    newRef = _referenceCopy(this);
                     delete newRef._context; // NOTE: related reference is not contextualized
+                    delete newRef._related;
 
                     var fkrTable = fkr.colset.columns[0].table;
                     if (fkrTable._isPureBinaryAssociation()) { // Association Table
@@ -759,7 +699,7 @@ var ERMrest = (function(module) {
                         newRef._related_key_column_positions = fkr.key.colset._getColumnPositions();
                         newRef._related_fk_column_positions = fkr.colset._getColumnPositions();
                     }
-
+                    
                     this._related.push(newRef);
                 }
 
@@ -796,8 +736,58 @@ var ERMrest = (function(module) {
         var referenceCopy = Object.create(Reference.prototype);
         // referenceCopy must be defined before _clone can copy values from source to referenceCopy
         module._clone(referenceCopy, source);
+
+        referenceCopy.contextualize = new Contextualize(referenceCopy);
         return referenceCopy;
     }
+
+    function Contextualize(reference) {
+        this._reference = reference;
+    }
+
+    Contextualize.prototype = {
+
+        /**
+         * The _record_ context of this reference.
+         * @type {ERMrest.Reference}
+         */
+        get detailed() {
+            return this._contextualize(module._contexts.DETAILED);
+        },
+
+        /**
+         * The _compact_ context of this reference.
+         * @type {ERMrest.Reference}
+         */
+        get compact() {
+            return this._contextualize(module._contexts.COMPACT);
+        },
+
+        /**
+         * The _compact/brief_ context of this reference.
+         * @type {ERMrest.Reference}
+         */
+        get compactBrief() {
+            return this._contextualize(module._contexts.COMPACT_BRIEF);
+        },
+
+        _contextualize: function(context) {
+            var source = this._reference;
+            var newRef = _referenceCopy(source);
+            delete newRef._related;
+
+            newRef._context = context;
+            var columnOrders = source._table.columns._contextualize(context).all();
+            newRef._columns = [];
+            for (var i = 0; i < columnOrders.length; i++) {
+                var column = columnOrders[i];
+                if (source._columns.indexOf(column) != -1) {
+                    newRef._columns.push(column);
+                }
+            }
+            return newRef;
+        }
+    };
 
     /**
      * Constructs a new Page. A _page_ represents a set of results returned from


### PR DESCRIPTION
Related Issue: #184 


**Why**
To create a new copy of `Reference` we use `_referenceCopy`. This function creates a new Reference and copies all the attributes of the current Reference object into the new one. Now if an attribute is an object, it will copy the reference of this object.

In `Reference` we have an object called `contextualize`. Using `_referenceCopy` in `Reference` just copies the reference of `contextualize` attributes. Therefore after
```javascript
var newRef = _referenceCopy(ref);
```
`newRef.contextualize` and `ref.contextualize` point to the same object and changing `newRef.contextualize._reference` will result in changing `ref.contextualize._reference`.

In `Reference.related`I used
```javascript
var newRef = _reference(this);
newRef.contextualize._reference = newRef;
```
Based on what I said, this will change`this.contextualize._reference` too. And since I am doing this for all the related references, all of them will have the same `contextualize._reference`.

**Solution**
The main issue is setting a pointer to `Reference` in `contextualize`. To avoid the problem, I extracted `contextualize` as a separate Class. Now instead of changing attributes of `contextualize`, I just create a new `Contextualize` object (`_referenceCopy` function takes care of this).


