### PR TITLE
Derived Association Reference

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -1257,7 +1257,7 @@ var ERMrest = (function(module) {
                     delete newRef._context; // NOTE: related reference is not contextualized
                     delete newRef._related;
                     delete newRef._referenceColumns;
-                    delete newRef._derivedAssociationRef;
+                    delete newRef.derivedAssociationReference;
 
                     // delete permissions
                     delete newRef._canCreate;
@@ -1287,11 +1287,11 @@ var ERMrest = (function(module) {
                         newRef._related_key_column_positions = fkr.key.colset._getColumnPositions();
                         newRef._related_fk_column_positions = otherFK.colset._getColumnPositions();
 
-                        // will be used in entry contexts
-                        newRef._derivedAssociationRef = new Reference(module._parse(this._location.compactUri + "/" + fkr.toString()), newRef._table.schema.catalog);
-                        newRef._derivedAssociationRef.session = this._session;
-                        newRef._derivedAssociationRef.origFKR = newRef.origFKR;
-                        newRef._derivedAssociationRef._secondFKR = otherFK;
+                        // will be used to determine whether this related reference is derived from association relation or not
+                        newRef.derivedAssociationReference = new Reference(module._parse(this._location.compactUri + "/" + fkr.toString()), newRef._table.schema.catalog);
+                        newRef.derivedAssociationReference.session = this._session;
+                        newRef.derivedAssociationReference.origFKR = newRef.origFKR;
+                        newRef.derivedAssociationReference._secondFKR = otherFK;
 
                     } else { // Simple inbound Table
                         newRef._table = fkrTable;
@@ -1376,7 +1376,7 @@ var ERMrest = (function(module) {
             this._displayname = table.displayname;
             delete this._referenceColumns;
             delete this._related;
-            delete this._derivedAssociationRef;
+            delete this.derivedAssociationReference;
             delete this._canCreate;
             delete this._canRead;
             delete this._canUpdate;
@@ -1463,14 +1463,7 @@ var ERMrest = (function(module) {
         },
 
         _contextualize: function(context) {
-            var source;
-
-            // if this is a related association table and context is edit, contextualize based on the association table.
-            if (this._reference._derivedAssociationRef && module._isEntryContext(context)) {
-                source = this._reference._derivedAssociationRef;
-            } else {
-                source = this._reference;
-            }
+            var source = this._reference;
 
             var newRef = _referenceCopy(source);
             delete newRef._related;
@@ -2213,8 +2206,8 @@ var ERMrest = (function(module) {
          * @type {ERMrest.Reference}
          */
         getAssociationRef: function(origTableData){
-            if (this._pageRef._derivedAssociationRef) {
-                var associationRef = this._pageRef._derivedAssociationRef,
+            if (this._pageRef.derivedAssociationReference) {
+                var associationRef = this._pageRef.derivedAssociationReference,
                     encoder = module._fixedEncodeURIComponent,
                     newFilter = [],
                     missingData = false;

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -101,9 +101,9 @@ exports.execute = function(options) {
                 ]}]);
             });
 
-            it('._derivedAssociationRef should be undefined', function() {
-                expect(related[0]._derivedAssociationRef).toBeUndefined();
-                expect(related[1]._derivedAssociationRef).toBeUndefined();
+            it('.derivedAssociationReference should be undefined', function() {
+                expect(related[0].derivedAssociationReference).toBeUndefined();
+                expect(related[1].derivedAssociationReference).toBeUndefined();
             });
 
             it('.read should return a Page object that is defined.', function(done) {
@@ -192,21 +192,9 @@ exports.execute = function(options) {
                 });
             });
 
-            it('._derivedAssociationRef should be defined.', function() {
-                expect(related[2]._derivedAssociationRef._table.name).toBe("association_table_with_toname");
-                expect(related[3]._derivedAssociationRef._table.name).toBe("association table with id");
-            });
-
-            it('.contextualize.entryEdit/.entryCreate/.entry should be created based on the assocation table rather than the reference it is referring to.', function(){
-                var refs;
-                refs = [ related[2].contextualize.entryEdit, related[2].contextualize.entryCreate, related[2].contextualize.entry];
-                refs.forEach(function (ref) {
-                    expect(ref._table.name).toBe("association_table_with_toname");
-                });
-                refs = [related[3].contextualize.entryEdit, related[3].contextualize.entryCreate, related[3].contextualize.entry];
-                refs.forEach(function (ref) {
-                    expect(ref._table.name).toBe("association table with id");
-                });
+            it('.derivedAssociationReference should be defined.', function() {
+                expect(related[2].derivedAssociationReference._table.name).toBe("association_table_with_toname");
+                expect(related[3].derivedAssociationReference._table.name).toBe("association table with id");
             });
 
             it('.read should return a Page object that is defined.', function(done) {


### PR DESCRIPTION
This PR exposes the `derievedAssociationReference` and removes the logic in contextualize to change the reference in case of association. This logic should be moved to chaise.

**_This PR will break the chaise test-cases._** 