### PR TITLE
Updated URL parser to handle simple entity linking #190

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -121,17 +121,25 @@ var ERMrest = (function(module) {
         // Expected format: "[schema_name:]table_name[/{attribute::op::value}{&attribute::op::value}*]"
         parts = this._compactPath.split('/');
 
+        // if has linking, use the last part as the main table
+        var linking = parts[parts.length - 1].match(/(\(.*\)=\(.*:.*:.*\))/);
+        if (linking && linking[1]) {
+            var rightParts = linking[1].split("=")[1].match(/\(([^:]*):([^:]*):([^\)]*)\)/);
+            this._schemaName = rightParts[1];
+            this._tableName = rightParts[2];
+        }
+
         // first schema name and first table name
         // we can't handle complex path right now, only knows the first schema and table
         // so after doing a Reference.relate() and generate a new uri/location, we don't have schema/table information here
         if (parts[0]) {
             var params = parts[0].split(':');
             if (params.length > 1) {
-                this._firstSchemaName = decodeURIComponent(params[0]);
-                this._firstTableName = decodeURIComponent(params[1]);
+                this._projectionSchemaName = decodeURIComponent(params[0]);
+                this._projectionTableName = decodeURIComponent(params[1]);
             } else {
-                this._firstSchemaName = '';
-                this._firstTableName = decodeURIComponent(params[0]);
+                this._projectionSchemaName = '';
+                this._projectionTableName = decodeURIComponent(params[0]);
             }
         }
 
@@ -268,16 +276,32 @@ var ERMrest = (function(module) {
          *
          * @returns {string} The schema name in the projection table
          */
-        get firstSchemaName() {
-            return this._firstSchemaName;
+        get projectionSchemaName() {
+            return this._projectionSchemaName;
         },
 
         /**
          * Subject to change soon
          * @returns {string} The table name in the projection table
          */
-        get firstTableName() {
-            return this._firstTableName;
+        get projectionTableName() {
+            return this._projectionTableName;
+        },
+
+        /**
+         *
+         * @returns {string} the schema name which the uri referres to
+         */
+        get schemaName() {
+            return (this._schemaName? this._schemaName : this._projectionSchemaName);
+        },
+
+        /**
+         *
+         * @returns {string} the table name which the uri referres to
+         */
+        get tableName() {
+            return (this._tableName? this._tableName : this._projectionTableName);
         },
 
         /**

--- a/js/reference.js
+++ b/js/reference.js
@@ -69,7 +69,7 @@ var ERMrest = (function(module) {
             server.catalogs.get(reference._location.catalog).then(function (catalog) {
                 reference._meta = catalog.meta;
 
-                reference._table   = catalog.schemas.get(reference._location.firstSchemaName).tables.get(reference._location.firstTableName);
+                reference._table   = catalog.schemas.get(reference._location.schemaName).tables.get(reference._location.tableName);
                 reference._columns = reference._table.columns.all();
                 reference._shortestKey = reference._table.shortestKey;
 

--- a/test/specs/parser/tests/01.parser.js
+++ b/test/specs/parser/tests/01.parser.js
@@ -26,8 +26,8 @@ exports.execute = function (options) {
                 expect(location.sortObject).toBe(null);
                 expect(location.paging).toBeUndefined();
                 expect(location.pagingObject).toBe(null);
-                expect(location.firstSchemaName).toBe(schemaName);
-                expect(location.firstTableName).toBe(tableName);
+                expect(location.schemaName).toBe(schemaName);
+                expect(location.tableName).toBe(tableName);
                 expect(location._firstFilter instanceof options.ermRest.ParsedFilter).toBe(true);
             });
 
@@ -74,8 +74,8 @@ exports.execute = function (options) {
                 expect(location.pagingObject.row.length).toBe(1);
                 expect(location.pagingObject.row[0]).toBe("some random text");
                 expect(location.catalog).toBe(catalogId.toString());
-                expect(location.firstSchemaName).toBe(schemaName);
-                expect(location.firstTableName).toBe(tableName);
+                expect(location.schemaName).toBe(schemaName);
+                expect(location.tableName).toBe(tableName);
                 expect(location._firstFilter instanceof options.ermRest.ParsedFilter).toBe(true);
             });
 
@@ -123,8 +123,8 @@ exports.execute = function (options) {
                 expect(location.sortObject).toBe(null);
                 expect(location.paging).toBeUndefined();
                 expect(location.pagingObject).toBe(null);
-                expect(location.firstSchemaName).toBe(schemaName);
-                expect(location.firstTableName).toBe(tableName);
+                expect(location.schemaName).toBe(schemaName);
+                expect(location.tableName).toBe(tableName);
                 expect(location._firstFilter instanceof options.ermRest.ParsedFilter).toBe(true);
             });
 
@@ -145,6 +145,68 @@ exports.execute = function (options) {
                 expect(filter2.column).toBe("id");
                 expect(filter2.operator).toBe("=");
                 expect(filter2.value).toBe(secondEntityId.toString());
+            });
+        });
+
+        describe('Entity linking,', function() {
+            var parsedFilter;
+            var lowerLimit = 1,
+                upperLimit = 10,
+                sort = "id,summary",
+                text = "some%20random%20text",
+                tableName2 = "parse_table_2";
+            var complexPath = "/catalog/" + catalogId + "/entity/" + schemaName + ":"
+                + tableName + "/id::gt::" + lowerLimit + "&id::lt::" + upperLimit + "/(id)=(" + schemaName + ":" + tableName2 + ":id2)"
+                + "@sort(" + sort + ")" + "@after(" + text + ")";
+
+            it('_parse should take a uri with multiple filters and return a location object.', function() {
+                var location = options.ermRest._parse(options.url + complexPath);
+                parsedFilter = location._firstFilter;
+
+                expect(location).toBeDefined();
+                expect(location.uri).toBe(options.url + complexPath);
+                expect(location.compactUri).toBe(options.url + "/catalog/" + catalogId + "/entity/" + schemaName + ":"
+                    + tableName + "/id::gt::" + lowerLimit + "&id::lt::" + upperLimit + "/(id)=(" + schemaName + ":" + tableName2 + ":id2)") ;
+                expect(location.api).toBe("entity");
+                expect(location.path).toBe(schemaName + ":"
+                    + tableName + "/id::gt::" + lowerLimit + "&id::lt::" + upperLimit + "/(id)=(" + schemaName + ":" + tableName2 + ":id2)"
+                    + "@sort(" + sort + ")"  + "@after(" + text + ")");
+                expect(location.compactPath).toBe(schemaName + ":"
+                    + tableName + "/id::gt::" + lowerLimit + "&id::lt::" + upperLimit + "/(id)=(" + schemaName + ":" + tableName2 + ":id2)" );
+                expect(location.sort).toBe("@sort(" + sort + ")");
+                expect(location.sortObject[0].column).toBe("id");
+                expect(location.sortObject[0].descending).toBe(false);
+                expect(location.sortObject[1].column).toBe("summary");
+                expect(location.sortObject[1].descending).toBe(false);
+                expect(location.paging).toBe("@after(" + text + ")");
+                expect(location.pagingObject.before).toBe(false);
+                expect(location.pagingObject.row.length).toBe(2);
+                expect(location.pagingObject.row[0]).toBe("some random text");
+                expect(location.catalog).toBe(catalogId.toString());
+                expect(location.projectionSchemaName).toBe(schemaName);
+                expect(location.projectionTableName).toBe(tableName);
+                expect(location.schemaName).toBe(schemaName);
+                expect(location.tableName).toBe(tableName2);
+                expect(location._firstFilter instanceof options.ermRest.ParsedFilter).toBe(true);
+            });
+
+            it('parsedFilter should have methods and values properly defined.', function() {
+                expect(parsedFilter).toBeDefined();
+
+                expect(parsedFilter.type).toBe("Conjunction");
+                expect(parsedFilter.filters).toBeDefined();
+
+                var filter1 = parsedFilter.filters[0];
+                expect(filter1.type).toBe("BinaryPredicate");
+                expect(filter1.column).toBe("id");
+                expect(filter1.operator).toBe("::gt::");
+                expect(filter1.value).toBe(lowerLimit.toString());
+
+                var filter2 = parsedFilter.filters[1];
+                expect(filter2.type).toBe("BinaryPredicate");
+                expect(filter2.column).toBe("id");
+                expect(filter2.operator).toBe("::lt::");
+                expect(filter2.value).toBe(upperLimit.toString());
             });
         });
     });

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -38,8 +38,8 @@ exports.execute = function (options) {
                 expect(reference._location.uri).toBe(singleEnitityUri);
                 expect(reference._location.service).toBe(options.url);
                 expect(reference._location.catalog).toBe(catalog_id.toString());
-                expect(reference._location.firstSchemaName).toBe(schemaName);
-                expect(reference._location.firstTableName).toBe(tableName);
+                expect(reference._location.schemaName).toBe(schemaName);
+                expect(reference._location.tableName).toBe(tableName);
 
                 expect(reference.contextualize._reference).toBe(reference);
             });

--- a/test/support/single.spec.js
+++ b/test/support/single.spec.js
@@ -1,7 +1,7 @@
 require('./../utils/starter.spec.js').runTests({
     description: 'In reference,',
     testCases: [
-        "/reference/tests/05.reference_values.js"
+        "/reference/tests/01.reference_values.js"
     ],
     schemaConfigurations: [
         "/reference/conf/reference.conf.json",


### PR DESCRIPTION
Changes for #190 
Updated the parser to handle URL with entity linking. This allows record-two to link related tables to recordset.