### PR TITLE
Use MalformedURIError

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -79,11 +79,11 @@ var ERMrest = (function(module) {
                             if (!schema)
                                 schema = schemas[i];
                             else
-                                throw new Error("Ambiguous table name " + reference._location.tableName + ". Schema name is required.");
+                                throw new module.MalformedURIError("Ambiguous table name " + reference._location.tableName + ". Schema name is required.");
                         }
                     }
                     if (!schema)
-                        throw new Error("Table " + reference._location.tableName + " not found");
+                        throw new module.MalformedURIError("Table " + reference._location.tableName + " not found");
 
                     reference._table = schema.tables.get(reference._location.tableName);
                 } else


### PR DESCRIPTION
Use MalformedURIError when invalid URI components instead of general Error.