### PR TITLE
Regular expression search for numerics, integers, and floats

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -411,7 +411,7 @@ var ERMrest = (function(module) {
                     if (t.match(/^[0-9]+$/)) {
                         exp = "(^|[^1-9])0*" + module._encodeRegexp(t) + "([^0-9]|$)";
                     // matches a float, aka a number one decimal
-                    } else if (t.match(/^([0-9]*[.][0-9]+)$/)) {
+                    } else if (t.match(/^([0-9]+[.][0-9]*|[0-9]*[.][0-9]+)$/)) {
                         exp = "(^|[^1-9])0*" + module._encodeRegexp(t);
                     // matches everything else (words and anything with multiple decimals)
                     } else {

--- a/js/parser.js
+++ b/js/parser.js
@@ -406,8 +406,21 @@ var ERMrest = (function(module) {
                 if (term.trim().length > 0 ) terms = terms.concat(term.trim().split(/[\s]+/)); // split by white spaces
 
                 terms.forEach(function(t, index, array) {
-                    filterString += (index === 0? "" : "&") + "*::ciregexp::" + module._fixedEncodeURIComponent(t);
+                    var exp;
+                    // matches an integer, aka just a number
+                    if (t.match(/^[0-9]+$/)) {
+                        exp = "(^|[^1-9])0*" + module._encodeRegexp(t) + "([^0-9]|$)";
+                    // matches a float, aka a number one decimal
+                    } else if (t.match(/^([0-9]*[.][0-9]+)$/)) {
+                        exp = "(^|[^1-9])0*" + module._encodeRegexp(t);
+                    // matches everything else (words and anything with multiple decimals)
+                    } else {
+                        exp = module._encodeRegexp(t);
+                    }
+
+                    filterString += (index === 0? "" : "&") + "*::ciregexp::" + module._fixedEncodeURIComponent(exp);
                 });
+
 
             } else {
                 this._searchTerm = null;

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -142,6 +142,20 @@ var ERMrest = (function(module) {
         });
     };
 
+    /**
+     * @function
+     * @param {String} regExp string to be regular expression encoded
+     * @desc converts the string into a regular expression with properly encoded characters
+     */
+    module._encodeRegexp = function (str) {
+        var stringReplaceExp = /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$]/g;
+        // the first '\' escapes the second '\' which is used to escape the matched character in the returned string
+        // $& represents the matched character
+        var escapedRegexString = str.replace(stringReplaceExp, '\\$&');
+
+        return escapedRegexString;
+    };
+
     module._nextChar = function (c) {
         return String.fromCharCode(c.charCodeAt(0) + 1);
     };

--- a/test/specs/reference/tests/13.search.js
+++ b/test/specs/reference/tests/13.search.js
@@ -5,7 +5,8 @@ exports.execute = function (options) {
             schemaName = "reference_schema",
             tableName = "paging table w sort",
             filter1 = "*::ciregexp::hank",
-            filter2 = "*::ciregexp::11";
+            // filter2 is a regular expression that will be url encoded.
+            filter2 = "*::ciregexp::" + options.ermRest._fixedEncodeURIComponent("(^|[^1-9])0*11([^0-9]|$)");
 
         var multipleEntityUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
             + tableName;
@@ -223,7 +224,8 @@ exports.execute = function (options) {
             });
 
             it("with multiple quoted terms split by a space across multiple columns.", function(done) {
-                var quotedFilter = "*::ciregexp::william&*::ciregexp::17";
+                // searching for integer values converts them into a regular expression
+                var quotedFilter = "*::ciregexp::william&*::ciregexp::" + options.ermRest._fixedEncodeURIComponent("(^|[^1-9])0*17([^0-9]|$)");
 
                 reference2 = reference1.search("\"william\" \"17\"");
                 expect(reference2.location.searchTerm).toBe("\"william\" \"17\"");
@@ -303,7 +305,7 @@ exports.execute = function (options) {
             var limit = 20;
 
             it('location should have correct search parameters ', function() {
-                expect(reference3.location.searchTerm).toBe("hank 11");
+                expect(reference3.location.searchTerm).toBe("hank (^|[^1-9])0*11([^0-9]|$)");
                 expect(reference3.location.searchFilter).toBe(filter1 + "&" + filter2);
             });
 


### PR DESCRIPTION
This PR adds functionality to search for integers as full text only and floats from the start of the phrase where significant digits begin.

Tests pending.