### PR TITLE
Alternative Tables in Related Entities

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1506,7 +1506,7 @@ get the mapping column given the from column
 <a name="ERMrest.Mapping+getFromColumn"></a>
 
 #### mapping.getFromColumn(toCol) ⇒ <code>[Column](#ERMrest.Column)</code>
-get the mapping column given the from column
+get the mapping column given the to column
 
 **Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
 **Returns**: <code>[Column](#ERMrest.Column)</code> - mapping column  

--- a/js/core.js
+++ b/js/core.js
@@ -2495,7 +2495,7 @@ var ERMrest = (function (module) {
          * @param {ERMrest.Column} toCol
          * @returns {ERMrest.Column} mapping column
          * @throws {ERMrest.NotFoundError} no mapping column found
-         * @desc get the mapping column given the from column
+         * @desc get the mapping column given the to column
          */
         getFromColumn: function (toCol) {
             for (var i = 0; i < this._to.length; i++) {

--- a/js/parser.js
+++ b/js/parser.js
@@ -168,10 +168,14 @@ var ERMrest = (function(module) {
             index -= 1;
         }
 
+        this._hasJoin = false;
+        this._lastJoin = null;
+
         // if has linking, use the last part as the main table
         var colMapping;
         var linking = parts[index].match(/\((.*)\)=\((.*:.*:.*)\)/);
         if (linking) {
+            this._hasJoin = true;
             var leftCols = linking[1].split(",");
             var rightParts = linking[2].match(/([^:]*):([^:]*):([^\)]*)/);
             this._schemaName = decodeURIComponent(rightParts[1]);
@@ -181,6 +185,12 @@ var ERMrest = (function(module) {
             for (var j = 0; j < leftCols.length; j++) {
                 colMapping[decodeURIComponent(leftCols[j])] = decodeURIComponent(rightCols[j]);
             }
+            this._lastJoin = {
+                "leftCols": leftCols.map(function(colName) {return decodeURIComponent(colName);}),
+                "leftColsStr": linking[1],
+                "rightCols": rightCols.map(function(colName) {return decodeURIComponent(colName);}),
+                "rightColsStr": linking[2],
+            };
         }
 
         // first schema name and first table name
@@ -392,6 +402,18 @@ var ERMrest = (function(module) {
          */
         get queryParamsString() {
             return this._queryParamsString;
+        },
+
+        /**
+        * If there's a join(linking) at the end or not.
+        * @return {boolean}
+        */
+        get hasJoin() {
+            return this._hasJoin;
+        },
+
+        get lastJoin() {
+            return this._lastJoin;
         },
 
         /**
@@ -641,7 +663,7 @@ var ERMrest = (function(module) {
 
     /**
      * given the string of parameters, create an object of them.
-     * 
+     *
      * @param {String} params the string representation of the query params
      * @returns {Object} the query params object
      * @private

--- a/test/specs/reference/conf/reference_schema_altTables/data/association_table.json
+++ b/test/specs/reference/conf/reference_schema_altTables/data/association_table.json
@@ -1,0 +1,4 @@
+[{"id_related":"1" ,"id_base":"00001"},
+{"id_related":"1" ,"id_base":"00002"},
+{"id_related":"2" ,"id_base":"00002"},
+{"id_related":"3" ,"id_base":"00003"}]

--- a/test/specs/reference/conf/reference_schema_altTables/data/base table.json
+++ b/test/specs/reference/conf/reference_schema_altTables/data/base table.json
@@ -4,5 +4,5 @@
   {"id":"00004","name":"Henry","value":4, "fk_to_related":"1"},
   {"id":"00005","name":"Helga","value":66, "fk_to_related":"4"},
   {"id":"00006","name":"Harry","value":23, "fk_to_related":"4"},
-  {"id":"00007","name":"Ramona","value":1, "fk_to_related":"3"},
+  {"id":"00007","name":"Ramona","value":1, "fk_to_related":"1"},
   {"id":"00008","name":"Ralph","value":160, "fk_to_related":"2"}]

--- a/test/specs/reference/conf/reference_schema_altTables/data/base table.json
+++ b/test/specs/reference/conf/reference_schema_altTables/data/base table.json
@@ -1,8 +1,8 @@
-[{"id":"00001","name":"Hank","value":12},
-  {"id":"00002","name":"Harold","value":17},
-  {"id":"00003","name":"Heather","value":26},
-  {"id":"00004","name":"Henry","value":4},
-  {"id":"00005","name":"Helga","value":66},
-  {"id":"00006","name":"Harry","value":23},
-  {"id":"00007","name":"Ramona","value":1},
-  {"id":"00008","name":"Ralph","value":160}]
+[{"id":"00001","name":"Hank","value":12, "fk_to_related":"1"},
+  {"id":"00002","name":"Harold","value":17, "fk_to_related":"2"},
+  {"id":"00003","name":"Heather","value":26, "fk_to_related":"3"},
+  {"id":"00004","name":"Henry","value":4, "fk_to_related":"1"},
+  {"id":"00005","name":"Helga","value":66, "fk_to_related":"4"},
+  {"id":"00006","name":"Harry","value":23, "fk_to_related":"4"},
+  {"id":"00007","name":"Ramona","value":1, "fk_to_related":"3"},
+  {"id":"00008","name":"Ralph","value":160, "fk_to_related":"2"}]

--- a/test/specs/reference/conf/reference_schema_altTables/data/related_table.json
+++ b/test/specs/reference/conf/reference_schema_altTables/data/related_table.json
@@ -1,0 +1,5 @@
+[{"id":"1", "name":"one"},
+{"id":"2", "name":"two"},
+{"id":"3", "name":"three"},
+{"id":"4", "name":"four"},
+{"id":"5", "name":"five"}]

--- a/test/specs/reference/conf/reference_schema_altTables/schema.json
+++ b/test/specs/reference/conf/reference_schema_altTables/schema.json
@@ -14,7 +14,26 @@
         }
       ],
       "entityCount": 0,
-      "foreign_keys": [],
+      "foreign_keys": [
+          {
+              "comment": "",
+              "foreign_key_columns": [{
+                  "table_name": "base table",
+                  "schema_name": "reference schema altTables",
+                  "column_name": "fk_to_related"
+              }],
+              "referenced_columns": [{
+                  "table_name": "related_table",
+                  "schema_name": "reference schema altTables",
+                  "column_name": "id"
+              }],
+              "annotations": {
+                  "tag:isrd.isi.edu,2016:foreign-key": {
+                      "from_name": "base table inbound related"
+                  }
+              }
+          }
+      ],
       "table_name": "base table",
       "schema_name": "reference schema altTables",
       "column_definitions": [
@@ -36,17 +55,27 @@
           "type": {
             "typename": "integer"
           }
+        }, {
+            "name": "fk_to_related",
+            "type": {
+                "typename": "text"
+            }
         }
       ],
       "annotations": {
         "tag:isrd.isi.edu,2016:table-alternatives": {
           "detailed": ["reference schema altTables", "alt table detailed"],
           "compact": ["reference schema altTables", "alt table compact"],
-          "entry": ["reference schema altTables", "base table"]
+          "entry": ["reference schema altTables", "base table"],
+          "*": ["reference schema altTables", "alt table detailed"]
         },
         "tag:isrd.isi.edu,2016:app-links": {
-          "detailed": "tag:isrd.isi.edu,2016:chaise:search",
+          "detailed": "tag:isrd.isi.edu,2016:chaise:record",
+          "compact": "tag:isrd.isi.edu,2016:chaise:recordset",
           "*": "detailed"
+        },
+        "tag:isrd.isi.edu,2016:visible-columns": {
+            "*": ["id", "name", "value"]
         }
       }
     },
@@ -293,16 +322,106 @@
           }
         }
       ]
+    },
+    "related_table": {
+      "comment":"",
+      "kind": "table",
+      "keys": [
+        {
+          "comment": null,
+          "annotations": {},
+          "unique_columns": [
+            "id"
+          ]
+        }
+      ],
+      "foreign_keys": [],
+      "table_name": "related_table",
+      "schema_name": "reference schema altTables",
+      "column_definitions": [
+        {
+          "name": "id",
+          "nullok": false,
+          "type": {
+            "typename": "text"
+          }
+        },
+        {
+          "name": "name",
+          "type": {
+            "typename": "text"
+          }
+        }
+      ],
+      "annotations": {}
+    },
+    "association_table": {
+      "comment":"",
+      "kind": "table",
+      "keys": [
+        {
+          "comment": null,
+          "annotations": {},
+          "unique_columns": [
+            "id_related", "id_base"
+          ]
+        }
+      ],
+      "foreign_keys": [
+          {
+              "comment": "",
+              "foreign_key_columns": [{
+                  "table_name": "association_table",
+                  "schema_name": "reference schema altTables",
+                  "column_name": "id_related"
+              }],
+              "referenced_columns": [{
+                  "table_name": "related_table",
+                  "schema_name": "reference schema altTables",
+                  "column_name": "id"
+              }],
+              "annotations": {}
+          },
+          {
+              "comment": "",
+              "foreign_key_columns": [{
+                  "table_name": "association_table",
+                  "schema_name": "reference schema altTables",
+                  "column_name": "id_base"
+              }],
+              "referenced_columns": [{
+                  "table_name": "base table",
+                  "schema_name": "reference schema altTables",
+                  "column_name": "id"
+              }],
+              "annotations": {
+                  "tag:isrd.isi.edu,2016:foreign-key": {
+                      "to_name": "base table association related"
+                  }
+              }
+          }
+      ],
+      "table_name": "association_table",
+      "schema_name": "reference schema altTables",
+      "column_definitions": [
+        {
+          "name": "id_related",
+          "nullok": false,
+          "type": {
+            "typename": "text"
+          }
+        },
+        {
+          "name": "id_base",
+          "nullok": false,
+          "type": {
+            "typename": "text"
+          }
+        }
+      ],
+      "annotations": {}
     }
   },
-  "table_names": [
-    "base table",
-    "alt table detailed",
-    "alt table compact",
-    "base table no app link",
-    "alt table detailed 2",
-    "alt table compact 2"
-  ],
   "comment": null,
   "annotations": {
     "tag:isrd.isi.edu,2016:app-links": {

--- a/test/specs/reference/tests/08.alternative_tables.js
+++ b/test/specs/reference/tests/08.alternative_tables.js
@@ -16,6 +16,8 @@ exports.execute = function (options) {
             altDetailedTable2Encoded = "alt%20table%20detailed%202",
             altCompactTable2 = "alt table compact 2",
             altCompactTable2Encoded = "alt%20table%20compact%202",
+            relatedTable = "related_table",
+            associatonTable = "association_table",
             entityId = "00001",
             value = "12";
 
@@ -70,6 +72,14 @@ exports.execute = function (options) {
          *      a. contextualize entry (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
+         * 13) start from related table with join to base with filters
+         *      a. contextualize entry (base_table)
+         *      b. contextualize detailed (alt_table_detailed)
+         *      c. contextualize compact (alt_table_compact)
+         * 14) start from related_table with join to base on shared key with filters
+         *      a. contextualize entry (base_table)
+         *      b. contextualize detailed (alt_table_detailed)
+         *      c. contextualize compact (alt_table_compact)
          */
 
         var uri1 = options.url + "/catalog/" + catalog_id + "/entity/"
@@ -107,6 +117,13 @@ exports.execute = function (options) {
 
         var uri12 = options.url + "/catalog/" + catalog_id + "/entity/" + schemaNameEncoded + ":"
             + altCompactTable1Encoded + "/id%20y=00001;id%20y=00002;id%20y=00003;id%20y=00004;id%20y=00005;id%20y=00006";
+
+        var uri13 = options.url + "/catalog/" + catalog_id + "/entity/" + schemaNameEncoded + ":"
+            + relatedTable + "/id=1/(id)=(" + schemaNameEncoded + ":" + baseTable1Encoded + ":fk_to_related)";
+
+        var uri14 = options.url + "/catalog/" + catalog_id + "/entity/" + schemaNameEncoded + ":"
+            + relatedTable + "/id=1/(id)=(" + schemaNameEncoded + ":" + associatonTable + ":id_related)/(id_base)=("
+            + schemaNameEncoded + ":" + baseTable1Encoded + ":id)";
 
 
         describe('1. base table with no entity filters,', function() {
@@ -188,7 +205,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -241,7 +258,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -294,7 +311,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -385,7 +402,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -438,7 +455,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -491,7 +508,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -784,7 +801,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -837,7 +854,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -890,7 +907,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -986,7 +1003,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1039,7 +1056,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1092,7 +1109,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1181,7 +1198,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1234,7 +1251,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1287,7 +1304,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1576,7 +1593,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1629,7 +1646,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1682,7 +1699,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1778,7 +1795,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1831,7 +1848,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1884,7 +1901,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -1973,7 +1990,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -2026,7 +2043,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -2079,7 +2096,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -2368,7 +2385,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -2421,7 +2438,7 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {
@@ -2474,7 +2491,397 @@ exports.execute = function (options) {
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.tuples.length).toBe(1);
-                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12});
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+        });
+
+        describe('13. related_table join with base with filter,', function() {
+            var reference, reference2, page, tuple;
+            var limit = 25;
+
+            it('13.1 resolve should return a Reference object that is defined.', function(done) {
+                options.ermRest.resolve(uri13, {cid: "test"}).then(function (response) {
+                    reference = response;
+                    reference.session = { attributes: [] };
+
+                    expect(reference).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('13.2 base table should be properly defined', function() {
+                expect(reference._table.name).toBe(baseTable1);
+                expect(reference._table._alternatives.detailed.name).toBe(altDetailedTable1);
+                expect(reference._table._alternatives.compact.name).toBe(altCompactTable1);
+                expect(reference._table._baseTable.name).toBe(baseTable1);
+            });
+
+            it('13.3. reference should be properly defined', function() {
+                expect(reference._location.uri).toBe(uri13);
+                expect(reference._location.service).toBe(options.url);
+                expect(reference._location.catalog).toBe(catalog_id.toString());
+                expect(reference._location.schemaName).toBe(schemaName);
+                expect(reference._location.tableName).toBe(baseTable1);
+
+            });
+
+            it('13.A contextualize entry should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entry;
+                expect(reference2._table.name).toBe(baseTable1);
+                expect(reference2._shortestKey.length).toBe(1);
+                expect(reference2._shortestKey[0].name).toBe("id");
+                expect(reference2.displayname.value).toBe(baseTable1);
+            });
+
+            it('13.A.1 read should return a Page object that is defined.', function(done) {
+                reference2.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('13.A.2 page data should be the values from base table.', function() {
+                expect(page._ref).toBe(reference2);
+                expect(page._data.length).toBe(2);
+
+                tuple = page.tuples[0];
+                expect(tuple._pageRef).toBe(reference2);
+                expect(tuple._data.id).toBe("00001");
+                expect(tuple._data.name).toBe("Hank");
+                expect(tuple._data.value).toBe(12);
+            });
+
+            it('13.A.3 tuple reference should be on the base table with correct filter', function() {
+                expect(tuple.reference).toBeDefined();
+                expect(tuple.reference._table.name).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
+                expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
+            });
+
+            it('13.A.4 tuple read should return correct data from base table', function(done) {
+                tuple.reference.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+                    expect(page.tuples.length).toBe(1);
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('13.B contextualize detailed should return a new reference with alternative table', function() {
+                reference2 = reference.contextualize.detailed;
+                expect(reference2._table.name).toBe(altDetailedTable1);
+                expect(reference2._shortestKey.length).toBe(1);
+                expect(reference2._shortestKey[0].name).toBe("id x");
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
+            });
+
+            it('13.B.1 read should return a Page object that is defined.', function(done) {
+                reference2.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('13.B.2 page data should be the values from alternative table.', function() {
+                expect(page._ref).toBe(reference2);
+                expect(page._data.length).toBe(2);
+
+                tuple = page.tuples[0];
+                expect(tuple._pageRef).toBe(reference2);
+                expect(tuple._data["id x"]).toBe("00001");
+                expect(tuple._data.details).toBe("Hank, Male 23");
+            });
+
+            it('13.B.3 tuple reference should be on the base table with correct filter', function() {
+                expect(tuple.reference).toBeDefined();
+                expect(tuple.reference._table.name).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
+                expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
+            });
+
+            it('13.B.4 tuple read should return correct data from base table', function(done) {
+                tuple.reference.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+                    expect(page.tuples.length).toBe(1);
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('13.C contextualize compact should return a new reference with alternative table', function() {
+                reference2 = reference.contextualize.compact;
+                expect(reference2._table.name).toBe(altCompactTable1);
+                expect(reference2._shortestKey.length).toBe(1);
+                expect(reference2._shortestKey[0].name).toBe("id y");
+                expect(reference2.displayname.value).toBe(altCompactTable1);
+            });
+
+            it('13.C.1 read should return a Page object that is defined.', function(done) {
+                reference2.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('13.C.2 page data should be the values from alternative table.', function() {
+                expect(page._ref).toBe(reference2);
+                expect(page._data.length).toBe(2);
+
+                tuple = page.tuples[0];
+                expect(tuple._pageRef).toBe(reference2);
+                expect(tuple._data["id y"]).toBe("00001");
+                expect(tuple._data.summary).toBe("Hank 23");
+            });
+
+            it('13.C.3 tuple reference should be on the base table with correct filter', function() {
+                expect(tuple.reference).toBeDefined();
+                expect(tuple.reference._table.name).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
+                expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
+            });
+
+            it('13.C.4 tuple read should return correct data from base table', function(done) {
+                tuple.reference.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+                    expect(page.tuples.length).toBe(1);
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+        });
+
+        describe('14. related_table join with base with filter,', function() {
+            var reference, reference2, page, tuple;
+            var limit = 25;
+
+            it('14.1 resolve should return a Reference object that is defined.', function(done) {
+                options.ermRest.resolve(uri14, {cid: "test"}).then(function (response) {
+                    reference = response;
+                    reference.session = { attributes: [] };
+
+                    expect(reference).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('14.2 base table should be properly defined', function() {
+                expect(reference._table.name).toBe(baseTable1);
+                expect(reference._table._alternatives.detailed.name).toBe(altDetailedTable1);
+                expect(reference._table._alternatives.compact.name).toBe(altCompactTable1);
+                expect(reference._table._baseTable.name).toBe(baseTable1);
+            });
+
+            it('14.3. reference should be properly defined', function() {
+                expect(reference._location.uri).toBe(uri14);
+                expect(reference._location.service).toBe(options.url);
+                expect(reference._location.catalog).toBe(catalog_id.toString());
+                expect(reference._location.schemaName).toBe(schemaName);
+                expect(reference._location.tableName).toBe(baseTable1);
+
+            });
+
+            it('14.A contextualize entry should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entry;
+                expect(reference2._table.name).toBe(baseTable1);
+                expect(reference2._shortestKey.length).toBe(1);
+                expect(reference2._shortestKey[0].name).toBe("id");
+                expect(reference2.displayname.value).toBe(baseTable1);
+            });
+
+            it('14.A.1 read should return a Page object that is defined.', function(done) {
+                reference2.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('14.A.2 page data should be the values from base table with filter.', function() {
+                expect(page._ref).toBe(reference2);
+                expect(page._data.length).toBe(2);
+
+                tuple = page.tuples[0];
+                expect(tuple._pageRef).toBe(reference2);
+                expect(tuple._data.id).toBe("00001");
+                expect(tuple._data.name).toBe("Hank");
+                expect(tuple._data.value).toBe(12);
+            });
+
+            it('14.A.3 tuple reference should be on the base table with correct filter', function() {
+                expect(tuple.reference).toBeDefined();
+                expect(tuple.reference._table.name).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
+                expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
+            });
+
+            it('14.A.4 tuple read should return correct data from base table', function(done) {
+                tuple.reference.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+                    expect(page.tuples.length).toBe(1);
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('14.B contextualize detailed should return a new reference with alternative table', function() {
+                reference2 = reference.contextualize.detailed;
+                expect(reference2._table.name).toBe(altDetailedTable1);
+                expect(reference2._shortestKey.length).toBe(1);
+                expect(reference2._shortestKey[0].name).toBe("id x");
+                expect(reference2.displayname.value).toBe(altDetailedTable1);
+            });
+
+            it('14.B.1 read should return a Page object that is defined.', function(done) {
+                reference2.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('14.B.2 page data should be the values from alternative table with filter.', function() {
+                expect(page._ref).toBe(reference2);
+                expect(page._data.length).toBe(2);
+
+                tuple = page.tuples[0];
+                expect(tuple._pageRef).toBe(reference2);
+                expect(tuple._data["id x"]).toBe("00001");
+                expect(tuple._data.details).toBe("Hank, Male 23");
+            });
+
+            it('14.B.3 tuple reference should be on the base table with correct filter', function() {
+                expect(tuple.reference).toBeDefined();
+                expect(tuple.reference._table.name).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
+                expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
+            });
+
+            it('14.B.4 tuple read should return correct data from base table', function(done) {
+                tuple.reference.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+                    expect(page.tuples.length).toBe(1);
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('14.C contextualize compact should return a new reference with alternative table', function() {
+                reference2 = reference.contextualize.compact;
+                expect(reference2._table.name).toBe(altCompactTable1);
+                expect(reference2._shortestKey.length).toBe(1);
+                expect(reference2._shortestKey[0].name).toBe("id y");
+                expect(reference2.displayname.value).toBe(altCompactTable1);
+            });
+
+            it('14.C.1 read should return a Page object that is defined.', function(done) {
+                reference2.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('14.C.2 page data should be the values from alternative table.', function() {
+                expect(page._ref).toBe(reference2);
+                expect(page._data.length).toBe(2);
+
+                tuple = page.tuples[0];
+                expect(tuple._pageRef).toBe(reference2);
+                expect(tuple._data["id y"]).toBe("00001");
+                expect(tuple._data.summary).toBe("Hank 23");
+            });
+
+            it('14.C.3 tuple reference should be on the base table with correct filter', function() {
+                expect(tuple.reference).toBeDefined();
+                expect(tuple.reference._table.name).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
+                expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
+            });
+
+            it('14.C.4 tuple read should return correct data from base table', function(done) {
+                tuple.reference.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+                    expect(page.tuples.length).toBe(1);
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
 
                     done();
                 }, function (err) {

--- a/test/specs/reference/tests/08.alternative_tables.js
+++ b/test/specs/reference/tests/08.alternative_tables.js
@@ -2501,7 +2501,7 @@ exports.execute = function (options) {
             });
         });
 
-        describe('13. related_table join with base with filter,', function() {
+        describe('13. related_table join on different keys with base with filter,', function() {
             var reference, reference2, page, tuple;
             var limit = 25;
 
@@ -2558,7 +2558,7 @@ exports.execute = function (options) {
 
             it('13.A.2 page data should be the values from base table.', function() {
                 expect(page._ref).toBe(reference2);
-                expect(page._data.length).toBe(2);
+                expect(page._data.length).toBe(3);
 
                 tuple = page.tuples[0];
                 expect(tuple._pageRef).toBe(reference2);
@@ -2612,7 +2612,7 @@ exports.execute = function (options) {
 
             it('13.B.2 page data should be the values from alternative table.', function() {
                 expect(page._ref).toBe(reference2);
-                expect(page._data.length).toBe(2);
+                expect(page._data.length).toBe(3);
 
                 tuple = page.tuples[0];
                 expect(tuple._pageRef).toBe(reference2);
@@ -2665,7 +2665,7 @@ exports.execute = function (options) {
 
             it('13.C.2 page data should be the values from alternative table.', function() {
                 expect(page._ref).toBe(reference2);
-                expect(page._data.length).toBe(2);
+                expect(page._data.length).toBe(3);
 
                 tuple = page.tuples[0];
                 expect(tuple._pageRef).toBe(reference2);
@@ -2696,7 +2696,7 @@ exports.execute = function (options) {
             });
         });
 
-        describe('14. related_table join with base with filter,', function() {
+        describe('14. related_table join on shared key with base with filter,', function() {
             var reference, reference2, page, tuple;
             var limit = 25;
 

--- a/test/specs/reference/tests/09.app_linking.js
+++ b/test/specs/reference/tests/09.app_linking.js
@@ -90,7 +90,7 @@ exports.execute = function (options) {
                     reference.session = { attributes: [] };
 
                     // uncontextualized
-                    result = searchURL + "/" + reference.location.path;
+                    result = recordURL + "/" + reference.location.path;
                     expect(reference.appLink).toBe(result);
 
                     done();
@@ -102,19 +102,19 @@ exports.execute = function (options) {
 
             it('2.2 contextualize for detailed should return correct app link, ', function() {
                 reference_d = reference.contextualize.detailed;
-                result = searchURL + "/" + reference_d.location.path;
+                result = recordURL + "/" + reference_d.location.path;
                 expect(reference_d.appLink).toBe(result);
             });
 
             it('2.3 contextualize for compact should return correct app link, ', function() {
                 reference_c = reference_d.contextualize.compact;
-                result = searchURL + "/" + reference_c.location.path;
+                result = recordsetURL + "/" + reference_c.location.path;
                 expect(reference_c.appLink).toBe(result);
             });
 
             it('2.4 contextualize for entry should return correct app link, ', function() {
                 reference_e = reference_c.contextualize.entry;
-                result = searchURL + "/" + reference_e.location.path;
+                result = recordURL + "/" + reference_e.location.path;
                 expect(reference_e.appLink).toBe(result);
             });
 


### PR DESCRIPTION
This PR changes the logic of applying alternative tables in `contextualize` function. 

Old logic was solely based on filter. But since the parser doesn't understand filters when there are multiple joins, [it was buggy](#366).

If the last part of uri is a join and this join is on the base table's key (the key that alternative tables have foreign key to), we will swap the join to point to the alternative table. Otherwise it will add another join to the alternative table.

For instance, let's assume the following:
```
"->": foreignkey

-------------------
inbound related:
  T1_alter -> T1
  T2 -> T1

  the uri with filter on T2 and join:
    T2/id=1/(id)=(T1:id)

  the uri that points to alternative table after new changes:
    T2/id=1/(id)=(T1_alter:id)

-------------------
association related:
  T1_alter -> T1
  T2 <- assoc -> T1

  the uri with filter on T2 and join:
    T2/id=1/(id)=(assoc:id2)/(id1)=(T1:id)

  the uri that points to alternative table after new changes:
    T2/id=1/(id)=(assoc:id2)/(id1)=(T1_alter:id)

```
You can see how this works in related entities [in here](https://dev.rebuildingakidney.org/~ashafaei/chaise/record/#2/test:y/id=10). Compare it with [previous build](https://dev.rebuildingakidney.org/chaise/record/#2/test:y/id=10) which is showing more results.

Related Issue: #366 
__Chaise test cases are passing with this branch of ermrestjs__