### PR TITLE
Sort key columns #195.

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1770,6 +1770,14 @@ var ERMrest = (function (module) {
             uniqueColumns.push(col);
             col.memberOfKeys.push(this);
         }
+        // sort columns by name
+        uniqueColumns.sort(function(c1, c2) {
+            if (c1.name < c2.name)
+                return -1;
+            if (c1.name > c2.name)
+                return 1;
+            return 0;
+        });
 
         /**
          * @type {ERMrest.ColSet}

--- a/test/specs/annotation/tests/03.table_display.js
+++ b/test/specs/annotation/tests/03.table_display.js
@@ -153,12 +153,12 @@ exports.execute = function (options) {
                 });
             });
 
-            it('tuple displayname should return "id:label" column.', function() {
+            it('tuple displayname should return "description:id" column.', function() {
                 var tuples = page.tuples;
                 for(var i = 0; i < limit; i++) {
                     var tuple = tuples[i];
                     var displayname = tuple.displayname;
-                    expect(displayname).toBe(tuple.values[0] + ":" + tuple.values[1]);
+                    expect(displayname).toBe(tuple.values[1] + ":" + tuple.values[0]);
                 }
             });
         });

--- a/test/support/single.spec.js
+++ b/test/support/single.spec.js
@@ -1,10 +1,9 @@
 require('./../utils/starter.spec.js').runTests({
     description: 'In reference,',
     testCases: [
-        "/reference/tests/01.reference_values.js"
+        "/annotation/tests/03.table_display.js"
     ],
     schemaConfigurations: [
-        "/reference/conf/reference.conf.json",
-        "/reference/conf/reference_2.conf.json"
+        "/annotation/conf/table_display.conf.json"
     ]
 });


### PR DESCRIPTION
PR for #195 
This issue addresses a problem in testing where a tuple's displayname (a list of key's column names) is in random order. This PR sorts the key columns alphabetically so we can expect the column's ordering.