### PR TITLE
Alternative Table Bugs

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -1949,16 +1949,17 @@ var ERMrest = (function(module) {
                             if ((source._table._isAlternativeTable() && filter.column === source._table._altForeignKey.colset.columns[0].name) ||
                                 (!source._table._isAlternativeTable() && filter.column === sharedKey.colset.columns[0].name)) {
 
-                                if (newTable._isAlternativeTable()) // to alternative table
+                                if (newTable._isAlternativeTable()) { // to alternative table
                                     filterString = module._fixedEncodeURIComponent(newTable._altForeignKey.colset.columns[0].name) +
                                         "=" + filter.value;
-                                else // to base table
+                                } else { // to base table
                                     filterString = module._fixedEncodeURIComponent(sharedKey.colset.columns[0].name) + "=" + filter.value;
-                            }
+                                }
 
-                            newLocationString = source._location.service + "/catalog/" + module._fixedEncodeURIComponent(source._location.catalog) + "/" +
-                                                source._location.api + "/" + module._fixedEncodeURIComponent(newTable.schema.name) + ":" + module._fixedEncodeURIComponent(newTable.name) + "/" +
-                                                filterString;
+                                newLocationString = source._location.service + "/catalog/" + module._fixedEncodeURIComponent(source._location.catalog) + "/" +
+                                                    source._location.api + "/" + module._fixedEncodeURIComponent(newTable.schema.name) + ":" + module._fixedEncodeURIComponent(newTable.name) + "/" +
+                                                    filterString;
+                            }
 
                         } else if (filter.type === module.filterTypes.CONJUNCTION && filter.filters.length === sharedKey.colset.length()) {
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -1731,7 +1731,6 @@ var ERMrest = (function(module) {
             this._displayname = table.displayname;
             delete this._referenceColumns;
             delete this._related;
-            delete this.derivedAssociationReference;
             delete this._canCreate;
             delete this._canRead;
             delete this._canUpdate;
@@ -1846,7 +1845,8 @@ var ERMrest = (function(module) {
             * cases:
             *   1. same table: do nothing
             *   2. has join
-            *       2.1. on same key: swap join
+            *       2.1. source is base, newTable is alternative:
+            *           - If the join is on the alternative shared key, swap the joins.
             *       2.2. otherwise: use join
             *   3. doesn't have join
             *       3.1. no filter: swap table and update location only
@@ -1866,7 +1866,7 @@ var ERMrest = (function(module) {
 
                 var newLocationString;
 
-                if (source._location.hasJoin && newTable._isAlternativeTable()) {
+                if (source._location.hasJoin) {
                     // returns true if join is on alternative shared key
                     var joinOnAlternativeKey = function () {
                         var joinCols = source._location.lastJoin.rightCols,
@@ -1912,7 +1912,7 @@ var ERMrest = (function(module) {
                     };
 
                     // 2.1. if _altSharedKey is the same as the join
-                    if (joinOnAlternativeKey(source)) {
+                    if (!source._table._isAlternativeTable() && newTable._isAlternativeTable() && joinOnAlternativeKey(source)) {
                         // change to-columns of the join
                         newLocationString =  source._location.compactUri;
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "bower": "x",
     "closurecompiler": "x",
-    "jasmine": "x",
+    "jasmine": "2.5.3",
     "jasmine-spec-reporter": "^2.5.0",
     "jsdoc": "x",
     "jsdoc-to-markdown": "x",

--- a/test/specs/reference/conf/reference_schema_altTables/schema.json
+++ b/test/specs/reference/conf/reference_schema_altTables/schema.json
@@ -66,8 +66,7 @@
         "tag:isrd.isi.edu,2016:table-alternatives": {
           "detailed": ["reference schema altTables", "alt table detailed"],
           "compact": ["reference schema altTables", "alt table compact"],
-          "entry": ["reference schema altTables", "base table"],
-          "*": ["reference schema altTables", "alt table detailed"]
+          "entry/create": ["reference schema altTables", "base table"]
         },
         "tag:isrd.isi.edu,2016:app-links": {
           "detailed": "tag:isrd.isi.edu,2016:chaise:record",
@@ -203,7 +202,7 @@
         "tag:isrd.isi.edu,2016:table-alternatives": {
           "detailed": ["reference schema altTables", "alt table detailed 2"],
           "compact": ["reference schema altTables", "alt table compact 2"],
-          "entry": ["reference schema altTables", "base table no app link"]
+          "entry/create": ["reference schema altTables", "base table no app link"]
         }
       }
     },

--- a/test/specs/reference/tests/08.alternative_tables.js
+++ b/test/specs/reference/tests/08.alternative_tables.js
@@ -25,59 +25,59 @@ exports.execute = function (options) {
          * Test Cases:
          *
          * 1) start from base_table with no filter
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 2) start from base_table with single entity shared key filter (single col)
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 3) start from base_table with single entity shared key filter (multi col)
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 4) start from base_table with other filters
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 5) start from alt_table_detailed with no filter
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 6) start from alt_table_detailed with single entity shared key filter (single col)
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 7) start from alt_table_detailed with single entity shared key filter (multi col)
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 8) start from alt_table_detailed with other filters
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 9) start from alt_table_compact with no filter
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 10) start from alt_table_compact with single entity shared key filter (single col)
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 11) start from alt_table_compact with single entity shared key filter (multi col)
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 12) start from alt_table_compact with other filters
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 13) start from related table with join to base with filters
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          * 14) start from related_table with join to base on shared key with filters
-         *      a. contextualize entry (base_table)
+         *      a. contextualize entry/create (base_table)
          *      b. contextualize detailed (alt_table_detailed)
          *      c. contextualize compact (alt_table_compact)
          */
