### PR TITLE
Association Reference In Tuple

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -230,6 +230,7 @@ to use for ERMrest JavaScript agents.
         * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> &#124; <code>undefined</code>
         * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
         * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
+        * [.canUnlink](#ERMrest.Reference+canUnlink) : <code>boolean</code> &#124; <code>undefined</code>
         * [.display](#ERMrest.Reference+display) : <code>Object</code>
         * [.related](#ERMrest.Reference+related) : <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
         * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
@@ -259,6 +260,7 @@ to use for ERMrest JavaScript agents.
         * [.displayname](#ERMrest.Tuple+displayname) : <code>string</code>
         * [.update()](#ERMrest.Tuple+update) ⇒ <code>Promise</code>
         * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
+        * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : <code>[Reference](#ERMrest.Reference)</code>
     * [.ReferenceColumn](#ERMrest.ReferenceColumn)
         * [new ReferenceColumn(reference, column, foreignKeyRef)](#new_ERMrest.ReferenceColumn_new)
         * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
@@ -1846,6 +1848,7 @@ Constructor for a ParsedFilter.
     * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> &#124; <code>undefined</code>
     * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
     * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
+    * [.canUnlink](#ERMrest.Reference+canUnlink) : <code>boolean</code> &#124; <code>undefined</code>
     * [.display](#ERMrest.Reference+display) : <code>Object</code>
     * [.related](#ERMrest.Reference+related) : <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
     * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
@@ -2025,6 +2028,18 @@ be determined and the value will be `undefined`.
 Indicates whether the client has the permission to _delete_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
+
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+<a name="ERMrest.Reference+canUnlink"></a>
+
+#### reference.canUnlink : <code>boolean</code> &#124; <code>undefined</code>
+Indicates whether the client has the permission to _unlink_
+the referenced resource(s). In some cases, this permission cannot
+be determined and the value will be `undefined`.
+
+unlink: deleting the association table.
+Reference can be unlinked, if it's derived from an association table,
+and the association table _canDelete_ is true.
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+display"></a>
@@ -2318,6 +2333,7 @@ if (content) {
     * [.displayname](#ERMrest.Tuple+displayname) : <code>string</code>
     * [.update()](#ERMrest.Tuple+update) ⇒ <code>Promise</code>
     * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
+    * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : <code>[Reference](#ERMrest.Reference)</code>
 
 <a name="new_ERMrest.Tuple_new"></a>
 
@@ -2445,6 +2461,20 @@ and therefore an asynchronous operation that returns a promise.
 
 **Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
 **Returns**: <code>Promise</code> - a promise (TBD the result object)  
+<a name="ERMrest.Tuple+getAssociationRef"></a>
+
+#### tuple.getAssociationRef() : <code>[Reference](#ERMrest.Reference)</code>
+If the Tuple is derived from an association related table,
+this function will return a reference to the corresponding
+entity of this tuple's association table. 
+
+For example, assume
+Table1(K1,C1) <- AssocitaitonTable(FK1, FK2) -> Table2(K2,C2)
+and current tuple is from Table2 with k2 = "2". 
+With origFKRData = {"k1": "1"} this function will return a reference
+to AssocitaitonTable with FK1 = "1"" and FK2 = "2".
+
+**Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.ReferenceColumn"></a>
 
 ### ERMrest.ReferenceColumn

--- a/doc/api.md
+++ b/doc/api.md
@@ -230,7 +230,6 @@ to use for ERMrest JavaScript agents.
         * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> &#124; <code>undefined</code>
         * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
         * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
-        * [.canUnlink](#ERMrest.Reference+canUnlink) : <code>boolean</code> &#124; <code>undefined</code>
         * [.display](#ERMrest.Reference+display) : <code>Object</code>
         * [.related](#ERMrest.Reference+related) : <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
         * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
@@ -1848,7 +1847,6 @@ Constructor for a ParsedFilter.
     * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> &#124; <code>undefined</code>
     * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
     * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
-    * [.canUnlink](#ERMrest.Reference+canUnlink) : <code>boolean</code> &#124; <code>undefined</code>
     * [.display](#ERMrest.Reference+display) : <code>Object</code>
     * [.related](#ERMrest.Reference+related) : <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
     * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
@@ -2028,18 +2026,6 @@ be determined and the value will be `undefined`.
 Indicates whether the client has the permission to _delete_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
-
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
-<a name="ERMrest.Reference+canUnlink"></a>
-
-#### reference.canUnlink : <code>boolean</code> &#124; <code>undefined</code>
-Indicates whether the client has the permission to _unlink_
-the referenced resource(s). In some cases, this permission cannot
-be determined and the value will be `undefined`.
-
-unlink: deleting the association table.
-Reference can be unlinked, if it's derived from an association table,
-and the association table _canDelete_ is true.
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+display"></a>

--- a/js/reference.js
+++ b/js/reference.js
@@ -1217,6 +1217,7 @@ var ERMrest = (function(module) {
 
                         // will be used in entry contexts
                         newRef._derivedAssociationRef = new Reference(module._parse(this._location.compactUri + "/" + fkr.toString()), newRef._table.schema.catalog);
+                        newRef._derivedAssociationRef.session = this._session;
                         newRef._derivedAssociationRef.origFKR = newRef.origFKR;
                         newRef._derivedAssociationRef._secondFKR = otherFK;
 
@@ -2160,7 +2161,8 @@ var ERMrest = (function(module) {
                         newFilter.join("&")
                     ].join("/");
 
-                    return new Reference(module._parse(uri), this._pageRef._table.schema.catalog);
+                    var reference = new Reference(module._parse(uri), this._pageRef._table.schema.catalog);
+                    reference.session = associationRef._session;
                 }
                 
             } else {
@@ -2209,6 +2211,7 @@ var ERMrest = (function(module) {
              * @desc The reference object that represents the table of this PseudoColumn
              */
             this.reference =  new Reference(module._parse(ermrestURI), table.schema.catalog);
+            this.reference = reference._session;
 
             /**
              * @type {ERMrest.ForeignKeyRef}

--- a/js/reference.js
+++ b/js/reference.js
@@ -2212,7 +2212,7 @@ var ERMrest = (function(module) {
              * @desc The reference object that represents the table of this PseudoColumn
              */
             this.reference =  new Reference(module._parse(ermrestURI), table.schema.catalog);
-            this.reference = reference._session;
+            this.reference.session = reference._session;
 
             /**
              * @type {ERMrest.ForeignKeyRef}

--- a/js/reference.js
+++ b/js/reference.js
@@ -537,36 +537,6 @@ var ERMrest = (function(module) {
         },
 
         /**
-         * Indicates whether the client has the permission to _unlink_
-         * the referenced resource(s). In some cases, this permission cannot
-         * be determined and the value will be `undefined`.
-         * 
-         * unlink: deleting the association table.
-         * Reference can be unlinked, if it's derived from an association table,
-         * and the association table _canDelete_ is true.
-         * @type {(boolean|undefined)}
-         */
-        get canUnlink() {
-            if (this._canUnlink === undefined) {
-                if (this._derivedAssociationRef) {
-                    var ref = this._derivedAssociationRef;
-                    ref.session = this._session;
-                    this._canUnlink = !ref._table._isNonDeletable && !ref._table._isGenerated && !ref._table._isImmutable && ref._checkPermissions("content_write_user");
-
-                    if (this._canUnlink) {
-                        var allColumnsDisabled = ref.columns.every(function (col) {
-                            return (col.getInputDisabled(module._contexts.EDIT) !== false);
-                        });
-                        this._canUnlink = !allColumnsDisabled;
-                    }
-                } else {
-                    this._canUnlink = false;
-                }
-            }
-            return this._canUnlink;
-        },
-
-        /**
 
         /**
          * This is a private funtion that checks the user permissions for modifying the affiliated entity, record or table
@@ -1222,7 +1192,6 @@ var ERMrest = (function(module) {
                     delete newRef._canRead;
                     delete newRef._canUpdate;
                     delete newRef._canDelete;
-                    delete newRef._canUnlink;
 
                     newRef.origFKR = fkr; // it will be used to trace back the reference
 
@@ -1339,7 +1308,6 @@ var ERMrest = (function(module) {
             delete this._canRead;
             delete this._canUpdate;
             delete this._canDelete;
-            delete this._canUnlink;
         }
     };
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -2163,6 +2163,7 @@ var ERMrest = (function(module) {
 
                     var reference = new Reference(module._parse(uri), this._pageRef._table.schema.catalog);
                     reference.session = associationRef._session;
+                    return reference;
                 }
                 
             } else {

--- a/test/specs/reference/conf/reference_schema/data/association table with id.json
+++ b/test/specs/reference/conf/reference_schema/data/association table with id.json
@@ -1,3 +1,3 @@
-[{"ID":1,"id_from_ref_table":9001,"id_from_inbound_related_table":1},
-{"ID":2,"id_from_ref_table":9003,"id_from_inbound_related_table":2},
-{"ID":3,"id_from_ref_table":9003,"id_from_inbound_related_table":3}]
+[{"ID":1,"id from ref table":9001,"id_from_inbound_related_table":1},
+{"ID":2,"id from ref table":9003,"id_from_inbound_related_table":2},
+{"ID":3,"id from ref table":9003,"id_from_inbound_related_table":3}]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -262,7 +262,8 @@
             "annotations": {
                 "tag:misd.isi.edu,2015:display": {
                     "name": "association table displayname"
-                }
+                },
+                "tag:isrd.isi.edu,2016:non-deletable": {}
             }
         },
         "association_table_with_extra": {

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -239,16 +239,22 @@ exports.execute = function(options) {
                 
             });
 
+            
             it('Tuple.getAssociationRef should return the filtered assocation reference.', function() {
-                var url = options.url + "/catalog/" + catalog_id + "/entity/";
+                var url = options.url + "/catalog/" + catalog_id + "/entity/", ref;
 
-                var ref = pageWithID.tuples[0].getAssociationRef({"id":9003});
+                ref = pageWithID.tuples[0].getAssociationRef({"id":9003});
                 expect(ref).not.toBe(null);
                 expect(ref.uri).toEqual(url+"reference_schema:association%20table%20with%20id/id%20from%20ref%20table=9003&id_from_inbound_related_table=2");
 
                 ref = pageWithToName.tuples[0].getAssociationRef({"id":9003});
                 expect(ref).not.toBe(null);
                 expect(ref.uri).toEqual(url + "reference_schema:association_table_with_toname/id_from_ref_table=9003&id_from_inbound_related_table=1");
+            });
+
+            it('Tuple.getAssociationRef should return null, if the given data is incomplete.', function() {
+                var ref = pageWithToName.tuples[0].getAssociationRef({"not the id":9003});
+                expect(ref).toBe(null);
             });
         });
 

--- a/test/specs/reference/tests/06.permissions.js
+++ b/test/specs/reference/tests/06.permissions.js
@@ -734,58 +734,7 @@ exports.execute = function (options) {
 
             });
         });
-
-        describe("check unlink permission,", function () {
-            var session, reference;
-            var mockSessionObject = {
-                attributes: [
-                    {id: "write-tester"}
-                ]
-            };
-
-            beforeAll(function () {
-                nock.disableNetConnect();
-            });
-
-            it("should mock the session and set the session on the reference.", function (done) {
-
-                nock(options.url).get("/authn/session").reply(200, mockSessionObject);
-
-                options.ermRest._http.get(options.url + "/authn/session").then(function (response) {
-                    expect(response.data).toEqual(mockSessionObject);
-                    session = response.data;
-
-                    return options.ermRest.resolve(singleEnitityUri, {cid: "test"})
-                }).then(function (response) {
-                    reference = response.contextualize.detailed;
-                    reference.session = mockSessionObject;
-
-                    expect(reference._session).toEqual(mockSessionObject);
-
-                    done();
-                }, function (error) {
-                    console.dir(error);
-                    done.fail();
-                });
-            });
-
-            it('when reference is not a related association table, canUnlink should return false.', function () {
-                expect(reference.canUnlink).toBe(false);
-            });
-
-            it("when association table is none-deletable, generated, or immutable, canUnlink should return false.", function () {
-                //association table with id
-                var ref = reference.related[3];
-                expect(ref.canUnlink).toBe(false);
-            });
-
-            it("otherwise, canUnlink should return true.", function () {
-                //association_table_with_toname
-                var ref = reference.related[2];
-                expect(ref.canUnlink).toBeTruthy();
-            });
-        });
-
+        
         afterEach(function () {
             nock.cleanAll();
         });


### PR DESCRIPTION
Related Issue: #313

#### Tuple.getAssociation (origTableData) 
Will return a reference to the corresponding entity of current tuple's association table. For example, assume this scenario:
``` javascript
    // Table1(K1,C1) <- AssocitaitonTable(FK1, FK2) -> Table2(K2,C2)

   // from Table1 with k1 = 1
   var tuple = t1Ref.tuples[0];

   // from Table2 with k2 = 2
   var relatedTuple = t1Ref.related[0].tuples[0]; 

   // reference to AssociationTable with FK1=1 and FK2=2
   var associationRef = relatedTuple.getAssociation(tuple.data); 
```
It will return `null` if table is not derived from a pure and binary association relation, or data is missing.