### PR TITLE
fixes #311 stringify objects

### DIFF
--- a/js/utilities.js
+++ b/js/utilities.js
@@ -599,6 +599,9 @@ var ERMrest = (function(module) {
             if (value === null) {
                 return '';
             }
+            if (typeof value === 'object') {
+                return JSON.stringify(value);
+            }
             return value.toString();
         },
 

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -64,6 +64,8 @@ exports.execute = function (options) {
             var printText = formatUtils.printText;
             expect(printText(null)).toBe('');
             expect(printText("<b>Some text! &amp;</b>")).toBe('<b>Some text! &amp;</b>');
+            expect(printText({key:123})).toBe('{"key":123}');
+            expect(printText({key:123,subkey:{subsubkey:456}})).toBe('{"key":123,"subkey":{"subsubkey":456}}');
         });
 
         it('printMarkdown() should process Markdown into HTML.', function() {


### PR DESCRIPTION
This just addressed the issue that when `printText` encounters an Object it uses JSON.stringify() to produce the text rather than object.toString().