### PR TITLE
Improve shortest key algorithm using column names.

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -752,7 +752,7 @@ var ERMrest = (function (module) {
                             if (aSerial === bSerial) {
                                 for (var i = 0; i < a.colset.length(); i++) { // both key have same length
                                     var aName = a.colset.columns[i].name;
-                                    var bName = a.colset.columns[i].name;
+                                    var bName = b.colset.columns[i].name;
                                     if (aName < bName)
                                         return -1;
                                     if (aName > bName)

--- a/js/core.js
+++ b/js/core.js
@@ -748,7 +748,19 @@ var ERMrest = (function (module) {
                                 return (current.toUpperCase().startsWith("INT") || current.toUpperCase().startsWith("SERIAL"));
                             }) ? 1 : 0);
 
-                            return bSerial - aSerial; // will make a before b if negative, b before a if positive
+                            // two keys still equal, compare col name
+                            if (aSerial === bSerial) {
+                                for (var i = 0; i < a.colset.length(); i++) { // both key have same length
+                                    var aName = a.colset.columns[i].name;
+                                    var bName = a.colset.columns[i].name;
+                                    if (aName < bName)
+                                        return -1;
+                                    if (aName > bName)
+                                        return 1;
+                                }
+
+                            } else
+                                return bSerial - aSerial; // will make a before b if negative, b before a if positive
                         } else
                             return val;
                     });

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -88,6 +88,76 @@
                     }
                 }
             }
+        },
+        "multi_key_table": {
+            "comment": "",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id"
+                    ]
+                },
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "value"
+                    ]
+                },
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "a"
+                    ]
+                },
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id", "name"
+                    ]
+                }
+            ],
+            "entityCount": 0,
+            "foreign_keys": [],
+            "table_name": "multi_key_table",
+            "schema_name": "common_schema_2",
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "serial"
+                    }
+                },
+                {
+                    "name": "name",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "value",
+                    "nullok": false,
+                    "type": {
+                        "typename": "serial"
+                    }
+                },
+                {
+                    "name": "a",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "annotations": {
+            }
         }
     },
     "schema_name": "common_schema_2",

--- a/test/specs/common/tests/03.table.js
+++ b/test/specs/common/tests/03.table.js
@@ -1,0 +1,20 @@
+exports.execute = function(options) {
+
+    describe('About the Table class, ', function() {
+        var schemaName2 = 'common_schema_2', multi_key_table;
+
+        beforeAll(function(done) {
+            multi_key_table = options.catalog.schemas.get(schemaName2).tables.get('multi_key_table');
+            done();
+        });
+
+        // Test Cases:
+        describe('Table class, ', function() {
+
+            it('Shortest key', function(){
+                expect(multi_key_table.shortestKey.length).toBe(1);
+                expect(multi_key_table.shortestKey[0].name).toBe("id");
+            });
+        });
+    });
+};


### PR DESCRIPTION
If two keys are equal length and both are the same type, use column names to determine order.