### PR TITLE
isForeignKey made public

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -291,6 +291,7 @@ to use for ERMrest JavaScript agents.
         * [.comment](#ERMrest.ReferenceColumn+comment) : <code>string</code>
         * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> &#124; <code>object</code>
         * [.sortable](#ERMrest.ReferenceColumn+sortable) : <code>boolean</code>
+        * [.isForeignKey](#ERMrest.ReferenceColumn+isForeignKey) : <code>boolean</code>
         * [.formatvalue(data)](#ERMrest.ReferenceColumn+formatvalue) ⇒ <code>string</code>
         * [.filteredRef(column, data)](#ERMrest.ReferenceColumn+filteredRef) ⇒ <code>[Reference](#ERMrest.Reference)</code>
         * [.formatPresentation(data, options)](#ERMrest.ReferenceColumn+formatPresentation) ⇒ <code>Object</code>
@@ -2694,6 +2695,7 @@ to AssocitaitonTable with FK1 = "1"" and FK2 = "2".
     * [.comment](#ERMrest.ReferenceColumn+comment) : <code>string</code>
     * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> &#124; <code>object</code>
     * [.sortable](#ERMrest.ReferenceColumn+sortable) : <code>boolean</code>
+    * [.isForeignKey](#ERMrest.ReferenceColumn+isForeignKey) : <code>boolean</code>
     * [.formatvalue(data)](#ERMrest.ReferenceColumn+formatvalue) ⇒ <code>string</code>
     * [.filteredRef(column, data)](#ERMrest.ReferenceColumn+filteredRef) ⇒ <code>[Reference](#ERMrest.Reference)</code>
     * [.formatPresentation(data, options)](#ERMrest.ReferenceColumn+formatPresentation) ⇒ <code>Object</code>
@@ -2800,6 +2802,12 @@ Heuristics are as follows:
 - Column:
      - column_order defined -> use it.
      - use column actual value.
+
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+<a name="ERMrest.ReferenceColumn+isForeignKey"></a>
+
+#### referenceColumn.isForeignKey : <code>boolean</code>
+returns the private value _isForeignKey
 
 **Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+formatvalue"></a>

--- a/js/reference.js
+++ b/js/reference.js
@@ -3059,6 +3059,14 @@ var ERMrest = (function(module) {
         },
 
         /**
+         * @desc returns the private value _isForeignKey
+         * @type {boolean}
+         */
+        get isForeignKey() {
+            return this._isForeignKey;
+        },
+
+        /**
          * Formats a value corresponding to this reference-column definition.
          * @param {Object} data The 'raw' data value.
          * @returns {string} The formatted value.

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -111,18 +111,18 @@ exports.execute = function (options) {
             });
         });
 
-        describe('._isForeignKey, ', function () {
+        describe('.isForeignKey, ', function () {
             it ('for PseudoColumns that are foreign key should return true.', function () {
                 for (var i = 1; i < 16; i++) {
-                    expect(compactColumns[i]._isForeignKey).toBe(true);
+                    expect(compactColumns[i].isForeignKey).toBe(true);
                     if (i == 4) i = 10;
                 }
             });
 
             it ('for other columns should return undefined.', function () {
-                expect(compactColumns[0]._isForeignKey).toBe(undefined);
+                expect(compactColumns[0].isForeignKey).toBe(undefined);
                 for (var i = 5; i < 11; i++) {
-                    expect(compactColumns[i]._isForeignKey).toBe(undefined);
+                    expect(compactColumns[i].isForeignKey).toBe(undefined);
                 }
             });
         });


### PR DESCRIPTION
This PR addresses issue #374. This is so that checking for if a column is a foreign key can be done in `ermrestJS` instead of the apps that use that API.

This PR needs to be merged before the [corresponding PR](https://github.com/informatics-isi-edu/chaise/pull/1071) in chaise.