### PR TITLE
Unalias keys in page returned from reference.update

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -252,6 +252,7 @@ to use for ERMrest JavaScript agents.
         * [new Tuple(reference, data)](#new_ERMrest.Tuple_new)
         * [.reference](#ERMrest.Tuple+reference) ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
         * [.data](#ERMrest.Tuple+data) : <code>Object</code>
+        * [.data](#ERMrest.Tuple+data)
         * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
         * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
         * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
@@ -2312,6 +2313,7 @@ if (content) {
     * [new Tuple(reference, data)](#new_ERMrest.Tuple_new)
     * [.reference](#ERMrest.Tuple+reference) ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
     * [.data](#ERMrest.Tuple+data) : <code>Object</code>
+    * [.data](#ERMrest.Tuple+data)
     * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
     * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
     * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
@@ -2358,6 +2360,15 @@ and both the old and new value for the modified key are submitted together
 for proper updating.
 
 **Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+<a name="ERMrest.Tuple+data"></a>
+
+#### tuple.data
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| data | <code>Object</code> | the data to be updated |
+
 <a name="ERMrest.Tuple+canUpdate"></a>
 
 #### tuple.canUpdate : <code>boolean</code> &#124; <code>undefined</code>

--- a/doc/api.md
+++ b/doc/api.md
@@ -236,7 +236,7 @@ to use for ERMrest JavaScript agents.
             * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
         * [.read(limit)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
         * [.sort(sort)](#ERMrest.Reference+sort)
-        * [.update(tbd)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
+        * [.update(tuples)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
         * [.delete()](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
         * [.search(term)](#ERMrest.Reference+search)
     * [.Page](#ERMrest.Page)
@@ -251,7 +251,7 @@ to use for ERMrest JavaScript agents.
     * [.Tuple](#ERMrest.Tuple)
         * [new Tuple(reference, data)](#new_ERMrest.Tuple_new)
         * [.reference](#ERMrest.Tuple+reference) ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
-        * [.data](#ERMrest.Tuple+data)
+        * [.data](#ERMrest.Tuple+data) : <code>Object</code>
         * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
         * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
         * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
@@ -1853,7 +1853,7 @@ Constructor for a ParsedFilter.
         * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
     * [.read(limit)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
     * [.sort(sort)](#ERMrest.Reference+sort)
-    * [.update(tbd)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
+    * [.update(tuples)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
     * [.delete()](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
     * [.search(term)](#ERMrest.Reference+search)
 
@@ -2153,7 +2153,7 @@ Return a new Reference with the new sorting
 
 <a name="ERMrest.Reference+update"></a>
 
-#### reference.update(tbd) ⇒ <code>Promise</code>
+#### reference.update(tuples) ⇒ <code>Promise</code>
 Updates a set of resources.
 
 **Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
@@ -2161,7 +2161,7 @@ Updates a set of resources.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| tbd | <code>Array</code> | TBD parameters. Probably an array of pairs of [ (keys+values, allvalues)]+ ] for all entities to be updated. |
+| tuples | <code>Array</code> | array of tuple objects so that the new data nd old data can be used to determine key changes. tuple.data has the new data tuple._oldData has the data before changes were made |
 
 <a name="ERMrest.Reference+delete"></a>
 
@@ -2311,7 +2311,7 @@ if (content) {
 * [.Tuple](#ERMrest.Tuple)
     * [new Tuple(reference, data)](#new_ERMrest.Tuple_new)
     * [.reference](#ERMrest.Tuple+reference) ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
-    * [.data](#ERMrest.Tuple+data)
+    * [.data](#ERMrest.Tuple+data) : <code>Object</code>
     * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
     * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
     * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
@@ -2346,7 +2346,17 @@ This is the reference of the Tuple
 **Returns**: <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code> - reference of the Tuple  
 <a name="ERMrest.Tuple+data"></a>
 
-#### tuple.data
+#### tuple.data : <code>Object</code>
+Used for getting the current set of data for the reference.
+This stores the original data in the _oldData object to preserve
+it before any changes are made and those values can be properly
+used in update requests.
+
+Notably, if a key value is changed, the old value needs to be kept
+track of so that the column projections for the uri can be properly created
+and both the old and new value for the modified key are submitted together
+for proper updating.
+
 **Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+canUpdate"></a>
 
@@ -2452,11 +2462,11 @@ and therefore an asynchronous operation that returns a promise.
 #### tuple.getAssociationRef() : <code>[Reference](#ERMrest.Reference)</code>
 If the Tuple is derived from an association related table,
 this function will return a reference to the corresponding
-entity of this tuple's association table. 
+entity of this tuple's association table.
 
 For example, assume
 Table1(K1,C1) <- AssocitaitonTable(FK1, FK2) -> Table2(K2,C2)
-and current tuple is from Table2 with k2 = "2". 
+and current tuple is from Table2 with k2 = "2".
 With origFKRData = {"k1": "1"} this function will return a reference
 to AssocitaitonTable with FK1 = "1"" and FK2 = "2".
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -1025,7 +1025,8 @@ var ERMrest = (function(module) {
                         for (var m = 0; m < responseColumns.length; m++) {
                             var columnAlias = responseColumns[m];
                             if (columnAlias.endsWith(newAlias)) {
-                                var columnName = columnAlias.slice(0, (columnAlias.indexOf(newAlias)));
+                                // alias is always at end and length 2
+                                var columnName = columnAlias.slice(0, columnAlias.length-newAlias.length);
                                 pageData[j][columnName] = response.data[j][columnAlias];
                             }
                         }

--- a/js/reference.js
+++ b/js/reference.js
@@ -1942,6 +1942,14 @@ var ERMrest = (function(module) {
         },
 
         /**
+         *
+         * @param {Object} data - the data to be updated
+         */
+        set data(data) {
+            // TODO needs to be implemented rather than modifying the values directly from UI
+        },
+
+        /**
          * Indicates whether the client can update this tuple. Because
          * some policies may be undecidable until query execution, this
          * property may also be `undefined`.

--- a/js/reference.js
+++ b/js/reference.js
@@ -927,8 +927,9 @@ var ERMrest = (function(module) {
 
         /**
          * Updates a set of resources.
-         * @param {!Array} tbd TBD parameters. Probably an array of pairs of
-         * [ (keys+values, allvalues)]+ ] for all entities to be updated.
+         * @param {Array} tuples array of tuple objects so that the new data nd old data can be used to determine key changes.
+         * tuple.data has the new data
+         * tuple._oldData has the data before changes were made
          * @returns {Promise} page A promise for a page result or errors.
          */
         update: function(tuples) {
@@ -1920,7 +1921,17 @@ var ERMrest = (function(module) {
         },
 
         /**
+         * Used for getting the current set of data for the reference.
+         * This stores the original data in the _oldData object to preserve
+         * it before any changes are made and those values can be properly
+         * used in update requests.
          *
+         * Notably, if a key value is changed, the old value needs to be kept
+         * track of so that the column projections for the uri can be properly created
+         * and both the old and new value for the modified key are submitted together
+         * for proper updating.
+         *
+         * @type {(json Object)}
          */
         get data() {
             if (this._oldData === undefined) {
@@ -2130,18 +2141,18 @@ var ERMrest = (function(module) {
         /**
          * If the Tuple is derived from an association related table,
          * this function will return a reference to the corresponding
-         * entity of this tuple's association table. 
-         * 
+         * entity of this tuple's association table.
+         *
          * For example, assume
          * Table1(K1,C1) <- AssocitaitonTable(FK1, FK2) -> Table2(K2,C2)
-         * and current tuple is from Table2 with k2 = "2". 
+         * and current tuple is from Table2 with k2 = "2".
          * With origFKRData = {"k1": "1"} this function will return a reference
          * to AssocitaitonTable with FK1 = "1"" and FK2 = "2".
-         * 
+         *
          * @type {ERMrest.Reference}
          */
         getAssociationRef: function(origTableData){
-            if (this._pageRef._derivedAssociationRef) {          
+            if (this._pageRef._derivedAssociationRef) {
                 var associationRef = this._pageRef._derivedAssociationRef,
                     encoder = module._fixedEncodeURIComponent,
                     newFilter = [],
@@ -2169,7 +2180,7 @@ var ERMrest = (function(module) {
                 missingData = missingData || !addFilter(associationRef._secondFKR, this._data);
 
                 if (missingData) {
-                    return null;    
+                    return null;
                 } else {
                     var loc = associationRef._location;
                     var uri = [
@@ -2182,13 +2193,13 @@ var ERMrest = (function(module) {
                     reference.session = associationRef._session;
                     return reference;
                 }
-                
+
             } else {
                 return null;
             }
-            
-        }            
-        
+
+        }
+
 
     };
 
@@ -2355,7 +2366,7 @@ var ERMrest = (function(module) {
                         caption,
                         isNull = false,
                         i;
-                
+
                     for (i = 0; i < fkColumns.length; i++) {
                         if (fkColumns[i].default === null || fkColumns[i].default === undefined) {
                             isNull = true; //return null if one of them is null;

--- a/js/reference.js
+++ b/js/reference.js
@@ -1931,7 +1931,7 @@ var ERMrest = (function(module) {
          * and both the old and new value for the modified key are submitted together
          * for proper updating.
          *
-         * @type {(json Object)}
+         * @type {Object}
          */
         get data() {
             if (this._oldData === undefined) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -1018,7 +1018,7 @@ var ERMrest = (function(module) {
                             uri += ')';
                         }
 
-                        // reform the data
+                        // unalias the keys for the page data
                         pageData[j] = {};
                         var responseColumns = Object.keys(response.data[j]);
 


### PR DESCRIPTION
The update function handles updating multiple records at a time already. To work with this in the UI, we needed to make sure that the page returned from `reference.update()` had the keys in the data properly named. They were being returned as the aliased column name rather than the column name, so the resultset view for `recordedit` was getting `undefined` for values in `page.tuple.values`.

These changes should fix that. Rather than using the response data from the ermrest request to generate the Page object, I slice the alias off the end of the keys returned (keys are the aliased column names) from ermrest and create a new object to put into the data array used to create a Page.