### PR TITLE
Expand association table linkage to create and entry contexts

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -1029,8 +1029,9 @@ var ERMrest = (function(module) {
                         newRef._related_key_column_positions = fkr.key.colset._getColumnPositions();
                         newRef._related_fk_column_positions = otherFK.colset._getColumnPositions();
 
-                        // will be used in edit contextualize
+                        // will be used in entry contexts
                         newRef._derivedAssociationRef = new Reference(module._parse(this._location.compactUri + "/" + fkr.toString()), newRef._table.schema.catalog);
+                        newRef._derivedAssociationRef.origFKR = newRef.origFKR;
 
                     } else { // Simple inbound Table
                         newRef._table = fkrTable;
@@ -1209,8 +1210,9 @@ var ERMrest = (function(module) {
 
         _contextualize: function(context) {
             var source;
+            var entryContexts = [module._contexts.CREATE, module._contexts.EDIT, module._contexts.ENTRY];
             // if this is a related association table and context is edit, contextualize based on the association table.
-            if (this._reference._derivedAssociationRef && context == module._contexts.EDIT) {
+            if (this._reference._derivedAssociationRef && entryContexts.indexOf(context) != -1) {
                 source = this._reference._derivedAssociationRef;
             } else {
                 source = this._reference;
@@ -1219,7 +1221,6 @@ var ERMrest = (function(module) {
             var newRef = _referenceCopy(source);
             delete newRef._related;
             delete newRef._pseudoColumns;
-            delete newRef._derivedAssociationRef;
 
             newRef._context = context;
 

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -190,12 +190,16 @@ exports.execute = function(options) {
                 expect(related[3]._derivedAssociationRef._table.name).toBe("association table with id");
             });
 
-            it('.contextualize.entryEdit should be created based on the assocation table rather than the reference it is referring to.', function(){
-                var ref;
-                ref = related[2].contextualize.entryEdit;
-                expect(ref._table.name).toBe("association_table_with_toname");
-                ref = related[3].contextualize.entryEdit;
-                expect(ref._table.name).toBe("association table with id");
+            it('.contextualize.entryEdit/.entryCreate/.entry should be created based on the assocation table rather than the reference it is referring to.', function(){
+                var refs;
+                refs = [ related[2].contextualize.entryEdit, related[2].contextualize.entryCreate, related[2].contextualize.entry];
+                refs.forEach(function (ref) {
+                    expect(ref._table.name).toBe("association_table_with_toname");
+                });
+                refs = [related[3].contextualize.entryEdit, related[3].contextualize.entryCreate, related[3].contextualize.entry];
+                refs.forEach(function (ref) {
+                    expect(ref._table.name).toBe("association table with id");
+                });
             });
 
             it('.read should return a Page object that is defined.', function(done) {


### PR DESCRIPTION
Related Issue in chaise: [chaise-768](https://github.com/informatics-isi-edu/chaise/issues/768).

Currently in `contextualize.entryEdit`, if the reference is actually an association related reference, we contextualize based on the association reference; rather than the current reference. 

Since chaise is using `contextualize.entryCreate` instead, this PR will expand this behaviour to all the entry contexts (`contextualize.entryEdit`, `contextualize.entryCreate`, and `contextualize.entry`).