### PR TITLE
Allow appLinkFn to take context in case tag is not defined.

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -841,8 +841,11 @@ var ERMrest = (function(module) {
             var tag = (this._context? this._table._getAppLink(this._context): this._table._getAppLink());
             if (tag && module._appLinkFn) {
                 return module._appLinkFn(tag, this._location);
-            } else
-                return undefined; // app link not specified by annotation
+            } else if (!tag && this._context)
+                return module._appLinkFn(null, this._location, this._context); // app link not specified by annotation
+            else {
+                return undefined;
+            }
         },
 
         setNewTable: function(table) {

--- a/test/specs/reference/tests/09.app_linking.js
+++ b/test/specs/reference/tests/09.app_linking.js
@@ -91,7 +91,7 @@ exports.execute = function (options) {
         describe('2. for app linking without table annotation,', function() {
             var reference, reference_d, reference_c, reference_e, result;
 
-            it('2.1 uncontextualized reference should have default (no app) link, ', function(done) {
+            it('2.1 uncontextualized reference should have default link, ', function(done) {
                 options.ermRest.appLinkFn(appLinkFn);
                 options.ermRest.resolve(base2Uri, {cid: "test"}).then(function (response) {
                     reference = response;


### PR DESCRIPTION
This is an extension to the app link issue that was already merged. This update allows chaise to determine default app link by providing context.