### PR TITLE
Change template rendering according to issue #218

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1438,7 +1438,7 @@ var ERMrest = (function (module) {
             }
 
             // If value is null or empty, return value on basis of `show_nulls`
-            if (value === null || value === '') {
+            if (value === null || value.trim() === '') {
                 return { isHTML: false, value: this._getNullValue(options ? options.context : undefined) };
             }
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -1088,7 +1088,7 @@ var ERMrest = (function(module) {
                         var value = module._renderTemplate(this._ref.display._markdownPattern, keyValues);
 
                         // If value is null or empty, return value on basis of `show_nulls`
-                        if (value === null || value === '') {
+                        if (value === null || value.trim() === '') {
                             value = module._getNullValue(this, this._ref.context, [this._ref.table, this._ref.table.schema]);
                         }
 
@@ -1346,7 +1346,7 @@ var ERMrest = (function(module) {
                     var pattern = module._renderTemplate(template, keyValues);
 
                     // Render markdown content for the pattern
-                    this._displayname = module._formatUtils.printMarkdown(pattern, { inline: true });
+                    this._displayname = (pattern === null || pattern.trim() === '') ? "" : module._formatUtils.printMarkdown(pattern, { inline: true });
                 }
                 // no row_name annotation, use column with title, name, term, label or id:text type
                 // or use the unique key

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -785,7 +785,36 @@ var ERMrest = (function(module) {
             });
         }
 
-        return module._mustache.render(template, obj);
+        var conditionalRegex = /\{\{(#|\^)(\w+)\}\}/;
+
+        // If no conditional Mustache statements of the form {{#var}}{{/var1}} not found thne do direct null check
+        if (!conditionalRegex.exec(template)) {
+
+            /* 
+             * Code to do template/string replacement using values and set pattern as null if any of the
+             * values turn out to be null or undefined
+             */
+            for (var key in keyValues) {
+                var search = "{{" + key + "}}";
+       
+                // Check for a match for the search string
+                if (template.match(search)) {
+                    if (keyValues[key] === null || keyValues[key] === undefined) {
+                       return null;
+                    } 
+                }
+            }
+        }
+
+        var content;
+
+        try {
+            content = module._mustache.render(template, obj);
+        } catch(e) {
+            content = null;
+        }
+
+        return content;
     };
 
     /**

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -136,9 +136,10 @@ exports.execute = function (options) {
         it('module._renderTemplate() should function correctly', function() {
             expect(module._renderTemplate("My name is {{name}}", {name: 'John'})).toBe("My name is John");
             expect(module._renderTemplate("My name is {{name}}", { name: null })).toBe(null);
+            expect(module._renderTemplate("My name is {{name}}", {})).toBe(null);
             expect(module._renderTemplate("My name is {{#name}}{{name}}{{/name}}", {})).toBe("My name is ");
             expect(module._renderTemplate("My name is {{^name}}{{name}}{{/name}}", {})).toBe("My name is ");
-             expect(module._renderTemplate("My name is {{^name}}John{{/name}}", {})).toBe("My name is John");
+            expect(module._renderTemplate("My name is {{^name}}John{{/name}}", {})).toBe("My name is John");
         });
 
     });

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -103,6 +103,7 @@ exports.execute = function (options) {
             expect(printMarkdown(dropdownMarkdown)).toBe(dropdownHTML);  
 
             expect(printMarkdown(iframeMarkdown + "\n" + dropdownMarkdown)).toBe(iframeHTML + dropdownHTML);
+
         });
 
         it('printGeneSeq() should format gene sequences correctly.', function() {
@@ -130,6 +131,14 @@ exports.execute = function (options) {
                 expect(printGeneSeq(testCase.input, {increment: -34})).toBe(testCase.negativeIncrement);
                 expect(printGeneSeq(testCase.input, {separator: '-', increment: 5})).toBe(testCase.incrementOf5WithDashes);
             }
+        });
+
+        it('module._renderTemplate() should function correctly', function() {
+            expect(module._renderTemplate("My name is {{name}}", {name: 'John'})).toBe("My name is John");
+            expect(module._renderTemplate("My name is {{name}}", { name: null })).toBe(null);
+            expect(module._renderTemplate("My name is {{#name}}{{name}}{{/name}}", {})).toBe("My name is ");
+            expect(module._renderTemplate("My name is {{^name}}{{name}}{{/name}}", {})).toBe("My name is ");
+             expect(module._renderTemplate("My name is {{^name}}John{{/name}}", {})).toBe("My name is John");
         });
 
     });

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -145,18 +145,18 @@ exports.execute = function (options) {
         describe('for tuple 2 with row values {"id":4002, "url": "https://www.google.com"},', function() {
 
             var values = ['4002',
-                          '<h2></h2>\n',
+                          null,
                           '',
                           '<p><img src="http://example.com/4002.png" alt="image"></p>\n',
                           '<p><img src="https://www.google.com/4002.png" alt="image with size" width="400" height="400"></p>\n',
                           '<p><a href="https://www.google.com" download="">download link</a></p>\n',
-                          '<div class="embed-block"><div class="embed-caption"> caption</div><iframe src="http://example.com/iframe" width="300" ></iframe></div>',
+                          '',
                           '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '<p><strong>Name is :</strong><br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                          '',
                           ''];
 
             // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, false, true, true, true, true, true, true, true];
+            var isHTML = [false, false, false, true, true, true, false, true, false, true];
 
             testTupleValidity(2, values, isHTML);
         });
@@ -164,17 +164,17 @@ exports.execute = function (options) {
         describe('for tuple 3 with row values {"id":4003 },', function() {
 
             var values = ['4003',
-                          '<h2></h2>\n',
+                          null,
                           '',
                           '<p><img src="http://example.com/4003.png" alt="image"></p>\n',
                           '<p><img src="/4003.png" alt="image with size" width="400" height="400"></p>\n',
                           '<p><a href="" download="">download link</a></p>\n',
-                          '<div class="embed-block"><div class="embed-caption"> caption</div><iframe src="http://example.com/iframe" width="300" ></iframe></div>',
+                          '',
                           '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '<p><strong>Name is :</strong><br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                          '',
                           ''];
             // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, false, true, true, true, true, true, true, true];
+            var isHTML = [false, false, false, true, true, true, false, true, false, true];
 
             testTupleValidity(3, values, isHTML);
         });

--- a/test/support/single.spec.js.sample
+++ b/test/support/single.spec.js.sample
@@ -1,6 +1,6 @@
 require('./../utils/starter.spec.js').runTests({
     description: 'In print utilities, ',
     testCases: [
-        "/reference/tests/07.contextualize.js"
+        "/print_utils/tests/01.print_utils.js"
     ]
 });


### PR DESCRIPTION
Now the `_renderTemplate` function checks for existence of `{{#.*}}` or `{{^.*}}` strings in the template. If they're not present, then it explicitly checks for null values in the template, returning a null.