### PR TITLE
Reference.update and Reference.create fixed to work with pseudocolumns

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -244,6 +244,7 @@ to use for ERMrest JavaScript agents.
         * [.display](#ERMrest.Reference+display) : <code>Object</code>
         * [.related](#ERMrest.Reference+related) : <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
         * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
+            * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
         * [.read(limit)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
         * [.sort(sort)](#ERMrest.Reference+sort)
         * [.update(tbd)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
@@ -1928,6 +1929,7 @@ Constructor for a ParsedFilter.
     * [.display](#ERMrest.Reference+display) : <code>Object</code>
     * [.related](#ERMrest.Reference+related) : <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
     * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
+        * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
     * [.read(limit)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
     * [.sort(sort)](#ERMrest.Reference+sort)
     * [.update(tbd)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
@@ -2148,6 +2150,16 @@ or errors (TBD).
 | --- | --- | --- |
 | data | <code>Array</code> | The array of data to be created as new tuples. |
 
+<a name="ERMrest.Reference+create..columnDiff"></a>
+
+##### create~columnDiff()
+This gets the difference between the two column sets. This is not the _symmetric_ difference.
+If minuend is [1,2,3,4,5]
+and subtrahend is [4,5,6]
+the difference is [1,2,3]
+The 6 is ignored because we only want to know what's in the minuend that is not in the subtrahend
+
+**Kind**: inner method of <code>[create](#ERMrest.Reference+create)</code>  
 <a name="ERMrest.Reference+read"></a>
 
 #### reference.read(limit) ⇒ <code>Promise</code>
@@ -2420,7 +2432,7 @@ See [canUpdate](#ERMrest.Tuple+canUpdate) for a usage example.
 <a name="ERMrest.Tuple+values"></a>
 
 #### tuple.values : <code>Array.&lt;string&gt;</code>
-The array of formatted/raw values of this tuple on basis of context "edit". 
+The array of formatted/raw values of this tuple on basis of context "edit".
 The ordering of the values in the array matches the ordering of the columns
 in the reference (see [columns](#ERMrest.Reference+columns)).
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -481,9 +481,12 @@ var ERMrest = (function(module) {
                      * If not set in any row, add it to defaults.
                      * If 1 row has it set and none of the others, it cannot be part of defaults
                     **/
-                    data.forEach(function (row) {
-                        if (row[columnName]) notSet = false;
-                    });
+                    for (var m = 0; m < data.length; m++) {
+                        if (data[m][columnName]) {
+                            notSet = false;
+                            break;
+                        }
+                    }
 
                     if (notSet) defaults.push(columnName);
                 });

--- a/js/reference.js
+++ b/js/reference.js
@@ -261,7 +261,7 @@ var ERMrest = (function(module) {
          */
         get columns() {
             if (this._pseudoColumns === undefined) {
-                this._pseudoColumns = this._table.columns._contextualize(this._context, this._columns);    
+                this._pseudoColumns = this._table.columns._contextualize(this._context, this._columns);
             }
             return this._pseudoColumns;
         },
@@ -413,9 +413,6 @@ var ERMrest = (function(module) {
                 //  get the defaults list for the referenced relation's table
                 var defaults = getDefaults();
 
-                //  get and format the data
-                // var formattedData = formatData(data);
-
                 // construct the uri
                 var uri = this._location.compactUri;
                 for (var i = 0; i < defaults.length; i++) {
@@ -468,17 +465,47 @@ var ERMrest = (function(module) {
             }
 
             function getDefaults() {
+                // any row in data is sufficient. data should include the full set of visible columns
+                var visibleColumnsNames = Object.keys(data[0]);
+                var tableColumnsNames = self._table.columns._columns.map(function (col) {
+                    return col.name;
+                });
                 // This is gets the difference between the table's set of columns and the reference's set of columns
-                var defaults = module._columnDiff(self._table.columns._columns, self.columns);
+                var defaults = columnDiff(tableColumnsNames, visibleColumnsNames);
 
-                var columns = self.columns;
-                for (var i = 0; i < columns.length; i++) {
-                    if (columns[i].type.name.indexOf("serial") === 0) {
-                        defaults.push(columns[i].name);
-                    }
-                }
+                // loop through the data and add any columns not set to the defaults
+                visibleColumnsNames.forEach(function (columnName) {
+                    var notSet = true;
+                    /**
+                     * Loop through the rows and make sure the current column is not set in any of the rows.
+                     * If not set in any row, add it to defaults.
+                     * If 1 row has it set and none of the others, it cannot be part of defaults
+                    **/
+                    data.forEach(function (row) {
+                        if (row[columnName]) notSet = false;
+                    });
+
+                    if (notSet) defaults.push(columnName);
+                });
 
                 return defaults;
+            }
+
+            /**
+             * This gets the difference between the two column sets. This is not the _symmetric_ difference.
+             * If minuend is [1,2,3,4,5]
+             * and subtrahend is [4,5,6]
+             * the difference is [1,2,3]
+             * The 6 is ignored because we only want to know what's in the minuend that is not in the subtrahend
+             */
+            function columnDiff(minuend, subtrahend) {
+                var difference = [];
+
+                difference = minuend.filter(function(col) {
+                    return subtrahend.indexOf(col) == -1;
+                });
+
+                return difference;
             }
         },
 
@@ -564,12 +591,12 @@ var ERMrest = (function(module) {
                     }
                     this._location.sortObject = sortObject;
                 }
- 
+
                 /*
                 * Change api to attributegroup for retrieving the foreign key data
                 * This will just affect the http request and not this._location
                 *
-                * NOTE: 
+                * NOTE:
                 * This piece of code is dependent on the same assumptions as the current parser, which are:
                 *   1. There is no alias in url (more precisely `M`, `F1`, `F2`, `F3`, ...)
                 *   2. Filter comes before the link syntax.
@@ -594,7 +621,7 @@ var ERMrest = (function(module) {
 
                     // create the uri with attributegroup and alias
                     uri = [this._location.service, "catalog", this._location.catalog, "attributegroup", compactPath].join("/");
-                    
+
                     // add joins for foreign keys
                     for (k = this._table.foreignKeys.length() - 1;k >= 0 ; k--) {
                         // /F2:=left(id)=(s:t:c)/$M/F1:=left(id2)=(s1:t1:c1)/
@@ -618,7 +645,7 @@ var ERMrest = (function(module) {
                         }
                     }
 
-                    uri += keys.join(",") + ";M:=array(M:*)," + fkList;      
+                    uri += keys.join(",") + ";M:=array(M:*)," + fkList;
                 }
 
                 // insert @sort()
@@ -744,9 +771,7 @@ var ERMrest = (function(module) {
                 }
 
                 // The list of column names to use in the uri
-                columnProjections = this.columns.map(function (col) {
-                    return col.name;
-                });
+                columnProjections = Object.keys(tuples[0].data);
 
                 // always alias the shortest key in the uri
                 for (var j = 0; j < shortestKeyNames.length; j++) {
@@ -1181,7 +1206,7 @@ var ERMrest = (function(module) {
             delete newRef._pseudoColumns;
             delete newRef._derivedAssociationRef;
 
-            newRef._context = context;            
+            newRef._context = context;
 
             // use the base table to get the alternative table of that context.
             // a base table's .baseTable is itself
@@ -1373,17 +1398,17 @@ var ERMrest = (function(module) {
          * This is the structure of this._linkedData
          * this._linkedData[i] = {`s:constraintName`: data}
          * That is for retrieving data for a foreign key, you should do the following:
-         * 
+         *
          * var fkData = this._linkedData[i][foreignKey.constraint_names[0].join(":")];
          */
         this._linkedData = [];
 
         if (this._ref._table.foreignKeys.length() > 0) { // attributegroup output
             try {
-                this._data = [];            
+                this._data = [];
                 var i, j, fks = reference._table.foreignKeys.all();
                 for (i = 0; i < data.length; i++) {
-                    this._data.push(data[i].M[0]); 
+                    this._data.push(data[i].M[0]);
 
                     this._linkedData.push({});
                     for (j = fks.length - 1; j >= 0 ; j--) {
@@ -1743,7 +1768,7 @@ var ERMrest = (function(module) {
         },
 
         /**
-         * The array of formatted/raw values of this tuple on basis of context "edit". 
+         * The array of formatted/raw values of this tuple on basis of context "edit".
          * The ordering of the values in the array matches the ordering of the columns
          * in the reference (see {@link ERMrest.Reference#columns}).
          *
@@ -1768,7 +1793,7 @@ var ERMrest = (function(module) {
 
                 this._values = [];
                 this._isHTML = [];
-                
+
                 var column;
 
                 // If context is entry/edit
@@ -1790,7 +1815,7 @@ var ERMrest = (function(module) {
                         }
                     }
                 } else {
-                    
+
                     var keyValues = module._getFormattedKeyValues(this._pageRef._table.columns, this._pageRef._context, this._data);
 
                     /*
@@ -1805,7 +1830,7 @@ var ERMrest = (function(module) {
                             formattedValues[i] = column.formatPresentation(this._linkedData[column._constraintName], {context: this._pageRef._context});
                         } else {
                             formattedValues[i] = column.formatPresentation(keyValues[column.name], { keyValues : keyValues , columns: this._pageRef.columns, context: this._pageRef._context });
-                            
+
                             if (column.type.name === "gene_sequence") {
                                 formattedValues[i].isHTML = true;
                             }

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -61,32 +61,6 @@ var ERMrest = (function(module) {
 
     /**
      * @function
-     * @param {Array} minuend an array of Column Objects
-     * @param {Array} subtrahend an array of Column Objects
-     * @desc
-     * This gets the difference between the two column sets. This is not the _symmetric_ difference.
-     * If minuend is [1,2,3,4,5]
-     * and subtrahend is [4,5,6]
-     * the difference is [1,2,3]
-     * The 6 is ignored because we only want to know what's in the minuend that is not in the subtrahend
-     * @returns {Array} difference an array of Column Objects
-     */
-    module._columnDiff = function (minuend, subtrahend) {
-        var difference = [];
-
-        difference = minuend.filter(function(col) {
-            return subtrahend.indexOf(col) == -1;
-        });
-
-        difference = difference.map(function(col) {
-            return col.name;
-        });
-
-        return difference;
-    };
-
-    /**
-     * @function
      * @param {String} str string to be converted.
      * @desc
      * Converts a string to title case (separators are space, hyphen, and underscore)
@@ -742,7 +716,7 @@ var ERMrest = (function(module) {
                         if (attrs[0].children[0].type == "link_open") {
                             var iframeHTML = "<iframe ", openingLink = attrs[0].children[0];
                             var enlargeLink, posTop = true;
-                            
+
                             // Add all attributes to the iframe
                             openingLink.attrs.forEach(function(attr) {
                                 if (attr[0] == "href") {
@@ -757,7 +731,7 @@ var ERMrest = (function(module) {
                                iframeHTML += " ";
                             });
                             html += iframeHTML + "></iframe>";
-                            
+
                             var captionHTML = "";
 
                             // If the next attribute is not a closing link then iterate
@@ -774,23 +748,23 @@ var ERMrest = (function(module) {
                                     }
                                 }
                             }
-                            
+
                             // If enlarge link is set then add an anchor tag for captionHTML
                             if (enlargeLink) {
                                  if (!captionHTML.trim().length) captionHTML = "Enlarge";
                                 captionHTML = '<a href="' + enlargeLink + '" target="_blank">'  + captionHTML + '</a>';
                             }
-                            
+
                             // Encapsulate the captionHTML inside a figcaption tag with class embed-caption
                             if (posTop) {
                                 html = '<figcaption class="embed-caption">' + captionHTML + "</figcaption>" + html;
                             } else {
                                 html += '<figcaption class="embed-caption">' + captionHTML + "</figcaption>";
                             }
-                            
+
                             // Encapsulate the iframe inside a figure tag
                             html = '<figure class="embed-block">' + html + "</figure>";
-                        }  
+                        }
                     }
                     // if attrs was empty or it didn't find any link simply render the internal markdown
                     if (html === "") {
@@ -901,28 +875,28 @@ var ERMrest = (function(module) {
             /*
              * Checks whether string matches format ":::image [CAPTION](LINK){ATTR=VALUE .CLASSNAME}"
              * String inside '{}' is Optional, specifies attributes to be applied to prev element
-             */ 
+             */
             validate: function(params) {
                 return params.trim().match(/image\s+(.*$)/i);
             },
 
             render: function (tokens, idx) {
-                
-                // Get token string after regeexp matching to determine actual internal markdown 
+
+                // Get token string after regeexp matching to determine actual internal markdown
                 var m = tokens[idx].info.trim().match(/image\s+(.*)$/i);
 
-                // If this is the opening tag i.e. starts with "::: image " 
+                // If this is the opening tag i.e. starts with "::: image "
                 if (tokens[idx].nesting === 1 && m.length > 0) {
 
                     // Extract remaining string before closing tag and get its parsed markdown attributes
                     var attrs = md.parseInline(m[1]), html = "";
-                    if (attrs && attrs.length == 1 && attrs[0].children) { 
+                    if (attrs && attrs.length == 1 && attrs[0].children) {
 
                         // Check If the markdown is a link
                         if (attrs[0].children[0].type == "link_open") {
                             var imageHTML = "<img ", openingLink = attrs[0].children[0];
                             var enlargeLink, posTop = true;
-                            
+
                             // Add all attributes to the image
                             openingLink.attrs.forEach(function(attr) {
                                 if (attr[0] == "href") {
@@ -938,9 +912,9 @@ var ERMrest = (function(module) {
                             });
 
                             html += imageHTML + "/>";
-                            
+
                             var captionHTML = "";
-                            
+
                             // If the next attribute is not a closing link then iterate
                             // over all the children until link_close is encountered rednering their markdown
                             if (attrs[0].children[1].type != 'link_close') {
@@ -955,24 +929,24 @@ var ERMrest = (function(module) {
                                     }
                                 }
                             }
-                            
+
                             // Add caption html
                             if (posTop) {
                                 html = '<figcaption class="embed-caption">' + captionHTML + "</figcaption>" + html;
                             } else {
                                 html = html + '<figcaption class="embed-caption">' + captionHTML + "</figcaption>";
                             }
-                            
+
                             // If link is specified, then wrap the image and figcaption inside anchor tag
                             if (enlargeLink) {
                                 html = '<a href="' + enlargeLink + '" target="_blank">' + html + '</a>' ;
                             }
-                            
+
                             // Encapsulate the iframe inside a paragraph tag
                             html = '<figure class="embed-block" style="display:inline-block;">' + html + "</figure>";
-                        }  
+                        }
                     }
-                    
+
                     // if attrs was empty or it didn't find any link simply render the internal markdown
                     if (html === "") {
                         html = md.render(m[1]);
@@ -981,7 +955,7 @@ var ERMrest = (function(module) {
 
                     return html;
                 } else {
-                  // closing tag 
+                  // closing tag
                   return '';
                 }
             }
@@ -1020,7 +994,7 @@ var ERMrest = (function(module) {
       return module._escapeReplacementsForMarkdown.reduce(
         function(text, replacement) {
           return text.replace(replacement[0], replacement[1]);
-        }, text); 
+        }, text);
     };
 
     /**
@@ -1052,14 +1026,14 @@ var ERMrest = (function(module) {
                 // If it is part of escaped variable then simply ignore it
                 if (escapedVariables.indexOf(p) == -1) {
 
-                    // Grab the actual variable NAME from the string {{NAME}} 
+                    // Grab the actual variable NAME from the string {{NAME}}
                     var variable = replaceVarRegexp.exec(p)[1];
 
                     // If the variable starts with "#", "^" or ends with "/", we ignore them as they're block tags.
                     // If the variable starts with "&" then we ignore it as it is already in the Mustache format of non-escaping
                     if (!variable.startsWith("&") && !variable.startsWith("#") && !variable.startsWith("^") && !variable.endsWith("/")) {
                         replaceVariables["{{" +variable + "}}"] = variable;
-                    } 
+                    }
                 }
             });
         }
@@ -1068,7 +1042,7 @@ var ERMrest = (function(module) {
         for(var variable in replaceVariables) {
             text = text.replaceAll(variable,"{{&" + replaceVariables[variable] + "}}");
         }
-        
+
         return text;
     };
 


### PR DESCRIPTION
This PR addresses the changes to `reference.columns` to include pseudocolumns that replace the originating column. Update only required a minor change. 

Create needed some changes to the way the defaults are generated. All of the visible columns are now sent as part of the payload from chaise to ermrestJS. This means that values that were not set will have `null` as their value. The defaults function looks through this set and figures out if that column should be included in the list of defaults that ermrest should try to populate.

Assigning to @shinyichen. Mentioning @howdyjessie and @RFSH if that want to look at it as well.
