### PR TITLE
Change displayname

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -58,7 +58,7 @@ to use for ERMrest JavaScript agents.
         * [.name](#ERMrest.Schema+name)
         * [.ignore](#ERMrest.Schema+ignore) : <code>boolean</code>
         * [.annotations](#ERMrest.Schema+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
-        * [.displayname](#ERMrest.Schema+displayname) : <code>string</code>
+        * [.displayname](#ERMrest.Schema+displayname) : <code>object</code>
         * [.tables](#ERMrest.Schema+tables) : <code>[Tables](#ERMrest.Tables)</code>
         * [.comment](#ERMrest.Schema+comment) : <code>string</code>
     * [.Tables](#ERMrest.Tables)
@@ -76,7 +76,7 @@ to use for ERMrest JavaScript agents.
             * [.ignore](#ERMrest.Table+ignore) : <code>boolean</code>
             * [._baseTable](#ERMrest.Table+_baseTable) : <code>[Table](#ERMrest.Table)</code>
             * [.annotations](#ERMrest.Table+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
-            * [.displayname](#ERMrest.Table+displayname) : <code>string</code>
+            * [.displayname](#ERMrest.Table+displayname) : <code>object</code>
             * [.columns](#ERMrest.Table+columns) : <code>[Columns](#ERMrest.Columns)</code>
             * [.keys](#ERMrest.Table+keys) : <code>[Keys](#ERMrest.Keys)</code>
             * [.foreignKeys](#ERMrest.Table+foreignKeys) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
@@ -124,7 +124,7 @@ to use for ERMrest JavaScript agents.
         * [.comment](#ERMrest.Column+comment) : <code>string</code>
         * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
         * [.annotations](#ERMrest.Column+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
-        * [.displayname](#ERMrest.Column+displayname) : <code>string</code>
+        * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
         * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : <code>[Array.&lt;Key&gt;](#ERMrest.Key)</code>
         * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
         * [.formatvalue(data)](#ERMrest.Column+formatvalue) ⇒ <code>string</code>
@@ -223,7 +223,7 @@ to use for ERMrest JavaScript agents.
     * [.Reference](#ERMrest.Reference)
         * [new Reference(location, catalog)](#new_ERMrest.Reference_new)
         * [.contextualize](#ERMrest.Reference+contextualize)
-        * [.displayname](#ERMrest.Reference+displayname) : <code>string</code>
+        * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
         * [.uri](#ERMrest.Reference+uri) : <code>string</code>
         * [.session](#ERMrest.Reference+session)
         * [.table](#ERMrest.Reference+table) : <code>[Table](#ERMrest.Table)</code>
@@ -522,7 +522,7 @@ check for schema name existence
     * [.name](#ERMrest.Schema+name)
     * [.ignore](#ERMrest.Schema+ignore) : <code>boolean</code>
     * [.annotations](#ERMrest.Schema+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
-    * [.displayname](#ERMrest.Schema+displayname) : <code>string</code>
+    * [.displayname](#ERMrest.Schema+displayname) : <code>object</code>
     * [.tables](#ERMrest.Schema+tables) : <code>[Tables](#ERMrest.Tables)</code>
     * [.comment](#ERMrest.Schema+comment) : <code>string</code>
 
@@ -555,8 +555,10 @@ Constructor for the Catalog.
 **Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+displayname"></a>
 
-#### schema.displayname : <code>string</code>
+#### schema.displayname : <code>object</code>
 Preferred display name for user presentation only.
+this.displayname.isHTML will return true/false
+this.displayname.value has the value
 
 **Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+tables"></a>
@@ -631,7 +633,7 @@ get table by table name
         * [.ignore](#ERMrest.Table+ignore) : <code>boolean</code>
         * [._baseTable](#ERMrest.Table+_baseTable) : <code>[Table](#ERMrest.Table)</code>
         * [.annotations](#ERMrest.Table+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
-        * [.displayname](#ERMrest.Table+displayname) : <code>string</code>
+        * [.displayname](#ERMrest.Table+displayname) : <code>object</code>
         * [.columns](#ERMrest.Table+columns) : <code>[Columns](#ERMrest.Columns)</code>
         * [.keys](#ERMrest.Table+keys) : <code>[Keys](#ERMrest.Keys)</code>
         * [.foreignKeys](#ERMrest.Table+foreignKeys) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
@@ -689,8 +691,10 @@ then might be changed on the second pass if this is an alternative table
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+displayname"></a>
 
-#### table.displayname : <code>string</code>
+#### table.displayname : <code>object</code>
 Preferred display name for user presentation only.
+this.displayname.isHTML will return true/false
+this.displayname.value has the value
 
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+columns"></a>
@@ -1052,7 +1056,7 @@ Constructor for Columns.
     * [.comment](#ERMrest.Column+comment) : <code>string</code>
     * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
     * [.annotations](#ERMrest.Column+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
-    * [.displayname](#ERMrest.Column+displayname) : <code>string</code>
+    * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
     * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : <code>[Array.&lt;Key&gt;](#ERMrest.Key)</code>
     * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
     * [.formatvalue(data)](#ERMrest.Column+formatvalue) ⇒ <code>string</code>
@@ -1119,8 +1123,10 @@ Documentation for this column
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+displayname"></a>
 
-#### column.displayname : <code>string</code>
+#### column.displayname : <code>object</code>
 Preferred display name for user presentation only.
+this.displayname.isHTML will return true/false
+this.displayname.value has the value
 
 **Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+memberOfKeys"></a>
@@ -1876,7 +1882,7 @@ Constructor for a ParsedFilter.
 * [.Reference](#ERMrest.Reference)
     * [new Reference(location, catalog)](#new_ERMrest.Reference_new)
     * [.contextualize](#ERMrest.Reference+contextualize)
-    * [.displayname](#ERMrest.Reference+displayname) : <code>string</code>
+    * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
     * [.uri](#ERMrest.Reference+uri) : <code>string</code>
     * [.session](#ERMrest.Reference+session)
     * [.table](#ERMrest.Reference+table) : <code>[Table](#ERMrest.Table)</code>
@@ -1939,8 +1945,10 @@ different compared to `reference.columns`.
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+displayname"></a>
 
-#### reference.displayname : <code>string</code>
+#### reference.displayname : <code>object</code>
 The display name for this reference.
+displayname.isHTML will return true/false
+displayname.value has the value
 
 **Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+uri"></a>

--- a/js/core.js
+++ b/js/core.js
@@ -499,8 +499,11 @@ var ERMrest = (function (module) {
         this._nameStyle = {}; // Used in the displayname to store the name styles.
 
         /**
-         * @type {string}
-         * @desc Preferred display name for user presentation only.
+         * @type {object}
+         * @desc
+         * Preferred display name for user presentation only.
+         * this.displayname.isHTML will return true/false
+         * this.displayname.value has the value
          */
         this.displayname = module._determineDisplayName(this, null);
 
@@ -715,8 +718,11 @@ var ERMrest = (function (module) {
         this._displayKeys = {}; // Used for display key
 
         /**
-         * @type {string}
-         * @desc Preferred display name for user presentation only.
+         * @type {object}
+         * @desc
+         * Preferred display name for user presentation only.
+         * this.displayname.isHTML will return true/false
+         * this.displayname.value has the value
          */
         this.displayname = module._determineDisplayName(this, this.schema);
 
@@ -1834,8 +1840,11 @@ var ERMrest = (function (module) {
         this._display = {};  // Used for column.display annotation.
 
         /**
-         * @type {string}
-         * @desc Preferred display name for user presentation only.
+         * @type {object}
+         * @desc
+         * Preferred display name for user presentation only.
+         * this.displayname.isHTML will return true/false
+         * this.displayname.value has the value
          */
         this.displayname = module._determineDisplayName(this, this.table);
 

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -133,20 +133,22 @@ var ERMrest = (function(module) {
      * column elements of a model.
      */
     module._determineDisplayName = function (element, parentElement) {
-        var displayname = element.name;
-        var hasDisplayName = false;
+        var value = element.name,
+            hasDisplayName = false,
+            isHTML = false;
         try {
             var display_annotation = element.annotations.get(module._annotations.DISPLAY);
             if (display_annotation && display_annotation.content) {
 
                 //get the markdown display name
                 if(display_annotation.content.markdown_name) {
-                    displayname = module._formatUtils.printMarkdown(display_annotation.content.markdown_name, { inline: true });
+                    value = module._formatUtils.printMarkdown(display_annotation.content.markdown_name, { inline: true });
+                    isHTML = true;
                     hasDisplayName = true;
                 } 
                 //get the specified display name
                 else if (display_annotation.content.name){
-                    displayname = display_annotation.content.name;
+                    value = display_annotation.content.name;
                     hasDisplayName = true;
                 }
 
@@ -176,18 +178,19 @@ var ERMrest = (function(module) {
         // if name was not specified and name styles are defined, apply the heuristic functions (name styles)
         if(!hasDisplayName && element._nameStyle){
             if(element._nameStyle.markdown){
-                displayname = module._formatUtils.printMarkdown(element.name, { inline: true });
+                value = module._formatUtils.printMarkdown(element.name, { inline: true });
+                isHTML = true;
             } else {
                 if(element._nameStyle.underline_space){
-                    displayname = module._underlineToSpace(displayname);
+                    value = module._underlineToSpace(value);
                 }
                 if(element._nameStyle.title_case){
-                    displayname = module._toTitleCase(displayname);
+                    value = module._toTitleCase(value);
                 }
             }
         }
 
-        return displayname;
+        return {"isHTML": isHTML, "value": value};
     };
 
     /**

--- a/test/specs/annotation/tests/01.displayname.js
+++ b/test/specs/annotation/tests/01.displayname.js
@@ -11,65 +11,70 @@ exports.execute = function (options) {
         // Test Cases:
 
         it('schema should use name styles (`underline_space`, `title_case`) that are defined in its display annotations.', function () {
-            expect(schema.displayname).toBe("schema with underlinespace without titlecase");
+            expect(schema.displayname.value).toBe("schema with underlinespace without titlecase");
+            expect(schema.displayname.isHTML).toBe(false);
         });
 
         it('table should use its own markdown_name that is defind in display annotation.', function () {
-            expect(schema.tables.get("table_with_markdownname").displayname).toBe("<strong>Table Name</strong>");
+            checkTable("table_with_markdownname", "<strong>Table Name</strong>", true);
         });
 
         it('table should use its own name that is defined in display annotation.', function () {
-            expect(schema.tables.get("table_with_name").displayname).toBe("Table Name");
+            checkTable("table_with_name", "Table Name", false);
         });
 
         it('table should use its own name styles (`underline_space`, `title_case`, `markdown`) that are defined in its display annotation.', function () {
-            expect(schema.tables.get("table_with_titlecase").displayname).toBe("Table With Titlecase");
-            expect(schema.tables.get("table_with_titlecase_without_underlinespace").displayname).toBe("Table_With_Titlecase_Without_Underlinespace");
-            expect(schema.tables.get("**table with markdown**").displayname).toBe("<strong>table with markdown</strong>");
+            checkTable("table_with_titlecase", "Table With Titlecase", false);
+            checkTable("table_with_titlecase_without_underlinespace", "Table_With_Titlecase_Without_Underlinespace", false);
+            checkTable("**table with markdown**", "<strong>table with markdown</strong>", true);
         });
 
         it('table should use schema name styles when `name_style`, `name`, and `markdown_name` are not defined in its display annotation.', function () {
-            expect(schema.tables.get("table_without_display_annotation").displayname).toBe("table without display annotation");
+            checkTable("table_without_display_annotation", "table without display annotation", false);
         });
 
         it('column should use its own markdown_name that is defined in display annotation.', function () {
-            expect(schema.tables.get("table_with_markdownname").columns.get("column_with_markdownname").displayname).toBe("<em>Column name</em>");
-            expect(schema.tables.get("**table with markdown**").columns.get("column_with_markdownname").displayname).toBe("<em>Column name</em>");
-            expect(schema.tables.get("table_with_name").columns.get("column_with_markdownname").displayname).toBe("<em>Column name</em>");
-            expect(schema.tables.get("table_with_titlecase").columns.get("column_with_markdownname").displayname).toBe("<em>Column name</em>");
-            expect(schema.tables.get("table_without_display_annotation").columns.get("column_with_markdownname").displayname).toBe("<em>Column name</em>");
+            checkColumn("table_with_markdownname", "column_with_markdownname", "<em>Column name</em>", true);
+            checkColumn("**table with markdown**", "column_with_markdownname", "<em>Column name</em>", true);
+            checkColumn("table_with_name", "column_with_markdownname", "<em>Column name</em>", true);
+            checkColumn("table_with_titlecase", "column_with_markdownname", "<em>Column name</em>", true);
+            checkColumn("table_without_display_annotation", "column_with_markdownname", "<em>Column name</em>", true);
         });
 
         it('column should use its own name that is defined in display annotation.', function () {
-            expect(schema.tables.get("table_with_name").columns.get("column_with_name").displayname).toBe("Column Name");
-            expect(schema.tables.get("table_with_titlecase").columns.get("column_with_name_2").displayname).toBe("Column Name 2");
-            expect(schema.tables.get("table_without_display_annotation").columns.get("column_with_name_3").displayname).toBe("Column Name 3");
-            expect(schema.tables.get("**table with markdown**").columns.get("column_with_name").displayname).toBe("Column Name");
+            checkColumn("table_with_name", "column_with_name", "Column Name", false);
+            checkColumn("table_with_titlecase", "column_with_name_2", "Column Name 2", false);
+            checkColumn("table_without_display_annotation", "column_with_name_3", "Column Name 3", false);
+            checkColumn("**table with markdown**", "column_with_name", "Column Name", false);
         });
 
         it('column should use its own name styles (`underline_space`, `title_case`, `markdown`) that are defined in its display annotation.', function () {
-            var col = schema.tables.get("table_with_name").columns.get("column_with_titlecase");
-            expect(col.displayname).toBe("Column With Titlecase");
-            col = schema.tables.get("table_with_titlecase_without_underlinespace").columns.get("column_with_underlinespace_without_titlecase");
-            expect(col.displayname).toBe("column with underlinespace without titlecase");
-            col = schema.tables.get("table_with_markdownname").columns.get("**column with markdown**");
-            expect(col.displayname).toBe("<strong>column with markdown</strong>");
-            col = schema.tables.get("**table with markdown**").columns.get("**column without markdown**");
-            expect(col.displayname).toBe("**Column Without Markdown**");
+            checkColumn("table_with_name", "column_with_titlecase", "Column With Titlecase", false);
+            checkColumn("table_with_titlecase_without_underlinespace", "column_with_underlinespace_without_titlecase", "column with underlinespace without titlecase", false);
+            checkColumn("table_with_markdownname", "**column with markdown**", "<strong>column with markdown</strong>", true);
+            checkColumn("**table with markdown**", "**column without markdown**", "**Column Without Markdown**", false);
         });
 
         it('column should use table name styles when `name_style`, `name`, and `markdown_name` are not defined in its display annotation.', function () {
-            var col = schema.tables.get("table_with_titlecase_without_underlinespace").columns.get("column_without_display_annotation");
-            expect(col.displayname).toBe("Column_Without_Display_Annotation");
-            col = schema.tables.get("table_with_titlecase").columns.get("column_without_display_annotation_3");
-            expect(col.displayname).toBe("Column Without Display Annotation 3");
-            col = schema.tables.get("**table with markdown**").columns.get("**Column Without Display Annotation**");
-            expect(col.displayname).toBe("<strong>Column Without Display Annotation</strong>");
+            checkColumn("table_with_titlecase_without_underlinespace", "column_without_display_annotation", "Column_Without_Display_Annotation", false);
+            checkColumn("table_with_titlecase", "column_without_display_annotation_3", "Column Without Display Annotation 3", false);
+            checkColumn("**table with markdown**", "**Column Without Display Annotation**", "<strong>Column Without Display Annotation</strong>", true);
         });
 
         it("column should use schema name styles when `name_style` , `name`, and `markdown_name` are not defined in its display annotation nor table's display annotation.", function () {
-            var col = schema.tables.get("table_without_display_annotation").columns.get("column_without_display_annotation_2");
-            expect(col.displayname).toBe("column without display annotation 2");
+            checkColumn("table_without_display_annotation", "column_without_display_annotation_2", "column without display annotation 2", false);
         });
+
+        // Helpers:
+
+        function checkTable(tableName, expectedValue, expectedHTML) {
+            expect(schema.tables.get(tableName).displayname.value).toBe(expectedValue);
+            expect(schema.tables.get(tableName).displayname.isHTML).toBe(expectedHTML);
+        }
+
+        function checkColumn(tableName, columnName, expectedValue, expectedHTML) {
+            expect(schema.tables.get(tableName).columns.get(columnName).displayname.value).toBe(expectedValue);
+            expect(schema.tables.get(tableName).columns.get(columnName).displayname.isHTML).toBe(expectedHTML);
+        }
     });
 };

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -144,7 +144,7 @@ exports.execute = function (options) {
             // Methods that are currently implemented
             it('reference should have methods properly defined.', function() {
                 expect(reference.uri).toBe(reference._location.uri);
-                expect(reference.displayname).toBe(reference._table.name);
+                expect(reference.displayname.value).toBe(reference._table.name);
                 expect(reference.table).toBe(reference._table);
                 expect(reference.canCreate).toBeDefined();
                 expect(reference.canUpdate).toBeDefined();

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -67,11 +67,11 @@ exports.execute = function(options) {
 
             describe('.displayname, ', function() {
                 it('should use from_name when annotation is present.', function() {
-                    expect(related[0].displayname).toBe("from_name_value");
+                    expect(related[0].displayname.value).toBe("from_name_value");
                 });
 
                 it('should use the name of the table when annotation is not present.', function() {
-                    expect(related[1].displayname).toBe("inbound_related_reference_table");
+                    expect(related[1].displayname.value).toBe("inbound_related_reference_table");
                 });
             });
 
@@ -151,11 +151,11 @@ exports.execute = function(options) {
 
             describe('.displayname, ', function (){
                 it('should use to_name when annotation is present.', function() {
-                  expect(related[2].displayname).toBe("to_name_value");
+                  expect(related[2].displayname.value).toBe("to_name_value");
                 });
 
                 it('should use the displayname of assocation table when annotation is not present.', function() {
-                  expect(related[3].displayname).toBe(associationTableWithIDDisplayname);
+                  expect(related[3].displayname.value).toBe(associationTableWithIDDisplayname);
                 });
             });
 
@@ -283,7 +283,7 @@ exports.execute = function(options) {
             });
 
             it('should be sorted by displayname.', function() {
-                expect(related2[0].displayname).toBe("first_related");
+                expect(related2[0].displayname.value).toBe("first_related");
             });
 
             it('should be sorted by order of key columns when displayname is the same.', function (){

--- a/test/specs/reference/tests/08.alternative_tables.js
+++ b/test/specs/reference/tests/08.alternative_tables.js
@@ -148,7 +148,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable1);
+                expect(reference2.displayname.value).toBe(baseTable1);
             });
 
             it('1.A.1 read should return a Page object that is defined.', function(done) {
@@ -178,7 +178,7 @@ exports.execute = function (options) {
             it('1.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -202,7 +202,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable1);
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
             });
 
             it('1.B.1 read should return a Page object that is defined.', function(done) {
@@ -231,7 +231,7 @@ exports.execute = function (options) {
             it('1.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -255,7 +255,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable1);
+                expect(reference2.displayname.value).toBe(altCompactTable1);
             });
 
             it('1.C.1 read should return a Page object that is defined.', function(done) {
@@ -284,7 +284,7 @@ exports.execute = function (options) {
             it('1.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -345,7 +345,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable1);
+                expect(reference2.displayname.value).toBe(baseTable1);
             });
 
             it('2.A.1 read should return a Page object that is defined.', function(done) {
@@ -375,7 +375,7 @@ exports.execute = function (options) {
             it('2.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -399,7 +399,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable1);
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
             });
 
             it('2.B.1 read should return a Page object that is defined.', function(done) {
@@ -428,7 +428,7 @@ exports.execute = function (options) {
             it('2.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -452,7 +452,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable1);
+                expect(reference2.displayname.value).toBe(altCompactTable1);
             });
 
             it('2.C.1 read should return a Page object that is defined.', function(done) {
@@ -481,7 +481,7 @@ exports.execute = function (options) {
             it('2.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -543,7 +543,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable2);
+                expect(reference2.displayname.value).toBe(baseTable2);
             });
 
             it('3.A.1 read should return a Page object that is defined.', function(done) {
@@ -573,7 +573,7 @@ exports.execute = function (options) {
             it('3.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable2);
-                expect(tuple.reference.displayname).toBe(baseTable2);
+                expect(tuple.reference.displayname.value).toBe(baseTable2);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable2Encoded+ "/id=00001&value=12");
             });
 
@@ -597,7 +597,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable2);
+                expect(reference2.displayname.value).toBe(altDetailedTable2);
             });
 
             it('3.B.1 read should return a Page object that is defined.', function(done) {
@@ -627,7 +627,7 @@ exports.execute = function (options) {
             it('3.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable2);
-                expect(tuple.reference.displayname).toBe(baseTable2);
+                expect(tuple.reference.displayname.value).toBe(baseTable2);
                 var success = (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/id=00001&value=12") ||
                     (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/value=12&id=00001");
                 expect(success).toBe(true);
@@ -653,7 +653,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable2);
+                expect(reference2.displayname.value).toBe(altCompactTable2);
             });
 
             it('3.C.1 read should return a Page object that is defined.', function(done) {
@@ -682,7 +682,7 @@ exports.execute = function (options) {
             it('3.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable2);
-                expect(tuple.reference.displayname).toBe(baseTable2);
+                expect(tuple.reference.displayname.value).toBe(baseTable2);
                 var success = (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/id=00001&value=12") ||
                     (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/value=12&id=00001");
                 expect(success).toBe(true);
@@ -744,7 +744,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable1);
+                expect(reference2.displayname.value).toBe(baseTable1);
             });
 
             it('4.A.1 read should return a Page object that is defined.', function(done) {
@@ -774,7 +774,7 @@ exports.execute = function (options) {
             it('4.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -798,7 +798,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable1);
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
             });
 
             it('4.B.1 read should return a Page object that is defined.', function(done) {
@@ -827,7 +827,7 @@ exports.execute = function (options) {
             it('4.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -851,7 +851,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable1);
+                expect(reference2.displayname.value).toBe(altCompactTable1);
             });
 
             it('4.C.1 read should return a Page object that is defined.', function(done) {
@@ -880,7 +880,7 @@ exports.execute = function (options) {
             it('4.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -946,7 +946,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable1);
+                expect(reference2.displayname.value).toBe(baseTable1);
             });
 
             it('5.A.1 read should return a Page object that is defined.', function(done) {
@@ -976,7 +976,7 @@ exports.execute = function (options) {
             it('5.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1000,7 +1000,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable1);
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
             });
 
             it('5.B.1 read should return a Page object that is defined.', function(done) {
@@ -1029,7 +1029,7 @@ exports.execute = function (options) {
             it('5.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1053,7 +1053,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable1);
+                expect(reference2.displayname.value).toBe(altCompactTable1);
             });
 
             it('5.C.1 read should return a Page object that is defined.', function(done) {
@@ -1082,7 +1082,7 @@ exports.execute = function (options) {
             it('5.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1141,7 +1141,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable1);
+                expect(reference2.displayname.value).toBe(baseTable1);
             });
 
             it('6.A.1 read should return a Page object that is defined.', function(done) {
@@ -1171,7 +1171,7 @@ exports.execute = function (options) {
             it('6.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1195,7 +1195,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable1);
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
             });
 
             it('6.B.1 read should return a Page object that is defined.', function(done) {
@@ -1224,7 +1224,7 @@ exports.execute = function (options) {
             it('6.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1248,7 +1248,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable1);
+                expect(reference2.displayname.value).toBe(altCompactTable1);
             });
 
             it('6.C.1 read should return a Page object that is defined.', function(done) {
@@ -1277,7 +1277,7 @@ exports.execute = function (options) {
             it('6.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1337,7 +1337,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable2);
+                expect(reference2.displayname.value).toBe(baseTable2);
             });
 
             it('7.A.1 read should return a Page object that is defined.', function(done) {
@@ -1367,7 +1367,7 @@ exports.execute = function (options) {
             it('7.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable2);
-                expect(tuple.reference.displayname).toBe(baseTable2);
+                expect(tuple.reference.displayname.value).toBe(baseTable2);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable2Encoded+ "/id=00001&value=12");
             });
 
@@ -1391,7 +1391,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable2);
+                expect(reference2.displayname.value).toBe(altDetailedTable2);
             });
 
             it('7.B.1 read should return a Page object that is defined.', function(done) {
@@ -1421,7 +1421,7 @@ exports.execute = function (options) {
             it('7.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable2);
-                expect(tuple.reference.displayname).toBe(baseTable2);
+                expect(tuple.reference.displayname.value).toBe(baseTable2);
                 var success = (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/id=00001&value=12") ||
                     (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/value=12&id=00001");
                 expect(success).toBe(true);
@@ -1447,7 +1447,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable2);
+                expect(reference2.displayname.value).toBe(altCompactTable2);
             });
 
             it('7.C.1 read should return a Page object that is defined.', function(done) {
@@ -1476,7 +1476,7 @@ exports.execute = function (options) {
             it('7.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable2);
-                expect(tuple.reference.displayname).toBe(baseTable2);
+                expect(tuple.reference.displayname.value).toBe(baseTable2);
                 var success = (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/id=00001&value=12") ||
                     (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/value=12&id=00001");
                 expect(success).toBe(true);
@@ -1536,7 +1536,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable1);
+                expect(reference2.displayname.value).toBe(baseTable1);
             });
 
             it('8.A.1 read should return a Page object that is defined.', function(done) {
@@ -1566,7 +1566,7 @@ exports.execute = function (options) {
             it('8.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1590,7 +1590,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable1);
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
             });
 
             it('8.B.1 read should return a Page object that is defined.', function(done) {
@@ -1619,7 +1619,7 @@ exports.execute = function (options) {
             it('8.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1643,7 +1643,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable1);
+                expect(reference2.displayname.value).toBe(altCompactTable1);
             });
 
             it('8.C.1 read should return a Page object that is defined.', function(done) {
@@ -1672,7 +1672,7 @@ exports.execute = function (options) {
             it('8.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1738,7 +1738,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable1);
+                expect(reference2.displayname.value).toBe(baseTable1);
             });
 
             it('9.A.1 read should return a Page object that is defined.', function(done) {
@@ -1768,7 +1768,7 @@ exports.execute = function (options) {
             it('9.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1792,7 +1792,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable1);
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
             });
 
             it('9.B.1 read should return a Page object that is defined.', function(done) {
@@ -1821,7 +1821,7 @@ exports.execute = function (options) {
             it('9.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1845,7 +1845,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable1);
+                expect(reference2.displayname.value).toBe(altCompactTable1);
             });
 
             it('9.C.1 read should return a Page object that is defined.', function(done) {
@@ -1874,7 +1874,7 @@ exports.execute = function (options) {
             it('9.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1933,7 +1933,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable1);
+                expect(reference2.displayname.value).toBe(baseTable1);
             });
 
             it('10.A.1 read should return a Page object that is defined.', function(done) {
@@ -1963,7 +1963,7 @@ exports.execute = function (options) {
             it('10.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -1987,7 +1987,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable1);
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
             });
 
             it('10.B.1 read should return a Page object that is defined.', function(done) {
@@ -2016,7 +2016,7 @@ exports.execute = function (options) {
             it('10.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -2040,7 +2040,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable1);
+                expect(reference2.displayname.value).toBe(altCompactTable1);
             });
 
             it('10.C.1 read should return a Page object that is defined.', function(done) {
@@ -2069,7 +2069,7 @@ exports.execute = function (options) {
             it('10.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -2129,7 +2129,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable2);
+                expect(reference2.displayname.value).toBe(baseTable2);
             });
 
             it('11.A.1 read should return a Page object that is defined.', function(done) {
@@ -2159,7 +2159,7 @@ exports.execute = function (options) {
             it('11.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable2);
-                expect(tuple.reference.displayname).toBe(baseTable2);
+                expect(tuple.reference.displayname.value).toBe(baseTable2);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable2Encoded+ "/id=00001&value=12");
             });
 
@@ -2183,7 +2183,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable2);
+                expect(reference2.displayname.value).toBe(altDetailedTable2);
             });
 
             it('11.B.1 read should return a Page object that is defined.', function(done) {
@@ -2213,7 +2213,7 @@ exports.execute = function (options) {
             it('11.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable2);
-                expect(tuple.reference.displayname).toBe(baseTable2);
+                expect(tuple.reference.displayname.value).toBe(baseTable2);
                 var success = (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/id=00001&value=12") ||
                     (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/value=12&id=00001");
                 expect(success).toBe(true);
@@ -2239,7 +2239,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable2);
+                expect(reference2.displayname.value).toBe(altCompactTable2);
             });
 
             it('11.C.1 read should return a Page object that is defined.', function(done) {
@@ -2268,7 +2268,7 @@ exports.execute = function (options) {
             it('11.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable2);
-                expect(tuple.reference.displayname).toBe(baseTable2);
+                expect(tuple.reference.displayname.value).toBe(baseTable2);
                 var success = (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/id=00001&value=12") ||
                     (tuple.reference._location.path === schemaNameEncoded + ":" + baseTable2Encoded+ "/value=12&id=00001");
                 expect(success).toBe(true);
@@ -2328,7 +2328,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
-                expect(reference2.displayname).toBe(baseTable1);
+                expect(reference2.displayname.value).toBe(baseTable1);
             });
 
             it('12.A.1 read should return a Page object that is defined.', function(done) {
@@ -2358,7 +2358,7 @@ exports.execute = function (options) {
             it('12.A.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -2382,7 +2382,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altDetailedTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id x");
-                expect(reference2.displayname).toBe(altDetailedTable1);
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
             });
 
             it('12.B.1 read should return a Page object that is defined.', function(done) {
@@ -2411,7 +2411,7 @@ exports.execute = function (options) {
             it('12.B.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
@@ -2435,7 +2435,7 @@ exports.execute = function (options) {
                 expect(reference2._table.name).toBe(altCompactTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id y");
-                expect(reference2.displayname).toBe(altCompactTable1);
+                expect(reference2.displayname.value).toBe(altCompactTable1);
             });
 
             it('12.C.1 read should return a Page object that is defined.', function(done) {
@@ -2464,7 +2464,7 @@ exports.execute = function (options) {
             it('12.C.3 tuple reference should be on the base table with correct filter', function() {
                 expect(tuple.reference).toBeDefined();
                 expect(tuple.reference._table.name).toBe(baseTable1);
-                expect(tuple.reference.displayname).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -170,30 +170,29 @@ exports.execute = function (options) {
         describe('.displayname, ', function () {
             describe('for pseudoColumns that are foreign key, ', function () {
                 it('should use the foreignKey\'s to_name.', function () {
-                    expect(detailedColumns[1].displayname).toBe("to_name_value");
-                    expect(detailedColumns[11].displayname).toBe("to_name_value");
+                    checkDisplayname(detailedColumns[1].displayname, "to_name_value", false);
                 });
 
                 describe('when foreignKey\'s to_name is not defined, ', function () {
                     describe('for simple foreign keys, ', function () {
                         it('should use column\'s displayname in the absence of to_name in foreignKey.', function () {
-                            expect(detailedColumns[2].displayname).toBe("Column 2 Name");
+                            checkDisplayname(detailedColumns[2].displayname, "Column 2 Name", false);
                         });
 
                         it('should be disambiguated with Table.displayname when there are multiple foreignkeys.', function () {
-                            expect(detailedColumns[3].displayname).toBe("Column 3 Name (reference_table)");
-                            expect(detailedColumns[4].displayname).toBe("Column 3 Name (reference_values)");
+                            checkDisplayname(detailedColumns[3].displayname, "Column 3 Name (reference_table)", false);
+                            checkDisplayname(detailedColumns[4].displayname, "Column 3 Name (reference_values)", false);
                         });
                     });
 
                     describe('for composite foreign keys, ', function () {
                         it('should use referenced table\'s displayname in the absence of to_name in foreignKey.', function () {
-                            expect(detailedColumns[12].displayname).toBe("table_w_composite_key_2");
+                            checkDisplayname(detailedColumns[12].displayname, "table_w_composite_key_2", false);
                         });
 
                         it('should be disambiguated with displayname of columns when there are multiple foreignkeys to that table.', function () {
-                            expect(detailedColumns[13].displayname).toBe("table_w_composite_key (Column 3 Name, col_5)");
-                            expect(detailedColumns[14].displayname).toBe("table_w_composite_key (col_4, col_5)");
+                            checkDisplayname(detailedColumns[13].displayname, "table_w_composite_key (Column 3 Name, col_5)", false);
+                            checkDisplayname(detailedColumns[14].displayname, "table_w_composite_key (col_4, col_5)", false);
                         });
                     })
 
@@ -202,12 +201,12 @@ exports.execute = function (options) {
 
             it('for pseudoColumns that are key, should return the consitutent column displaynames seperated by space.', function() {
                 // simple
-                expect(detailedColumns[0].displayname).toBe("id");
-                expect(compactBriefRef.columns[0].displayname).toBe("Column 3 Name col_6");
+                checkDisplayname(detailedColumns[0].displayname, "id", false);
+                checkDisplayname(compactBriefRef.columns[0].displayname, "Column 3 Name col_6", false);
             });         
 
             it('for other columns, should return the base column\'s displayname.', function () {
-                expect(detailedColumns[5].displayname).toBe("Column 3 Name");
+                checkDisplayname(detailedColumns[5].displayname, "Column 3 Name", false);
             });
         });
 
@@ -403,4 +402,9 @@ exports.execute = function (options) {
             });
         });
     });
+
+    function checkDisplayname(displayname, expectedVal, expectedHTML) {
+        expect(displayname.value).toBe(expectedVal);
+        expect(displayname.isHTML).toBe(expectedHTML);
+    }
 }


### PR DESCRIPTION
This PR will turn the displayname of `Column`, `Table`, `Schema`, and `Reference` into an object with `isHTML` and `value` attributes.

Merging this PR will break the chaise test-cases. So it should be merged alongside the required changes in chaise.