### PR TITLE
Fixed issue #224

### DIFF
--- a/js/utilities.js
+++ b/js/utilities.js
@@ -269,12 +269,17 @@ var ERMrest = (function(module) {
     module._getFormattedKeyValues = function(ref, data) {
         var keyValues = {};
 
-        for (var i = 0; i < ref.columns.length; i++) {
-            var col = ref.columns[i];
-            keyValues[col.name] = col.formatvalue(data[col.name], { context: ref._context });
-
+        for (var k in data) {
+            
+            try {
+                var col = ref._table.columns.get(k);
+                keyValues[k] = col.formatvalue(data[k], { context: ref._context });
+            } catch(e) {
+                keyValues[k] = data[k];
+            }
+            
             // Inject raw data in the keyvalues object prefixed with an '_'
-            keyValues["_" + col.name] = data[col.name];
+            keyValues["_" + k] = data[k];
         }
 
         return keyValues;

--- a/test/specs/reference/conf/reference_schema/data/reference_values.json
+++ b/test/specs/reference/conf/reference_schema/data/reference_values.json
@@ -1,7 +1,7 @@
 [{"id":4000, "some_markdown": "**date is :**", "name":"Hank", "url": "https://www.google.com", "some_gene_sequence": "GATCGATCGCGTATT" },
- {"id":4001, "name":"Harold"},
+ {"id":4001, "name":"Harold","some_invisible_column": "Junior"},
  {"id":4002, "url": "https://www.google.com"},
- {"id":4003},
- {"id":4004, "name": "weird & HTML < " },
- {"id":4005, "name": "<a href='javascript:alert();'></a>" },
- {"id":4006, "name": "<script>alert();</script>", "some_gene_sequence": "GATCGATCGCGTATT"}]
+ {"id":4003 ,"some_invisible_column": "Freshmen"},
+ {"id":4004, "name": "weird & HTML < "},
+ {"id":4005, "name": "<a href='javascript:alert();'></a>", "some_invisible_column": "Senior"},
+ {"id":4006, "name": "<script>alert();</script>", "some_gene_sequence": "GATCGATCGCGTATT", "some_invisible_column": "Sophomore"}]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -577,9 +577,33 @@
                     "type": {
                         "typename": "gene_sequence"
                     }
+                },
+                {
+                    "name": "column_using_invisble_column",
+                    "type" : {
+                        "typename": "text"
+                    },
+                    "annotations" : {
+                        "tag:isrd.isi.edu,2016:column-display" : {
+                            "*" : {
+                                "markdown_pattern" : "[{{some_invisible_column}}](http://example.com/{{some_invisible_column}})",
+                                "show_nulls": "NA"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "some_invisible_column",
+                    "type" : {
+                        "typename": "text"
+                    }
                 }
             ],
-            "annotations": { }
+            "annotations": { 
+                "tag:isrd.isi.edu,2016:visible-columns": {
+                  "*": ["id", "name", "url", "image", "image_with_size", "download_link", "iframe", "some_markdown", "some_markdown_with_pattern", "some_gene_sequence", "column_using_invisble_column"]
+                }
+            }
         }
     },
     "table_names": [

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -86,9 +86,9 @@ exports.execute = function (options) {
          */
         var testTupleValidity = function(tupleIndex, expectedValues, expectedIsHTMLValues) {
 
-            it("should return 10 values for a tuple", function() {
+            it("should return 12 values for a tuple", function() {
                 var values = tuples[tupleIndex].values;
-                expect(values.length).toBe(10);
+                expect(values.length).toBe(12);
             });
             
             checkValueAndIsHTML("id", tupleIndex, 0, expectedValues, expectedIsHTMLValues);
@@ -115,15 +115,16 @@ exports.execute = function (options) {
                           '<div class="embed-block"><div class="embed-caption">Hank caption</div><iframe src="http://example.com/iframe" width="300" ></iframe></div>',
                           '<p><strong>date is :</strong></p>\n',
                           '<p><strong>Name is :</strong> Hank\n<strong>date is :</strong></p>\n',
-                          '<code>GATCGATCGC GTATT</code>'];
+                          '<code>GATCGATCGC GTATT</code>',
+                          'NA'];
 
             // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, true, true, true, true, true, true, true, true];
+            var isHTML = [false, true, true, true, true, true, true, true, true, true, false];
 
             testTupleValidity(0, values, isHTML);
         });
 
-        describe('for tuple 1 with row values {"id":4001, "name":"Harold"},', function() {
+        describe('for tuple 1 with row values {"id":4001, "name":"Harold","some_invisible_column": "Junior"},', function() {
 
             var values = ['4001',
                           '<h2>Harold</h2>\n',
@@ -134,10 +135,11 @@ exports.execute = function (options) {
                           '<div class="embed-block"><div class="embed-caption">Harold caption</div><iframe src="http://example.com/iframe" width="300" ></iframe></div>',
                           '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
                           '<p><strong>Name is :</strong> Harold\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          ''];
+                          '',
+                          '<p><a href="http://example.com/Junior">Junior</a></p>\n'];
 
             // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, true, true, true, true, true, true, true, true];
+            var isHTML = [false, true, true, true, true, true, true, true, true, true, true];
 
             testTupleValidity(1, values, isHTML);            
         });
@@ -153,15 +155,16 @@ exports.execute = function (options) {
                           '',
                           '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
                           '',
-                          ''];
+                          '',
+                          'NA'];
 
             // Change last false to true once gene_sequence type is added
-            var isHTML = [false, false, false, true, true, true, false, true, false, true];
+            var isHTML = [false, false, false, true, true, true, false, true, false, true, false];
 
             testTupleValidity(2, values, isHTML);
         });
 
-        describe('for tuple 3 with row values {"id":4003 },', function() {
+        describe('for tuple 3 with row values {"id":4003 ,"some_invisible_column": "Freshmen"},', function() {
 
             var values = ['4003',
                           null,
@@ -172,9 +175,10 @@ exports.execute = function (options) {
                           '',
                           '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
                           '',
-                          ''];
+                          '',
+                          '<p><a href="http://example.com/Freshmen">Freshmen</a></p>\n'];
             // Change last false to true once gene_sequence type is added
-            var isHTML = [false, false, false, true, true, true, false, true, false, true];
+            var isHTML = [false, false, false, true, true, true, false, true, false, true, true];
 
             testTupleValidity(3, values, isHTML);
         });
@@ -190,15 +194,16 @@ exports.execute = function (options) {
                           '<div class="embed-block"><div class="embed-caption">weird &amp; HTML &lt;  caption</div><iframe src="http://example.com/iframe" width="300" ></iframe></div>',
                           '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
                           '<p><strong>Name is :</strong> weird &amp; HTML &lt;<br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          ''];
+                          '',
+                          'NA'];
 
             // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, true, true, true, true, true, true, true, true];
+            var isHTML = [false, true, true, true, true, true, true, true, true, true, false];
 
             testTupleValidity(4, values, isHTML);
         });
 
-        describe('for tuple 5 with row values {"id":4005, "name": "<a href=\'javascript:alert();\'></a>" },', function() {
+        describe('for tuple 5 with row values {"id":4005, "name": "<a href=\'javascript:alert();\'></a>" , "some_invisible_column": "Senior"},', function() {
 
             var values = ['4005',
                           '<h2>&lt;a href=\'javascript:alert();\'&gt;&lt;/a&gt;</h2>\n',
@@ -209,15 +214,16 @@ exports.execute = function (options) {
                           '<div class="embed-block"><div class="embed-caption">&lt;a href=‘javascript:alert();’&gt;&lt;/a&gt; caption</div><iframe src="http://example.com/iframe" width="300" ></iframe></div>',
                           '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
                           '<p><strong>Name is :</strong> &lt;a href=\'javascript:alert();\'&gt;&lt;/a&gt;\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          ''];
+                          '',
+                          '<p><a href="http://example.com/Senior">Senior</a></p>\n'];
 
             // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, true, true, true, true, true, true, true, true];
+            var isHTML = [false, true, true, true, true, true, true, true, true, true, true];
 
             testTupleValidity(5, values, isHTML);
         });
 
-        describe('for tuple 6 with row values {"id":4006, "name": "<script>alert();</script>", "some_gene_sequence": "GATCGATCGCGTATT" },', function() {
+        describe('for tuple 6 with row values {"id":4006, "name": "<script>alert();</script>", "some_gene_sequence": "GATCGATCGCGTATT" , "some_invisible_column": "Sophomore"},', function() {
 
             var values = ['4006',
                           '<h2>&lt;script&gt;alert();&lt;/script&gt;</h2>\n',
@@ -228,10 +234,11 @@ exports.execute = function (options) {
                           '<div class="embed-block"><div class="embed-caption">&lt;script&gt;alert();&lt;/script&gt; caption</div><iframe src="http://example.com/iframe" width="300" ></iframe></div>',
                           '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
                           '<p><strong>Name is :</strong> &lt;script&gt;alert();&lt;/script&gt;\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '<code>GATCGATCGC GTATT</code>'];
+                          '<code>GATCGATCGC GTATT</code>',
+                          '<p><a href="http://example.com/Sophomore">Sophomore</a></p>\n'];
 
             // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, true, true, true, true, true, true, true, true];
+            var isHTML = [false, true, true, true, true, true, true, true, true, true, true];
 
             testTupleValidity(6, values, isHTML);
         });


### PR DESCRIPTION
@hongsudt  Currently, the template only allow referencing to the visible column only. We need to allow the annotation to access the formatted value of any columns in the Tuple.

Instead of referring the `ref.colums`, I am referring the `ref._table.columns` to find the column and format it accordingly.