@@ -160,8 +160,8 @@ exports.execute = function (options) {
 
             });
 
-            it('1.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('1.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -357,8 +357,8 @@ exports.execute = function (options) {
 
             });
 
-            it('2.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('2.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -555,8 +555,8 @@ exports.execute = function (options) {
 
             });
 
-            it('3.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('3.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -756,8 +756,8 @@ exports.execute = function (options) {
 
             });
 
-            it('4.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('4.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -958,8 +958,8 @@ exports.execute = function (options) {
 
             });
 
-            it('5.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('5.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -1153,8 +1153,8 @@ exports.execute = function (options) {
 
             });
 
-            it('6.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('6.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -1349,8 +1349,8 @@ exports.execute = function (options) {
 
             });
 
-            it('7.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('7.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -1548,8 +1548,8 @@ exports.execute = function (options) {
 
             });
 
-            it('8.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('8.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -1750,8 +1750,8 @@ exports.execute = function (options) {
 
             });
 
-            it('9.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('9.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -1945,8 +1945,8 @@ exports.execute = function (options) {
 
             });
 
-            it('10.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('10.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -2141,8 +2141,8 @@ exports.execute = function (options) {
 
             });
 
-            it('11.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('11.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable2);
                 expect(reference2._shortestKey.length).toBe(2);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -2340,8 +2340,8 @@ exports.execute = function (options) {
 
             });
 
-            it('12.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('12.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -2502,7 +2502,7 @@ exports.execute = function (options) {
         });
 
         describe('13. related_table join on different keys with base with filter,', function() {
-            var reference, reference2, page, tuple;
+            var reference, reference2, reference3, page, tuple;
             var limit = 25;
 
             it('13.1 resolve should return a Reference object that is defined.', function(done) {
@@ -2535,8 +2535,8 @@ exports.execute = function (options) {
 
             });
 
-            it('13.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('13.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");
@@ -2694,6 +2694,59 @@ exports.execute = function (options) {
                     done.fail();
                 });
             });
+
+            it("13.D contextualizing a contextualized reference should not remove the join., ", function () {
+                reference3 = reference2.contextualize.entry;
+                expect(reference3._table.name).toBe(baseTable1);
+                expect(reference3._shortestKey.length).toBe(1);
+                expect(reference3._shortestKey[0].name).toBe("id");
+                expect(reference3.displayname.value).toBe(baseTable1);
+            });
+
+            it('13.D.1 read should return a Page object that is defined.', function(done) {
+                reference3.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
+
+            it('13.D.2 page data should be the values from alternative table.', function() {
+                expect(page._ref).toBe(reference3);
+                expect(page._data.length).toBe(3);
+
+                tuple = page.tuples[0];
+                expect(tuple._pageRef).toBe(reference3);
+                expect(tuple._data["id"]).toBe("00001");
+                expect(tuple._data.name).toBe("Hank");
+            });
+
+            it('13.D.3 tuple reference should be on the base table with correct filter', function() {
+                expect(tuple.reference).toBeDefined();
+                expect(tuple.reference._table.name).toBe(baseTable1);
+                expect(tuple.reference.displayname.value).toBe(baseTable1);
+                expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
+            });
+
+            it('13.D.4 tuple read should return correct data from base table', function(done) {
+                tuple.reference.read(limit).then(function (response) {
+                    page = response;
+
+                    expect(page).toEqual(jasmine.any(Object));
+                    expect(page.tuples.length).toBe(1);
+                    expect(page.tuples[0]._data).toEqual({"id":"00001","name":"Hank","value":12,"fk_to_related":"1"});
+
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            });
         });
 
         describe('14. related_table join on shared key with base with filter,', function() {
@@ -2730,8 +2783,8 @@ exports.execute = function (options) {
 
             });
 
-            it('14.A contextualize entry should return a new reference with base table', function() {
-                reference2 = reference.contextualize.entry;
+            it('14.A contextualize entry/create should return a new reference with base table', function() {
+                reference2 = reference.contextualize.entryCreate;
                 expect(reference2._table.name).toBe(baseTable1);
                 expect(reference2._shortestKey.length).toBe(1);
                 expect(reference2._shortestKey[0].name).toBe("id");


### PR DESCRIPTION
This PR will fix #395 and [chaise#1073](https://github.com/informatics-isi-edu/chaise/issues/1073).

The #395 happened because of buggy logic in applying alternative table. The is the fixed logic:

> When there's a join in the uri,
> - if uri is pointing to the base table, and we want to switch to
  alternative table. If the join is on the same shared key, we should
swap the join.
> - otherwise fall to the general case: adding new join

With this change the [chaise#1073](https://github.com/informatics-isi-edu/chaise/issues/1073) should not happen. Although the code was buggy and in some cases was using an undefined string, which I fixed.

Also jasmine has released  the [2.6.0](https://github.com/jasmine/jasmine/releases/tag/v2.6.0) version, which caused [various test cases to fail](https://travis-ci.org/informatics-isi-edu/ermrestjs/builds/225804425). I fixed the jasmine version to the previous stable (2.5.3) and was trying to find the reason why they are failing with 2.6.0 (is it because of a bug in jasmine, or deprecated api) but haven't figured it out yet. 