### PR TITLE
Fix PseudoColumn Null Bug

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -139,6 +139,7 @@ to use for ERMrest JavaScript agents.
         * [.comment](#ERMrest.PseudoColumn+comment) : <code>string</code>
         * [.table](#ERMrest.PseudoColumn+table) : <code>[Table](#ERMrest.Table)</code>
         * [.reference](#ERMrest.PseudoColumn+reference) : <code>[Reference](#ERMrest.Reference)</code>
+        * [.foreignKey](#ERMrest.PseudoColumn+foreignKey) : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
         * [.formatPresentation()](#ERMrest.PseudoColumn+formatPresentation)
     * [.Annotations](#ERMrest.Annotations)
         * [new Annotations()](#new_ERMrest.Annotations_new)
@@ -1159,6 +1160,7 @@ returns string representation of Column
     * [.comment](#ERMrest.PseudoColumn+comment) : <code>string</code>
     * [.table](#ERMrest.PseudoColumn+table) : <code>[Table](#ERMrest.Table)</code>
     * [.reference](#ERMrest.PseudoColumn+reference) : <code>[Reference](#ERMrest.Reference)</code>
+    * [.foreignKey](#ERMrest.PseudoColumn+foreignKey) : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
     * [.formatPresentation()](#ERMrest.PseudoColumn+formatPresentation)
 
 <a name="new_ERMrest.PseudoColumn_new"></a>
@@ -1206,6 +1208,12 @@ Preferred display name for user presentation only.
 
 #### pseudoColumn.reference : <code>[Reference](#ERMrest.Reference)</code>
 The reference object that represents the table of this PseudoColumn
+
+**Kind**: instance property of <code>[PseudoColumn](#ERMrest.PseudoColumn)</code>  
+<a name="ERMrest.PseudoColumn+foreignKey"></a>
+
+#### pseudoColumn.foreignKey : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
+The Foreign key object that this PseudoColumn is created based on
 
 **Kind**: instance property of <code>[PseudoColumn](#ERMrest.PseudoColumn)</code>  
 <a name="ERMrest.PseudoColumn+formatPresentation"></a>

--- a/js/core.js
+++ b/js/core.js
@@ -1593,6 +1593,7 @@ var ERMrest = (function (module) {
             // heuristics
             else {
                 var compositeFKs = {}, compositeFKKey, colAdded;
+                var editContexts = [module._contexts.CREATE, module._contexts.EDIT];
                 for (i = 0; i < columns.length; i++) {
                     col = columns[i];
                     colAdded = false;
@@ -1620,8 +1621,8 @@ var ERMrest = (function (module) {
                             // multiple composite FKR
                             else { 
                                 
-                                // add the column first
-                                if (!colAdded) {
+                                // add the column if context is not create or edit
+                                if (!colAdded && editContexts.indexOf(context) === -1) {
                                     visiblePseudoColumns.push(col);
                                     colAdded = true;
                                 }
@@ -1921,7 +1922,6 @@ var ERMrest = (function (module) {
         Column.call(this, foreignKey._table, column._jsonColumn);
 
         
-        this._foreignKey = foreignKey;
         this._constraintName = foreignKey.constraint_names[0].join(":");
         this._column = column;
 
@@ -2007,16 +2007,27 @@ var ERMrest = (function (module) {
         this.reference =  module._createReference(module._parse(ermrestURI), this.table.schema.catalog);
 
         /**
+         * @type {ERMrest.ForeignKeyRef}
+         * @desc The Foreign key object that this PseudoColumn is created based on
+         */
+        this.foreignKey = foreignKey;
+
+        /**
          * @desc Formats the presentation value corresponding to this PseudoColumn.
          * It will be a url with:
          *  - caption: row-name
          *  - link: link to detailed view of reference
          */
         this.formatPresentation = function (data, options) {
-            var value;
+            var value, caption;
+
+            // if data is empty
+            if (typeof data === "undefined" || data === null || Object.keys(data).length === 0) {
+                return {isHTML: false, value: this._getNullValue(options ? options.context : undefined)};
+            }
 
             // use row name as the caption
-            var caption = module._generateRowName(this.table, options ? options.context : undefined, data);
+            caption = module._generateRowName(this.table, options ? options.context : undefined, data);
 
             // if caption has a link, don't add the link.
             if (caption.match(/<a/)) {
@@ -2043,6 +2054,10 @@ var ERMrest = (function (module) {
             }
 
             return {isHTML: true, value: value};
+        };
+
+        this._getNullValue =  function(context) {
+            return this._column._getNullValue(context);
         };
         
     }

--- a/js/reference.js
+++ b/js/reference.js
@@ -1363,15 +1363,20 @@ var ERMrest = (function(module) {
         this._linkedData = [];
 
         if (this._ref._table.foreignKeys.length() > 0) { // attributegroup output
-            this._data = [];            
-            var i, j, fks = reference._table.foreignKeys.all();
-            for (i = 0; i < data.length; i++) {
-                this._data.push(data[i].M[0]); 
+            try {
+                this._data = [];            
+                var i, j, fks = reference._table.foreignKeys.all();
+                for (i = 0; i < data.length; i++) {
+                    this._data.push(data[i].M[0]); 
 
-                this._linkedData.push({});
-                for (j = fks.length - 1; j >= 0 ; j--) {
-                    this._linkedData[i][fks[j].constraint_names[0].join(":")] = data[i]["F"+(j+1)][0];
+                    this._linkedData.push({});
+                    for (j = fks.length - 1; j >= 0 ; j--) {
+                        this._linkedData[i][fks[j].constraint_names[0].join(":")] = data[i]["F"+(j+1)][0];
+                    }
                 }
+            } catch(exception) { // could not find the expected aliases
+                this._linkedData = [];
+                this._data = data;
             }
         } else { // entity output
             this._data = data;
@@ -1576,7 +1581,7 @@ var ERMrest = (function(module) {
     function Tuple(pageReference, data, linkedData) {
         this._pageRef = pageReference;
         this._data = data;
-        this._linkedData = linkedData;
+        this._linkedData = (typeof linkedData === "object") ? linkedData : {};
     }
 
     Tuple.prototype = {
@@ -1757,12 +1762,17 @@ var ERMrest = (function(module) {
                     // Return raw values according to the visibility and sequence of columns
                     for (i = 0; i < this._pageRef.columns.length; i++) {
                         column = this._pageRef.columns[i];
+                        this._isHTML[i] = false;
                         if (column.isPseudo) {
-                            this._values[i] = module._generateRowName(column.table, this._pageRef._context, this._linkedData[column._constraintName]);
+                            if (!this._linkedData || !this._linkedData[column._constraintName] || Object.keys(this._linkedData[column._constraintName]).length === 0) {
+                                this._values[i] = column._getNullValue(this._pageRef._context);
+                            } else {
+                                this._values[i] = module._generateRowName(column.table, this._pageRef._context, this._linkedData[column._constraintName]);
+                                this._isHTML[i] = true;
+                            }
                         } else {
                             this._values[i] = this._data[column.name];
                         }
-                        this._isHTML[i] = false;
                     }
                 } else {
                     

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -358,9 +358,10 @@ var ERMrest = (function(module) {
         // Get the columns for shortestKey
         var keyColumns = table.shortestKey;
 
-        if (keyColumns.length >= table.columns.length) {
-            return null;
-        }
+        // TODO this check needs to change. it is supposed to check if the table has a key or not
+        // if (keyColumns.length >= table.columns.length) {
+        //     return null;
+        // }
 
         var values = [];
 

--- a/test/specs/reference/conf/reference_schema/data/reference_table_outbound_fks.json
+++ b/test/specs/reference/conf/reference_schema/data/reference_table_outbound_fks.json
@@ -2,21 +2,23 @@
     {
         "id": "1",
         "col_1": "9000",
-        "col_2": "9001",
+        "col_2": null,
         "col_3": "4000",
         "col_4": "4001",
         "col_5": "4002",
         "col_6": "4003",
+        "col_7": null,
         "reference_schema:outbound_fk_7": "12"
     },
     {
         "id": "2",
         "col_1": "9001",
-        "col_2": "9002",
+        "col_2": null,
         "col_3": "4000",
         "col_4": "4002",
         "col_5": "4003",
         "col_6": "4004",
+        "col_7": null,
         "reference_schema:outbound_fk_7": "13"
     }
 ]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -915,6 +915,35 @@
                         }
                     ],
                     "annotations": {}
+                },
+                {
+                    "comment": "composite fk to reference, one value is null",
+                    "names": [["reference_schema", "outbound_fk_9"]],
+                    "foreign_key_columns": [
+                      {
+                          "schema_name": "reference_schema",
+                          "table_name": "reference_table_outbound_fks",
+                          "column_name": "col_7"
+                      },
+                      {
+                          "schema_name": "reference_schema",
+                          "table_name": "reference_table_outbound_fks",
+                          "column_name": "col_5"
+                      }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "schema_name": "reference_schema",
+                            "table_name": "table_w_composite_key",
+                            "column_name": "id_1"
+                        },
+                        {
+                            "schema_name": "reference_schema",
+                            "table_name": "table_w_composite_key",
+                            "column_name": "id_2"
+                        }
+                    ],
+                    "annotations": {}
                 }
             ],
             "column_definitions": [
@@ -972,6 +1001,13 @@
                 },
                 {
                     "name": "col_6",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "comment": "is in multiple composite FKRs"
+                },
+                {
+                    "name": "col_7",
                     "type": {
                         "typename": "text"
                     },


### PR DESCRIPTION
This PR 
  - Fixes #249 bug.
  - Handles #248.
  - Exposes `PseudoColumn.foreignkey`.