### PR TITLE
Added default property to referenceColumn

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -269,6 +269,7 @@ to use for ERMrest JavaScript agents.
         * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>string</code>
         * [.type](#ERMrest.ReferenceColumn+type) : <code>[Type](#ERMrest.Type)</code>
         * [.nullok](#ERMrest.ReferenceColumn+nullok) : <code>Boolean</code>
+        * [.default](#ERMrest.ReferenceColumn+default)
         * [.comment](#ERMrest.ReferenceColumn+comment) : <code>string</code>
         * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> &#124; <code>object</code>
         * [.formatvalue(data)](#ERMrest.ReferenceColumn+formatvalue) ⇒ <code>string</code>
@@ -2459,6 +2460,7 @@ and therefore an asynchronous operation that returns a promise.
     * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>string</code>
     * [.type](#ERMrest.ReferenceColumn+type) : <code>[Type](#ERMrest.Type)</code>
     * [.nullok](#ERMrest.ReferenceColumn+nullok) : <code>Boolean</code>
+    * [.default](#ERMrest.ReferenceColumn+default)
     * [.comment](#ERMrest.ReferenceColumn+comment) : <code>string</code>
     * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> &#124; <code>object</code>
     * [.formatvalue(data)](#ERMrest.ReferenceColumn+formatvalue) ⇒ <code>string</code>
@@ -2518,6 +2520,12 @@ Preferred display name for user presentation only.
 <a name="ERMrest.ReferenceColumn+nullok"></a>
 
 #### referenceColumn.nullok : <code>Boolean</code>
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+<a name="ERMrest.ReferenceColumn+default"></a>
+
+#### referenceColumn.default
+Returns the default value (or function) for this column
+
 **Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+comment"></a>
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -2562,7 +2562,7 @@ Formats the presentation value corresponding to this reference-column definition
 <a name="ERMrest.ReferenceColumn+getInputDisabled"></a>
 
 #### referenceColumn.getInputDisabled() : <code>boolean</code> &#124; <code>object</code>
-Indicates if the input should be disabled, in different contexts 
+Indicates if the input should be disabled, in different contexts
 true: input must be disabled
 false:  input can be enabled
 object: input msut be disabled (show .message to user)

--- a/js/reference.js
+++ b/js/reference.js
@@ -2117,8 +2117,6 @@ var ERMrest = (function(module) {
 
         this._base = column;
 
-        this.default = column.default;
-
         /**
          * @type {boolean}
          * @desc indicates this represents is a PseudoColumn or a Column.
@@ -2254,8 +2252,10 @@ var ERMrest = (function(module) {
          * @desc Returns the default value (or function) for this column
          */
          get default() {
-            if (typeof foreignKey === 'undefined' || !foreignKey.simple) {
+            if (!this.isPseudo) {
                 return this._base.default;
+            } else {
+                // TODO handle the case for pseudo columns (foreign keys)
             }
          },
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -292,7 +292,7 @@ var ERMrest = (function(module) {
                  * */
 
                 this._referenceColumns = [];
-                
+
                 // check if we should hide some columns or not.
                 // NOTE: if the reference is actually an inbound related reference, we should hide the foreign key that created this link.
                 var hasOrigFKR = typeof this.origFKR != "undefined" && this.origFKR !== null && !this.origFKR._table._isPureBinaryAssociation();
@@ -1630,7 +1630,7 @@ var ERMrest = (function(module) {
                     this._linkedData.push(tempData);
                 }
             }
-        } 
+        }
         // entity output (linkedData is empty)
         else {
             this._data = data;
@@ -2117,12 +2117,14 @@ var ERMrest = (function(module) {
 
         this._base = column;
 
+        this.default = column.default;
+
         /**
          * @type {boolean}
          * @desc indicates this represents is a PseudoColumn or a Column.
          */
         this.isPseudo = false;
-        
+
         if (typeof foreignKey != 'undefined') {
             this.isPseudo = true;
 
@@ -2261,7 +2263,7 @@ var ERMrest = (function(module) {
          * true: input must be disabled
          * false:  input can be enabled
          * object: input msut be disabled (show .message to user)
-         * 
+         *
          * @type {boolean|object}
          */
         get inputDisabled() {
@@ -2279,7 +2281,7 @@ var ERMrest = (function(module) {
         formatvalue: function(data, options) {
             return this._base.formatvalue(data, options);
         },
-        
+
         /**
          * Formats the presentation value corresponding to this reference-column definition.
          * @param {String} data The 'formatted' data value.
@@ -2299,7 +2301,7 @@ var ERMrest = (function(module) {
             var shortestKey = this.table.shortestKey, // the shortest key of the table
                 fkKey = this.foreignKey.key.colset.columns, // the key that creates this PseudoColumn
                 key, // the key that is going to be used in href
-                caption, value, i; 
+                caption, value, i;
 
             // check if we have data for the given columns
             var hasData = function (cols) {
@@ -2322,7 +2324,7 @@ var ERMrest = (function(module) {
             // use row name as the caption
             caption = module._generateRowName(this.table, options ? options.context : undefined, data);
 
-            // use fk key for displayname: "col_1:col_2:col_3" 
+            // use fk key for displayname: "col_1:col_2:col_3"
             if (caption.trim() === '') {
 
                 var keyValues = [];
@@ -2355,15 +2357,15 @@ var ERMrest = (function(module) {
                 value = '<a href="' + ref.contextualize.detailed.appLink +'">' + caption + '</a>';
             }
 
-            return {isHTML: true, value: value};            
+            return {isHTML: true, value: value};
         },
 
         /**
-         * @desc Indicates if the input should be disabled, in different contexts 
+         * @desc Indicates if the input should be disabled, in different contexts
          * true: input must be disabled
          * false:  input can be enabled
          * object: input msut be disabled (show .message to user)
-         * 
+         *
          * @type {boolean|object}
          */
         getInputDisabled: function (context) {
@@ -2417,7 +2419,7 @@ var ERMrest = (function(module) {
         _getNullValue: function (context) {
             return this._base._getNullValue(context);
         },
-        
+
     };
 
     return module;

--- a/js/reference.js
+++ b/js/reference.js
@@ -2251,6 +2251,15 @@ var ERMrest = (function(module) {
         },
 
         /**
+         * @desc Returns the default value (or function) for this column
+         */
+         get default() {
+            if (typeof foreignKey === 'undefined' || !foreignKey.simple) {
+                return this._base.default;
+            }
+         },
+
+        /**
          * @desc Documentation for this reference-column
          * @type {string}
          */


### PR DESCRIPTION
We want to be able to set default values in recordedit when creating entities. `Column.default` is already a property, so I'm just exposing the default value for the `referenceColumn` object.