### PR TITLE
Remove immutable and generated annotations from canDelete

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -211,7 +211,7 @@ var ERMrest = (function(module) {
          * The display name for this reference.
          * displayname.isHTML will return true/false
          * displayname.value has the value
-         * 
+         *
          * @type {object}
          */
         get displayname () {
@@ -577,18 +577,8 @@ var ERMrest = (function(module) {
             // can delete if all are true
             // 1) table is not non-deletable
             // 2) user has write permission
-            // 3) table is not generated
-            // 4) table is not immutable
-            // 5) not all visible columns in the table are generated/immutable
             if (this._canDelete === undefined) {
-                this._canDelete = !this._table._isNonDeletable && !this._table._isGenerated && !this._table._isImmutable && this._checkPermissions("content_write_user");
-
-                if (this._canDelete) {
-                    var allColumnsDisabled = this.columns.every(function (col) {
-                        return (col.getInputDisabled(module._contexts.EDIT) !== false);
-                    });
-                    this._canDelete = !allColumnsDisabled;
-                }
+                this._canDelete = !this._table._isNonDeletable && this._checkPermissions("content_write_user");
             }
             return this._canDelete;
         },
@@ -2582,7 +2572,7 @@ var ERMrest = (function(module) {
             if (!this.isPseudo) {
                 return this._base.formatPresentation(data, options);
             }
-            
+
             var context = options ? options.context : undefined;
             var nullValue = {isHTML: false, value: this._getNullValue(context)};
 
@@ -2644,7 +2634,7 @@ var ERMrest = (function(module) {
                             // if one of the values isHTMl, should not add link
                             addLink = addLink ? !presentation.isHTML : false;
                         } catch (exception) {
-                            // the value doesn't exist 
+                            // the value doesn't exist
                             return nullValue;
                         }
                     }
@@ -2689,7 +2679,7 @@ var ERMrest = (function(module) {
                     var formattedValues = module._getFormattedKeyValues(fkey.table.columns, context, data),
                         keyCols = [],
                         col;
-                    
+
                     for (i = 0; i < fkey.colset.columns.length; i++) {
                         col = fkey.colset.columns[i];
                         keyCols.push(col.formatPresentation(formattedValues[col.name], {context: context, formattedValues: formattedValues}).value);

--- a/test/specs/reference/tests/06.permissions.js
+++ b/test/specs/reference/tests/06.permissions.js
@@ -199,7 +199,7 @@ exports.execute = function (options) {
                 });
             });
 
-            describe("generated schema should return true only for read, false for all", function () {
+            describe("generated schema should return true for read and delete, false for all else", function () {
 
                 it("canCreate.", function () {
                     expect(reference.canCreate).toBe(false);
@@ -214,7 +214,7 @@ exports.execute = function (options) {
                 });
 
                 it("canDelete.", function () {
-                    expect(reference.canDelete).toBe(false);
+                    expect(reference.canDelete).toBe(true);
                 });
 
             });
@@ -257,7 +257,7 @@ exports.execute = function (options) {
                 });
             });
 
-            describe("generated table should return true only for read, false for all", function () {
+            describe("generated table should return true only for read and delete, false for all else", function () {
 
                 it("canCreate.", function () {
                     expect(reference.canCreate).toBe(false);
@@ -272,7 +272,7 @@ exports.execute = function (options) {
                 });
 
                 it("canDelete.", function () {
-                    expect(reference.canDelete).toBe(false);
+                    expect(reference.canDelete).toBe(true);
                 });
 
             });
@@ -314,7 +314,7 @@ exports.execute = function (options) {
                 });
             });
 
-            describe("generated columns should return true only for read, false for all", function () {
+            describe("generated columns should return true only for read and delete, false for all else", function () {
 
                 it("canCreate.", function () {
                     expect(reference.canCreate).toBe(false);
@@ -329,7 +329,7 @@ exports.execute = function (options) {
                 });
 
                 it("canDelete.", function () {
-                    expect(reference.canDelete).toBe(false);
+                    expect(reference.canDelete).toBe(true);
                 });
 
             });
@@ -428,7 +428,7 @@ exports.execute = function (options) {
                 });
             });
 
-            describe("immutable schema should return true for create and read, false for all", function () {
+            describe("immutable schema should return true for create, read, and delete, false for update", function () {
 
                 it("canCreate.", function () {
                     expect(reference.canCreate).toBe(true);
@@ -443,7 +443,7 @@ exports.execute = function (options) {
                 });
 
                 it("canDelete.", function () {
-                    expect(reference.canDelete).toBe(false);
+                    expect(reference.canDelete).toBe(true);
                 });
 
             });
@@ -486,7 +486,7 @@ exports.execute = function (options) {
                 });
             });
 
-            describe("immutable table should return true for create and read, false for all", function () {
+            describe("immutable table should return true for create, read, and delete, false for update", function () {
 
                 it("canCreate.", function () {
                     expect(reference.canCreate).toBe(true);
@@ -501,7 +501,7 @@ exports.execute = function (options) {
                 });
 
                 it("canDelete.", function () {
-                    expect(reference.canDelete).toBe(false);
+                    expect(reference.canDelete).toBe(true);
                 });
 
             });
@@ -543,7 +543,7 @@ exports.execute = function (options) {
                 });
             });
 
-            describe("immutable columns should return true for create and read, false for all", function () {
+            describe("immutable columns should return true for create, read, and delete, false for update", function () {
 
                 it("canCreate.", function () {
                     expect(reference.canCreate).toBe(true);
@@ -558,7 +558,7 @@ exports.execute = function (options) {
                 });
 
                 it("canDelete.", function () {
-                    expect(reference.canDelete).toBe(false);
+                    expect(reference.canDelete).toBe(true);
                 });
 
             });
@@ -731,10 +731,9 @@ exports.execute = function (options) {
                 it("canDelete.", function () {
                     expect(reference.canDelete).toBe(false);
                 });
-
             });
         });
-        
+
         afterEach(function () {
             nock.cleanAll();
         });


### PR DESCRIPTION
Reference.canDelete used to follow a more conservative logic by returning false if the model had generated or immutable annotations. Now only the non-deletable annotation is considered.