### PR TITLE
Enabled newline characters to be treated as <br>

### DIFF
--- a/js/node.js
+++ b/js/node.js
@@ -29,7 +29,7 @@ if (typeof module === 'object' && module.exports && typeof require === 'function
      * Inject _markdownIt module in ERMrest
      * Make markdownit use Sub, Sup and Attrs plugin
      */
-    ERMrest._markdownIt = require('markdown-it')()
+    ERMrest._markdownIt = require('markdown-it')({ typographer : true })
                             .use(require('markdown-it-sub')) // add subscript support
                             .use(require('markdown-it-sup')) // add superscript support;
                             .use(require('markdown-it-attrs')); // add attrs support
@@ -111,7 +111,7 @@ if (typeof module === 'object' && module.exports && typeof require === 'function
              * Inject _markdownIt module in ERMrest
              * Make markdownit use Sub, Sup and Attrs plugin
              */
-            ERMrest._markdownIt = window.markdownit()
+            ERMrest._markdownIt = window.markdownit({ typographer : true })
                     .use(window.markdownitSub)
                     .use(window.markdownitSup)
                     .use(window.markdownItAttrs);


### PR DESCRIPTION
Currently markdown parser strips down "\n" character. To avoid it doing that, I am enabling line breaks option.