### PR TITLE
Format numeric columns as floats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,10 @@ before_install:
   - sudo npm install
   - cd ..
   - cd ermrestjs
+  - sudo cp test/ermrest_config.json /home/ermrest
+  - sudo chmod a+r /home/ermrest/ermrest_config.json
   - sudo npm install
+  - sudo service apache2 restart
 
 install:
   - sudo make build

--- a/js/core.js
+++ b/js/core.js
@@ -842,10 +842,10 @@ var ERMrest = (function (module) {
         /**
          * @param {string} context used to figure out if the column has markdown_pattern annoation or not.
          * @returns{Column[]|undefined} list of columns. If couldn't find a suitable columns will return undefined.
-         * @desc 
+         * @desc
          * returns the key that can be used for display purposes.
          */
-        _getDisplayKey: function (context) {            
+        _getDisplayKey: function (context) {
             if (!(context in this._displayKeys)) {
                 var key;
                 if (this.keys.length() !== 0) {
@@ -872,14 +872,14 @@ var ERMrest = (function (module) {
                             if (keyA.colset.columns.length != keyB.colset.columns.length) {
                                 return keyA.colset.columns.length > keyB.colset.columns.length;
                             }
-                            
+
                             // has more text
                             var aTextCount = countTextColumns(keyA);
                             var bTextCount = countTextColumns(keyB);
                             if (aTextCount != bTextCount) {
                                 return aTextCount < bTextCount;
                             }
-                            
+
                             // the one that has lower column position
                             return keyA.colset._getColumnPositions() > keyB.colset._getColumnPositions();
                         })[0];
@@ -1706,11 +1706,11 @@ var ERMrest = (function (module) {
                 case 'date':
                     data = utils.printDate(data, options);
                     break;
+                case 'numeric':
                 case 'float4':
                 case 'float8':
                     data = utils.printFloat(data, options);
                     break;
-                case 'numeric':
                 case 'int2':
                 case 'int4':
                 case 'int8':
@@ -1861,7 +1861,7 @@ var ERMrest = (function (module) {
          * @desc foreign key that this column is a member of
          */
         this.memberOfForeignKeys = [];
-        
+
     }
 
     Column.prototype = {

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -596,7 +596,8 @@ var ERMrest = (function(module) {
         /**
          * @function
          * @param {Object} value A float value to transform
-         * @param {Object} [options] Configuration options. One accepted so far: {numDecDigits: 5}
+         * @param {Object} [options] Configuration options.
+         * - "numFracDigits" is the number of fractional digits to appear after the decimal point
          * @return {string} A string representation of value
          * @desc Formats a given float value into a string for display. Removes leading 0s; adds thousands separator.
          */
@@ -608,8 +609,8 @@ var ERMrest = (function(module) {
             }
 
             value = parseFloat(value);
-            if (options.numDecDigits) {
-                value = value.toFixed(options.numDecDigits); // toFixed() rounds the value, is ok?
+            if (options.numFracDigits) {
+                value = value.toFixed(options.numFracDigits); // toFixed() rounds the value, is ok?
             } else {
                 value = value.toFixed(4);
             }

--- a/test/ermrest_config.json
+++ b/test/ermrest_config.json
@@ -1,0 +1,122 @@
+{
+  "registry": {
+    "type": "postgres",
+    "dsn": "dbname=ermrest",
+    "acls": {
+      "create_catalog_permit": [
+        "admin"
+      ]
+    }
+  },
+  "catalog_factory": {
+    "type": "postgres",
+    "dsn": "dbname=ermrest",
+    "_comment": "Postgres template params are based on libpq args (e.g., host, user, password)]",
+    "template": {
+      "type": "postgres",
+      "dbname": "PROVIDED BY FACTORY"
+    }
+  },
+  "column_types": {
+    "boolean": {
+      "aliases": [
+        "bool"
+      ]
+    },
+    "date": null,
+    "float4": {
+      "aliases": [
+        "real"
+      ]
+    },
+    "float8": {
+      "aliases": [
+        "double precision"
+      ]
+    },
+    "int2": {
+      "aliases": [
+        "smallint"
+      ]
+    },
+    "int4": {
+      "aliases": [
+        "integer",
+        "int"
+      ]
+    },
+    "int8": {
+      "aliases": [
+        "bigint"
+      ]
+    },
+    "interval": null,
+    "longtext": null,
+    "markdown": null,
+    "gene_sequence": null,
+    "serial2": {
+      "aliases": [
+        "smallserial"
+      ]
+    },
+    "serial4": {
+      "aliases": [
+        "serial"
+      ]
+    },
+    "serial8": {
+      "aliases": [
+        "bigserial"
+      ]
+    },
+    "text": {
+      "aliases": [
+        "character varying"
+      ]
+    },
+    "timestamptz": {
+      "aliases": [
+        "timestamptz",
+        "timestamp with time zone"
+      ]
+    },
+    "uuid": null,
+    "json": null,
+    "jsonb": null,
+    "timestamp": {
+      "aliases": [
+        "timestamp without time zone"
+      ]
+    }
+  },
+  "column_types_readonly": {
+    "json": null,
+    "numeric": null,
+    "text": {
+      "aliases": [
+        "char",
+        "bpchar",
+        "varchar"
+      ],
+      "regexps": [
+        "(text|character)( +varying)?( *[(][0-9]+[)])?$"
+      ]
+    },
+    "time": {
+      "aliases": [
+        "time with time zone",
+        "time without time zone"
+      ]
+    }
+  },
+  "change_notification": {
+    "AMQP": {
+      "connection": {
+        "host": "localhost"
+      },
+      "exchange": "ermrest_changes",
+      "routing_key": ""
+    }
+  },
+  "default_limit": 100
+}

--- a/test/ermrest_config.json
+++ b/test/ermrest_config.json
@@ -34,6 +34,7 @@
         "double precision"
       ]
     },
+    "numeric": null,
     "int2": {
       "aliases": [
         "smallint"
@@ -91,7 +92,6 @@
   },
   "column_types_readonly": {
     "json": null,
-    "numeric": null,
     "text": {
       "aliases": [
         "char",

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -45,6 +45,10 @@
                     "type": { "typename": "float8" }
                 },
                 {
+                    "name": "table_1_numeric",
+                    "type": { "typename": "numeric" }
+                },
+                {
                     "name": "table_1_int2",
                     "type": { "typename": "int2" }
                 },

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -214,11 +214,20 @@ exports.execute = function(options) {
                     it('float8 columns correctly.', function() {
                         var spy = spyOn(formatUtils, 'printFloat').and.callThrough();
                         var col = table1_schema2.columns.get('table_1_float8');
-                        var options = {numDecDigits: 7};
+                        var options = {numFracDigits: 7};
                         formattedValue = col.formatvalue(234523523.023045230450245, options);
                         expect(spy).toHaveBeenCalledWith(234523523.023045230450245, options);
                         expect(formattedValue).toBe('234,523,523.0230452');
                     });
+
+                    it('numeric columns correctly.', function() {
+                        var spy = spyOn(formatUtils, 'printFloat').and.callThrough();
+                        var col = table1_schema2.columns.get('table_1_numeric');
+                        var options = {numFracDigits: 8};
+                        formattedValue = col.formatvalue(456456.234682307474076, options);
+                        expect(spy).toHaveBeenCalledWith(456456.234682307474076, options);
+                        expect(formattedValue).toBe('456,456.23468231');
+                    })
 
                     afterEach(function() {
                         expect(formattedValue).toEqual(jasmine.any(String));
@@ -251,7 +260,7 @@ exports.execute = function(options) {
                         var spy = spyOn(formatUtils, 'printInteger').and.callThrough();
                         var col = table1_schema2.columns.get('table_1_int8');
                         var int8 = 9007199254740991; // Max safe integer in JS
-                        var options = {numDecDigits: 7};
+                        var options = {numFracDigits: 7};
                         formattedValue = col.formatvalue(int8);
                         expect(spy).toHaveBeenCalledWith(int8, undefined);
                         expect(formattedValue).toBe('9,007,199,254,740,991');

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -5,7 +5,7 @@ exports.execute = function (options) {
         // Test Cases:
         it('printFloat() should format floats correctly.', function () {
             var printFloat = formatUtils.printFloat;
-            var options = {numDecDigits: 4};
+            var options = {numFracDigits: 4};
             expect(printFloat(null)).toBe('');
             expect(printFloat(1234.0, options)).toBe('1,234.0000');
             expect(printFloat(23.0)).toBe('23.0000');


### PR DESCRIPTION
This PR fixes the bug where numeric columns were being formatted as integers instead of floats (#333).

For testing purposes, the `numeric` type has been added to a new `ermrest_config.json` so that Travis builds can create `numeric` columns. They were previously considered read-only.