### PR TITLE
Html errors

### DIFF
--- a/js/http.js
+++ b/js/http.js
@@ -197,7 +197,7 @@ var ERMrest = (function (module) {
                              // If we get an HTTP error with HTML in it, this means something the server returned as an error.
                              // Ermrest never produces HTML errors, so this was produced by the server itself
                              if (response.headers()['content-type'] && response.headers()['content-type'].indexOf("html") > -1) {
-                                 response.status = response.statusCode = _http_status_codes.service_unavailable;
+                                 response.status = response.statusCode = _http_status_codes.internal_server_error;
                                  response.data = "An unexpected error has occurred. Please report this problem to your system administrators.";
                              } else {
                                  response.status = response.statusCode = _http_status_codes.no_content;
@@ -246,7 +246,7 @@ var ERMrest = (function (module) {
                             // If we get an HTTP error with HTML in it, this means something the server returned as an error.
                             // Ermrest never produces HTML errors, so this was produced by the server itself
                             if (response.headers()['content-type'] && response.headers()['content-type'].indexOf("html") > -1) {
-                                response.status = response.statusCode = _http_status_codes.service_unavailable;
+                                response.status = response.statusCode = _http_status_codes.internal_server_error;
                                 response.data = "An unexpected error has occurred. Please report this problem to your system administrators.";
                             }
 

--- a/js/http.js
+++ b/js/http.js
@@ -196,7 +196,7 @@ var ERMrest = (function (module) {
 
                              // If we get an HTTP error with HTML in it, this means something the server returned as an error.
                              // Ermrest never produces HTML errors, so this was produced by the server itself
-                             if (response.headers()['content-type'].indexOf("html") > -1) {
+                             if (response.headers()['content-type'] && response.headers()['content-type'].indexOf("html") > -1) {
                                  response.status = response.statusCode = _http_status_codes.service_unavailable;
                                  response.data = "An unexpected error has occurred. Please report this problem to your system administrators.";
                              } else {
@@ -245,7 +245,7 @@ var ERMrest = (function (module) {
                         } else {
                             // If we get an HTTP error with HTML in it, this means something the server returned as an error.
                             // Ermrest never produces HTML errors, so this was produced by the server itself
-                            if (response.headers()['content-type'].indexOf("html") > -1) {
+                            if (response.headers()['content-type'] && response.headers()['content-type'].indexOf("html") > -1) {
                                 response.status = response.statusCode = _http_status_codes.service_unavailable;
                                 response.data = "An unexpected error has occurred. Please report this problem to your system administrators.";
                             }

--- a/js/http.js
+++ b/js/http.js
@@ -140,12 +140,26 @@ var ERMrest = (function (module) {
                              * Both of the currently supported delete operations
                              * (entity/ and attribute/) return 204 No Content.
                              */
-                            response.status = response.statusCode = _http_status_codes.no_content;
+
+                             // If we get an HTTP error with HTML in it, this means something the server returned as an error.
+                             // Ermrest never produces HTML errors, so this was produced by the server itself
+                             if (response.headers()['content-type'].indexOf("html") > -1) {
+                                 response.status = response.statusCode = _http_status_codes.service_unavailable;
+                                 response.data = "An unexpected error has occurred. Please report this problem to your system administrators.";
+                             } else {
+                                 response.status = response.statusCode = _http_status_codes.no_content;
+                             }
 
                             module._onload().then(function() {
                                 deferred.resolve(response);
                             });
                         } else {
+                            // If we get an HTTP error with HTML in it, this means something the server returned as an error.
+                            // Ermrest never produces HTML errors, so this was produced by the server itself
+                            if (response.headers()['content-type'].indexOf("html") > -1) {
+                                response.status = response.statusCode = _http_status_codes.service_unavailable;
+                                response.data = "An unexpected error has occurred. Please report this problem to your system administrators.";
+                            }
 
                             module._onload().then(function() {
                                 deferred.reject(response);

--- a/test/specs/errors/spec.js
+++ b/test/specs/errors/spec.js
@@ -5,7 +5,8 @@ require('./../../utils/starter.spec.js').runTests({
         "/errors/tests/02.schema_error.js",
         "/errors/tests/03.table_error.js",
         "/errors/tests/04.entity_error.js",
-        "/errors/tests/05.http_retry_error.js"
+        "/errors/tests/05.http_retry_error.js",
+        "/errors/tests/07.http_content_error.js"
     ],
     schemaConfigurations: [
         "/errors/conf/error.conf.json"

--- a/test/specs/errors/tests/07.http_content_error.js
+++ b/test/specs/errors/tests/07.http_content_error.js
@@ -34,7 +34,7 @@ exports.execute = function (options) {
                 .reply(404, htmlResponseMessage, {"Content-Type": "text/html"});
 
             server.catalogs.get(id).then(null, function(err) {
-                expect(err.code).toBe(503);
+                expect(err.code).toBe(500);
                 expect(err.message).toBe(terminalErrorMessage);
 
                 done();

--- a/test/specs/errors/tests/07.http_content_error.js
+++ b/test/specs/errors/tests/07.http_content_error.js
@@ -1,0 +1,53 @@
+var nock = require('nock');
+
+exports.execute = function (options) {
+
+    describe("For determining HTTP response objects with content type including HTML,", function () {
+        var server, url, catalog,
+            id = "7345274", // something very far out of range
+            ops = {allowUnmocked: true};
+
+        var htmlResponseMessage = '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">'
+            + '<html>'
+                + '<head>'
+                    + '<title>404 Not Found</title>'
+                + '</head>'
+                + '<body>'
+                    + '<h1>Not Found</h1>'
+                    + '<p>The requested URL /t.html was not found on this server.</p>'
+                + '</body>'
+            + '</html>';
+
+        var terminalErrorMessage = "An unexpected error has occurred. Please report this problem to your system administrators.";
+
+        beforeAll(function () {
+            server = options.server;
+            catalog = options.catalog;
+            url = options.url.replace('ermrest', '');
+
+            server._http.max_retries = 0;
+        });
+
+        it("should be returned as a 503 error.", function (done) {
+            nock(url, ops)
+                .get("/ermrest/catalog/" + id + "/schema?cid=null")
+                .reply(404, htmlResponseMessage, {"Content-Type": "text/html"});
+
+            server.catalogs.get(id).then(null, function(err) {
+                expect(err.code).toBe(503);
+                expect(err.message).toBe(terminalErrorMessage);
+
+                done();
+            }).catch(function() {
+                expect(false).toBe(true);
+                done();
+            });
+        });
+
+	    afterAll(function() {
+            nock.cleanAll();
+	        nock.enableNetConnect();
+	    });
+
+    });
+};


### PR DESCRIPTION
This PR addresses [issue #1036](https://github.com/informatics-isi-edu/chaise/issues/1036) reported in chaise.

It was decided that when an HTTP error is returned with `content-type` including HTML, this is an error generated from the server (Apache) rather than our code. `Ermrest` does not produce HTML errors, only JSON errors.

In the case of an HTML error being returned, it had to be because of some server error that `Ermrest` did not catch. This is seen as a server error and changed to a `503 Service Unavailable` error.