### PR TITLE
Table is aware of it's `kind`

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -82,6 +82,7 @@ to use for ERMrest JavaScript agents.
             * [.foreignKeys](#ERMrest.Table+foreignKeys) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
             * [.referredBy](#ERMrest.Table+referredBy) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
             * [.comment](#ERMrest.Table+comment) : <code>string</code>
+            * [.kind](#ERMrest.Table+kind) : <code>string</code>
             * [.shortestKey](#ERMrest.Table+shortestKey)
             * [._getDisplayKey(context)](#ERMrest.Table+_getDisplayKey)
         * _static_
@@ -648,6 +649,7 @@ get table by table name
         * [.foreignKeys](#ERMrest.Table+foreignKeys) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
         * [.referredBy](#ERMrest.Table+referredBy) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
         * [.comment](#ERMrest.Table+comment) : <code>string</code>
+        * [.kind](#ERMrest.Table+kind) : <code>string</code>
         * [.shortestKey](#ERMrest.Table+shortestKey)
         * [._getDisplayKey(context)](#ERMrest.Table+_getDisplayKey)
     * _static_
@@ -729,6 +731,12 @@ All the FKRs to this table.
 
 #### table.comment : <code>string</code>
 Documentation for this table
+
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+<a name="ERMrest.Table+kind"></a>
+
+#### table.kind : <code>string</code>
+The type of this table
 
 **Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+shortestKey"></a>

--- a/js/core.js
+++ b/js/core.js
@@ -764,6 +764,12 @@ var ERMrest = (function (module) {
          */
         this.comment = jsonTable.comment;
 
+        /**
+         * @desc The type of this table
+         * @type {string}
+         */
+        this.kind = jsonTable.kind;
+
         if (this.annotations.contains(module._annotations.APP_LINKS)) {
             this._appLinksAnnotation = this.annotations.get(module._annotations.APP_LINKS).content;
         }

--- a/js/reference.js
+++ b/js/reference.js
@@ -528,7 +528,7 @@ var ERMrest = (function(module) {
                 // 3) not all visible columns in the table are generated
                 var ref = (this._context === module._contexts.CREATE) ? this : this.contextualize.entryCreate;
 
-                this._canCreate = !ref._table._isGenerated && ref._checkPermissions("content_write_user");
+                this._canCreate = ref._table.kind !== module._tableKinds.VIEW && !ref._table._isGenerated && ref._checkPermissions("content_write_user");
 
                 if (this._canCreate) {
                     var allColumnsDisabled = ref.columns.every(function (col) {
@@ -569,7 +569,7 @@ var ERMrest = (function(module) {
             if (this._canUpdate === undefined) {
                 var ref = (this._context === module._contexts.EDIT) ? this : this.contextualize.entryEdit;
 
-                this._canUpdate = !ref._table._isGenerated && !ref._table._isImmutable && ref._checkPermissions("content_write_user");
+                this._canUpdate = ref._table.kind !== module._tableKinds.VIEW && !ref._table._isGenerated && !ref._table._isImmutable && ref._checkPermissions("content_write_user");
 
                 if (this._canUpdate) {
                     var allColumnsDisabled = ref.columns.every(function (col) {
@@ -593,7 +593,7 @@ var ERMrest = (function(module) {
             // 1) table is not non-deletable
             // 2) user has write permission
             if (this._canDelete === undefined) {
-                this._canDelete = !this._table._isNonDeletable && this._checkPermissions("content_write_user");
+                this._canDelete = this._table.kind !== module._tableKinds.VIEW && !this._table._isNonDeletable && this._checkPermissions("content_write_user");
             }
             return this._canDelete;
         },

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -489,7 +489,7 @@ var ERMrest = (function(module) {
         }
 
         return {
-            "value": module._formatUtils.printMarkdown(pattern, { inline: true }), 
+            "value": module._formatUtils.printMarkdown(pattern, { inline: true }),
             "unformatted": (typeof unformatted === 'undefined' || unformatted === null ) ? pattern : unformatted,
             "isHTML": true
         };
@@ -1346,6 +1346,11 @@ var ERMrest = (function(module) {
     module._contextArray = ["compact", "compact/brief", "compact/select", "entry/create", "detailed", "entry/edit", "entry", "filter", "*", "row_name"];
 
     module._entryContexts = [module._contexts.CREATE, module._contexts.EDIT, module._contexts.ENTRY];
+
+    module._tableKinds = Object.freeze({
+        TABLE: "table",
+        VIEW: "view"
+    });
 
     /*
      * @desc List of display type for table-display annotation


### PR DESCRIPTION
This PR addresses issue #381. `Table` has a new property called `kind`. This is already a property of our json tables (`table._jsonTable.kind`), it's just being exposed as a proper call to our Table APIs. I created an `enum` for this as well in case any of this changes in the future. 

Views should not be creatable, editable, or deletable. This cannot be tested with unit testing in `ermrestJS` because our `ermrest` APIs don't support creating views. To create a view, you have to use PSQL directly.

At this [link](https://synapse-dev.isrd.isi.edu/~jchudy/chaise/recordset/#1/Zebrafish:Pointclouds) you can see the `Pointclouds view` is not creatable, editable, or deletable. You can't create a new entity for this view, you can't edit the full set, you can't edit an individual row, and you can't delete a row.

At this [link](https://synapse-dev.isrd.isi.edu/~jchudy/chaise/record/#1/Zebrafish:Subject/ID=ZfCza20170410A) you can see the same thing for the `Pointclouds` related table. There is no `Add` link and there is no `Edit` or `Delete` link for the rows in that related table.