### PR TITLE
Reference delete

### DIFF
--- a/js/http.js
+++ b/js/http.js
@@ -130,7 +130,7 @@ var ERMrest = (function (module) {
                             count += 1;
                             setTimeout(asyncfn, delay);
                             delay *= 2;
-                        } else if (count && method == 'delete' && response.status == _http_status_codes.not_found) {
+                        } else if (method == 'delete' && response.status == _http_status_codes.not_found) {
                             /* SPECIAL CASE: "retried delete"
                              * This indicates that a 'delete' was attempted, but
                              * failed due to a transient error. It was retried
@@ -140,13 +140,13 @@ var ERMrest = (function (module) {
                              * Both of the currently supported delete operations
                              * (entity/ and attribute/) return 204 No Content.
                              */
-                            response.status = _http_status_codes.no_content;
-                            
+                            response.status = response.statusCode = _http_status_codes.no_content;
+
                             module._onload().then(function() {
                                 deferred.resolve(response);
                             });
                         } else {
-                            
+
                             module._onload().then(function() {
                                 deferred.reject(response);
                             });

--- a/js/reference.js
+++ b/js/reference.js
@@ -750,7 +750,6 @@ var ERMrest = (function(module) {
                 };
 
                 this._server._http.delete(this.uri, config).then(function deleteReference(response) {
-                    console.log(response);
 
                     defer.resolve();
                 }, function error(response) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -741,8 +741,26 @@ var ERMrest = (function(module) {
          */
         delete: function() {
             try {
-                // TODO
-                notimplemented();
+                var defer = module._q.defer();
+
+                var config = {
+                    headers: {
+                        "If-Match": this._etag
+                    }
+                };
+
+                this._server._http.delete(this.uri, config).then(function deleteReference(response) {
+                    console.log(response);
+
+                    defer.resolve();
+                }, function error(response) {
+                    var error = module._responseToError(response);
+                    return defer.reject(error);
+                }).catch(function (error) {
+                    return defer.reject(error);
+                });
+
+                return defer.promise;
             }
             catch (e) {
                 return module._q.reject(e);

--- a/js/reference.js
+++ b/js/reference.js
@@ -305,7 +305,7 @@ var ERMrest = (function(module) {
             if (this._canRead === undefined) {
                 this._canRead = this._checkPermissions("content_read_user");
             }
-            return undefined;
+            return this._canRead;
         },
 
         /**

--- a/js/reference.js
+++ b/js/reference.js
@@ -290,7 +290,7 @@ var ERMrest = (function(module) {
          */
         get canCreate() {
             if (this._canCreate === undefined) {
-                this._canCreate = this._checkPermissions('content_write_user');
+                this._canCreate = this._checkPermissions("content_write_user");
             }
             return this._canCreate;
         },
@@ -302,6 +302,9 @@ var ERMrest = (function(module) {
          * @type {(boolean|undefined)}
          */
         get canRead() {
+            if (this._canRead === undefined) {
+                this._canRead = this._checkPermissions("content_read_user");
+            }
             return undefined;
         },
 
@@ -313,7 +316,7 @@ var ERMrest = (function(module) {
          */
         get canUpdate() {
             if (this._canUpdate === undefined) {
-                this._canUpdate = this._checkPermissions('content_write_user');
+                this._canUpdate = this._checkPermissions("content_write_user");
             }
             return this._canUpdate;
         },
@@ -325,7 +328,10 @@ var ERMrest = (function(module) {
          * @type {(boolean|undefined)}
          */
         get canDelete() {
-            return undefined;
+            if (this._canDelete === undefined) {
+                this._canDelete = this._checkPermissions("content_write_user");
+            }
+            return this._canUpdate;
         },
 
         /**

--- a/test/specs/errors/tests/04.entity_error.js
+++ b/test/specs/errors/tests/04.entity_error.js
@@ -4,7 +4,7 @@ var httpError = require('../helpers/http_error.js');
 exports.execute = function (options) {
 
     describe('For determining Entity Errors, ', function () {
-        var server = options.server, ermRest = options.ermRest, url = options.url.replace('ermrest', ''), ops = {allowUnmocked: true}, 
+        var server = options.server, ermRest = options.ermRest, url = options.url.replace('ermrest', ''), ops = {allowUnmocked: true},
         			catalog, schema, table, column, catalogId = 1, entityId = "8000";
 
 		httpError.setup(options);
@@ -16,7 +16,7 @@ exports.execute = function (options) {
             catalogId = options.catalogId;
 
             server._http.max_retries = 0;
-            
+
             table.keys.all().forEach(function(k) {
                 k.colset.columns.forEach(function(c) {
                     if (c.name == 'id') column = c;
@@ -115,7 +115,7 @@ exports.execute = function (options) {
 
         describe("Entity DELETE exceptions", function() {
 
-            httpError.testForErrors("DELETE", ["400", "401", "403", "404", "409", "500", "503"], function(error, done) {
+            httpError.testForErrors("DELETE", ["400", "401", "403", "409", "500", "503"], function(error, done) {
                 var filter = new ermRest.BinaryPredicate(table.columns.get(column.name), "=", entityId);
                 table.entity.delete(filter).then(null, function(err) {
                     expect(err instanceof ermRest[error.type]).toBeTruthy();

--- a/test/specs/reference/conf/delete.conf.json
+++ b/test/specs/reference/conf/delete.conf.json
@@ -1,0 +1,15 @@
+{
+    "catalog": {},
+    "schema": {
+        "name": "delete_schema",
+        "createNew": true,
+        "path": "test/specs/reference/conf/delete_schema/schema.json"
+    },
+    "tables": {
+        "createNew": true
+    },
+    "entities": {
+        "createNew": true,
+        "path": "test/specs/reference/conf/delete_schema/data"
+    }
+}

--- a/test/specs/reference/conf/delete_schema/data/delete_table.json
+++ b/test/specs/reference/conf/delete_schema/data/delete_table.json
@@ -1,0 +1,1 @@
+[{"key_col": 1, "text_col": "delete text", "int_col": 22}]

--- a/test/specs/reference/conf/delete_schema/schema.json
+++ b/test/specs/reference/conf/delete_schema/schema.json
@@ -1,0 +1,48 @@
+{
+    "schema_name": "delete_schema",
+    "tables": {
+        "delete_table": {
+            "comment": "Table to represent deleting entities",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "key_col"
+                    ]
+                }
+            ],
+            "foreign_keys": [],
+            "table_name": "delete_table",
+            "schema_name": "delete_schema",
+            "column_definitions": [
+                {
+                    "name": "key_col",
+                    "nullok": false,
+                    "type": {
+                        "typename": "int"
+                    }
+                }, {
+                    "name": "text_col",
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    }
+                }, {
+                    "name": "int_col",
+                    "nullok": true,
+                    "type": {
+                        "typename": "int"
+                    }
+                }
+            ],
+            "annotations": {}
+        }
+    },
+    "table_names": [
+        "delete_table"
+    ],
+    "comment": null,
+    "annotations": {}
+}

--- a/test/specs/reference/spec.js
+++ b/test/specs/reference/spec.js
@@ -10,12 +10,14 @@ require('./../../utils/starter.spec.js').runTests({
         "/reference/tests/07.contextualize.js",
         "/reference/tests/08.alternative_tables.js",
         "/reference/tests/09.app_linking.js",
-        "/reference/tests/10.update.js"
+        "/reference/tests/10.update.js",
+        "/reference/tests/11.delete.js"
     ],
     schemaConfigurations: [
         "/reference/conf/reference.conf.json",
         "/reference/conf/reference_2.conf.json",
         "/reference/conf/reference_altTables.conf.json",
-        "/reference/conf/update.conf.json"
+        "/reference/conf/update.conf.json",
+        "/reference/conf/delete.conf.json"
     ]
 });

--- a/test/specs/reference/tests/06.permissions.js
+++ b/test/specs/reference/tests/06.permissions.js
@@ -46,9 +46,22 @@ exports.execute = function (options) {
                 });
             });
 
-            it("should return true for canUpdate and canCreate.", function () {
-                expect(reference.canUpdate).toBeTruthy();
-                expect(reference.canCreate).toBeTruthy();
+            describe("should return true for ", function () {
+                it("canCreate.", function () {
+                    expect(reference.canCreate).toBeTruthy();
+                });
+
+                it("canRead.", function () {
+                    expect(reference.canRead).toBeTruthy();
+                });
+
+                it("canUpdate.", function () {
+                    expect(reference.canUpdate).toBeTruthy();
+                });
+
+                it("canDelete.", function () {
+                    expect(reference.canDelete).toBeTruthy();
+                });
             });
         });
 
@@ -86,9 +99,18 @@ exports.execute = function (options) {
                 });
             });
 
-            it("should return false for canUpdate and canCreate.", function () {
-                expect(reference.canUpdate).toBeFalsy();
-                expect(reference.canCreate).toBeFalsy();
+            describe("should return false for ", function () {
+                it("canCreate.", function () {
+                    expect(reference.canCreate).toBeFalsy();
+                });
+
+                it("canUpdate.", function () {
+                    expect(reference.canUpdate).toBeFalsy();
+                });
+
+                it("canDelete.", function () {
+                    expect(reference.canDelete).toBeFalsy();
+                });
             });
         });
 

--- a/test/specs/reference/tests/06.permissions.js
+++ b/test/specs/reference/tests/06.permissions.js
@@ -112,6 +112,10 @@ exports.execute = function (options) {
                     expect(reference.canDelete).toBeFalsy();
                 });
             });
+
+            it("should return true for canRead.", function () {
+                expect(reference.canRead).toBeTruthy();
+            });
         });
 
         afterEach(function () {

--- a/test/specs/reference/tests/11.delete.js
+++ b/test/specs/reference/tests/11.delete.js
@@ -1,0 +1,33 @@
+exports.execute = function (options) {
+
+    describe("deleting reference objects, ", function () {
+        var catalogId = process.env.DEFAULT_CATALOG,
+            schemaName = "delete_schema",
+            tableName = "delete_table";
+
+        var baseUri = options.url + "/catalog/" + catalogId + "/entity/" + schemaName + ':' + tableName;
+
+        it("should properly delete the referenced entity from the table.", function (done) {
+            var reference,
+                uri = baseUri + "/key_col=1";
+
+            options.ermRest.resolve(uri, {cid: "test"}).then(function (response) {
+                reference = response;
+
+                // need to read to have the etag
+                return reference.read(1);
+            }).then(function (response) {
+                return reference.delete();
+            }).then(function (response) {
+                return reference.read(1);
+            }).then(function (response) {
+                expect(response._data.length).toBe(0);
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+    });
+};

--- a/test/specs/reference/tests/11.delete.js
+++ b/test/specs/reference/tests/11.delete.js
@@ -3,25 +3,48 @@ exports.execute = function (options) {
     describe("deleting reference objects, ", function () {
         var catalogId = process.env.DEFAULT_CATALOG,
             schemaName = "delete_schema",
-            tableName = "delete_table";
+            tableName = "delete_table",
+            reference;
 
         var baseUri = options.url + "/catalog/" + catalogId + "/entity/" + schemaName + ':' + tableName;
 
-        it("should properly delete the referenced entity from the table.", function (done) {
-            var reference,
-                uri = baseUri + "/key_col=1";
-
+        beforeAll(function (done) {
+            var uri = baseUri + "/key_col=1";
             options.ermRest.resolve(uri, {cid: "test"}).then(function (response) {
                 reference = response;
+                done();
+            }).catch(function (error) {
+                console.dir();
+                done.fail();
+            });
+        });
 
-                // need to read to have the etag
-                return reference.read(1);
-            }).then(function (response) {
+        it("should properly delete the referenced entity from the table.", function (done) {
+            // need to read to have the etag
+            reference.read(1).then(function (response) {
                 return reference.delete();
             }).then(function (response) {
+                // response should be empty
+                expect(response).not.toBeDefined();
+
                 return reference.read(1);
             }).then(function (response) {
+                // Reading an object that doesn't exist should return no data
                 expect(response._data.length).toBe(0);
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+
+        // entity with key_col = 1 deleted previously
+        it("should return a positive error code when trying to delete an already deleted entity.", function (done) {
+            reference.delete().then(function (response) {
+                // response should be a positive status code triggering the success calback
+                // response object should be undefined
+                expect(response).not.toBeDefined();
 
                 done();
             }).catch(function (error) {


### PR DESCRIPTION
This PR addresses deleting entities via the Reference.delete API. This is currently only an implementation for ermrestJS.

Assigning to @shinyichen and mentioning @howdyjessie to look at it.