### PR TITLE
Shortest key

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -82,6 +82,7 @@ to use for ERMrest JavaScript agents.
             * [.foreignKeys](#ERMrest.Table+foreignKeys) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
             * [.referredBy](#ERMrest.Table+referredBy) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
             * [.comment](#ERMrest.Table+comment) : <code>string</code>
+            * [.shortestKey](#ERMrest.Table+shortestKey)
             * [._getDisplayKey(context)](#ERMrest.Table+_getDisplayKey)
         * _static_
             * [.Entity](#ERMrest.Table.Entity)
@@ -647,6 +648,7 @@ get table by table name
         * [.foreignKeys](#ERMrest.Table+foreignKeys) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
         * [.referredBy](#ERMrest.Table+referredBy) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
         * [.comment](#ERMrest.Table+comment) : <code>string</code>
+        * [.shortestKey](#ERMrest.Table+shortestKey)
         * [._getDisplayKey(context)](#ERMrest.Table+_getDisplayKey)
     * _static_
         * [.Entity](#ERMrest.Table.Entity)
@@ -729,6 +731,13 @@ All the FKRs to this table.
 Documentation for this table
 
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+<a name="ERMrest.Table+shortestKey"></a>
+
+#### table.shortestKey
+The columns that create the shortest key
+
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+**Type{column[]}**:   
 <a name="ERMrest.Table+_getDisplayKey"></a>
 
 #### table._getDisplayKey(context)

--- a/test/specs/annotation/conf/displayname/schema.json
+++ b/test/specs/annotation/conf/displayname/schema.json
@@ -18,6 +18,7 @@
         {
           "comment": null,
           "name": "id",
+          "nullok": false,
           "type": {
             "typename": "serial4"
           }
@@ -74,6 +75,7 @@
         {
           "comment": null,
           "name": "id",
+          "nullok": false,
           "type": {
             "typename": "serial4"
           }
@@ -166,7 +168,6 @@
         {
           "comment": null,
           "name": "column_with_name",
-          "default": null,
           "nullok": false,
           "type": {
             "typename": "text"
@@ -220,7 +221,6 @@
         {
           "comment": null,
           "name": "column_with_name_2",
-          "default": null,
           "nullok": false,
           "type": {
             "typename": "serial4"
@@ -282,7 +282,6 @@
         {
           "comment": null,
           "name": "column_without_display_annotation",
-          "default": null,
           "nullok": false,
           "type": {
             "typename": "serial4"
@@ -336,7 +335,6 @@
         {
           "comment": null,
           "name": "column_with_name_3",
-          "default": null,
           "nullok": false,
           "type": {
             "typename": "int4"

--- a/test/specs/annotation/conf/table_display/schema.json
+++ b/test/specs/annotation/conf/table_display/schema.json
@@ -119,11 +119,19 @@
         },
         {
           "name": "description",
+          "nullok": false,
           "type": {
             "typename": "text"
           }
         }
-      ]
+      ],
+      "annotations": {
+        "tag:isrd.isi.edu,2016:visible-columns" : {
+          "*": [
+            "id", "description"
+          ]
+        }
+      }
     },
     "table_w_table_display_annotation": {
       "kind": "table",

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -111,7 +111,7 @@
                 }
             }
         },
-        "multi_key_table": {
+        "table_wo_notnull_key": {
             "comment": "",
             "kind": "table",
             "keys": [
@@ -121,58 +121,23 @@
                     "unique_columns": [
                         "id"
                     ]
-                },
-                {
-                    "comment": null,
-                    "annotations": {},
-                    "unique_columns": [
-                        "value"
-                    ]
-                },
-                {
-                    "comment": null,
-                    "annotations": {},
-                    "unique_columns": [
-                        "a"
-                    ]
-                },
-                {
-                    "comment": null,
-                    "annotations": {},
-                    "unique_columns": [
-                        "id", "name"
-                    ]
                 }
             ],
             "entityCount": 0,
             "foreign_keys": [],
-            "table_name": "multi_key_table",
+            "table_name": "table_wo_notnull_key",
             "schema_name": "common_schema_2",
             "column_definitions": [
                 {
                     "name": "id",
-                    "nullok": false,
-                    "type": {
-                        "typename": "serial"
-                    }
-                },
-                {
-                    "name": "name",
-                    "nullok": false,
+                    "nullok": true,
                     "type": {
                         "typename": "text"
                     }
                 },
                 {
-                    "name": "value",
-                    "nullok": false,
-                    "type": {
-                        "typename": "serial"
-                    }
-                },
-                {
-                    "name": "a",
-                    "nullok": false,
+                    "name": "col",
+                    "nullok": true,
                     "type": {
                         "typename": "text"
                     }
@@ -180,6 +145,153 @@
             ],
             "annotations": {
             }
+        },
+        "table_w_dif_len_keys": {
+            "comment": "",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": ["col_1", "col_2", "col_3"]
+                },
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": ["col_3"]
+                },
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": ["col_1", "col_2"]
+                }
+            ],
+            "entityCount": 0,
+            "foreign_keys": [],
+            "table_name": "table_w_dif_len_keys",
+            "schema_name": "common_schema_2",
+            "column_definitions": [
+                {
+                    "name": "col_1",
+                    "nullok": false,
+                    "type": {
+                        "typename": "serial"
+                    }
+                },
+                {
+                    "name": "col_2",
+                    "nullok": false,
+                    "type": {
+                        "typename": "serial"
+                    }
+                },
+                {
+                    "name": "col_3",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "annotations": {}
+        },
+        "multi_w_same_len_keys_w_all_serial": {
+            "comment": "",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": ["col_1", "col_2"]
+                },
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": ["col_2", "col_3"]
+                },
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": ["col_1", "col_2", "col_3"]
+                }
+            ],
+            "entityCount": 0,
+            "foreign_keys": [],
+            "table_name": "multi_w_same_len_keys_w_all_serial",
+            "schema_name": "common_schema_2",
+            "column_definitions": [
+                {
+                    "name": "col_1",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col_2",
+                    "nullok": false,
+                    "type": {
+                        "typename": "serial"
+                    }
+                },
+                {
+                    "name": "col_3",
+                    "nullok": false,
+                    "type": {
+                        "typename": "serial"
+                    }
+                }
+            ],
+            "annotations": {}
+        },
+        "multi_w_same_len_keys": {
+            "comment": "",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": ["col_1", "col_2", "col_3"]
+                },
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": ["col_1", "col_2"]
+                },
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": ["col_2", "col_3"]
+                }
+            ],
+            "entityCount": 0,
+            "foreign_keys": [],
+            "table_name": "multi_w_same_len_keys",
+            "schema_name": "common_schema_2",
+            "column_definitions": [
+                {
+                    "name": "col_1",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col_2",
+                    "nullok": false,
+                    "type": {
+                        "typename": "serial"
+                    }
+                },
+                {
+                    "name": "col_3",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "annotations": {}
         }
     },
     "schema_name": "common_schema_2",

--- a/test/specs/common/tests/03.table.js
+++ b/test/specs/common/tests/03.table.js
@@ -1,25 +1,46 @@
 exports.execute = function(options) {
 
-    describe('About the Table class, ', function() {
-        var schemaName2 = 'common_schema_2', multi_key_table;
+    describe('Table class, ', function() {
+        var schemaName = 'common_schema_2';
+        var tables;
 
-        beforeAll(function(done) {
-            multi_key_table = options.catalog.schemas.get(schemaName2).tables.get('multi_key_table');
+         beforeAll(function (done) {
+            tables = options.catalog.schemas.get(schemaName).tables;
             done();
         });
 
         // Test Cases:
-        describe('Table class, ', function() {
-
-            it('Shortest key', function(){
-                expect(multi_key_table.shortestKey.length).toBe(1);
-                expect(multi_key_table.shortestKey[0].name).toBe("id");
+        describe('Shortest key, ', function () {
+            it("should return an error if table doesn't have any not-null key.", function () {
+                checkError("table_wo_notnull_key", "Table `table_wo_notnull_key` does not have any not-null key.");
             });
 
-            it("Reference", function() {
-                expect(multi_key_table.reference.uri).toBe(multi_key_table._uri);
-                expect(multi_key_table.reference._table).toBe(multi_key_table);
+            it("should return the shortest key.", function () {
+                checkShortestKey("table_w_dif_len_keys", ["col_3"]);
+            });
+
+            it('when keys have the same length, should return the one that is all integer/serial.', function () {
+                checkShortestKey("multi_w_same_len_keys_w_all_serial", ["col_2", "col_3"]);
+            });
+
+            it("otherwise should sort keys based on their column names and return the first one.", function () {
+                checkShortestKey("multi_w_same_len_keys", ["col_1", "col_2"]);
             });
         });
+
+
+        // Helper Functions: 
+
+        function checkError(tableName, errorMessage) {
+            expect(function () {
+                var sk = tables.get(tableName).shortestKey;
+            }).toThrow(errorMessage);
+        }
+
+        function checkShortestKey(tableName, expectedCols) {
+            expect(tables.get(tableName).shortestKey.map(function (col) {
+                return col.name;
+            })).toEqual(expectedCols);
+        }
     });
 };

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -205,10 +205,12 @@
             "column_definitions": [
                 {
                     "name": "id_from_ref_table",
+                    "nullok": false,
                     "type": {"typename":"text"}
                 },
                 {
                     "name": "id_from_inbound_related_table",
+                    "nullok": false,
                     "type": {"typename":"text"}
                 }
             ]
@@ -258,14 +260,17 @@
             "column_definitions": [
                 {
                   "name": "ID",
+                  "nullok": false,
                   "type": {"typename":"serial4"}
                 },
                 {
                     "name": "id from ref table",
+                    "nullok": false,
                     "type": {"typename":"text"}
                 },
                 {
                     "name": "id_from_inbound_related_table",
+                    "nullok": false,
                     "type": {"typename":"text"}
                 }
             ],
@@ -323,10 +328,12 @@
                 },
                 {
                     "name": "id_from_ref_table",
+                    "nullok": false,
                     "type": {"typename":"text"}
                 },
                 {
                     "name": "id_from_inbound_related_table",
+                    "nullok": false,
                     "type": {"typename":"text"}
                 }
             ]
@@ -551,6 +558,7 @@
             "column_definitions": [
                 {
                     "name": "id",
+                    "nullok": false,
                     "type": {
                         "typename": "text"
                     }
@@ -716,18 +724,21 @@
             "column_definitions": [
                 {
                     "name": "id",
+                    "nullok": false,
                     "type": {
                         "typename": "text"
                     }
                 },
                 {
                     "name": "id_1",
+                    "nullok": false,
                     "type": {
                         "typename": "text"
                     }
                 },
                 {
                     "name": "id_2",
+                    "nullok": false,
                     "type": {
                         "typename": "text"
                     }
@@ -917,6 +928,7 @@
             "column_definitions": [
                 {
                     "name": "id_fk",
+                    "nullok": false,
                     "type": {
                         "typename": "text"
                     }
@@ -1222,7 +1234,7 @@
                 },
                 {
                     "name": "col_1",
-                    "default": null,
+                    "nullok": false,
                     "type": {
                         "typename": "text"
                     },
@@ -1393,6 +1405,7 @@
             "column_definitions": [
                 {
                     "name": "id",
+                    "nullok": false,
                     "type": {
                         "typename": "text"
                     }
@@ -1434,6 +1447,9 @@
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns" : {
+                    "*": [
+                        "id", "col_1", "col_with_slash/",  ["reference_schema", "table_w_slash_fk_1"], ["reference_schema", "table_w_slash_fk_2"]
+                    ],
                     "compact/brief": [
                         "id", "col_with_slash/", ["reference_schema", "table_w_slash_fk_1"], ["reference_schema", "table_w_slash_fk_2"]
                     ]
@@ -1570,7 +1586,6 @@
             "column_definitions": [
                 {
                     "name": "id",
-                    "default": null,
                     "nullok": false,
                     "type": {
                         "typename": "serial4"
@@ -1646,7 +1661,6 @@
             "column_definitions": [
                 {
                     "name": "id",
-                    "default": null,
                     "nullok": false,
                     "type": {
                         "typename": "serial4"
@@ -1711,7 +1725,6 @@
             "column_definitions": [
                 {
                     "name": "id",
-                    "default": null,
                     "nullok": false,
                     "type": {
                         "typename": "serial4"
@@ -1756,7 +1769,6 @@
             "column_definitions": [
                 {
                     "name": "id",
-                    "default": null,
                     "nullok": false,
                     "type": {
                         "typename": "serial4"

--- a/test/specs/reference/conf/reference_schema_2/schema.json
+++ b/test/specs/reference/conf/reference_schema_2/schema.json
@@ -148,6 +148,7 @@
             }],
             "column_definitions": [{
                 "name": "id",
+                "nullok": false,
                 "type": {
                     "typename": "text"
                 }

--- a/test/specs/reference/tests/14.outbound_fks.js
+++ b/test/specs/reference/tests/14.outbound_fks.js
@@ -208,7 +208,7 @@ exports.execute = function (options) {
          *
          * expected output for ref.columns in detailed, compact/select, and entry/edit contexts:
          * 0:   id
-         * 1:   outbound_fk_1 (check to_name) (check nullok)
+         * 1:   outbound_fk_1 (check to_name)
          * 2:   outbound_fk_2  -> is null
          * 3:   outbound_fk_3 (check disambiguation) (check nullok)
          * 4:   outbound_fk_4 (check disambiguation)
@@ -365,18 +365,6 @@ exports.execute = function (options) {
 
             describe('when visible-columns annotation is not present for the context, ', function () {
                 describe('PseudoColumn for key, ', function () {
-                    it('if key columns are nullable, should not be added.', function (done) {
-                        options.ermRest.resolve(singleEnitityUriCompositeKey, {cid:"test"}).then(function(ref) {
-                            expect(ref.columns[0].isPseudo).toBe(false);
-                            expect(ref.columns[0].name).toEqual("id");
-
-                            done();
-                        }, function (err) {
-                            console.dir(err);
-                            done.fail();
-                        });
-                    });
-
                     it('if key is simple and its contituent columns are part of simple foreign key, should not be added (instead it should apply the PseudoColumn for foreignkey logic.)', function(done) {
                         options.ermRest.resolve(singleEnitityUriSimpleKeyFK, {cid:"test"}).then(function(ref) {
                             expect(ref.columns[0].isPseudo).toBe(true);

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -253,7 +253,7 @@ exports.execute = function (options) {
 
                 it('otherwise should return true.', function () {
                     // simple fk
-                    expect(compactColumns[1].nullok).toBe(true);
+                    expect(compactColumns[2].nullok).toBe(true);
                     // composite fk, all true
                     expect(compactColumns[14].nullok).toBe(true);
                 });


### PR DESCRIPTION
1. If table doesn't have any key with not-null columns, throw error
2. From the keys with not-null columns, choose the one
  2.1. That is shortest.
  2.2. That all of its constituent columns are serial or integer.
  2.3. That has lower column positions.
(first applicable)