### PR TITLE
Asset Pseudo Column

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ $(TEST): $(BUILD)
 	@touch $(TEST)
 
 # Rule to install the package
-.PHONY: install installm 
+.PHONY: install installm
 install: $(ERMRESTJSDIR)/$(PKG) $(ERMRESTJSDIR)/$(VER) $(LIBS)
 
 installm: install $(ERMRESTJSDIR)/$(MIN)

--- a/doc/api.md
+++ b/doc/api.md
@@ -37,7 +37,7 @@ to use for ERMrest JavaScript agents.
     * [.Server](#ERMrest.Server)
         * [new Server(uri)](#new_ERMrest.Server_new)
         * [.uri](#ERMrest.Server+uri) : <code>string</code>
-        * [.catalogs](#ERMrest.Server+catalogs) : <code>[Catalogs](#ERMrest.Catalogs)</code>
+        * [.catalogs](#ERMrest.Server+catalogs) : [<code>Catalogs</code>](#ERMrest.Catalogs)
     * [.Catalogs](#ERMrest.Catalogs)
         * [new Catalogs(server)](#new_ERMrest.Catalogs_new)
         * [.length()](#ERMrest.Catalogs+length) ⇒ <code>Number</code>
@@ -46,44 +46,44 @@ to use for ERMrest JavaScript agents.
     * [.Catalog](#ERMrest.Catalog)
         * [new Catalog(server, id)](#new_ERMrest.Catalog_new)
         * [.id](#ERMrest.Catalog+id) : <code>string</code>
-        * [.schemas](#ERMrest.Catalog+schemas) : <code>[Schemas](#ERMrest.Schemas)</code>
-        * [.constraintByNamePair(pair, subject)](#ERMrest.Catalog+constraintByNamePair) ⇒ <code>Object</code> &#124; <code>null</code>
+        * [.schemas](#ERMrest.Catalog+schemas) : [<code>Schemas</code>](#ERMrest.Schemas)
+        * [.constraintByNamePair(pair, subject)](#ERMrest.Catalog+constraintByNamePair) ⇒ <code>Object</code> \| <code>null</code>
     * [.Schemas](#ERMrest.Schemas)
         * [new Schemas()](#new_ERMrest.Schemas_new)
         * [.length()](#ERMrest.Schemas+length) ⇒ <code>Number</code>
         * [.all()](#ERMrest.Schemas+all) ⇒ <code>Array</code>
         * [.names()](#ERMrest.Schemas+names) ⇒ <code>Array</code>
-        * [.get(name)](#ERMrest.Schemas+get) ⇒ <code>[Schema](#ERMrest.Schema)</code>
+        * [.get(name)](#ERMrest.Schemas+get) ⇒ [<code>Schema</code>](#ERMrest.Schema)
         * [.has(name)](#ERMrest.Schemas+has) ⇒ <code>boolean</code>
     * [.Schema](#ERMrest.Schema)
         * [new Schema(catalog, jsonSchema)](#new_ERMrest.Schema_new)
-        * [.catalog](#ERMrest.Schema+catalog) : <code>[Catalog](#ERMrest.Catalog)</code>
+        * [.catalog](#ERMrest.Schema+catalog) : [<code>Catalog</code>](#ERMrest.Catalog)
         * [.name](#ERMrest.Schema+name)
         * [.ignore](#ERMrest.Schema+ignore) : <code>boolean</code>
-        * [.annotations](#ERMrest.Schema+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+        * [.annotations](#ERMrest.Schema+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
         * [.displayname](#ERMrest.Schema+displayname) : <code>object</code>
-        * [.tables](#ERMrest.Schema+tables) : <code>[Tables](#ERMrest.Tables)</code>
+        * [.tables](#ERMrest.Schema+tables) : [<code>Tables</code>](#ERMrest.Tables)
         * [.comment](#ERMrest.Schema+comment) : <code>string</code>
     * [.Tables](#ERMrest.Tables)
         * [new Tables()](#new_ERMrest.Tables_new)
         * [.all()](#ERMrest.Tables+all) ⇒ <code>Array</code>
         * [.length()](#ERMrest.Tables+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Tables+names) ⇒ <code>Array</code>
-        * [.get(name)](#ERMrest.Tables+get) ⇒ <code>[Table](#ERMrest.Table)</code>
+        * [.get(name)](#ERMrest.Tables+get) ⇒ [<code>Table</code>](#ERMrest.Table)
     * [.Table](#ERMrest.Table)
         * [new Table(schema, jsonTable)](#new_ERMrest.Table_new)
         * _instance_
-            * [.schema](#ERMrest.Table+schema) : <code>[Schema](#ERMrest.Schema)</code>
+            * [.schema](#ERMrest.Table+schema) : [<code>Schema</code>](#ERMrest.Schema)
             * [.name](#ERMrest.Table+name)
-            * [.entity](#ERMrest.Table+entity) : <code>[Entity](#ERMrest.Table.Entity)</code>
+            * [.entity](#ERMrest.Table+entity) : [<code>Entity</code>](#ERMrest.Table.Entity)
             * [.ignore](#ERMrest.Table+ignore) : <code>boolean</code>
-            * [._baseTable](#ERMrest.Table+_baseTable) : <code>[Table](#ERMrest.Table)</code>
-            * [.annotations](#ERMrest.Table+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+            * [._baseTable](#ERMrest.Table+_baseTable) : [<code>Table</code>](#ERMrest.Table)
+            * [.annotations](#ERMrest.Table+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
             * [.displayname](#ERMrest.Table+displayname) : <code>object</code>
-            * [.columns](#ERMrest.Table+columns) : <code>[Columns](#ERMrest.Columns)</code>
-            * [.keys](#ERMrest.Table+keys) : <code>[Keys](#ERMrest.Keys)</code>
-            * [.foreignKeys](#ERMrest.Table+foreignKeys) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
-            * [.referredBy](#ERMrest.Table+referredBy) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
+            * [.columns](#ERMrest.Table+columns) : [<code>Columns</code>](#ERMrest.Columns)
+            * [.keys](#ERMrest.Table+keys) : [<code>Keys</code>](#ERMrest.Keys)
+            * [.foreignKeys](#ERMrest.Table+foreignKeys) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
+            * [.referredBy](#ERMrest.Table+referredBy) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
             * [.comment](#ERMrest.Table+comment) : <code>string</code>
             * [.kind](#ERMrest.Table+kind) : <code>string</code>
             * [.shortestKey](#ERMrest.Table+shortestKey)
@@ -116,32 +116,32 @@ to use for ERMrest JavaScript agents.
         * [.length()](#ERMrest.Columns+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Columns+names) ⇒ <code>Array</code>
         * [.has(name)](#ERMrest.Columns+has) ⇒ <code>boolean</code>
-        * [.get(name)](#ERMrest.Columns+get) ⇒ <code>[Column](#ERMrest.Column)</code>
-        * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ <code>[Column](#ERMrest.Column)</code>
+        * [.get(name)](#ERMrest.Columns+get) ⇒ [<code>Column</code>](#ERMrest.Column)
+        * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ [<code>Column</code>](#ERMrest.Column)
     * [.Column](#ERMrest.Column)
         * [new Column(table, jsonColumn)](#new_ERMrest.Column_new)
         * [.position](#ERMrest.Column+position) : <code>number</code>
-        * [.table](#ERMrest.Column+table) : <code>[Table](#ERMrest.Table)</code>
+        * [.table](#ERMrest.Column+table) : [<code>Table</code>](#ERMrest.Table)
         * [.name](#ERMrest.Column+name) : <code>string</code>
-        * [.type](#ERMrest.Column+type) : <code>[Type](#ERMrest.Type)</code>
+        * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
         * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
         * [.default](#ERMrest.Column+default) : <code>string</code>
         * [.comment](#ERMrest.Column+comment) : <code>string</code>
         * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
-        * [.annotations](#ERMrest.Column+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+        * [.annotations](#ERMrest.Column+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
         * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
-        * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : <code>[Array.&lt;Key&gt;](#ERMrest.Key)</code>
-        * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
+        * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
+        * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
         * [.formatvalue(data)](#ERMrest.Column+formatvalue) ⇒ <code>string</code>
         * [.formatPresentation(data, options)](#ERMrest.Column+formatPresentation) ⇒ <code>Object</code>
-        * [.toString()](#ERMrest.Column+toString)
+        * [.toString()](#ERMrest.Column+toString) ⇒ <code>string</code>
         * [.getDisplay(context)](#ERMrest.Column+getDisplay)
     * [.Annotations](#ERMrest.Annotations)
         * [new Annotations()](#new_ERMrest.Annotations_new)
-        * [.all()](#ERMrest.Annotations+all) ⇒ <code>[Array.&lt;Annotation&gt;](#ERMrest.Annotation)</code>
+        * [.all()](#ERMrest.Annotations+all) ⇒ [<code>Array.&lt;Annotation&gt;</code>](#ERMrest.Annotation)
         * [.length()](#ERMrest.Annotations+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Annotations+names) ⇒ <code>Array</code>
-        * [.get(uri)](#ERMrest.Annotations+get) ⇒ <code>[Annotation](#ERMrest.Annotation)</code>
+        * [.get(uri)](#ERMrest.Annotations+get) ⇒ [<code>Annotation</code>](#ERMrest.Annotation)
         * [.contains(uri)](#ERMrest.Annotations+contains) ⇒ <code>boolean</code>
     * [.Annotation](#ERMrest.Annotation)
         * [new Annotation(subject, uri, jsonAnnotation)](#new_ERMrest.Annotation_new)
@@ -151,13 +151,13 @@ to use for ERMrest JavaScript agents.
         * [new Keys()](#new_ERMrest.Keys_new)
         * [.all()](#ERMrest.Keys+all) ⇒ <code>Array.&lt;Key&gt;</code>
         * [.length()](#ERMrest.Keys+length) ⇒ <code>Number</code>
-        * [.colsets()](#ERMrest.Keys+colsets) ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
-        * [.get(colset)](#ERMrest.Keys+get) ⇒ <code>[Key](#ERMrest.Key)</code>
+        * [.colsets()](#ERMrest.Keys+colsets) ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
+        * [.get(colset)](#ERMrest.Keys+get) ⇒ [<code>Key</code>](#ERMrest.Key)
     * [.Key](#ERMrest.Key)
         * [new Key(table, jsonKey)](#new_ERMrest.Key_new)
         * [.table](#ERMrest.Key+table) : <code>Table</code>
-        * [.colset](#ERMrest.Key+colset) : <code>[ColSet](#ERMrest.ColSet)</code>
-        * [.annotations](#ERMrest.Key+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+        * [.colset](#ERMrest.Key+colset) : [<code>ColSet</code>](#ERMrest.ColSet)
+        * [.annotations](#ERMrest.Key+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
         * [.comment](#ERMrest.Key+comment) : <code>string</code>
         * [.constraint_names](#ERMrest.Key+constraint_names) : <code>Array</code>
         * [.simple](#ERMrest.Key+simple) : <code>boolean</code>
@@ -165,36 +165,36 @@ to use for ERMrest JavaScript agents.
     * [.ColSet](#ERMrest.ColSet)
         * [new ColSet(columns)](#new_ERMrest.ColSet_new)
         * [.columns](#ERMrest.ColSet+columns) : <code>Array</code>
-        * [.toString()](#ERMrest.ColSet+toString)
+        * [.toString()](#ERMrest.ColSet+toString) ⇒ <code>string</code>
         * [.length()](#ERMrest.ColSet+length) ⇒ <code>Number</code>
     * [.Mapping](#ERMrest.Mapping)
         * [new Mapping(from, to)](#new_ERMrest.Mapping_new)
-        * [.toString()](#ERMrest.Mapping+toString)
+        * [.toString()](#ERMrest.Mapping+toString) ⇒ <code>string</code>
         * [.length()](#ERMrest.Mapping+length) ⇒ <code>Number</code>
-        * [.domain()](#ERMrest.Mapping+domain) ⇒ <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
-        * [.get(fromCol)](#ERMrest.Mapping+get) ⇒ <code>[Column](#ERMrest.Column)</code>
-        * [.getFromColumn(toCol)](#ERMrest.Mapping+getFromColumn) ⇒ <code>[Column](#ERMrest.Column)</code>
+        * [.domain()](#ERMrest.Mapping+domain) ⇒ [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
+        * [.get(fromCol)](#ERMrest.Mapping+get) ⇒ [<code>Column</code>](#ERMrest.Column)
+        * [.getFromColumn(toCol)](#ERMrest.Mapping+getFromColumn) ⇒ [<code>Column</code>](#ERMrest.Column)
     * [.InboundForeignKeys](#ERMrest.InboundForeignKeys)
         * [new InboundForeignKeys(table)](#new_ERMrest.InboundForeignKeys_new)
     * [.ForeignKeys](#ERMrest.ForeignKeys)
-        * [.all()](#ERMrest.ForeignKeys+all) ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
-        * [.colsets()](#ERMrest.ForeignKeys+colsets) ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
+        * [.all()](#ERMrest.ForeignKeys+all) ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+        * [.colsets()](#ERMrest.ForeignKeys+colsets) ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
         * [.length()](#ERMrest.ForeignKeys+length) ⇒ <code>Number</code>
-        * [.mappings()](#ERMrest.ForeignKeys+mappings) ⇒ <code>[Array.&lt;Mapping&gt;](#ERMrest.Mapping)</code>
-        * [.get(colset)](#ERMrest.ForeignKeys+get) ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
+        * [.mappings()](#ERMrest.ForeignKeys+mappings) ⇒ [<code>Array.&lt;Mapping&gt;</code>](#ERMrest.Mapping)
+        * [.get(colset)](#ERMrest.ForeignKeys+get) ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
     * [.ForeignKeyRef](#ERMrest.ForeignKeyRef)
         * [new ForeignKeyRef(table, jsonFKR)](#new_ERMrest.ForeignKeyRef_new)
-        * [.colset](#ERMrest.ForeignKeyRef+colset) : <code>[ColSet](#ERMrest.ColSet)</code>
-        * [.key](#ERMrest.ForeignKeyRef+key) : <code>[Key](#ERMrest.Key)</code>
-        * [.mapping](#ERMrest.ForeignKeyRef+mapping) : <code>[Mapping](#ERMrest.Mapping)</code>
+        * [.colset](#ERMrest.ForeignKeyRef+colset) : [<code>ColSet</code>](#ERMrest.ColSet)
+        * [.key](#ERMrest.ForeignKeyRef+key) : [<code>Key</code>](#ERMrest.Key)
+        * [.mapping](#ERMrest.ForeignKeyRef+mapping) : [<code>Mapping</code>](#ERMrest.Mapping)
         * [.constraint_names](#ERMrest.ForeignKeyRef+constraint_names) : <code>Array</code>
         * [.from_name](#ERMrest.ForeignKeyRef+from_name) : <code>string</code>
         * [.to_name](#ERMrest.ForeignKeyRef+to_name) : <code>string</code>
         * [.ignore](#ERMrest.ForeignKeyRef+ignore) : <code>boolean</code>
-        * [.annotations](#ERMrest.ForeignKeyRef+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+        * [.annotations](#ERMrest.ForeignKeyRef+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
         * [.comment](#ERMrest.ForeignKeyRef+comment) : <code>string</code>
         * [.simple](#ERMrest.ForeignKeyRef+simple) : <code>Boolean</code>
-        * [.toString([reverse])](#ERMrest.ForeignKeyRef+toString)
+        * [.toString([reverse])](#ERMrest.ForeignKeyRef+toString) ⇒ <code>string</code>
         * [.getDomainValues(limit)](#ERMrest.ForeignKeyRef+getDomainValues) ⇒ <code>Promise</code>
     * [.Type](#ERMrest.Type)
         * [new Type(name)](#new_ERMrest.Type_new)
@@ -233,17 +233,17 @@ to use for ERMrest JavaScript agents.
         * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
         * [.uri](#ERMrest.Reference+uri) : <code>string</code>
         * [.session](#ERMrest.Reference+session)
-        * [.table](#ERMrest.Reference+table) : <code>[Table](#ERMrest.Table)</code>
-        * [.columns](#ERMrest.Reference+columns) : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
+        * [.table](#ERMrest.Reference+table) : [<code>Table</code>](#ERMrest.Table)
+        * [.columns](#ERMrest.Reference+columns) : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
             * [._referenceColumns](#ERMrest.Reference+columns+_referenceColumns)
         * [.isUnique](#ERMrest.Reference+isUnique) : <code>boolean</code>
-        * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> &#124; <code>undefined</code>
-        * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> &#124; <code>undefined</code>
-        * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
-        * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
+        * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> \| <code>undefined</code>
+        * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> \| <code>undefined</code>
+        * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> \| <code>undefined</code>
+        * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> \| <code>undefined</code>
         * [.display](#ERMrest.Reference+display) : <code>Object</code>
         * [._related](#ERMrest.Reference+_related)
-        * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : <code>[Reference](#ERMrest.Reference)</code>
+        * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
         * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
         * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
             * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
@@ -251,76 +251,80 @@ to use for ERMrest JavaScript agents.
         * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
         * [.update(tuples)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
         * [.delete(tuples)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
-        * [.related([tuple])](#ERMrest.Reference+related) ⇒ <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
+        * [.related([tuple])](#ERMrest.Reference+related) ⇒ [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
         * [.search(term)](#ERMrest.Reference+search) ⇒ <code>Reference</code>
     * [.Page](#ERMrest.Page)
         * [new Page(reference, etag, data, hasNext, hasPrevious)](#new_ERMrest.Page_new)
-        * [.reference](#ERMrest.Page+reference) : <code>[Reference](#ERMrest.Reference)</code>
-        * [.tuples](#ERMrest.Page+tuples) : <code>[Array.&lt;Tuple&gt;](#ERMrest.Tuple)</code>
+        * [.reference](#ERMrest.Page+reference) : [<code>Reference</code>](#ERMrest.Reference)
+        * [.tuples](#ERMrest.Page+tuples) : [<code>Array.&lt;Tuple&gt;</code>](#ERMrest.Tuple)
         * [.hasPrevious](#ERMrest.Page+hasPrevious) ⇒ <code>boolean</code>
-        * [.previous](#ERMrest.Page+previous) : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
+        * [.previous](#ERMrest.Page+previous) : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
         * [.hasNext](#ERMrest.Page+hasNext) ⇒ <code>boolean</code>
-        * [.next](#ERMrest.Page+next) : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
-        * [.content](#ERMrest.Page+content) : <code>string</code> &#124; <code>null</code>
+        * [.next](#ERMrest.Page+next) : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
+        * [.content](#ERMrest.Page+content) : <code>string</code> \| <code>null</code>
     * [.Tuple](#ERMrest.Tuple)
         * [new Tuple(reference, page, data)](#new_ERMrest.Tuple_new)
-        * [.reference](#ERMrest.Tuple+reference) ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
-        * [.page](#ERMrest.Tuple+page) ⇒ <code>[Page](#ERMrest.Page)</code> &#124; <code>\*</code>
+        * [.reference](#ERMrest.Tuple+reference) ⇒ [<code>Reference</code>](#ERMrest.Reference) \| <code>\*</code>
+        * [.page](#ERMrest.Tuple+page) ⇒ [<code>Page</code>](#ERMrest.Page) \| <code>\*</code>
         * [.data](#ERMrest.Tuple+data) : <code>Object</code>
         * [.data](#ERMrest.Tuple+data)
-        * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
-        * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
+        * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> \| <code>undefined</code>
+        * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> \| <code>undefined</code>
         * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
         * [.isHTML](#ERMrest.Tuple+isHTML) : <code>Array.&lt;string&gt;</code>
         * [.displayname](#ERMrest.Tuple+displayname) : <code>string</code>
         * [.update()](#ERMrest.Tuple+update) ⇒ <code>Promise</code>
         * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
-        * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : <code>[Reference](#ERMrest.Reference)</code>
+        * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : [<code>Reference</code>](#ERMrest.Reference)
     * [.ReferenceColumn](#ERMrest.ReferenceColumn)
-        * [new ReferenceColumn(reference, base, kwargs)](#new_ERMrest.ReferenceColumn_new)
+        * [new ReferenceColumn(reference, baseCols)](#new_ERMrest.ReferenceColumn_new)
         * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
-        * [.reference](#ERMrest.ReferenceColumn+reference) : <code>[Reference](#ERMrest.Reference)</code>
-        * [.foreignKey](#ERMrest.ReferenceColumn+foreignKey) : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
-        * [.key](#ERMrest.ReferenceColumn+key) : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
-        * [.table](#ERMrest.ReferenceColumn+table) : <code>[Table](#ERMrest.Table)</code>
+        * [.table](#ERMrest.ReferenceColumn+table) : [<code>Table</code>](#ERMrest.Table)
         * [.name](#ERMrest.ReferenceColumn+name) : <code>string</code>
         * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>string</code>
-        * [.type](#ERMrest.ReferenceColumn+type) : <code>[Type](#ERMrest.Type)</code>
+        * [.type](#ERMrest.ReferenceColumn+type) : [<code>Type</code>](#ERMrest.Type)
         * [.nullok](#ERMrest.ReferenceColumn+nullok) : <code>Boolean</code>
         * [.default](#ERMrest.ReferenceColumn+default) : <code>string</code>
         * [.comment](#ERMrest.ReferenceColumn+comment) : <code>string</code>
-        * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> &#124; <code>object</code>
+        * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> \| <code>object</code>
         * [.sortable](#ERMrest.ReferenceColumn+sortable) : <code>boolean</code>
-        * [.isForeignKey](#ERMrest.ReferenceColumn+isForeignKey) : <code>boolean</code>
         * [.formatvalue(data)](#ERMrest.ReferenceColumn+formatvalue) ⇒ <code>string</code>
-        * [.filteredRef(column, data)](#ERMrest.ReferenceColumn+filteredRef) ⇒ <code>[Reference](#ERMrest.Reference)</code>
         * [.formatPresentation(data, options)](#ERMrest.ReferenceColumn+formatPresentation) ⇒ <code>Object</code>
-        * [.getInputDisabled()](#ERMrest.ReferenceColumn+getInputDisabled) : <code>boolean</code> &#124; <code>object</code>
+        * [.getInputDisabled()](#ERMrest.ReferenceColumn+getInputDisabled) : <code>boolean</code> \| <code>object</code>
+    * [.ForeignKeyPseudoColumn](#ERMrest.ForeignKeyPseudoColumn)
+        * [new ForeignKeyPseudoColumn(reference, fk)](#new_ERMrest.ForeignKeyPseudoColumn_new)
+        * [.isPseudo](#ERMrest.ForeignKeyPseudoColumn+isPseudo) : <code>boolean</code>
+        * [.isForeignKey](#ERMrest.ForeignKeyPseudoColumn+isForeignKey) : <code>boolean</code>
+        * [.reference](#ERMrest.ForeignKeyPseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
+        * [.foreignKey](#ERMrest.ForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
+        * [.filteredRef(column, data)](#ERMrest.ForeignKeyPseudoColumn+filteredRef) ⇒ [<code>Reference</code>](#ERMrest.Reference)
+        * [.formatPresentation(data, options)](#ERMrest.ForeignKeyPseudoColumn+formatPresentation) ⇒ <code>Object</code>
+        * [._determineSortable()](#ERMrest.ForeignKeyPseudoColumn+_determineSortable)
     * [.Datapath](#ERMrest.Datapath) : <code>object</code>
         * [.DataPath](#ERMrest.Datapath.DataPath)
             * [new DataPath(table)](#new_ERMrest.Datapath.DataPath_new)
-            * [.catalog](#ERMrest.Datapath.DataPath+catalog) : <code>[Catalog](#ERMrest.Catalog)</code>
-            * [.context](#ERMrest.Datapath.DataPath+context) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+            * [.catalog](#ERMrest.Datapath.DataPath+catalog) : [<code>Catalog</code>](#ERMrest.Catalog)
+            * [.context](#ERMrest.Datapath.DataPath+context) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
             * [.entity](#ERMrest.Datapath.DataPath+entity)
                 * [.get()](#ERMrest.Datapath.DataPath+entity.get) ⇒ <code>Promise</code>
                 * [.delete(filter)](#ERMrest.Datapath.DataPath+entity.delete) ⇒ <code>Promise</code>
-            * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
-            * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+            * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
+            * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
         * [.PathTable](#ERMrest.Datapath.PathTable)
             * [new PathTable(table, datapath, alias)](#new_ERMrest.Datapath.PathTable_new)
-            * [.datapath](#ERMrest.Datapath.PathTable+datapath) : <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
-            * [.table](#ERMrest.Datapath.PathTable+table) : <code>[Table](#ERMrest.Table)</code>
+            * [.datapath](#ERMrest.Datapath.PathTable+datapath) : [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
+            * [.table](#ERMrest.Datapath.PathTable+table) : [<code>Table</code>](#ERMrest.Table)
             * [.alias](#ERMrest.Datapath.PathTable+alias) : <code>string</code>
-            * [.columns](#ERMrest.Datapath.PathTable+columns) : <code>[Columns](#ERMrest.Datapath.Columns)</code>
+            * [.columns](#ERMrest.Datapath.PathTable+columns) : [<code>Columns</code>](#ERMrest.Datapath.Columns)
             * [.toString()](#ERMrest.Datapath.PathTable+toString) ⇒ <code>string</code>
         * [.PathColumn](#ERMrest.Datapath.PathColumn)
             * [new PathColumn(column, pathtable)](#new_ERMrest.Datapath.PathColumn_new)
-            * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
-            * [.column](#ERMrest.Datapath.PathColumn+column) : <code>[Column](#ERMrest.Column)</code>
+            * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+            * [.column](#ERMrest.Datapath.PathColumn+column) : [<code>Column</code>](#ERMrest.Column)
         * [.Columns(table, pathtable)](#ERMrest.Datapath.Columns)
             * [.length()](#ERMrest.Datapath.Columns+length) ⇒ <code>Number</code>
             * [.names()](#ERMrest.Datapath.Columns+names) ⇒ <code>Array.&lt;String&gt;</code>
-            * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>
+            * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)
         * [.Operators()](#ERMrest.Datapath.Operators)
     * [.Filters](#ERMrest.Filters) : <code>object</code>
         * [.Negation](#ERMrest.Filters.Negation)
@@ -339,18 +343,18 @@ to use for ERMrest JavaScript agents.
             * [new BinaryPredicate(column, operator, rvalue)](#new_ERMrest.Filters.BinaryPredicate_new)
             * [.toUri()](#ERMrest.Filters.BinaryPredicate+toUri) ⇒ <code>string</code>
     * [.configure(http, q)](#ERMrest.configure)
-    * [.getServer(uri, [params])](#ERMrest.getServer) ⇒ <code>[Server](#ERMrest.Server)</code>
+    * [.getServer(uri, [params])](#ERMrest.getServer) ⇒ [<code>Server</code>](#ERMrest.Server)
     * [.resolve(uri, [params])](#ERMrest.resolve) ⇒ <code>Promise</code>
 
 <a name="ERMrest.Server"></a>
 
 ### ERMrest.Server
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Server](#ERMrest.Server)
     * [new Server(uri)](#new_ERMrest.Server_new)
     * [.uri](#ERMrest.Server+uri) : <code>string</code>
-    * [.catalogs](#ERMrest.Server+catalogs) : <code>[Catalogs](#ERMrest.Catalogs)</code>
+    * [.catalogs](#ERMrest.Server+catalogs) : [<code>Catalogs</code>](#ERMrest.Catalogs)
 
 <a name="new_ERMrest.Server_new"></a>
 
@@ -365,15 +369,15 @@ to use for ERMrest JavaScript agents.
 #### server.uri : <code>string</code>
 The URI of the ERMrest service
 
-**Kind**: instance property of <code>[Server](#ERMrest.Server)</code>  
+**Kind**: instance property of [<code>Server</code>](#ERMrest.Server)  
 <a name="ERMrest.Server+catalogs"></a>
 
-#### server.catalogs : <code>[Catalogs](#ERMrest.Catalogs)</code>
-**Kind**: instance property of <code>[Server](#ERMrest.Server)</code>  
+#### server.catalogs : [<code>Catalogs</code>](#ERMrest.Catalogs)
+**Kind**: instance property of [<code>Server</code>](#ERMrest.Server)  
 <a name="ERMrest.Catalogs"></a>
 
 ### ERMrest.Catalogs
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Catalogs](#ERMrest.Catalogs)
     * [new Catalogs(server)](#new_ERMrest.Catalogs_new)
@@ -389,24 +393,24 @@ Constructor for the Catalogs.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| server | <code>[Server](#ERMrest.Server)</code> | the server object. |
+| server | [<code>Server</code>](#ERMrest.Server) | the server object. |
 
 <a name="ERMrest.Catalogs+length"></a>
 
 #### catalogs.length() ⇒ <code>Number</code>
-**Kind**: instance method of <code>[Catalogs](#ERMrest.Catalogs)</code>  
+**Kind**: instance method of [<code>Catalogs</code>](#ERMrest.Catalogs)  
 **Returns**: <code>Number</code> - Returns the length of the catalogs.  
 <a name="ERMrest.Catalogs+names"></a>
 
 #### catalogs.names() ⇒ <code>Array</code>
-**Kind**: instance method of <code>[Catalogs](#ERMrest.Catalogs)</code>  
+**Kind**: instance method of [<code>Catalogs</code>](#ERMrest.Catalogs)  
 **Returns**: <code>Array</code> - Returns an array of names of catalogs.  
 <a name="ERMrest.Catalogs+get"></a>
 
 #### catalogs.get(id) ⇒ <code>Promise</code>
 Get a catalog by id. This call does catalog introspection.
 
-**Kind**: instance method of <code>[Catalogs](#ERMrest.Catalogs)</code>  
+**Kind**: instance method of [<code>Catalogs</code>](#ERMrest.Catalogs)  
 **Returns**: <code>Promise</code> - a promise that returns the catalog  if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [NotFoundError](#ERMrest.NotFoundError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
@@ -418,13 +422,13 @@ Get a catalog by id. This call does catalog introspection.
 <a name="ERMrest.Catalog"></a>
 
 ### ERMrest.Catalog
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Catalog](#ERMrest.Catalog)
     * [new Catalog(server, id)](#new_ERMrest.Catalog_new)
     * [.id](#ERMrest.Catalog+id) : <code>string</code>
-    * [.schemas](#ERMrest.Catalog+schemas) : <code>[Schemas](#ERMrest.Schemas)</code>
-    * [.constraintByNamePair(pair, subject)](#ERMrest.Catalog+constraintByNamePair) ⇒ <code>Object</code> &#124; <code>null</code>
+    * [.schemas](#ERMrest.Catalog+schemas) : [<code>Schemas</code>](#ERMrest.Schemas)
+    * [.constraintByNamePair(pair, subject)](#ERMrest.Catalog+constraintByNamePair) ⇒ <code>Object</code> \| <code>null</code>
 
 <a name="new_ERMrest.Catalog_new"></a>
 
@@ -434,7 +438,7 @@ Constructor for the Catalog.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| server | <code>[Server](#ERMrest.Server)</code> | the server object. |
+| server | [<code>Server</code>](#ERMrest.Server) | the server object. |
 | id | <code>string</code> | the catalog id. |
 
 <a name="ERMrest.Catalog+id"></a>
@@ -442,21 +446,21 @@ Constructor for the Catalog.
 #### catalog.id : <code>string</code>
 The catalog identifier.
 
-**Kind**: instance property of <code>[Catalog](#ERMrest.Catalog)</code>  
+**Kind**: instance property of [<code>Catalog</code>](#ERMrest.Catalog)  
 <a name="ERMrest.Catalog+schemas"></a>
 
-#### catalog.schemas : <code>[Schemas](#ERMrest.Schemas)</code>
-**Kind**: instance property of <code>[Catalog](#ERMrest.Catalog)</code>  
+#### catalog.schemas : [<code>Schemas</code>](#ERMrest.Schemas)
+**Kind**: instance property of [<code>Catalog</code>](#ERMrest.Catalog)  
 <a name="ERMrest.Catalog+constraintByNamePair"></a>
 
-#### catalog.constraintByNamePair(pair, subject) ⇒ <code>Object</code> &#124; <code>null</code>
+#### catalog.constraintByNamePair(pair, subject) ⇒ <code>Object</code> \| <code>null</code>
 returns the constraint object for the pair.
 
-**Kind**: instance method of <code>[Catalog](#ERMrest.Catalog)</code>  
-**Returns**: <code>Object</code> &#124; <code>null</code> - the constraint object. Null means the constraint name is not valid.  
+**Kind**: instance method of [<code>Catalog</code>](#ERMrest.Catalog)  
+**Returns**: <code>Object</code> \| <code>null</code> - the constraint object. Null means the constraint name is not valid.  
 **Throws**:
 
-- <code>[NotFoundError](#ERMrest.NotFoundError)</code> constraint not found
+- [<code>NotFoundError</code>](#ERMrest.NotFoundError) constraint not found
 
 
 | Param | Type | Description |
@@ -467,14 +471,14 @@ returns the constraint object for the pair.
 <a name="ERMrest.Schemas"></a>
 
 ### ERMrest.Schemas
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Schemas](#ERMrest.Schemas)
     * [new Schemas()](#new_ERMrest.Schemas_new)
     * [.length()](#ERMrest.Schemas+length) ⇒ <code>Number</code>
     * [.all()](#ERMrest.Schemas+all) ⇒ <code>Array</code>
     * [.names()](#ERMrest.Schemas+names) ⇒ <code>Array</code>
-    * [.get(name)](#ERMrest.Schemas+get) ⇒ <code>[Schema](#ERMrest.Schema)</code>
+    * [.get(name)](#ERMrest.Schemas+get) ⇒ [<code>Schema</code>](#ERMrest.Schema)
     * [.has(name)](#ERMrest.Schemas+has) ⇒ <code>boolean</code>
 
 <a name="new_ERMrest.Schemas_new"></a>
@@ -485,28 +489,28 @@ Constructor for the Schemas.
 <a name="ERMrest.Schemas+length"></a>
 
 #### schemas.length() ⇒ <code>Number</code>
-**Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
+**Kind**: instance method of [<code>Schemas</code>](#ERMrest.Schemas)  
 **Returns**: <code>Number</code> - number of schemas  
 <a name="ERMrest.Schemas+all"></a>
 
 #### schemas.all() ⇒ <code>Array</code>
-**Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
+**Kind**: instance method of [<code>Schemas</code>](#ERMrest.Schemas)  
 **Returns**: <code>Array</code> - Array of all schemas in the catalog  
 <a name="ERMrest.Schemas+names"></a>
 
 #### schemas.names() ⇒ <code>Array</code>
-**Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
+**Kind**: instance method of [<code>Schemas</code>](#ERMrest.Schemas)  
 **Returns**: <code>Array</code> - Array of schema names  
 <a name="ERMrest.Schemas+get"></a>
 
-#### schemas.get(name) ⇒ <code>[Schema](#ERMrest.Schema)</code>
+#### schemas.get(name) ⇒ [<code>Schema</code>](#ERMrest.Schema)
 get schema by schema name
 
-**Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
-**Returns**: <code>[Schema](#ERMrest.Schema)</code> - schema object  
+**Kind**: instance method of [<code>Schemas</code>](#ERMrest.Schemas)  
+**Returns**: [<code>Schema</code>](#ERMrest.Schema) - schema object  
 **Throws**:
 
-- <code>[NotFoundError](#ERMrest.NotFoundError)</code> schema not found
+- [<code>NotFoundError</code>](#ERMrest.NotFoundError) schema not found
 
 
 | Param | Type | Description |
@@ -518,7 +522,7 @@ get schema by schema name
 #### schemas.has(name) ⇒ <code>boolean</code>
 check for schema name existence
 
-**Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
+**Kind**: instance method of [<code>Schemas</code>](#ERMrest.Schemas)  
 **Returns**: <code>boolean</code> - if the schema exists or not  
 
 | Param | Type | Description |
@@ -528,16 +532,16 @@ check for schema name existence
 <a name="ERMrest.Schema"></a>
 
 ### ERMrest.Schema
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Schema](#ERMrest.Schema)
     * [new Schema(catalog, jsonSchema)](#new_ERMrest.Schema_new)
-    * [.catalog](#ERMrest.Schema+catalog) : <code>[Catalog](#ERMrest.Catalog)</code>
+    * [.catalog](#ERMrest.Schema+catalog) : [<code>Catalog</code>](#ERMrest.Catalog)
     * [.name](#ERMrest.Schema+name)
     * [.ignore](#ERMrest.Schema+ignore) : <code>boolean</code>
-    * [.annotations](#ERMrest.Schema+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+    * [.annotations](#ERMrest.Schema+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
     * [.displayname](#ERMrest.Schema+displayname) : <code>object</code>
-    * [.tables](#ERMrest.Schema+tables) : <code>[Tables](#ERMrest.Tables)</code>
+    * [.tables](#ERMrest.Schema+tables) : [<code>Tables</code>](#ERMrest.Tables)
     * [.comment](#ERMrest.Schema+comment) : <code>string</code>
 
 <a name="new_ERMrest.Schema_new"></a>
@@ -548,25 +552,25 @@ Constructor for the Catalog.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| catalog | <code>[Catalog](#ERMrest.Catalog)</code> | the catalog object. |
+| catalog | [<code>Catalog</code>](#ERMrest.Catalog) | the catalog object. |
 | jsonSchema | <code>string</code> | json of the schema. |
 
 <a name="ERMrest.Schema+catalog"></a>
 
-#### schema.catalog : <code>[Catalog](#ERMrest.Catalog)</code>
-**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
+#### schema.catalog : [<code>Catalog</code>](#ERMrest.Catalog)
+**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
 <a name="ERMrest.Schema+name"></a>
 
 #### schema.name
-**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
+**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
 <a name="ERMrest.Schema+ignore"></a>
 
 #### schema.ignore : <code>boolean</code>
-**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
+**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
 <a name="ERMrest.Schema+annotations"></a>
 
-#### schema.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
-**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
+#### schema.annotations : [<code>Annotations</code>](#ERMrest.Annotations)
+**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
 <a name="ERMrest.Schema+displayname"></a>
 
 #### schema.displayname : <code>object</code>
@@ -574,28 +578,28 @@ Preferred display name for user presentation only.
 this.displayname.isHTML will return true/false
 this.displayname.value has the value
 
-**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
+**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
 <a name="ERMrest.Schema+tables"></a>
 
-#### schema.tables : <code>[Tables](#ERMrest.Tables)</code>
-**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
+#### schema.tables : [<code>Tables</code>](#ERMrest.Tables)
+**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
 <a name="ERMrest.Schema+comment"></a>
 
 #### schema.comment : <code>string</code>
 Documentation for this schema
 
-**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
+**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
 <a name="ERMrest.Tables"></a>
 
 ### ERMrest.Tables
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Tables](#ERMrest.Tables)
     * [new Tables()](#new_ERMrest.Tables_new)
     * [.all()](#ERMrest.Tables+all) ⇒ <code>Array</code>
     * [.length()](#ERMrest.Tables+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Tables+names) ⇒ <code>Array</code>
-    * [.get(name)](#ERMrest.Tables+get) ⇒ <code>[Table](#ERMrest.Table)</code>
+    * [.get(name)](#ERMrest.Tables+get) ⇒ [<code>Table</code>](#ERMrest.Table)
 
 <a name="new_ERMrest.Tables_new"></a>
 
@@ -605,28 +609,28 @@ Constructor for the Tables.
 <a name="ERMrest.Tables+all"></a>
 
 #### tables.all() ⇒ <code>Array</code>
-**Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
+**Kind**: instance method of [<code>Tables</code>](#ERMrest.Tables)  
 **Returns**: <code>Array</code> - array of tables  
 <a name="ERMrest.Tables+length"></a>
 
 #### tables.length() ⇒ <code>Number</code>
-**Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
+**Kind**: instance method of [<code>Tables</code>](#ERMrest.Tables)  
 **Returns**: <code>Number</code> - number of tables  
 <a name="ERMrest.Tables+names"></a>
 
 #### tables.names() ⇒ <code>Array</code>
-**Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
+**Kind**: instance method of [<code>Tables</code>](#ERMrest.Tables)  
 **Returns**: <code>Array</code> - Array of table names  
 <a name="ERMrest.Tables+get"></a>
 
-#### tables.get(name) ⇒ <code>[Table](#ERMrest.Table)</code>
+#### tables.get(name) ⇒ [<code>Table</code>](#ERMrest.Table)
 get table by table name
 
-**Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
-**Returns**: <code>[Table](#ERMrest.Table)</code> - table  
+**Kind**: instance method of [<code>Tables</code>](#ERMrest.Tables)  
+**Returns**: [<code>Table</code>](#ERMrest.Table) - table  
 **Throws**:
 
-- <code>[NotFoundError](#ERMrest.NotFoundError)</code> table not found
+- [<code>NotFoundError</code>](#ERMrest.NotFoundError) table not found
 
 
 | Param | Type | Description |
@@ -636,22 +640,22 @@ get table by table name
 <a name="ERMrest.Table"></a>
 
 ### ERMrest.Table
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Table](#ERMrest.Table)
     * [new Table(schema, jsonTable)](#new_ERMrest.Table_new)
     * _instance_
-        * [.schema](#ERMrest.Table+schema) : <code>[Schema](#ERMrest.Schema)</code>
+        * [.schema](#ERMrest.Table+schema) : [<code>Schema</code>](#ERMrest.Schema)
         * [.name](#ERMrest.Table+name)
-        * [.entity](#ERMrest.Table+entity) : <code>[Entity](#ERMrest.Table.Entity)</code>
+        * [.entity](#ERMrest.Table+entity) : [<code>Entity</code>](#ERMrest.Table.Entity)
         * [.ignore](#ERMrest.Table+ignore) : <code>boolean</code>
-        * [._baseTable](#ERMrest.Table+_baseTable) : <code>[Table](#ERMrest.Table)</code>
-        * [.annotations](#ERMrest.Table+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+        * [._baseTable](#ERMrest.Table+_baseTable) : [<code>Table</code>](#ERMrest.Table)
+        * [.annotations](#ERMrest.Table+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
         * [.displayname](#ERMrest.Table+displayname) : <code>object</code>
-        * [.columns](#ERMrest.Table+columns) : <code>[Columns](#ERMrest.Columns)</code>
-        * [.keys](#ERMrest.Table+keys) : <code>[Keys](#ERMrest.Keys)</code>
-        * [.foreignKeys](#ERMrest.Table+foreignKeys) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
-        * [.referredBy](#ERMrest.Table+referredBy) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
+        * [.columns](#ERMrest.Table+columns) : [<code>Columns</code>](#ERMrest.Columns)
+        * [.keys](#ERMrest.Table+keys) : [<code>Keys</code>](#ERMrest.Keys)
+        * [.foreignKeys](#ERMrest.Table+foreignKeys) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
+        * [.referredBy](#ERMrest.Table+referredBy) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
         * [.comment](#ERMrest.Table+comment) : <code>string</code>
         * [.kind](#ERMrest.Table+kind) : <code>string</code>
         * [.shortestKey](#ERMrest.Table+shortestKey)
@@ -675,36 +679,36 @@ Constructor for Table.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| schema | <code>[Schema](#ERMrest.Schema)</code> | the schema object. |
+| schema | [<code>Schema</code>](#ERMrest.Schema) | the schema object. |
 | jsonTable | <code>string</code> | the json of the table. |
 
 <a name="ERMrest.Table+schema"></a>
 
-#### table.schema : <code>[Schema](#ERMrest.Schema)</code>
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+#### table.schema : [<code>Schema</code>](#ERMrest.Schema)
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+name"></a>
 
 #### table.name
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+entity"></a>
 
-#### table.entity : <code>[Entity](#ERMrest.Table.Entity)</code>
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+#### table.entity : [<code>Entity</code>](#ERMrest.Table.Entity)
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+ignore"></a>
 
 #### table.ignore : <code>boolean</code>
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+_baseTable"></a>
 
-#### table._baseTable : <code>[Table](#ERMrest.Table)</code>
+#### table._baseTable : [<code>Table</code>](#ERMrest.Table)
 this defaults to itself on the first pass of introspection
 then might be changed on the second pass if this is an alternative table
 
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+annotations"></a>
 
-#### table.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+#### table.annotations : [<code>Annotations</code>](#ERMrest.Annotations)
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+displayname"></a>
 
 #### table.displayname : <code>object</code>
@@ -712,50 +716,50 @@ Preferred display name for user presentation only.
 this.displayname.isHTML will return true/false
 this.displayname.value has the value
 
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+columns"></a>
 
-#### table.columns : <code>[Columns](#ERMrest.Columns)</code>
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+#### table.columns : [<code>Columns</code>](#ERMrest.Columns)
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+keys"></a>
 
-#### table.keys : <code>[Keys](#ERMrest.Keys)</code>
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+#### table.keys : [<code>Keys</code>](#ERMrest.Keys)
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+foreignKeys"></a>
 
-#### table.foreignKeys : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+#### table.foreignKeys : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+referredBy"></a>
 
-#### table.referredBy : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
+#### table.referredBy : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
 All the FKRs to this table.
 
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+comment"></a>
 
 #### table.comment : <code>string</code>
 Documentation for this table
 
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+kind"></a>
 
 #### table.kind : <code>string</code>
 The type of this table
 
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+shortestKey"></a>
 
 #### table.shortestKey
 The columns that create the shortest key
 
-**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 **Type{column[]}**:   
 <a name="ERMrest.Table+_getDisplayKey"></a>
 
 #### table._getDisplayKey(context)
 returns the key that can be used for display purposes.
 
-**Kind**: instance method of <code>[Table](#ERMrest.Table)</code>  
+**Kind**: instance method of [<code>Table</code>](#ERMrest.Table)  
 **Returns{column[]|undefined}**: list of columns. If couldn't find a suitable columns will return undefined.  
 
 | Param | Type | Description |
@@ -765,7 +769,7 @@ returns the key that can be used for display purposes.
 <a name="ERMrest.Table.Entity"></a>
 
 #### Table.Entity
-**Kind**: static class of <code>[Table](#ERMrest.Table)</code>  
+**Kind**: static class of [<code>Table</code>](#ERMrest.Table)  
 
 * [.Entity](#ERMrest.Table.Entity)
     * [new Entity(server, table)](#new_ERMrest.Table.Entity_new)
@@ -785,22 +789,22 @@ Constructor for Entity. This is a container in Table
 
 | Param | Type |
 | --- | --- |
-| server | <code>[Server](#ERMrest.Server)</code> | 
-| table | <code>[Table](#ERMrest.Table)</code> | 
+| server | [<code>Server</code>](#ERMrest.Server) | 
+| table | [<code>Table</code>](#ERMrest.Table) | 
 
 <a name="ERMrest.Table.Entity+count"></a>
 
 ##### entity.count([filter]) ⇒ <code>Promise</code>
 get the number of rows
 
-**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
+**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
 **Returns**: <code>Promise</code> - promise returning number of count if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
 
 | Param | Type |
 | --- | --- |
-| [filter] | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
+| [filter] | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) | 
 
 <a name="ERMrest.Table.Entity+get"></a>
 
@@ -809,16 +813,16 @@ get table rows with option filter, row limit and selected columns (in this order
 In order to use before & after on a Rows, limit must be speficied,
 output columns and sortby needs to have columns of a key
 
-**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
+**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
 **Returns**: <code>Promise</code> - promise returning rowset if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     ERMrest.Conflict, ERMrest.ForbiddenError or ERMrest.Unauthorized if rejected  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [filter] | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> |  |
+| [filter] | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) |  |
 | [limit] | <code>Number</code> | Number of rows |
-| [columns] | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> &#124; <code>Array.&lt;string&gt;</code> | Array of column names or Column objects output |
+| [columns] | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) \| <code>Array.&lt;string&gt;</code> | Array of column names or Column objects output |
 | [sortby] | <code>Array.&lt;Object&gt;</code> | An ordered array of {column, order} where column is column name or Column object, order is null (default), 'asc' or 'desc' |
 
 <a name="ERMrest.Table.Entity+getBefore"></a>
@@ -828,16 +832,16 @@ get a page of rows before a specific row
 In order to use before & after on a Rows, limit must be speficied,
 output columns and sortby needs to have columns of a key
 
-**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
+**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
 **Returns**: <code>Promise</code> - promise returning rowset if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     ERMrest.Conflict, ERMrest.ForbiddenError or ERMrest.Unauthorized if rejected  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> &#124; <code>null</code> | null if not being used |
+| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) \| <code>null</code> | null if not being used |
 | limit | <code>Number</code> | Required. Number of rows |
-| [columns] | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> &#124; <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
+| [columns] | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) \| <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
 | [sortby] | <code>Array.&lt;Object&gt;</code> | ordered array of {column, order} where column is column name or Column object, order is null (default), 'asc' or 'desc' |
 | row | <code>Object</code> | json row data used to getBefore |
 
@@ -846,16 +850,16 @@ output columns and sortby needs to have columns of a key
 ##### entity.getAfter(filter, limit, [columns], [sortby], row) ⇒ <code>Promise</code>
 get a page of rows after a specific row
 
-**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
+**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
 **Returns**: <code>Promise</code> - promise returning rowset if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     ERMrest.Conflict, ERMrest.ForbiddenError or ERMrest.Unauthorized if rejected  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> &#124; <code>null</code> | null is not being used |
+| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) \| <code>null</code> | null is not being used |
 | limit | <code>Number</code> | Required. Number of rows |
-| [columns] | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> &#124; <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
+| [columns] | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) \| <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
 | [sortby] | <code>Array.&lt;Object&gt;</code> | ordered array of {column, order} where column is column name or Column object, order is null (default), 'asc' or 'desc' |
 | row | <code>Object</code> | json row data used to getAfter |
 
@@ -864,19 +868,19 @@ get a page of rows after a specific row
 ##### entity.delete(filter) ⇒ <code>Promise</code>
 Delete rows from table based on the filter
 
-**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
+**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
 **Returns**: <code>Promise</code> - Promise that returns the json row data deleted if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
 
 | Param | Type |
 | --- | --- |
-| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
+| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) | 
 
 <a name="ERMrest.Table.Entity+put"></a>
 
 ##### entity.put(rows) ⇒ <code>Promise</code>
-**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
+**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
 **Returns**: <code>Promise</code> - Promise that returns the rows updated if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected
@@ -891,7 +895,7 @@ Update rows in the table
 ##### entity.post(rows, defaults) ⇒ <code>Promise</code>
 Create new entities
 
-**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
+**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
 **Returns**: <code>Promise</code> - Promise that returns the rows created if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [BadRequestError](#ERMrest.BadRequestError), [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
@@ -904,7 +908,7 @@ Create new entities
 <a name="ERMrest.Rows"></a>
 
 ### ERMrest.Rows
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Rows](#ERMrest.Rows)
     * [new Rows(table, jsonRows, filter, limit, columns, [sortby])](#new_ERMrest.Rows_new)
@@ -920,11 +924,11 @@ Create new entities
 
 | Param | Type | Description |
 | --- | --- | --- |
-| table | <code>[Table](#ERMrest.Table)</code> |  |
+| table | [<code>Table</code>](#ERMrest.Table) |  |
 | jsonRows | <code>Object</code> |  |
-| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> &#124; <code>null</code> | null if not being used |
+| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) \| <code>null</code> | null if not being used |
 | limit | <code>Number</code> | Number of rows |
-| columns | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> &#124; <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
+| columns | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) \| <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
 | [sortby] | <code>Array.&lt;Object&gt;</code> | An ordered array of {column, order} where column is column name or Column object, order is null/'' (default), 'asc' or 'desc' |
 
 <a name="ERMrest.Rows+data"></a>
@@ -934,21 +938,21 @@ The set of rows returns from the server. It is an Array of
 Objects that has keys and values based on the query that produced
 the Rows.
 
-**Kind**: instance property of <code>[Rows](#ERMrest.Rows)</code>  
+**Kind**: instance property of [<code>Rows</code>](#ERMrest.Rows)  
 <a name="ERMrest.Rows+length"></a>
 
 #### rows.length() ⇒ <code>number</code>
-**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
+**Kind**: instance method of [<code>Rows</code>](#ERMrest.Rows)  
 <a name="ERMrest.Rows+get"></a>
 
 #### rows.get() ⇒ <code>Row</code>
-**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
+**Kind**: instance method of [<code>Rows</code>](#ERMrest.Rows)  
 <a name="ERMrest.Rows+after"></a>
 
 #### rows.after() ⇒ <code>Promise</code>
 get the rows of the next page
 
-**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
+**Kind**: instance method of [<code>Rows</code>](#ERMrest.Rows)  
 **Returns**: <code>Promise</code> - promise that returns the rows if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
@@ -957,14 +961,14 @@ get the rows of the next page
 #### rows.before() ⇒ <code>Promise</code>
 get the rowset of the previous page
 
-**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
+**Kind**: instance method of [<code>Rows</code>](#ERMrest.Rows)  
 **Returns**: <code>Promise</code> - promise that returns a rowset if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
 <a name="ERMrest.Row"></a>
 
 ### ERMrest.Row
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Row](#ERMrest.Row)
     * [new Row(jsonRow)](#new_ERMrest.Row_new)
@@ -985,16 +989,16 @@ get the rowset of the previous page
 #### row.data : <code>Object</code>
 The row returned from the ith result in the Rows.data.
 
-**Kind**: instance property of <code>[Row](#ERMrest.Row)</code>  
+**Kind**: instance property of [<code>Row</code>](#ERMrest.Row)  
 <a name="ERMrest.Row+names"></a>
 
 #### row.names() ⇒ <code>Array</code>
-**Kind**: instance method of <code>[Row](#ERMrest.Row)</code>  
+**Kind**: instance method of [<code>Row</code>](#ERMrest.Row)  
 **Returns**: <code>Array</code> - Array of column names  
 <a name="ERMrest.Row+get"></a>
 
 #### row.get(name) ⇒ <code>Object</code>
-**Kind**: instance method of <code>[Row](#ERMrest.Row)</code>  
+**Kind**: instance method of [<code>Row</code>](#ERMrest.Row)  
 **Returns**: <code>Object</code> - column value  
 
 | Param | Type | Description |
@@ -1004,7 +1008,7 @@ The row returned from the ith result in the Rows.data.
 <a name="ERMrest.Columns"></a>
 
 ### ERMrest.Columns
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Columns](#ERMrest.Columns)
     * [new Columns(table)](#new_ERMrest.Columns_new)
@@ -1012,8 +1016,8 @@ The row returned from the ith result in the Rows.data.
     * [.length()](#ERMrest.Columns+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Columns+names) ⇒ <code>Array</code>
     * [.has(name)](#ERMrest.Columns+has) ⇒ <code>boolean</code>
-    * [.get(name)](#ERMrest.Columns+get) ⇒ <code>[Column](#ERMrest.Column)</code>
-    * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ <code>[Column](#ERMrest.Column)</code>
+    * [.get(name)](#ERMrest.Columns+get) ⇒ [<code>Column</code>](#ERMrest.Column)
+    * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ [<code>Column</code>](#ERMrest.Column)
 
 <a name="new_ERMrest.Columns_new"></a>
 
@@ -1028,22 +1032,22 @@ Constructor for Columns.
 <a name="ERMrest.Columns+all"></a>
 
 #### columns.all() ⇒ <code>Array</code>
-**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
+**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
 **Returns**: <code>Array</code> - array of all columns  
 <a name="ERMrest.Columns+length"></a>
 
 #### columns.length() ⇒ <code>Number</code>
-**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
+**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
 **Returns**: <code>Number</code> - number of columns  
 <a name="ERMrest.Columns+names"></a>
 
 #### columns.names() ⇒ <code>Array</code>
-**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
+**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
 **Returns**: <code>Array</code> - names of columns  
 <a name="ERMrest.Columns+has"></a>
 
 #### columns.has(name) ⇒ <code>boolean</code>
-**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
+**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
 **Returns**: <code>boolean</code> - whether Columns has this column or not  
 
 | Param | Type | Description |
@@ -1052,9 +1056,9 @@ Constructor for Columns.
 
 <a name="ERMrest.Columns+get"></a>
 
-#### columns.get(name) ⇒ <code>[Column](#ERMrest.Column)</code>
-**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
-**Returns**: <code>[Column](#ERMrest.Column)</code> - column  
+#### columns.get(name) ⇒ [<code>Column</code>](#ERMrest.Column)
+**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
+**Returns**: [<code>Column</code>](#ERMrest.Column) - column  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1062,8 +1066,8 @@ Constructor for Columns.
 
 <a name="ERMrest.Columns+getByPosition"></a>
 
-#### columns.getByPosition(pos) ⇒ <code>[Column](#ERMrest.Column)</code>
-**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
+#### columns.getByPosition(pos) ⇒ [<code>Column</code>](#ERMrest.Column)
+**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
 
 | Param | Type |
 | --- | --- |
@@ -1072,25 +1076,25 @@ Constructor for Columns.
 <a name="ERMrest.Column"></a>
 
 ### ERMrest.Column
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Column](#ERMrest.Column)
     * [new Column(table, jsonColumn)](#new_ERMrest.Column_new)
     * [.position](#ERMrest.Column+position) : <code>number</code>
-    * [.table](#ERMrest.Column+table) : <code>[Table](#ERMrest.Table)</code>
+    * [.table](#ERMrest.Column+table) : [<code>Table</code>](#ERMrest.Table)
     * [.name](#ERMrest.Column+name) : <code>string</code>
-    * [.type](#ERMrest.Column+type) : <code>[Type](#ERMrest.Type)</code>
+    * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
     * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
     * [.default](#ERMrest.Column+default) : <code>string</code>
     * [.comment](#ERMrest.Column+comment) : <code>string</code>
     * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
-    * [.annotations](#ERMrest.Column+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+    * [.annotations](#ERMrest.Column+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
     * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
-    * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : <code>[Array.&lt;Key&gt;](#ERMrest.Key)</code>
-    * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
+    * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
+    * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
     * [.formatvalue(data)](#ERMrest.Column+formatvalue) ⇒ <code>string</code>
     * [.formatPresentation(data, options)](#ERMrest.Column+formatPresentation) ⇒ <code>Object</code>
-    * [.toString()](#ERMrest.Column+toString)
+    * [.toString()](#ERMrest.Column+toString) ⇒ <code>string</code>
     * [.getDisplay(context)](#ERMrest.Column+getDisplay)
 
 <a name="new_ERMrest.Column_new"></a>
@@ -1105,7 +1109,7 @@ a Column _may not_ be a part of a Table.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| table | <code>[Table](#ERMrest.Table)</code> | the table object. |
+| table | [<code>Table</code>](#ERMrest.Table) | the table object. |
 | jsonColumn | <code>string</code> | the json column. |
 
 <a name="ERMrest.Column+position"></a>
@@ -1115,41 +1119,41 @@ The ordinal number or position of this column relative to other
 columns within the same scope.
 TODO: to be implemented
 
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+table"></a>
 
-#### column.table : <code>[Table](#ERMrest.Table)</code>
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+#### column.table : [<code>Table</code>](#ERMrest.Table)
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+name"></a>
 
 #### column.name : <code>string</code>
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+type"></a>
 
-#### column.type : <code>[Type](#ERMrest.Type)</code>
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+#### column.type : [<code>Type</code>](#ERMrest.Type)
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+nullok"></a>
 
 #### column.nullok : <code>Boolean</code>
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+default"></a>
 
 #### column.default : <code>string</code>
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+comment"></a>
 
 #### column.comment : <code>string</code>
 Documentation for this column
 
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+ignore"></a>
 
 #### column.ignore : <code>boolean</code>
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+annotations"></a>
 
-#### column.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+#### column.annotations : [<code>Annotations</code>](#ERMrest.Annotations)
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+displayname"></a>
 
 #### column.displayname : <code>object</code>
@@ -1157,25 +1161,25 @@ Preferred display name for user presentation only.
 this.displayname.isHTML will return true/false
 this.displayname.value has the value
 
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+memberOfKeys"></a>
 
-#### column.memberOfKeys : <code>[Array.&lt;Key&gt;](#ERMrest.Key)</code>
+#### column.memberOfKeys : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
 keys that this column is a member of
 
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+memberOfForeignKeys"></a>
 
-#### column.memberOfForeignKeys : <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
+#### column.memberOfForeignKeys : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
 foreign key that this column is a member of
 
-**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+formatvalue"></a>
 
 #### column.formatvalue(data) ⇒ <code>string</code>
 Formats a value corresponding to this column definition.
 
-**Kind**: instance method of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance method of [<code>Column</code>](#ERMrest.Column)  
 **Returns**: <code>string</code> - The formatted value.  
 
 | Param | Type | Description |
@@ -1187,7 +1191,7 @@ Formats a value corresponding to this column definition.
 #### column.formatPresentation(data, options) ⇒ <code>Object</code>
 Formats the presentation value corresponding to this column definition.
 
-**Kind**: instance method of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance method of [<code>Column</code>](#ERMrest.Column)  
 **Returns**: <code>Object</code> - A key value pair containing value and isHTML that detemrines the presenation.  
 
 | Param | Type | Description |
@@ -1197,17 +1201,17 @@ Formats the presentation value corresponding to this column definition.
 
 <a name="ERMrest.Column+toString"></a>
 
-#### column.toString()
+#### column.toString() ⇒ <code>string</code>
 returns string representation of Column
 
-**Kind**: instance method of <code>[Column](#ERMrest.Column)</code>  
-**Retuns**: <code>string</code> string representation of Column  
+**Kind**: instance method of [<code>Column</code>](#ERMrest.Column)  
+**Returns**: <code>string</code> - string representation of Column  
 <a name="ERMrest.Column+getDisplay"></a>
 
 #### column.getDisplay(context)
 display object for the column
 
-**Kind**: instance method of <code>[Column](#ERMrest.Column)</code>  
+**Kind**: instance method of [<code>Column</code>](#ERMrest.Column)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1216,14 +1220,14 @@ display object for the column
 <a name="ERMrest.Annotations"></a>
 
 ### ERMrest.Annotations
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Annotations](#ERMrest.Annotations)
     * [new Annotations()](#new_ERMrest.Annotations_new)
-    * [.all()](#ERMrest.Annotations+all) ⇒ <code>[Array.&lt;Annotation&gt;](#ERMrest.Annotation)</code>
+    * [.all()](#ERMrest.Annotations+all) ⇒ [<code>Array.&lt;Annotation&gt;</code>](#ERMrest.Annotation)
     * [.length()](#ERMrest.Annotations+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Annotations+names) ⇒ <code>Array</code>
-    * [.get(uri)](#ERMrest.Annotations+get) ⇒ <code>[Annotation](#ERMrest.Annotation)</code>
+    * [.get(uri)](#ERMrest.Annotations+get) ⇒ [<code>Annotation</code>](#ERMrest.Annotation)
     * [.contains(uri)](#ERMrest.Annotations+contains) ⇒ <code>boolean</code>
 
 <a name="new_ERMrest.Annotations_new"></a>
@@ -1233,29 +1237,29 @@ Constructor for Annotations.
 
 <a name="ERMrest.Annotations+all"></a>
 
-#### annotations.all() ⇒ <code>[Array.&lt;Annotation&gt;](#ERMrest.Annotation)</code>
-**Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
-**Returns**: <code>[Array.&lt;Annotation&gt;](#ERMrest.Annotation)</code> - list of all annotations  
+#### annotations.all() ⇒ [<code>Array.&lt;Annotation&gt;</code>](#ERMrest.Annotation)
+**Kind**: instance method of [<code>Annotations</code>](#ERMrest.Annotations)  
+**Returns**: [<code>Array.&lt;Annotation&gt;</code>](#ERMrest.Annotation) - list of all annotations  
 <a name="ERMrest.Annotations+length"></a>
 
 #### annotations.length() ⇒ <code>Number</code>
-**Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
+**Kind**: instance method of [<code>Annotations</code>](#ERMrest.Annotations)  
 **Returns**: <code>Number</code> - number of annotations  
 <a name="ERMrest.Annotations+names"></a>
 
 #### annotations.names() ⇒ <code>Array</code>
-**Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
+**Kind**: instance method of [<code>Annotations</code>](#ERMrest.Annotations)  
 **Returns**: <code>Array</code> - array of annotation names  
 <a name="ERMrest.Annotations+get"></a>
 
-#### annotations.get(uri) ⇒ <code>[Annotation](#ERMrest.Annotation)</code>
+#### annotations.get(uri) ⇒ [<code>Annotation</code>](#ERMrest.Annotation)
 get annotation by URI
 
-**Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
-**Returns**: <code>[Annotation](#ERMrest.Annotation)</code> - annotation  
+**Kind**: instance method of [<code>Annotations</code>](#ERMrest.Annotations)  
+**Returns**: [<code>Annotation</code>](#ERMrest.Annotation) - annotation  
 **Throws**:
 
-- <code>[NotFoundError](#ERMrest.NotFoundError)</code> annotation not found
+- [<code>NotFoundError</code>](#ERMrest.NotFoundError) annotation not found
 
 
 | Param | Type | Description |
@@ -1265,7 +1269,7 @@ get annotation by URI
 <a name="ERMrest.Annotations+contains"></a>
 
 #### annotations.contains(uri) ⇒ <code>boolean</code>
-**Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
+**Kind**: instance method of [<code>Annotations</code>](#ERMrest.Annotations)  
 **Returns**: <code>boolean</code> - whether or not annotation exists  
 
 | Param | Type | Description |
@@ -1275,7 +1279,7 @@ get annotation by URI
 <a name="ERMrest.Annotation"></a>
 
 ### ERMrest.Annotation
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Annotation](#ERMrest.Annotation)
     * [new Annotation(subject, uri, jsonAnnotation)](#new_ERMrest.Annotation_new)
@@ -1299,24 +1303,24 @@ Constructor for Annotation.
 #### annotation.subject : <code>string</code>
 One of schema,table,column,key,foreignkeyref
 
-**Kind**: instance property of <code>[Annotation](#ERMrest.Annotation)</code>  
+**Kind**: instance property of [<code>Annotation</code>](#ERMrest.Annotation)  
 <a name="ERMrest.Annotation+content"></a>
 
 #### annotation.content : <code>string</code>
 json content
 
-**Kind**: instance property of <code>[Annotation](#ERMrest.Annotation)</code>  
+**Kind**: instance property of [<code>Annotation</code>](#ERMrest.Annotation)  
 <a name="ERMrest.Keys"></a>
 
 ### ERMrest.Keys
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Keys](#ERMrest.Keys)
     * [new Keys()](#new_ERMrest.Keys_new)
     * [.all()](#ERMrest.Keys+all) ⇒ <code>Array.&lt;Key&gt;</code>
     * [.length()](#ERMrest.Keys+length) ⇒ <code>Number</code>
-    * [.colsets()](#ERMrest.Keys+colsets) ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
-    * [.get(colset)](#ERMrest.Keys+get) ⇒ <code>[Key](#ERMrest.Key)</code>
+    * [.colsets()](#ERMrest.Keys+colsets) ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
+    * [.get(colset)](#ERMrest.Keys+get) ⇒ [<code>Key</code>](#ERMrest.Key)
 
 <a name="new_ERMrest.Keys_new"></a>
 
@@ -1326,44 +1330,44 @@ Constructor for Keys.
 <a name="ERMrest.Keys+all"></a>
 
 #### keys.all() ⇒ <code>Array.&lt;Key&gt;</code>
-**Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
+**Kind**: instance method of [<code>Keys</code>](#ERMrest.Keys)  
 **Returns**: <code>Array.&lt;Key&gt;</code> - a list of all Keys  
 <a name="ERMrest.Keys+length"></a>
 
 #### keys.length() ⇒ <code>Number</code>
-**Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
+**Kind**: instance method of [<code>Keys</code>](#ERMrest.Keys)  
 **Returns**: <code>Number</code> - number of keys  
 <a name="ERMrest.Keys+colsets"></a>
 
-#### keys.colsets() ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
-**Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
-**Returns**: <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code> - array of colsets  
+#### keys.colsets() ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
+**Kind**: instance method of [<code>Keys</code>](#ERMrest.Keys)  
+**Returns**: [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet) - array of colsets  
 <a name="ERMrest.Keys+get"></a>
 
-#### keys.get(colset) ⇒ <code>[Key](#ERMrest.Key)</code>
+#### keys.get(colset) ⇒ [<code>Key</code>](#ERMrest.Key)
 get the key by the column set
 
-**Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
-**Returns**: <code>[Key](#ERMrest.Key)</code> - key of the colset  
+**Kind**: instance method of [<code>Keys</code>](#ERMrest.Keys)  
+**Returns**: [<code>Key</code>](#ERMrest.Key) - key of the colset  
 **Throws**:
 
-- <code>[NotFoundError](#ERMrest.NotFoundError)</code> Key not found
+- [<code>NotFoundError</code>](#ERMrest.NotFoundError) Key not found
 
 
 | Param | Type |
 | --- | --- |
-| colset | <code>[ColSet](#ERMrest.ColSet)</code> | 
+| colset | [<code>ColSet</code>](#ERMrest.ColSet) | 
 
 <a name="ERMrest.Key"></a>
 
 ### ERMrest.Key
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Key](#ERMrest.Key)
     * [new Key(table, jsonKey)](#new_ERMrest.Key_new)
     * [.table](#ERMrest.Key+table) : <code>Table</code>
-    * [.colset](#ERMrest.Key+colset) : <code>[ColSet](#ERMrest.ColSet)</code>
-    * [.annotations](#ERMrest.Key+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+    * [.colset](#ERMrest.Key+colset) : [<code>ColSet</code>](#ERMrest.ColSet)
+    * [.annotations](#ERMrest.Key+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
     * [.comment](#ERMrest.Key+comment) : <code>string</code>
     * [.constraint_names](#ERMrest.Key+constraint_names) : <code>Array</code>
     * [.simple](#ERMrest.Key+simple) : <code>boolean</code>
@@ -1377,7 +1381,7 @@ Constructor for Key.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| table | <code>[Table](#ERMrest.Table)</code> | the table object. |
+| table | [<code>Table</code>](#ERMrest.Table) | the table object. |
 | jsonKey | <code>string</code> | json key. |
 
 <a name="ERMrest.Key+table"></a>
@@ -1385,53 +1389,53 @@ Constructor for Key.
 #### key.table : <code>Table</code>
 Reference to the table that this Key belongs to.
 
-**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
+**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
 <a name="ERMrest.Key+colset"></a>
 
-#### key.colset : <code>[ColSet](#ERMrest.ColSet)</code>
-**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
+#### key.colset : [<code>ColSet</code>](#ERMrest.ColSet)
+**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
 <a name="ERMrest.Key+annotations"></a>
 
-#### key.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
-**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
+#### key.annotations : [<code>Annotations</code>](#ERMrest.Annotations)
+**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
 <a name="ERMrest.Key+comment"></a>
 
 #### key.comment : <code>string</code>
 Documentation for this key
 
-**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
+**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
 <a name="ERMrest.Key+constraint_names"></a>
 
 #### key.constraint_names : <code>Array</code>
 The exact `names` array in key definition
 
-**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
+**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
 <a name="ERMrest.Key+simple"></a>
 
 #### key.simple : <code>boolean</code>
 Indicates if the key is simple (not composite)
 
-**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
+**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
 <a name="ERMrest.Key+containsColumn"></a>
 
 #### key.containsColumn(column) ⇒ <code>boolean</code>
 whether key has a column
 
-**Kind**: instance method of <code>[Key](#ERMrest.Key)</code>  
+**Kind**: instance method of [<code>Key</code>](#ERMrest.Key)  
 
 | Param | Type |
 | --- | --- |
-| column | <code>[Column](#ERMrest.Column)</code> | 
+| column | [<code>Column</code>](#ERMrest.Column) | 
 
 <a name="ERMrest.ColSet"></a>
 
 ### ERMrest.ColSet
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.ColSet](#ERMrest.ColSet)
     * [new ColSet(columns)](#new_ERMrest.ColSet_new)
     * [.columns](#ERMrest.ColSet+columns) : <code>Array</code>
-    * [.toString()](#ERMrest.ColSet+toString)
+    * [.toString()](#ERMrest.ColSet+toString) ⇒ <code>string</code>
     * [.length()](#ERMrest.ColSet+length) ⇒ <code>Number</code>
 
 <a name="new_ERMrest.ColSet_new"></a>
@@ -1447,31 +1451,31 @@ Constructor for ColSet, a set of Column objects.
 <a name="ERMrest.ColSet+columns"></a>
 
 #### colSet.columns : <code>Array</code>
-**Kind**: instance property of <code>[ColSet](#ERMrest.ColSet)</code>  
+**Kind**: instance property of [<code>ColSet</code>](#ERMrest.ColSet)  
 <a name="ERMrest.ColSet+toString"></a>
 
-#### colSet.toString()
+#### colSet.toString() ⇒ <code>string</code>
 returns string representation of colset object: (s:t:c1,s:t:c2)
 
-**Kind**: instance method of <code>[ColSet](#ERMrest.ColSet)</code>  
-**Retuns**: <code>string</code> string representation of colset object  
+**Kind**: instance method of [<code>ColSet</code>](#ERMrest.ColSet)  
+**Returns**: <code>string</code> - string representation of colset object  
 <a name="ERMrest.ColSet+length"></a>
 
 #### colSet.length() ⇒ <code>Number</code>
-**Kind**: instance method of <code>[ColSet](#ERMrest.ColSet)</code>  
+**Kind**: instance method of [<code>ColSet</code>](#ERMrest.ColSet)  
 **Returns**: <code>Number</code> - number of columns  
 <a name="ERMrest.Mapping"></a>
 
 ### ERMrest.Mapping
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Mapping](#ERMrest.Mapping)
     * [new Mapping(from, to)](#new_ERMrest.Mapping_new)
-    * [.toString()](#ERMrest.Mapping+toString)
+    * [.toString()](#ERMrest.Mapping+toString) ⇒ <code>string</code>
     * [.length()](#ERMrest.Mapping+length) ⇒ <code>Number</code>
-    * [.domain()](#ERMrest.Mapping+domain) ⇒ <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
-    * [.get(fromCol)](#ERMrest.Mapping+get) ⇒ <code>[Column](#ERMrest.Column)</code>
-    * [.getFromColumn(toCol)](#ERMrest.Mapping+getFromColumn) ⇒ <code>[Column](#ERMrest.Column)</code>
+    * [.domain()](#ERMrest.Mapping+domain) ⇒ [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
+    * [.get(fromCol)](#ERMrest.Mapping+get) ⇒ [<code>Column</code>](#ERMrest.Column)
+    * [.getFromColumn(toCol)](#ERMrest.Mapping+getFromColumn) ⇒ [<code>Column</code>](#ERMrest.Column)
 
 <a name="new_ERMrest.Mapping_new"></a>
 
@@ -1479,62 +1483,62 @@ returns string representation of colset object: (s:t:c1,s:t:c2)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| from | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> | array of from Columns |
-| to | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> | array of to Columns |
+| from | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) | array of from Columns |
+| to | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) | array of to Columns |
 
 <a name="ERMrest.Mapping+toString"></a>
 
-#### mapping.toString()
+#### mapping.toString() ⇒ <code>string</code>
 returns string representation of Mapping object
 
-**Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
-**Retuns**: <code>string</code> string representation of Mapping object  
+**Kind**: instance method of [<code>Mapping</code>](#ERMrest.Mapping)  
+**Returns**: <code>string</code> - string representation of Mapping object  
 <a name="ERMrest.Mapping+length"></a>
 
 #### mapping.length() ⇒ <code>Number</code>
-**Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
+**Kind**: instance method of [<code>Mapping</code>](#ERMrest.Mapping)  
 **Returns**: <code>Number</code> - number of mapping columns  
 <a name="ERMrest.Mapping+domain"></a>
 
-#### mapping.domain() ⇒ <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
-**Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
-**Returns**: <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> - the from columns  
+#### mapping.domain() ⇒ [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
+**Kind**: instance method of [<code>Mapping</code>](#ERMrest.Mapping)  
+**Returns**: [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) - the from columns  
 <a name="ERMrest.Mapping+get"></a>
 
-#### mapping.get(fromCol) ⇒ <code>[Column](#ERMrest.Column)</code>
+#### mapping.get(fromCol) ⇒ [<code>Column</code>](#ERMrest.Column)
 get the mapping column given the from column
 
-**Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
-**Returns**: <code>[Column](#ERMrest.Column)</code> - mapping column  
+**Kind**: instance method of [<code>Mapping</code>](#ERMrest.Mapping)  
+**Returns**: [<code>Column</code>](#ERMrest.Column) - mapping column  
 **Throws**:
 
-- <code>[NotFoundError](#ERMrest.NotFoundError)</code> no mapping column found
+- [<code>NotFoundError</code>](#ERMrest.NotFoundError) no mapping column found
 
 
 | Param | Type |
 | --- | --- |
-| fromCol | <code>[Column](#ERMrest.Column)</code> | 
+| fromCol | [<code>Column</code>](#ERMrest.Column) | 
 
 <a name="ERMrest.Mapping+getFromColumn"></a>
 
-#### mapping.getFromColumn(toCol) ⇒ <code>[Column](#ERMrest.Column)</code>
+#### mapping.getFromColumn(toCol) ⇒ [<code>Column</code>](#ERMrest.Column)
 get the mapping column given the to column
 
-**Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
-**Returns**: <code>[Column](#ERMrest.Column)</code> - mapping column  
+**Kind**: instance method of [<code>Mapping</code>](#ERMrest.Mapping)  
+**Returns**: [<code>Column</code>](#ERMrest.Column) - mapping column  
 **Throws**:
 
-- <code>[NotFoundError](#ERMrest.NotFoundError)</code> no mapping column found
+- [<code>NotFoundError</code>](#ERMrest.NotFoundError) no mapping column found
 
 
 | Param | Type |
 | --- | --- |
-| toCol | <code>[Column](#ERMrest.Column)</code> | 
+| toCol | [<code>Column</code>](#ERMrest.Column) | 
 
 <a name="ERMrest.InboundForeignKeys"></a>
 
 ### ERMrest.InboundForeignKeys
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.InboundForeignKeys_new"></a>
 
 #### new InboundForeignKeys(table)
@@ -1543,74 +1547,74 @@ holds inbound foreignkeys of a table.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| table | <code>[Table](#ERMrest.Table)</code> | the table that this object is for |
+| table | [<code>Table</code>](#ERMrest.Table) | the table that this object is for |
 
 <a name="ERMrest.ForeignKeys"></a>
 
 ### ERMrest.ForeignKeys
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.ForeignKeys](#ERMrest.ForeignKeys)
-    * [.all()](#ERMrest.ForeignKeys+all) ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
-    * [.colsets()](#ERMrest.ForeignKeys+colsets) ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
+    * [.all()](#ERMrest.ForeignKeys+all) ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+    * [.colsets()](#ERMrest.ForeignKeys+colsets) ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
     * [.length()](#ERMrest.ForeignKeys+length) ⇒ <code>Number</code>
-    * [.mappings()](#ERMrest.ForeignKeys+mappings) ⇒ <code>[Array.&lt;Mapping&gt;](#ERMrest.Mapping)</code>
-    * [.get(colset)](#ERMrest.ForeignKeys+get) ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
+    * [.mappings()](#ERMrest.ForeignKeys+mappings) ⇒ [<code>Array.&lt;Mapping&gt;</code>](#ERMrest.Mapping)
+    * [.get(colset)](#ERMrest.ForeignKeys+get) ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
 
 <a name="ERMrest.ForeignKeys+all"></a>
 
-#### foreignKeys.all() ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
-**Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
-**Returns**: <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code> - an array of all foreign key references  
+#### foreignKeys.all() ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+**Kind**: instance method of [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)  
+**Returns**: [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef) - an array of all foreign key references  
 <a name="ERMrest.ForeignKeys+colsets"></a>
 
-#### foreignKeys.colsets() ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
-**Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
-**Returns**: <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code> - an array of the foreign keys' colsets  
+#### foreignKeys.colsets() ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
+**Kind**: instance method of [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)  
+**Returns**: [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet) - an array of the foreign keys' colsets  
 <a name="ERMrest.ForeignKeys+length"></a>
 
 #### foreignKeys.length() ⇒ <code>Number</code>
-**Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
+**Kind**: instance method of [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)  
 **Returns**: <code>Number</code> - number of foreign keys  
 <a name="ERMrest.ForeignKeys+mappings"></a>
 
-#### foreignKeys.mappings() ⇒ <code>[Array.&lt;Mapping&gt;](#ERMrest.Mapping)</code>
-**Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
-**Returns**: <code>[Array.&lt;Mapping&gt;](#ERMrest.Mapping)</code> - mappings  
+#### foreignKeys.mappings() ⇒ [<code>Array.&lt;Mapping&gt;</code>](#ERMrest.Mapping)
+**Kind**: instance method of [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)  
+**Returns**: [<code>Array.&lt;Mapping&gt;</code>](#ERMrest.Mapping) - mappings  
 <a name="ERMrest.ForeignKeys+get"></a>
 
-#### foreignKeys.get(colset) ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
+#### foreignKeys.get(colset) ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
 get the foreign key of the given column set
 
-**Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
-**Returns**: <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code> - foreign key reference of the colset  
+**Kind**: instance method of [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)  
+**Returns**: [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef) - foreign key reference of the colset  
 **Throws**:
 
-- <code>[NotFoundError](#ERMrest.NotFoundError)</code> foreign key not found
+- [<code>NotFoundError</code>](#ERMrest.NotFoundError) foreign key not found
 
 
 | Param | Type |
 | --- | --- |
-| colset | <code>[ColSet](#ERMrest.ColSet)</code> | 
+| colset | [<code>ColSet</code>](#ERMrest.ColSet) | 
 
 <a name="ERMrest.ForeignKeyRef"></a>
 
 ### ERMrest.ForeignKeyRef
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.ForeignKeyRef](#ERMrest.ForeignKeyRef)
     * [new ForeignKeyRef(table, jsonFKR)](#new_ERMrest.ForeignKeyRef_new)
-    * [.colset](#ERMrest.ForeignKeyRef+colset) : <code>[ColSet](#ERMrest.ColSet)</code>
-    * [.key](#ERMrest.ForeignKeyRef+key) : <code>[Key](#ERMrest.Key)</code>
-    * [.mapping](#ERMrest.ForeignKeyRef+mapping) : <code>[Mapping](#ERMrest.Mapping)</code>
+    * [.colset](#ERMrest.ForeignKeyRef+colset) : [<code>ColSet</code>](#ERMrest.ColSet)
+    * [.key](#ERMrest.ForeignKeyRef+key) : [<code>Key</code>](#ERMrest.Key)
+    * [.mapping](#ERMrest.ForeignKeyRef+mapping) : [<code>Mapping</code>](#ERMrest.Mapping)
     * [.constraint_names](#ERMrest.ForeignKeyRef+constraint_names) : <code>Array</code>
     * [.from_name](#ERMrest.ForeignKeyRef+from_name) : <code>string</code>
     * [.to_name](#ERMrest.ForeignKeyRef+to_name) : <code>string</code>
     * [.ignore](#ERMrest.ForeignKeyRef+ignore) : <code>boolean</code>
-    * [.annotations](#ERMrest.ForeignKeyRef+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
+    * [.annotations](#ERMrest.ForeignKeyRef+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
     * [.comment](#ERMrest.ForeignKeyRef+comment) : <code>string</code>
     * [.simple](#ERMrest.ForeignKeyRef+simple) : <code>Boolean</code>
-    * [.toString([reverse])](#ERMrest.ForeignKeyRef+toString)
+    * [.toString([reverse])](#ERMrest.ForeignKeyRef+toString) ⇒ <code>string</code>
     * [.getDomainValues(limit)](#ERMrest.ForeignKeyRef+getDomainValues) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.ForeignKeyRef_new"></a>
@@ -1619,66 +1623,66 @@ get the foreign key of the given column set
 
 | Param | Type |
 | --- | --- |
-| table | <code>[Table](#ERMrest.Table)</code> | 
+| table | [<code>Table</code>](#ERMrest.Table) | 
 | jsonFKR | <code>Object</code> | 
 
 <a name="ERMrest.ForeignKeyRef+colset"></a>
 
-#### foreignKeyRef.colset : <code>[ColSet](#ERMrest.ColSet)</code>
-**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+#### foreignKeyRef.colset : [<code>ColSet</code>](#ERMrest.ColSet)
+**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+key"></a>
 
-#### foreignKeyRef.key : <code>[Key](#ERMrest.Key)</code>
+#### foreignKeyRef.key : [<code>Key</code>](#ERMrest.Key)
 find key from referencedCols
 use index 0 since all refCols should be of the same schema:table
 
-**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+mapping"></a>
 
-#### foreignKeyRef.mapping : <code>[Mapping](#ERMrest.Mapping)</code>
-**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+#### foreignKeyRef.mapping : [<code>Mapping</code>](#ERMrest.Mapping)
+**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+constraint_names"></a>
 
 #### foreignKeyRef.constraint_names : <code>Array</code>
 The exact `names` array in foreign key definition
 TODO: it may need to change based on its usage
 
-**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+from_name"></a>
 
 #### foreignKeyRef.from_name : <code>string</code>
-**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+to_name"></a>
 
 #### foreignKeyRef.to_name : <code>string</code>
-**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+ignore"></a>
 
 #### foreignKeyRef.ignore : <code>boolean</code>
-**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+annotations"></a>
 
-#### foreignKeyRef.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
-**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+#### foreignKeyRef.annotations : [<code>Annotations</code>](#ERMrest.Annotations)
+**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+comment"></a>
 
 #### foreignKeyRef.comment : <code>string</code>
 Documentation for this foreign key reference
 
-**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+simple"></a>
 
 #### foreignKeyRef.simple : <code>Boolean</code>
 Indicates if the foreign key is simple (not composite)
 
-**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+toString"></a>
 
-#### foreignKeyRef.toString([reverse])
+#### foreignKeyRef.toString([reverse]) ⇒ <code>string</code>
 returns string representation of ForeignKeyRef object
 
-**Kind**: instance method of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
-**Retuns**: <code>string</code> string representation of ForeignKeyRef object  
+**Kind**: instance method of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+**Returns**: <code>string</code> - string representation of ForeignKeyRef object  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1687,7 +1691,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.ForeignKeyRef+getDomainValues"></a>
 
 #### foreignKeyRef.getDomainValues(limit) ⇒ <code>Promise</code>
-**Kind**: instance method of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
+**Kind**: instance method of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 **Returns**: <code>Promise</code> - promise that returns a rowset of the referenced key's table if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
@@ -1699,7 +1703,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.Type"></a>
 
 ### ERMrest.Type
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Type](#ERMrest.Type)
     * [new Type(name)](#new_ERMrest.Type_new)
@@ -1716,11 +1720,11 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.Type+name"></a>
 
 #### type.name
-**Kind**: instance property of <code>[Type](#ERMrest.Type)</code>  
+**Kind**: instance property of [<code>Type</code>](#ERMrest.Type)  
 <a name="ERMrest.TimedOutError"></a>
 
 ### ERMrest.TimedOutError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.TimedOutError_new"></a>
 
 #### new TimedOutError(status, message)
@@ -1733,7 +1737,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.BadRequestError"></a>
 
 ### ERMrest.BadRequestError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.BadRequestError_new"></a>
 
 #### new BadRequestError(status, message)
@@ -1746,7 +1750,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.UnauthorizedError"></a>
 
 ### ERMrest.UnauthorizedError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.UnauthorizedError_new"></a>
 
 #### new UnauthorizedError(status, message)
@@ -1759,7 +1763,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.ForbiddenError"></a>
 
 ### ERMrest.ForbiddenError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.ForbiddenError_new"></a>
 
 #### new ForbiddenError(status, message)
@@ -1772,7 +1776,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.NotFoundError"></a>
 
 ### ERMrest.NotFoundError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.NotFoundError_new"></a>
 
 #### new NotFoundError(status, message)
@@ -1785,7 +1789,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.ConflictError"></a>
 
 ### ERMrest.ConflictError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.ConflictError_new"></a>
 
 #### new ConflictError(status, message)
@@ -1798,7 +1802,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.PreconditionFailedError"></a>
 
 ### ERMrest.PreconditionFailedError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.PreconditionFailedError_new"></a>
 
 #### new PreconditionFailedError(status, message)
@@ -1811,7 +1815,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.InternalServerError"></a>
 
 ### ERMrest.InternalServerError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.InternalServerError_new"></a>
 
 #### new InternalServerError(status, message)
@@ -1824,7 +1828,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.ServiceUnavailableError"></a>
 
 ### ERMrest.ServiceUnavailableError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.ServiceUnavailableError_new"></a>
 
 #### new ServiceUnavailableError(status, message)
@@ -1837,7 +1841,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.InvalidFilterOperatorError"></a>
 
 ### ERMrest.InvalidFilterOperatorError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.InvalidFilterOperatorError_new"></a>
 
 #### new InvalidFilterOperatorError(message)
@@ -1851,7 +1855,7 @@ An invalid filter operator
 <a name="ERMrest.InvalidInputError"></a>
 
 ### ERMrest.InvalidInputError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.InvalidInputError_new"></a>
 
 #### new InvalidInputError(message)
@@ -1865,7 +1869,7 @@ An invalid input
 <a name="ERMrest.MalformedURIError"></a>
 
 ### ERMrest.MalformedURIError
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 <a name="new_ERMrest.MalformedURIError_new"></a>
 
 #### new MalformedURIError(message)
@@ -1879,7 +1883,7 @@ A malformed URI was passed to the API.
 <a name="ERMrest.ParsedFilter"></a>
 
 ### ERMrest.ParsedFilter
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.ParsedFilter](#ERMrest.ParsedFilter)
     * [new ParsedFilter(type)](#new_ERMrest.ParsedFilter_new)
@@ -1899,7 +1903,7 @@ Constructor for a ParsedFilter.
 <a name="ERMrest.ParsedFilter+setFilters"></a>
 
 #### parsedFilter.setFilters(filters)
-**Kind**: instance method of <code>[ParsedFilter](#ERMrest.ParsedFilter)</code>  
+**Kind**: instance method of [<code>ParsedFilter</code>](#ERMrest.ParsedFilter)  
 
 | Param | Description |
 | --- | --- |
@@ -1908,7 +1912,7 @@ Constructor for a ParsedFilter.
 <a name="ERMrest.ParsedFilter+setBinaryPredicate"></a>
 
 #### parsedFilter.setBinaryPredicate(colname, operator, value)
-**Kind**: instance method of <code>[ParsedFilter](#ERMrest.ParsedFilter)</code>  
+**Kind**: instance method of [<code>ParsedFilter</code>](#ERMrest.ParsedFilter)  
 
 | Param | Description |
 | --- | --- |
@@ -1919,7 +1923,7 @@ Constructor for a ParsedFilter.
 <a name="ERMrest.Reference"></a>
 
 ### ERMrest.Reference
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Reference](#ERMrest.Reference)
     * [new Reference(location, catalog)](#new_ERMrest.Reference_new)
@@ -1927,17 +1931,17 @@ Constructor for a ParsedFilter.
     * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
     * [.uri](#ERMrest.Reference+uri) : <code>string</code>
     * [.session](#ERMrest.Reference+session)
-    * [.table](#ERMrest.Reference+table) : <code>[Table](#ERMrest.Table)</code>
-    * [.columns](#ERMrest.Reference+columns) : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
+    * [.table](#ERMrest.Reference+table) : [<code>Table</code>](#ERMrest.Table)
+    * [.columns](#ERMrest.Reference+columns) : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
         * [._referenceColumns](#ERMrest.Reference+columns+_referenceColumns)
     * [.isUnique](#ERMrest.Reference+isUnique) : <code>boolean</code>
-    * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> &#124; <code>undefined</code>
-    * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> &#124; <code>undefined</code>
-    * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
-    * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
+    * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> \| <code>undefined</code>
+    * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> \| <code>undefined</code>
+    * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> \| <code>undefined</code>
+    * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> \| <code>undefined</code>
     * [.display](#ERMrest.Reference+display) : <code>Object</code>
     * [._related](#ERMrest.Reference+_related)
-    * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : <code>[Reference](#ERMrest.Reference)</code>
+    * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
     * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
     * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
         * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
@@ -1945,7 +1949,7 @@ Constructor for a ParsedFilter.
     * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
     * [.update(tuples)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
     * [.delete(tuples)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
-    * [.related([tuple])](#ERMrest.Reference+related) ⇒ <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
+    * [.related([tuple])](#ERMrest.Reference+related) ⇒ [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
     * [.search(term)](#ERMrest.Reference+search) ⇒ <code>Reference</code>
 
 <a name="new_ERMrest.Reference_new"></a>
@@ -1967,7 +1971,7 @@ Usage:
 | Param | Type | Description |
 | --- | --- | --- |
 | location | <code>ERMrest.Location</code> | The location object generated from parsing the URI |
-| catalog | <code>[Catalog](#ERMrest.Catalog)</code> | The catalog object. Since location.catalog is just an id, we need the actual catalog object too. |
+| catalog | [<code>Catalog</code>](#ERMrest.Catalog) | The catalog object. Since location.catalog is just an id, we need the actual catalog object too. |
 
 <a name="ERMrest.Reference+contextualize"></a>
 
@@ -1987,7 +1991,7 @@ The `reference` is unchanged, while `recordref` now represents a
 reconfigured reference. For instance, `recordref.columns` may be
 different compared to `reference.columns`.
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+displayname"></a>
 
 #### reference.displayname : <code>object</code>
@@ -1995,19 +1999,19 @@ The display name for this reference.
 displayname.isHTML will return true/false
 displayname.value has the value
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+uri"></a>
 
 #### reference.uri : <code>string</code>
 The string form of the `URI` for this reference.
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+session"></a>
 
 #### reference.session
 The session object from the server
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2015,13 +2019,13 @@ The session object from the server
 
 <a name="ERMrest.Reference+table"></a>
 
-#### reference.table : <code>[Table](#ERMrest.Table)</code>
+#### reference.table : [<code>Table</code>](#ERMrest.Table)
 The table object for this reference
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+columns"></a>
 
-#### reference.columns : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
+#### reference.columns : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
 The array of column definitions which represent the model of
 the resources accessible via this reference.
 
@@ -2039,7 +2043,7 @@ for (var i=0, len=reference.columns.length; i<len; i++) {
 }
 ```
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+columns+_referenceColumns"></a>
 
 ##### columns._referenceColumns
@@ -2067,7 +2071,7 @@ The logic is as follows:
 NOTE:
  + If this reference is actually an inbound related reference, we should hide the foreign key (and all of its columns) that created the link.
 
-**Kind**: instance property of <code>[columns](#ERMrest.Reference+columns)</code>  
+**Kind**: instance property of [<code>columns</code>](#ERMrest.Reference+columns)  
 <a name="ERMrest.Reference+isUnique"></a>
 
 #### reference.isUnique : <code>boolean</code>
@@ -2094,39 +2098,39 @@ Usage:
 console.log("This reference is unique?", (reference.isUnique ? 'yes' : 'no'));
 ```
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+canCreate"></a>
 
-#### reference.canCreate : <code>boolean</code> &#124; <code>undefined</code>
+#### reference.canCreate : <code>boolean</code> \| <code>undefined</code>
 Indicates whether the client has the permission to _create_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+canRead"></a>
 
-#### reference.canRead : <code>boolean</code> &#124; <code>undefined</code>
+#### reference.canRead : <code>boolean</code> \| <code>undefined</code>
 Indicates whether the client has the permission to _read_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+canUpdate"></a>
 
-#### reference.canUpdate : <code>boolean</code> &#124; <code>undefined</code>
+#### reference.canUpdate : <code>boolean</code> \| <code>undefined</code>
 Indicates whether the client has the permission to _update_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+canDelete"></a>
 
-#### reference.canDelete : <code>boolean</code> &#124; <code>undefined</code>
+#### reference.canDelete : <code>boolean</code> \| <code>undefined</code>
 Indicates whether the client has the permission to _delete_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+display"></a>
 
 #### reference.display : <code>Object</code>
@@ -2164,7 +2168,7 @@ if ( displayType === 'table') {
 }
 ```
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+_related"></a>
 
 #### reference._related
@@ -2202,19 +2206,19 @@ The logic for are sorted based on following attributes:
  2. position of key columns that are involved in the foreignkey
  3. position of columns that are involved in the foreignkey
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+unfilteredReference"></a>
 
-#### reference.unfilteredReference : <code>[Reference](#ERMrest.Reference)</code>
+#### reference.unfilteredReference : [<code>Reference</code>](#ERMrest.Reference)
 This will generate a new unfiltered reference each time.
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+appLink"></a>
 
 #### reference.appLink : <code>String</code>
 App-specific URL
 
-**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 **Throws**:
 
 - <code>Error</code> if `_appLinkFn` is not defined.
@@ -2227,7 +2231,7 @@ operation sets the `defaults` list according to the table
 specification, and not according to the contents of in the input
 tuple.
 
-**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
 **Returns**: <code>Promise</code> - A promise resolved w ith [Page](#ERMrest.Page) of results,
 or rejected with any of the following errors:
 - [InvalidInputError](#ERMrest.InvalidInputError): If `data` is not valid, or reference is not in `entry/create` context.
@@ -2247,7 +2251,7 @@ and subtrahend is [4,5,6]
 the difference is [1,2,3]
 The 6 is ignored because we only want to know what's in the minuend that is not in the subtrahend
 
-**Kind**: inner method of <code>[create](#ERMrest.Reference+create)</code>  
+**Kind**: inner method of [<code>create</code>](#ERMrest.Reference+create)  
 <a name="ERMrest.Reference+read"></a>
 
 #### reference.read(limit) ⇒ <code>Promise</code>
@@ -2270,7 +2274,7 @@ reference.read(10).then(
   });
 ```
 
-**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
 **Returns**: <code>Promise</code> - A promise resolved with [Page](#ERMrest.Page) of results,
 or rejected with any of these errors:
 - [InvalidInputError](#ERMrest.InvalidInputError): If `limit` is invalid.
@@ -2287,7 +2291,7 @@ or rejected with any of these errors:
 #### reference.sort(sort) ⇒ <code>Reference</code>
 Return a new Reference with the new sorting
 
-**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
 **Returns**: <code>Reference</code> - A new reference with the new sorting  
 **Throws**:
 
@@ -2303,7 +2307,7 @@ Return a new Reference with the new sorting
 #### reference.update(tuples) ⇒ <code>Promise</code>
 Updates a set of resources.
 
-**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
 **Returns**: <code>Promise</code> - A promise resolved with [Page](#ERMrest.Page) of results,
 or rejected with any of these errors:
 - [InvalidInputError](#ERMrest.InvalidInputError): If `limit` is invalid or reference is not in `entry/edit` context.
@@ -2318,7 +2322,7 @@ or rejected with any of these errors:
 #### reference.delete(tuples) ⇒ <code>Promise</code>
 Deletes the referenced resources.
 
-**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
 **Returns**: <code>Promise</code> - A promise resolved with empty object or rejected with any of these errors:
 - [InvalidInputError](#ERMrest.InvalidInputError): If `limit` is invalid.
 - ERMrestjs corresponding http errors, if ERMrest returns http error.  
@@ -2329,7 +2333,7 @@ Deletes the referenced resources.
 
 <a name="ERMrest.Reference+related"></a>
 
-#### reference.related([tuple]) ⇒ <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
+#### reference.related([tuple]) ⇒ [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
 The "related" references. Relationships are defined by foreign key
 references between [Table](#ERMrest.Table)s. Those references can be
 considered "outbound" where the table has FKRs to other entities or
@@ -2343,11 +2347,11 @@ ignore `B` and think of this relationship as `A <-> C`, unless `B`
 has other moderating attributes, for instance that indicate the
 `type` of relationship, but this is a model-depenent detail.
 
-**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [tuple] | <code>[Tuple](#ERMrest.Tuple)</code> | the current tuple |
+| [tuple] | [<code>Tuple</code>](#ERMrest.Tuple) | the current tuple |
 
 <a name="ERMrest.Reference+search"></a>
 
@@ -2359,7 +2363,7 @@ a) A string with no space: single term or regular expression
 b) A single term with space using ""
 c) use space for conjunction of terms
 
-**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
+**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
 **Returns**: <code>Reference</code> - A new reference with the new search  
 **Throws**:
 
@@ -2373,17 +2377,17 @@ c) use space for conjunction of terms
 <a name="ERMrest.Page"></a>
 
 ### ERMrest.Page
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Page](#ERMrest.Page)
     * [new Page(reference, etag, data, hasNext, hasPrevious)](#new_ERMrest.Page_new)
-    * [.reference](#ERMrest.Page+reference) : <code>[Reference](#ERMrest.Reference)</code>
-    * [.tuples](#ERMrest.Page+tuples) : <code>[Array.&lt;Tuple&gt;](#ERMrest.Tuple)</code>
+    * [.reference](#ERMrest.Page+reference) : [<code>Reference</code>](#ERMrest.Reference)
+    * [.tuples](#ERMrest.Page+tuples) : [<code>Array.&lt;Tuple&gt;</code>](#ERMrest.Tuple)
     * [.hasPrevious](#ERMrest.Page+hasPrevious) ⇒ <code>boolean</code>
-    * [.previous](#ERMrest.Page+previous) : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
+    * [.previous](#ERMrest.Page+previous) : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
     * [.hasNext](#ERMrest.Page+hasNext) ⇒ <code>boolean</code>
-    * [.next](#ERMrest.Page+next) : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
-    * [.content](#ERMrest.Page+content) : <code>string</code> &#124; <code>null</code>
+    * [.next](#ERMrest.Page+next) : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
+    * [.content](#ERMrest.Page+content) : <code>string</code> \| <code>null</code>
 
 <a name="new_ERMrest.Page_new"></a>
 
@@ -2402,7 +2406,7 @@ Usage:
 
 | Param | Type | Description |
 | --- | --- | --- |
-| reference | <code>[Reference](#ERMrest.Reference)</code> | The reference object from which this data was acquired. |
+| reference | [<code>Reference</code>](#ERMrest.Reference) | The reference object from which this data was acquired. |
 | etag | <code>String</code> | The etag from the reference object that produced this page |
 | data | <code>Array.&lt;Object&gt;</code> | The data returned from ERMrest. |
 | hasNext | <code>boolean</code> | Whether there is more data before this Page |
@@ -2410,13 +2414,13 @@ Usage:
 
 <a name="ERMrest.Page+reference"></a>
 
-#### page.reference : <code>[Reference](#ERMrest.Reference)</code>
+#### page.reference : [<code>Reference</code>](#ERMrest.Reference)
 The page's associated reference.
 
-**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
+**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
 <a name="ERMrest.Page+tuples"></a>
 
-#### page.tuples : <code>[Array.&lt;Tuple&gt;](#ERMrest.Tuple)</code>
+#### page.tuples : [<code>Array.&lt;Tuple&gt;</code>](#ERMrest.Tuple)
 An array of processed tuples. The results will be processed
 according to the contextualized scheme (model) of this reference.
 
@@ -2428,16 +2432,16 @@ for (var i=0, len=page.tuples.length; i<len; i++) {
 }
 ```
 
-**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
+**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
 <a name="ERMrest.Page+hasPrevious"></a>
 
 #### page.hasPrevious ⇒ <code>boolean</code>
 Whether there is more entities before this page
 
-**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
+**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
 <a name="ERMrest.Page+previous"></a>
 
-#### page.previous : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
+#### page.previous : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
 A reference to the previous set of results.
 
 Usage:
@@ -2450,16 +2454,16 @@ if (reference.previous) {
 }
 ```
 
-**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
+**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
 <a name="ERMrest.Page+hasNext"></a>
 
 #### page.hasNext ⇒ <code>boolean</code>
 Whether there is more entities after this page
 
-**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
+**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
 <a name="ERMrest.Page+next"></a>
 
-#### page.next : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
+#### page.next : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
 A reference to the next set of results.
 
 Usage:
@@ -2472,10 +2476,10 @@ if (reference.next) {
 }
 ```
 
-**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
+**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
 <a name="ERMrest.Page+content"></a>
 
-#### page.content : <code>string</code> &#124; <code>null</code>
+#### page.content : <code>string</code> \| <code>null</code>
 HTML representation of the whole page which uses table-display annotation.
 For more info you can refer {ERM.reference.display}
 
@@ -2487,26 +2491,26 @@ if (content) {
 }
 ```
 
-**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
+**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
 <a name="ERMrest.Tuple"></a>
 
 ### ERMrest.Tuple
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Tuple](#ERMrest.Tuple)
     * [new Tuple(reference, page, data)](#new_ERMrest.Tuple_new)
-    * [.reference](#ERMrest.Tuple+reference) ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
-    * [.page](#ERMrest.Tuple+page) ⇒ <code>[Page](#ERMrest.Page)</code> &#124; <code>\*</code>
+    * [.reference](#ERMrest.Tuple+reference) ⇒ [<code>Reference</code>](#ERMrest.Reference) \| <code>\*</code>
+    * [.page](#ERMrest.Tuple+page) ⇒ [<code>Page</code>](#ERMrest.Page) \| <code>\*</code>
     * [.data](#ERMrest.Tuple+data) : <code>Object</code>
     * [.data](#ERMrest.Tuple+data)
-    * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
-    * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
+    * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> \| <code>undefined</code>
+    * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> \| <code>undefined</code>
     * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
     * [.isHTML](#ERMrest.Tuple+isHTML) : <code>Array.&lt;string&gt;</code>
     * [.displayname](#ERMrest.Tuple+displayname) : <code>string</code>
     * [.update()](#ERMrest.Tuple+update) ⇒ <code>Promise</code>
     * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
-    * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : <code>[Reference](#ERMrest.Reference)</code>
+    * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : [<code>Reference</code>](#ERMrest.Reference)
 
 <a name="new_ERMrest.Tuple_new"></a>
 
@@ -2521,24 +2525,24 @@ Usage:
 
 | Param | Type | Description |
 | --- | --- | --- |
-| reference | <code>[Reference](#ERMrest.Reference)</code> | The reference object from which this data was acquired. |
-| page | <code>[Page](#ERMrest.Page)</code> | The Page object from which this data was acquired. |
+| reference | [<code>Reference</code>](#ERMrest.Reference) | The reference object from which this data was acquired. |
+| page | [<code>Page</code>](#ERMrest.Page) | The Page object from which this data was acquired. |
 | data | <code>Object</code> | The unprocessed tuple of data returned from ERMrest. |
 
 <a name="ERMrest.Tuple+reference"></a>
 
-#### tuple.reference ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
+#### tuple.reference ⇒ [<code>Reference</code>](#ERMrest.Reference) \| <code>\*</code>
 This is the reference of the Tuple
 
-**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
-**Returns**: <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code> - reference of the Tuple  
+**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Returns**: [<code>Reference</code>](#ERMrest.Reference) \| <code>\*</code> - reference of the Tuple  
 <a name="ERMrest.Tuple+page"></a>
 
-#### tuple.page ⇒ <code>[Page](#ERMrest.Page)</code> &#124; <code>\*</code>
+#### tuple.page ⇒ [<code>Page</code>](#ERMrest.Page) \| <code>\*</code>
 This is the page of the Tuple
 
-**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
-**Returns**: <code>[Page](#ERMrest.Page)</code> &#124; <code>\*</code> - page of the Tuple  
+**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Returns**: [<code>Page</code>](#ERMrest.Page) \| <code>\*</code> - page of the Tuple  
 <a name="ERMrest.Tuple+data"></a>
 
 #### tuple.data : <code>Object</code>
@@ -2552,11 +2556,11 @@ track of so that the column projections for the uri can be properly created
 and both the old and new value for the modified key are submitted together
 for proper updating.
 
-**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
 <a name="ERMrest.Tuple+data"></a>
 
 #### tuple.data
-**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2564,7 +2568,7 @@ for proper updating.
 
 <a name="ERMrest.Tuple+canUpdate"></a>
 
-#### tuple.canUpdate : <code>boolean</code> &#124; <code>undefined</code>
+#### tuple.canUpdate : <code>boolean</code> \| <code>undefined</code>
 Indicates whether the client can update this tuple. Because
 some policies may be undecidable until query execution, this
 property may also be `undefined`.
@@ -2582,17 +2586,17 @@ else {
 }
 ```
 
-**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
 <a name="ERMrest.Tuple+canDelete"></a>
 
-#### tuple.canDelete : <code>boolean</code> &#124; <code>undefined</code>
+#### tuple.canDelete : <code>boolean</code> \| <code>undefined</code>
 Indicates whether the client can delete this tuple. Because
 some policies may be undecidable until query execution, this
 property may also be `undefined`.
 
 See [canUpdate](#ERMrest.Tuple+canUpdate) for a usage example.
 
-**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
 <a name="ERMrest.Tuple+values"></a>
 
 #### tuple.values : <code>Array.&lt;string&gt;</code>
@@ -2615,7 +2619,7 @@ console.log(tuple.displayname, "has a", column.displayname,
     "with value", tuple.values[column.position]);
 ```
 
-**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
 <a name="ERMrest.Tuple+isHTML"></a>
 
 #### tuple.isHTML : <code>Array.&lt;string&gt;</code>
@@ -2630,7 +2634,7 @@ for (var i=0; len=reference.columns.length; i<len; i++) {
 }
 ```
 
-**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
 <a name="ERMrest.Tuple+displayname"></a>
 
 #### tuple.displayname : <code>string</code>
@@ -2644,14 +2648,14 @@ Usage:
 console.log("This tuple has a displayable name of ", tuple.displayname.value);
 ```
 
-**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
 <a name="ERMrest.Tuple+update"></a>
 
 #### tuple.update() ⇒ <code>Promise</code>
 Attempts to update this tuple. This is a server side transaction,
 and therefore an asynchronous operation that returns a promise.
 
-**Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Kind**: instance method of [<code>Tuple</code>](#ERMrest.Tuple)  
 **Returns**: <code>Promise</code> - a promise (TBD the result object)  
 <a name="ERMrest.Tuple+delete"></a>
 
@@ -2659,11 +2663,11 @@ and therefore an asynchronous operation that returns a promise.
 Attempts to delete this tuple. This is a server side transaction,
 and therefore an asynchronous operation that returns a promise.
 
-**Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Kind**: instance method of [<code>Tuple</code>](#ERMrest.Tuple)  
 **Returns**: <code>Promise</code> - a promise (TBD the result object)  
 <a name="ERMrest.Tuple+getAssociationRef"></a>
 
-#### tuple.getAssociationRef() : <code>[Reference](#ERMrest.Reference)</code>
+#### tuple.getAssociationRef() : [<code>Reference</code>](#ERMrest.Reference)
 If the Tuple is derived from an association related table,
 this function will return a reference to the corresponding
 entity of this tuple's association table.
@@ -2674,176 +2678,120 @@ and current tuple is from Table2 with k2 = "2".
 With origFKRData = {"k1": "1"} this function will return a reference
 to AssocitaitonTable with FK1 = "1"" and FK2 = "2".
 
-**Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Kind**: instance method of [<code>Tuple</code>](#ERMrest.Tuple)  
 <a name="ERMrest.ReferenceColumn"></a>
 
 ### ERMrest.ReferenceColumn
-**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.ReferenceColumn](#ERMrest.ReferenceColumn)
-    * [new ReferenceColumn(reference, base, kwargs)](#new_ERMrest.ReferenceColumn_new)
+    * [new ReferenceColumn(reference, baseCols)](#new_ERMrest.ReferenceColumn_new)
     * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
-    * [.reference](#ERMrest.ReferenceColumn+reference) : <code>[Reference](#ERMrest.Reference)</code>
-    * [.foreignKey](#ERMrest.ReferenceColumn+foreignKey) : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
-    * [.key](#ERMrest.ReferenceColumn+key) : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
-    * [.table](#ERMrest.ReferenceColumn+table) : <code>[Table](#ERMrest.Table)</code>
+    * [.table](#ERMrest.ReferenceColumn+table) : [<code>Table</code>](#ERMrest.Table)
     * [.name](#ERMrest.ReferenceColumn+name) : <code>string</code>
     * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>string</code>
-    * [.type](#ERMrest.ReferenceColumn+type) : <code>[Type](#ERMrest.Type)</code>
+    * [.type](#ERMrest.ReferenceColumn+type) : [<code>Type</code>](#ERMrest.Type)
     * [.nullok](#ERMrest.ReferenceColumn+nullok) : <code>Boolean</code>
     * [.default](#ERMrest.ReferenceColumn+default) : <code>string</code>
     * [.comment](#ERMrest.ReferenceColumn+comment) : <code>string</code>
-    * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> &#124; <code>object</code>
+    * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> \| <code>object</code>
     * [.sortable](#ERMrest.ReferenceColumn+sortable) : <code>boolean</code>
-    * [.isForeignKey](#ERMrest.ReferenceColumn+isForeignKey) : <code>boolean</code>
     * [.formatvalue(data)](#ERMrest.ReferenceColumn+formatvalue) ⇒ <code>string</code>
-    * [.filteredRef(column, data)](#ERMrest.ReferenceColumn+filteredRef) ⇒ <code>[Reference](#ERMrest.Reference)</code>
     * [.formatPresentation(data, options)](#ERMrest.ReferenceColumn+formatPresentation) ⇒ <code>Object</code>
-    * [.getInputDisabled()](#ERMrest.ReferenceColumn+getInputDisabled) : <code>boolean</code> &#124; <code>object</code>
+    * [.getInputDisabled()](#ERMrest.ReferenceColumn+getInputDisabled) : <code>boolean</code> \| <code>object</code>
 
 <a name="new_ERMrest.ReferenceColumn_new"></a>
 
-#### new ReferenceColumn(reference, base, kwargs)
+#### new ReferenceColumn(reference, baseCols)
 Constructor for ReferenceColumn. This class is a wrapper for [Column](#ERMrest.Column).
 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| reference | <code>[Reference](#ERMrest.Reference)</code> | column's reference |
-| base | <code>[Column](#ERMrest.Column)</code> | The column that this reference-column will be created based on. |
-| kwargs | <code>Object</code> | if it's not empty then the column is being created based on foreignkey or key. |
+| reference | [<code>Reference</code>](#ERMrest.Reference) | column's reference |
+| baseCols | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) | List of columns that this reference-column will be created based on. |
 
 <a name="ERMrest.ReferenceColumn+isPseudo"></a>
 
 #### referenceColumn.isPseudo : <code>boolean</code>
 indicates this represents is a PseudoColumn or a Column.
 
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
-<a name="ERMrest.ReferenceColumn+reference"></a>
-
-#### referenceColumn.reference : <code>[Reference](#ERMrest.Reference)</code>
-The reference object that represents the table of this PseudoColumn
-
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
-<a name="ERMrest.ReferenceColumn+foreignKey"></a>
-
-#### referenceColumn.foreignKey : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
-The Foreign key object that this PseudoColumn is created based on
-
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
-<a name="ERMrest.ReferenceColumn+key"></a>
-
-#### referenceColumn.key : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
-The Foreign key object that this PseudoColumn is created based on
-
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+table"></a>
 
-#### referenceColumn.table : <code>[Table](#ERMrest.Table)</code>
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+#### referenceColumn.table : [<code>Table</code>](#ERMrest.Table)
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+name"></a>
 
 #### referenceColumn.name : <code>string</code>
 name of the column.
 
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+displayname"></a>
 
 #### referenceColumn.displayname : <code>string</code>
-Preferred display name for user presentation only.
+name of the column.
 
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+type"></a>
 
-#### referenceColumn.type : <code>[Type](#ERMrest.Type)</code>
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+#### referenceColumn.type : [<code>Type</code>](#ERMrest.Type)
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+nullok"></a>
 
 #### referenceColumn.nullok : <code>Boolean</code>
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+default"></a>
 
 #### referenceColumn.default : <code>string</code>
 Returns the default value
 
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+comment"></a>
 
 #### referenceColumn.comment : <code>string</code>
 Documentation for this reference-column
 
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+inputDisabled"></a>
 
-#### referenceColumn.inputDisabled : <code>boolean</code> &#124; <code>object</code>
+#### referenceColumn.inputDisabled : <code>boolean</code> \| <code>object</code>
 Indicates if the input should be disabled
 true: input must be disabled
 false:  input can be enabled
 object: input msut be disabled (show .message to user)
 
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+sortable"></a>
 
 #### referenceColumn.sortable : <code>boolean</code>
 Heuristics are as follows:
 
 (first applicable rule from top to bottom)
+- multiple columns -> disable sort.
+- single column:
+ - column_order defined -> use it.
+ - use column actual value.
 
-- column_order = false -> disable sort.
-
-- PseudoColumn
-     - column_order defined -> use it.
-     - Foreign key:
-         - table has row_order -> use it.
-         - simple fk -> use the column's
-     - Key:
-         - simple key -> use the column's
-     - disable it
-- Column:
-     - column_order defined -> use it.
-     - use column actual value.
-
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
-<a name="ERMrest.ReferenceColumn+isForeignKey"></a>
-
-#### referenceColumn.isForeignKey : <code>boolean</code>
-returns the private value _isForeignKey
-
-**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+formatvalue"></a>
 
 #### referenceColumn.formatvalue(data) ⇒ <code>string</code>
 Formats a value corresponding to this reference-column definition.
 
-**Kind**: instance method of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance method of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 **Returns**: <code>string</code> - The formatted value.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | data | <code>Object</code> | The 'raw' data value. |
 
-<a name="ERMrest.ReferenceColumn+filteredRef"></a>
-
-#### referenceColumn.filteredRef(column, data) ⇒ <code>[Reference](#ERMrest.Reference)</code>
-This function takes in a tuple and generates a reference that is
-constrained based on the domain_filter_pattern annotation. If this
-annotation doesn't exist, it returns this (reference)
-`this` is the same as column.reference
-
-**Kind**: instance method of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
-**Returns**: <code>[Reference](#ERMrest.Reference)</code> - the constrained reference  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| column | <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code> | column that `this` is based on |
-| data | <code>Object</code> | tuple data with potential constraints |
-
 <a name="ERMrest.ReferenceColumn+formatPresentation"></a>
 
 #### referenceColumn.formatPresentation(data, options) ⇒ <code>Object</code>
 Formats the presentation value corresponding to this reference-column definition.
 
-**Kind**: instance method of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance method of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 **Returns**: <code>Object</code> - A key value pair containing value and isHTML that detemrines the presenation.  
 
 | Param | Type | Description |
@@ -2853,59 +2801,144 @@ Formats the presentation value corresponding to this reference-column definition
 
 <a name="ERMrest.ReferenceColumn+getInputDisabled"></a>
 
-#### referenceColumn.getInputDisabled() : <code>boolean</code> &#124; <code>object</code>
+#### referenceColumn.getInputDisabled() : <code>boolean</code> \| <code>object</code>
 Indicates if the input should be disabled, in different contexts
 true: input must be disabled
 false:  input can be enabled
 object: input msut be disabled (show .message to user)
+TODO should be removed in favor of inputDisabled
 
-**Kind**: instance method of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
+**Kind**: instance method of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+<a name="ERMrest.ForeignKeyPseudoColumn"></a>
+
+### ERMrest.ForeignKeyPseudoColumn
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+
+* [.ForeignKeyPseudoColumn](#ERMrest.ForeignKeyPseudoColumn)
+    * [new ForeignKeyPseudoColumn(reference, fk)](#new_ERMrest.ForeignKeyPseudoColumn_new)
+    * [.isPseudo](#ERMrest.ForeignKeyPseudoColumn+isPseudo) : <code>boolean</code>
+    * [.isForeignKey](#ERMrest.ForeignKeyPseudoColumn+isForeignKey) : <code>boolean</code>
+    * [.reference](#ERMrest.ForeignKeyPseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
+    * [.foreignKey](#ERMrest.ForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
+    * [.filteredRef(column, data)](#ERMrest.ForeignKeyPseudoColumn+filteredRef) ⇒ [<code>Reference</code>](#ERMrest.Reference)
+    * [.formatPresentation(data, options)](#ERMrest.ForeignKeyPseudoColumn+formatPresentation) ⇒ <code>Object</code>
+    * [._determineSortable()](#ERMrest.ForeignKeyPseudoColumn+_determineSortable)
+
+<a name="new_ERMrest.ForeignKeyPseudoColumn_new"></a>
+
+#### new ForeignKeyPseudoColumn(reference, fk)
+Constructor for ForeignKeyPseudoColumn. This class is a wrapper for [ForeignKeyRef](#ERMrest.ForeignKeyRef).
+This class extends the [ReferenceColumn](#ERMrest.ReferenceColumn)
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| reference | [<code>Reference</code>](#ERMrest.Reference) | column's reference |
+| fk | [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef) | the foreignkey |
+
+<a name="ERMrest.ForeignKeyPseudoColumn+isPseudo"></a>
+
+#### foreignKeyPseudoColumn.isPseudo : <code>boolean</code>
+indicates this represents is a PseudoColumn or a Column.
+
+**Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+<a name="ERMrest.ForeignKeyPseudoColumn+isForeignKey"></a>
+
+#### foreignKeyPseudoColumn.isForeignKey : <code>boolean</code>
+Indicates that this ReferenceColumn is a Foreign key.
+
+**Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+<a name="ERMrest.ForeignKeyPseudoColumn+reference"></a>
+
+#### foreignKeyPseudoColumn.reference : [<code>Reference</code>](#ERMrest.Reference)
+The reference object that represents the table of this PseudoColumn
+
+**Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+<a name="ERMrest.ForeignKeyPseudoColumn+foreignKey"></a>
+
+#### foreignKeyPseudoColumn.foreignKey : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
+The Foreign key object that this PseudoColumn is created based on
+
+**Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+<a name="ERMrest.ForeignKeyPseudoColumn+filteredRef"></a>
+
+#### foreignKeyPseudoColumn.filteredRef(column, data) ⇒ [<code>Reference</code>](#ERMrest.Reference)
+This function takes in a tuple and generates a reference that is
+constrained based on the domain_filter_pattern annotation. If this
+annotation doesn't exist, it returns this (reference)
+`this` is the same as column.reference
+
+**Kind**: instance method of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+**Returns**: [<code>Reference</code>](#ERMrest.Reference) - the constrained reference  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| column | [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn) | column that `this` is based on |
+| data | <code>Object</code> | tuple data with potential constraints |
+
+<a name="ERMrest.ForeignKeyPseudoColumn+formatPresentation"></a>
+
+#### foreignKeyPseudoColumn.formatPresentation(data, options) ⇒ <code>Object</code>
+Formats the presentation value corresponding to this reference-column definition.
+
+**Kind**: instance method of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+**Returns**: <code>Object</code> - A key value pair containing value and isHTML that detemrines the presenation.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| data | <code>String</code> | In case of pseudocolumn it's the raw data, otherwise'formatted' data value. |
+| options | <code>Object</code> | includes `context` and `formattedValues` |
+
+<a name="ERMrest.ForeignKeyPseudoColumn+_determineSortable"></a>
+
+#### foreignKeyPseudoColumn._determineSortable()
+**Kind**: instance method of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
 <a name="ERMrest.Datapath"></a>
 
 ### ERMrest.Datapath : <code>object</code>
-**Kind**: static namespace of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static namespace of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Datapath](#ERMrest.Datapath) : <code>object</code>
     * [.DataPath](#ERMrest.Datapath.DataPath)
         * [new DataPath(table)](#new_ERMrest.Datapath.DataPath_new)
-        * [.catalog](#ERMrest.Datapath.DataPath+catalog) : <code>[Catalog](#ERMrest.Catalog)</code>
-        * [.context](#ERMrest.Datapath.DataPath+context) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+        * [.catalog](#ERMrest.Datapath.DataPath+catalog) : [<code>Catalog</code>](#ERMrest.Catalog)
+        * [.context](#ERMrest.Datapath.DataPath+context) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
         * [.entity](#ERMrest.Datapath.DataPath+entity)
             * [.get()](#ERMrest.Datapath.DataPath+entity.get) ⇒ <code>Promise</code>
             * [.delete(filter)](#ERMrest.Datapath.DataPath+entity.delete) ⇒ <code>Promise</code>
-        * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
-        * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+        * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
+        * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
     * [.PathTable](#ERMrest.Datapath.PathTable)
         * [new PathTable(table, datapath, alias)](#new_ERMrest.Datapath.PathTable_new)
-        * [.datapath](#ERMrest.Datapath.PathTable+datapath) : <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
-        * [.table](#ERMrest.Datapath.PathTable+table) : <code>[Table](#ERMrest.Table)</code>
+        * [.datapath](#ERMrest.Datapath.PathTable+datapath) : [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
+        * [.table](#ERMrest.Datapath.PathTable+table) : [<code>Table</code>](#ERMrest.Table)
         * [.alias](#ERMrest.Datapath.PathTable+alias) : <code>string</code>
-        * [.columns](#ERMrest.Datapath.PathTable+columns) : <code>[Columns](#ERMrest.Datapath.Columns)</code>
+        * [.columns](#ERMrest.Datapath.PathTable+columns) : [<code>Columns</code>](#ERMrest.Datapath.Columns)
         * [.toString()](#ERMrest.Datapath.PathTable+toString) ⇒ <code>string</code>
     * [.PathColumn](#ERMrest.Datapath.PathColumn)
         * [new PathColumn(column, pathtable)](#new_ERMrest.Datapath.PathColumn_new)
-        * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
-        * [.column](#ERMrest.Datapath.PathColumn+column) : <code>[Column](#ERMrest.Column)</code>
+        * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+        * [.column](#ERMrest.Datapath.PathColumn+column) : [<code>Column</code>](#ERMrest.Column)
     * [.Columns(table, pathtable)](#ERMrest.Datapath.Columns)
         * [.length()](#ERMrest.Datapath.Columns+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Datapath.Columns+names) ⇒ <code>Array.&lt;String&gt;</code>
-        * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>
+        * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)
     * [.Operators()](#ERMrest.Datapath.Operators)
 
 <a name="ERMrest.Datapath.DataPath"></a>
 
 #### Datapath.DataPath
-**Kind**: static class of <code>[Datapath](#ERMrest.Datapath)</code>  
+**Kind**: static class of [<code>Datapath</code>](#ERMrest.Datapath)  
 
 * [.DataPath](#ERMrest.Datapath.DataPath)
     * [new DataPath(table)](#new_ERMrest.Datapath.DataPath_new)
-    * [.catalog](#ERMrest.Datapath.DataPath+catalog) : <code>[Catalog](#ERMrest.Catalog)</code>
-    * [.context](#ERMrest.Datapath.DataPath+context) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+    * [.catalog](#ERMrest.Datapath.DataPath+catalog) : [<code>Catalog</code>](#ERMrest.Catalog)
+    * [.context](#ERMrest.Datapath.DataPath+context) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
     * [.entity](#ERMrest.Datapath.DataPath+entity)
         * [.get()](#ERMrest.Datapath.DataPath+entity.get) ⇒ <code>Promise</code>
         * [.delete(filter)](#ERMrest.Datapath.DataPath+entity.delete) ⇒ <code>Promise</code>
-    * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
-    * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+    * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
+    * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
 
 <a name="new_ERMrest.Datapath.DataPath_new"></a>
 
@@ -2913,22 +2946,22 @@ object: input msut be disabled (show .message to user)
 
 | Param | Type |
 | --- | --- |
-| table | <code>[Table](#ERMrest.Table)</code> | 
+| table | [<code>Table</code>](#ERMrest.Table) | 
 
 <a name="ERMrest.Datapath.DataPath+catalog"></a>
 
-##### dataPath.catalog : <code>[Catalog](#ERMrest.Catalog)</code>
-**Kind**: instance property of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
+##### dataPath.catalog : [<code>Catalog</code>](#ERMrest.Catalog)
+**Kind**: instance property of [<code>DataPath</code>](#ERMrest.Datapath.DataPath)  
 <a name="ERMrest.Datapath.DataPath+context"></a>
 
-##### dataPath.context : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
-**Kind**: instance property of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
+##### dataPath.context : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+**Kind**: instance property of [<code>DataPath</code>](#ERMrest.Datapath.DataPath)  
 <a name="ERMrest.Datapath.DataPath+entity"></a>
 
 ##### dataPath.entity
 entity container
 
-**Kind**: instance property of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
+**Kind**: instance property of [<code>DataPath</code>](#ERMrest.Datapath.DataPath)  
 
 * [.entity](#ERMrest.Datapath.DataPath+entity)
     * [.get()](#ERMrest.Datapath.DataPath+entity.get) ⇒ <code>Promise</code>
@@ -2937,7 +2970,7 @@ entity container
 <a name="ERMrest.Datapath.DataPath+entity.get"></a>
 
 ###### entity.get() ⇒ <code>Promise</code>
-**Kind**: static method of <code>[entity](#ERMrest.Datapath.DataPath+entity)</code>  
+**Kind**: static method of [<code>entity</code>](#ERMrest.Datapath.DataPath+entity)  
 **Returns**: <code>Promise</code> - promise that returns a row data if resolved or
     [ERMrest.Errors.TimedOutError](ERMrest.Errors.TimedOutError), [ERMrest.Errors.InternalServerError](ERMrest.Errors.InternalServerError), [ERMrest.Errors.ServiceUnavailableError](ERMrest.Errors.ServiceUnavailableError),
     [ERMrest.Errors.ConflictError](ERMrest.Errors.ConflictError), [ERMrest.Errors.ForbiddenError](ERMrest.Errors.ForbiddenError) or [ERMrest.Errors.UnauthorizedError](ERMrest.Errors.UnauthorizedError) if rejected  
@@ -2946,51 +2979,51 @@ entity container
 ###### entity.delete(filter) ⇒ <code>Promise</code>
 delete entities
 
-**Kind**: static method of <code>[entity](#ERMrest.Datapath.DataPath+entity)</code>  
+**Kind**: static method of [<code>entity</code>](#ERMrest.Datapath.DataPath+entity)  
 **Returns**: <code>Promise</code> - promise that returns deleted entities if resolved or
     [ERMrest.Errors.TimedOutError](ERMrest.Errors.TimedOutError), [ERMrest.Errors.InternalServerError](ERMrest.Errors.InternalServerError), [ERMrest.Errors.ServiceUnavailableError](ERMrest.Errors.ServiceUnavailableError),
     [ERMrest.Errors.ConflictError](ERMrest.Errors.ConflictError), [ERMrest.Errors.ForbiddenError](ERMrest.Errors.ForbiddenError) or [ERMrest.Errors.UnauthorizedError](ERMrest.Errors.UnauthorizedError) if rejected  
 
 | Param | Type |
 | --- | --- |
-| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
+| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) | 
 
 <a name="ERMrest.Datapath.DataPath+filter"></a>
 
-##### dataPath.filter(filter) ⇒ <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
+##### dataPath.filter(filter) ⇒ [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
 this datapath is not modified
 
-**Kind**: instance method of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
-**Returns**: <code>[DataPath](#ERMrest.Datapath.DataPath)</code> - a shallow copy of this datapath with filter  
+**Kind**: instance method of [<code>DataPath</code>](#ERMrest.Datapath.DataPath)  
+**Returns**: [<code>DataPath</code>](#ERMrest.Datapath.DataPath) - a shallow copy of this datapath with filter  
 
 | Param | Type |
 | --- | --- |
-| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
+| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) | 
 
 <a name="ERMrest.Datapath.DataPath+extend"></a>
 
-##### dataPath.extend(table, context, link) ⇒ <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+##### dataPath.extend(table, context, link) ⇒ [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
 extend the Datapath with table
 
-**Kind**: instance method of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
+**Kind**: instance method of [<code>DataPath</code>](#ERMrest.Datapath.DataPath)  
 
 | Param | Type |
 | --- | --- |
-| table | <code>[Table](#ERMrest.Table)</code> | 
+| table | [<code>Table</code>](#ERMrest.Table) | 
 | context |  | 
 | link |  | 
 
 <a name="ERMrest.Datapath.PathTable"></a>
 
 #### Datapath.PathTable
-**Kind**: static class of <code>[Datapath](#ERMrest.Datapath)</code>  
+**Kind**: static class of [<code>Datapath</code>](#ERMrest.Datapath)  
 
 * [.PathTable](#ERMrest.Datapath.PathTable)
     * [new PathTable(table, datapath, alias)](#new_ERMrest.Datapath.PathTable_new)
-    * [.datapath](#ERMrest.Datapath.PathTable+datapath) : <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
-    * [.table](#ERMrest.Datapath.PathTable+table) : <code>[Table](#ERMrest.Table)</code>
+    * [.datapath](#ERMrest.Datapath.PathTable+datapath) : [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
+    * [.table](#ERMrest.Datapath.PathTable+table) : [<code>Table</code>](#ERMrest.Table)
     * [.alias](#ERMrest.Datapath.PathTable+alias) : <code>string</code>
-    * [.columns](#ERMrest.Datapath.PathTable+columns) : <code>[Columns](#ERMrest.Datapath.Columns)</code>
+    * [.columns](#ERMrest.Datapath.PathTable+columns) : [<code>Columns</code>](#ERMrest.Datapath.Columns)
     * [.toString()](#ERMrest.Datapath.PathTable+toString) ⇒ <code>string</code>
 
 <a name="new_ERMrest.Datapath.PathTable_new"></a>
@@ -2999,40 +3032,40 @@ extend the Datapath with table
 
 | Param | Type |
 | --- | --- |
-| table | <code>[Table](#ERMrest.Table)</code> | 
-| datapath | <code>[DataPath](#ERMrest.Datapath.DataPath)</code> | 
+| table | [<code>Table</code>](#ERMrest.Table) | 
+| datapath | [<code>DataPath</code>](#ERMrest.Datapath.DataPath) | 
 | alias | <code>string</code> | 
 
 <a name="ERMrest.Datapath.PathTable+datapath"></a>
 
-##### pathTable.datapath : <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
-**Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
+##### pathTable.datapath : [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
+**Kind**: instance property of [<code>PathTable</code>](#ERMrest.Datapath.PathTable)  
 <a name="ERMrest.Datapath.PathTable+table"></a>
 
-##### pathTable.table : <code>[Table](#ERMrest.Table)</code>
-**Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
+##### pathTable.table : [<code>Table</code>](#ERMrest.Table)
+**Kind**: instance property of [<code>PathTable</code>](#ERMrest.Datapath.PathTable)  
 <a name="ERMrest.Datapath.PathTable+alias"></a>
 
 ##### pathTable.alias : <code>string</code>
-**Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
+**Kind**: instance property of [<code>PathTable</code>](#ERMrest.Datapath.PathTable)  
 <a name="ERMrest.Datapath.PathTable+columns"></a>
 
-##### pathTable.columns : <code>[Columns](#ERMrest.Datapath.Columns)</code>
-**Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
+##### pathTable.columns : [<code>Columns</code>](#ERMrest.Datapath.Columns)
+**Kind**: instance property of [<code>PathTable</code>](#ERMrest.Datapath.PathTable)  
 <a name="ERMrest.Datapath.PathTable+toString"></a>
 
 ##### pathTable.toString() ⇒ <code>string</code>
-**Kind**: instance method of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
+**Kind**: instance method of [<code>PathTable</code>](#ERMrest.Datapath.PathTable)  
 **Returns**: <code>string</code> - uri of the PathTable  
 <a name="ERMrest.Datapath.PathColumn"></a>
 
 #### Datapath.PathColumn
-**Kind**: static class of <code>[Datapath](#ERMrest.Datapath)</code>  
+**Kind**: static class of [<code>Datapath</code>](#ERMrest.Datapath)  
 
 * [.PathColumn](#ERMrest.Datapath.PathColumn)
     * [new PathColumn(column, pathtable)](#new_ERMrest.Datapath.PathColumn_new)
-    * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
-    * [.column](#ERMrest.Datapath.PathColumn+column) : <code>[Column](#ERMrest.Column)</code>
+    * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+    * [.column](#ERMrest.Datapath.PathColumn+column) : [<code>Column</code>](#ERMrest.Column)
 
 <a name="new_ERMrest.Datapath.PathColumn_new"></a>
 
@@ -3040,50 +3073,50 @@ extend the Datapath with table
 
 | Param | Type |
 | --- | --- |
-| column | <code>[Column](#ERMrest.Column)</code> | 
-| pathtable | <code>[PathTable](#ERMrest.Datapath.PathTable)</code> | 
+| column | [<code>Column</code>](#ERMrest.Column) | 
+| pathtable | [<code>PathTable</code>](#ERMrest.Datapath.PathTable) | 
 
 <a name="ERMrest.Datapath.PathColumn+pathtable"></a>
 
-##### pathColumn.pathtable : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
-**Kind**: instance property of <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>  
+##### pathColumn.pathtable : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+**Kind**: instance property of [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)  
 <a name="ERMrest.Datapath.PathColumn+column"></a>
 
-##### pathColumn.column : <code>[Column](#ERMrest.Column)</code>
-**Kind**: instance property of <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>  
+##### pathColumn.column : [<code>Column</code>](#ERMrest.Column)
+**Kind**: instance property of [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)  
 <a name="ERMrest.Datapath.Columns"></a>
 
 #### Datapath.Columns(table, pathtable)
-**Kind**: static method of <code>[Datapath](#ERMrest.Datapath)</code>  
+**Kind**: static method of [<code>Datapath</code>](#ERMrest.Datapath)  
 
 | Param | Type |
 | --- | --- |
-| table | <code>[Table](#ERMrest.Table)</code> | 
-| pathtable | <code>[PathTable](#ERMrest.Datapath.PathTable)</code> | 
+| table | [<code>Table</code>](#ERMrest.Table) | 
+| pathtable | [<code>PathTable</code>](#ERMrest.Datapath.PathTable) | 
 
 
 * [.Columns(table, pathtable)](#ERMrest.Datapath.Columns)
     * [.length()](#ERMrest.Datapath.Columns+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Datapath.Columns+names) ⇒ <code>Array.&lt;String&gt;</code>
-    * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>
+    * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)
 
 <a name="ERMrest.Datapath.Columns+length"></a>
 
 ##### columns.length() ⇒ <code>Number</code>
-**Kind**: instance method of <code>[Columns](#ERMrest.Datapath.Columns)</code>  
+**Kind**: instance method of [<code>Columns</code>](#ERMrest.Datapath.Columns)  
 **Returns**: <code>Number</code> - number of path columns  
 <a name="ERMrest.Datapath.Columns+names"></a>
 
 ##### columns.names() ⇒ <code>Array.&lt;String&gt;</code>
-**Kind**: instance method of <code>[Columns](#ERMrest.Datapath.Columns)</code>  
+**Kind**: instance method of [<code>Columns</code>](#ERMrest.Datapath.Columns)  
 **Returns**: <code>Array.&lt;String&gt;</code> - a list of pathcolumn names  
 <a name="ERMrest.Datapath.Columns+get"></a>
 
-##### columns.get(colName) ⇒ <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>
+##### columns.get(colName) ⇒ [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)
 get PathColumn object by column name
 
-**Kind**: instance method of <code>[Columns](#ERMrest.Datapath.Columns)</code>  
-**Returns**: <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code> - returns the PathColumn  
+**Kind**: instance method of [<code>Columns</code>](#ERMrest.Datapath.Columns)  
+**Returns**: [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn) - returns the PathColumn  
 **Throws**:
 
 - <code>ERMrest.Errors.NotFoundError</code> column not found
@@ -3096,11 +3129,11 @@ get PathColumn object by column name
 <a name="ERMrest.Datapath.Operators"></a>
 
 #### Datapath.Operators()
-**Kind**: static method of <code>[Datapath](#ERMrest.Datapath)</code>  
+**Kind**: static method of [<code>Datapath</code>](#ERMrest.Datapath)  
 <a name="ERMrest.Filters"></a>
 
 ### ERMrest.Filters : <code>object</code>
-**Kind**: static namespace of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static namespace of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Filters](#ERMrest.Filters) : <code>object</code>
     * [.Negation](#ERMrest.Filters.Negation)
@@ -3122,7 +3155,7 @@ get PathColumn object by column name
 <a name="ERMrest.Filters.Negation"></a>
 
 #### Filters.Negation
-**Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
+**Kind**: static class of [<code>Filters</code>](#ERMrest.Filters)  
 
 * [.Negation](#ERMrest.Filters.Negation)
     * [new Negation(filter)](#new_ERMrest.Filters.Negation_new)
@@ -3139,12 +3172,12 @@ get PathColumn object by column name
 <a name="ERMrest.Filters.Negation+toUri"></a>
 
 ##### negation.toUri() ⇒ <code>string</code>
-**Kind**: instance method of <code>[Negation](#ERMrest.Filters.Negation)</code>  
+**Kind**: instance method of [<code>Negation</code>](#ERMrest.Filters.Negation)  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.Conjunction"></a>
 
 #### Filters.Conjunction
-**Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
+**Kind**: static class of [<code>Filters</code>](#ERMrest.Filters)  
 
 * [.Conjunction](#ERMrest.Filters.Conjunction)
     * [new Conjunction(filters)](#new_ERMrest.Filters.Conjunction_new)
@@ -3161,12 +3194,12 @@ get PathColumn object by column name
 <a name="ERMrest.Filters.Conjunction+toUri"></a>
 
 ##### conjunction.toUri() ⇒ <code>string</code>
-**Kind**: instance method of <code>[Conjunction](#ERMrest.Filters.Conjunction)</code>  
+**Kind**: instance method of [<code>Conjunction</code>](#ERMrest.Filters.Conjunction)  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.Disjunction"></a>
 
 #### Filters.Disjunction
-**Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
+**Kind**: static class of [<code>Filters</code>](#ERMrest.Filters)  
 
 * [.Disjunction](#ERMrest.Filters.Disjunction)
     * [new Disjunction(filters)](#new_ERMrest.Filters.Disjunction_new)
@@ -3183,12 +3216,12 @@ get PathColumn object by column name
 <a name="ERMrest.Filters.Disjunction+toUri"></a>
 
 ##### disjunction.toUri() ⇒ <code>string</code>
-**Kind**: instance method of <code>[Disjunction](#ERMrest.Filters.Disjunction)</code>  
+**Kind**: instance method of [<code>Disjunction</code>](#ERMrest.Filters.Disjunction)  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.UnaryPredicate"></a>
 
 #### Filters.UnaryPredicate
-**Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
+**Kind**: static class of [<code>Filters</code>](#ERMrest.Filters)  
 
 * [.UnaryPredicate](#ERMrest.Filters.UnaryPredicate)
     * [new UnaryPredicate(column, operator)](#new_ERMrest.Filters.UnaryPredicate_new)
@@ -3204,18 +3237,18 @@ get PathColumn object by column name
 
 | Param | Type |
 | --- | --- |
-| column | <code>[Column](#ERMrest.Column)</code> | 
+| column | [<code>Column</code>](#ERMrest.Column) | 
 | operator | <code>ERMrest.Filters.OPERATOR</code> | 
 
 <a name="ERMrest.Filters.UnaryPredicate+toUri"></a>
 
 ##### unaryPredicate.toUri() ⇒ <code>string</code>
-**Kind**: instance method of <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code>  
+**Kind**: instance method of [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate)  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.BinaryPredicate"></a>
 
 #### Filters.BinaryPredicate
-**Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
+**Kind**: static class of [<code>Filters</code>](#ERMrest.Filters)  
 
 * [.BinaryPredicate](#ERMrest.Filters.BinaryPredicate)
     * [new BinaryPredicate(column, operator, rvalue)](#new_ERMrest.Filters.BinaryPredicate_new)
@@ -3231,21 +3264,21 @@ get PathColumn object by column name
 
 | Param | Type |
 | --- | --- |
-| column | <code>[Column](#ERMrest.Column)</code> | 
+| column | [<code>Column</code>](#ERMrest.Column) | 
 | operator | <code>ERMrest.Filters.OPERATOR</code> | 
-| rvalue | <code>String</code> &#124; <code>Number</code> | 
+| rvalue | <code>String</code> \| <code>Number</code> | 
 
 <a name="ERMrest.Filters.BinaryPredicate+toUri"></a>
 
 ##### binaryPredicate.toUri() ⇒ <code>string</code>
-**Kind**: instance method of <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code>  
+**Kind**: instance method of [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate)  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.configure"></a>
 
 ### ERMrest.configure(http, q)
 This function is used to configure the module
 
-**Kind**: static method of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static method of [<code>ERMrest</code>](#ERMrest)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3254,16 +3287,16 @@ This function is used to configure the module
 
 <a name="ERMrest.getServer"></a>
 
-### ERMrest.getServer(uri, [params]) ⇒ <code>[Server](#ERMrest.Server)</code>
+### ERMrest.getServer(uri, [params]) ⇒ [<code>Server</code>](#ERMrest.Server)
 ERMrest server factory creates or reuses ERMrest.Server instances. The
 URI should be to the ERMrest _service_. For example,
 `https://www.example.org/ermrest`.
 
-**Kind**: static method of <code>[ERMrest](#ERMrest)</code>  
-**Returns**: <code>[Server](#ERMrest.Server)</code> - Returns a server instance.  
+**Kind**: static method of [<code>ERMrest</code>](#ERMrest)  
+**Returns**: [<code>Server</code>](#ERMrest.Server) - Returns a server instance.  
 **Throws**:
 
-- <code>[InvalidInputError](#ERMrest.InvalidInputError)</code> URI is missing
+- [<code>InvalidInputError</code>](#ERMrest.InvalidInputError) URI is missing
 
 
 | Param | Type | Default | Description |
@@ -3297,7 +3330,7 @@ ERMrest.resolve('https://example.org/catalog/42/entity/s:t/k=123').then(
   });
 ```
 
-**Kind**: static method of <code>[ERMrest](#ERMrest)</code>  
+**Kind**: static method of [<code>ERMrest</code>](#ERMrest)  
 **Returns**: <code>Promise</code> - Promise when resolved passes the
 [Reference](#ERMrest.Reference) object. If rejected, passes one of:
 [MalformedURIError](#ERMrest.MalformedURIError)
@@ -3322,7 +3355,7 @@ set callback function which will be called when a HTTP 401 Error occurs
 
 | Param | Type | Description |
 | --- | --- | --- |
-| fn | <code>[httpUnauthorizedFn](#httpUnauthorizedFn)</code> | callback function |
+| fn | [<code>httpUnauthorizedFn</code>](#httpUnauthorizedFn) | callback function |
 
 <a name="appLinkFn"></a>
 
@@ -3333,5 +3366,5 @@ set callback function that converts app tag to app URL
 
 | Param | Type | Description |
 | --- | --- | --- |
-| fn | <code>[appLinkFn](#appLinkFn)</code> | callback function |
+| fn | [<code>appLinkFn</code>](#appLinkFn) | callback function |
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -2063,20 +2063,26 @@ The logic is as follows:
          1.1.3 avoid duplicate foreign keys.
          1.1.4 make sure it is not hidden(+).
      1.2 otherwise find the corresponding column if exits and add it (avoid duplicate),
+         if the column has asset annotation, create an asset pseudo-column
 
 2.otherwise go through list of table columns
      2.0 create a pseudo-column for key if context is not detailed, entry, entry/create, or entry/edit and we have key that is notnull and notHTML
      2.1 check if column has not been processed before.
      2.2 hide the columns that are part of origFKR.
      2.3 if column is serial and part of a simple key hide it.
-     2.4 if it's not part of any foreign keys add the column.
+     2.4 if it's not part of any foreign keys
+         2.4.1 if it has asset annotation create an asset pseudo-column for it.
+         2.4.2 otherwise add the column.
      2.5 go through all of the foreign keys that this column is part of.
          2.5.1 make sure it is not hidden(+).
          2.5.2 if it's simple fk, just create PseudoColumn
          2.5.3 otherwise add the column just once and append just one PseudoColumn (avoid duplicate)
 
 NOTE:
- + If this reference is actually an inbound related reference, we should hide the foreign key (and all of its columns) that created the link.
+ + If asset annotation was used and context is entry,
+   we should remove the columns that are used as filename, byte, sha256, or md5.
+ + If this reference is actually an inbound related reference,
+   we should hide the foreign key (and all of its columns) that created the link.
 
 **Kind**: instance property of [<code>columns</code>](#ERMrest.Reference+columns)  
 <a name="ERMrest.Reference+isUnique"></a>
@@ -2926,6 +2932,17 @@ The Foreign key object that this PseudoColumn is created based on
 
 ### ERMrest.AssetPseudoColumn
 **Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| useDefault | <code>boolean</code> | whether we should use default heuristics or NotFoundError |
+| filenameColumn | <code>string</code> \| <code>null</code> | if it's string, then it is the name of column we want to store filename inside of it. |
+| byteCountColumn | <code>string</code> \| <code>null</code> | if it's string, then it is the name of column we want to store byte count inside of it. |
+| md5 | <code>string</code> \| <code>boolean</code> \| <code>null</code> | if it's string, then it is the name of column we want to store md5 inside of it. If it's true, that means we must use md5. |
+| sha256 | <code>string</code> \| <code>boolean</code> \| <code>null</code> | if it's string, then it is the name of column we want to store sha256 inside of it. If it's true, that means we must use sha256. |
+| filenameExtFilter | <code>Array.&lt;string&gt;</code> \| <code>null</code> | set of filename extension filters for use by upload agents to indicate to the user the acceptable filename patterns. |
+
 
 * [.AssetPseudoColumn](#ERMrest.AssetPseudoColumn)
     * [new AssetPseudoColumn(reference, column)](#new_ERMrest.AssetPseudoColumn_new)

--- a/doc/api.md
+++ b/doc/api.md
@@ -298,8 +298,15 @@ to use for ERMrest JavaScript agents.
         * [.reference](#ERMrest.ForeignKeyPseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
         * [.foreignKey](#ERMrest.ForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
         * [.filteredRef(column, data)](#ERMrest.ForeignKeyPseudoColumn+filteredRef) ⇒ [<code>Reference</code>](#ERMrest.Reference)
-        * [.formatPresentation(data, options)](#ERMrest.ForeignKeyPseudoColumn+formatPresentation) ⇒ <code>Object</code>
-        * [._determineSortable()](#ERMrest.ForeignKeyPseudoColumn+_determineSortable)
+    * [.KeyPseudoColumn](#ERMrest.KeyPseudoColumn)
+        * [new KeyPseudoColumn(reference, key)](#new_ERMrest.KeyPseudoColumn_new)
+        * [.isPseudo](#ERMrest.KeyPseudoColumn+isPseudo) : <code>boolean</code>
+        * [.isKey](#ERMrest.KeyPseudoColumn+isKey) : <code>boolean</code>
+        * [.key](#ERMrest.KeyPseudoColumn+key) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
+    * [.AssetPseudoColumn](#ERMrest.AssetPseudoColumn)
+        * [new AssetPseudoColumn(reference, column)](#new_ERMrest.AssetPseudoColumn_new)
+        * [.isPseudo](#ERMrest.AssetPseudoColumn+isPseudo) : <code>boolean</code>
+        * [.isAsset](#ERMrest.AssetPseudoColumn+isAsset) : <code>boolean</code>
     * [.Datapath](#ERMrest.Datapath) : <code>object</code>
         * [.DataPath](#ERMrest.Datapath.DataPath)
             * [new DataPath(table)](#new_ERMrest.Datapath.DataPath_new)
@@ -2821,8 +2828,6 @@ TODO should be removed in favor of inputDisabled
     * [.reference](#ERMrest.ForeignKeyPseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
     * [.foreignKey](#ERMrest.ForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
     * [.filteredRef(column, data)](#ERMrest.ForeignKeyPseudoColumn+filteredRef) ⇒ [<code>Reference</code>](#ERMrest.Reference)
-    * [.formatPresentation(data, options)](#ERMrest.ForeignKeyPseudoColumn+formatPresentation) ⇒ <code>Object</code>
-    * [._determineSortable()](#ERMrest.ForeignKeyPseudoColumn+_determineSortable)
 
 <a name="new_ERMrest.ForeignKeyPseudoColumn_new"></a>
 
@@ -2876,23 +2881,82 @@ annotation doesn't exist, it returns this (reference)
 | column | [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn) | column that `this` is based on |
 | data | <code>Object</code> | tuple data with potential constraints |
 
-<a name="ERMrest.ForeignKeyPseudoColumn+formatPresentation"></a>
+<a name="ERMrest.KeyPseudoColumn"></a>
 
-#### foreignKeyPseudoColumn.formatPresentation(data, options) ⇒ <code>Object</code>
-Formats the presentation value corresponding to this reference-column definition.
+### ERMrest.KeyPseudoColumn
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
-**Kind**: instance method of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
-**Returns**: <code>Object</code> - A key value pair containing value and isHTML that detemrines the presenation.  
+* [.KeyPseudoColumn](#ERMrest.KeyPseudoColumn)
+    * [new KeyPseudoColumn(reference, key)](#new_ERMrest.KeyPseudoColumn_new)
+    * [.isPseudo](#ERMrest.KeyPseudoColumn+isPseudo) : <code>boolean</code>
+    * [.isKey](#ERMrest.KeyPseudoColumn+isKey) : <code>boolean</code>
+    * [.key](#ERMrest.KeyPseudoColumn+key) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
+
+<a name="new_ERMrest.KeyPseudoColumn_new"></a>
+
+#### new KeyPseudoColumn(reference, key)
+Constructor for KeyPseudoColumn. This class is a wrapper for [Key](#ERMrest.Key).
+This class extends the [ReferenceColumn](#ERMrest.ReferenceColumn)
+
 
 | Param | Type | Description |
 | --- | --- | --- |
-| data | <code>String</code> | In case of pseudocolumn it's the raw data, otherwise'formatted' data value. |
-| options | <code>Object</code> | includes `context` and `formattedValues` |
+| reference | [<code>Reference</code>](#ERMrest.Reference) | column's reference |
+| key | [<code>Key</code>](#ERMrest.Key) | the key |
 
-<a name="ERMrest.ForeignKeyPseudoColumn+_determineSortable"></a>
+<a name="ERMrest.KeyPseudoColumn+isPseudo"></a>
 
-#### foreignKeyPseudoColumn._determineSortable()
-**Kind**: instance method of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+#### keyPseudoColumn.isPseudo : <code>boolean</code>
+indicates this represents is a PseudoColumn or a Column.
+
+**Kind**: instance property of [<code>KeyPseudoColumn</code>](#ERMrest.KeyPseudoColumn)  
+<a name="ERMrest.KeyPseudoColumn+isKey"></a>
+
+#### keyPseudoColumn.isKey : <code>boolean</code>
+Indicates that this ReferenceColumn is a key.
+
+**Kind**: instance property of [<code>KeyPseudoColumn</code>](#ERMrest.KeyPseudoColumn)  
+<a name="ERMrest.KeyPseudoColumn+key"></a>
+
+#### keyPseudoColumn.key : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
+The Foreign key object that this PseudoColumn is created based on
+
+**Kind**: instance property of [<code>KeyPseudoColumn</code>](#ERMrest.KeyPseudoColumn)  
+<a name="ERMrest.AssetPseudoColumn"></a>
+
+### ERMrest.AssetPseudoColumn
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+
+* [.AssetPseudoColumn](#ERMrest.AssetPseudoColumn)
+    * [new AssetPseudoColumn(reference, column)](#new_ERMrest.AssetPseudoColumn_new)
+    * [.isPseudo](#ERMrest.AssetPseudoColumn+isPseudo) : <code>boolean</code>
+    * [.isAsset](#ERMrest.AssetPseudoColumn+isAsset) : <code>boolean</code>
+
+<a name="new_ERMrest.AssetPseudoColumn_new"></a>
+
+#### new AssetPseudoColumn(reference, column)
+Constructor for AssetPseudoColumn.
+This class is a wrapper for [Column](#ERMrest.Column) objects that have asset annotation.
+This class extends the [ReferenceColumn](#ERMrest.ReferenceColumn)
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| reference | [<code>Reference</code>](#ERMrest.Reference) | column's reference |
+| column | [<code>Column</code>](#ERMrest.Column) | the asset column |
+
+<a name="ERMrest.AssetPseudoColumn+isPseudo"></a>
+
+#### assetPseudoColumn.isPseudo : <code>boolean</code>
+indicates this represents is a PseudoColumn or a Column.
+
+**Kind**: instance property of [<code>AssetPseudoColumn</code>](#ERMrest.AssetPseudoColumn)  
+<a name="ERMrest.AssetPseudoColumn+isAsset"></a>
+
+#### assetPseudoColumn.isAsset : <code>boolean</code>
+Indicates that this ReferenceColumn is an asset.
+
+**Kind**: instance property of [<code>AssetPseudoColumn</code>](#ERMrest.AssetPseudoColumn)  
 <a name="ERMrest.Datapath"></a>
 
 ### ERMrest.Datapath : <code>object</code>

--- a/doc/api.md
+++ b/doc/api.md
@@ -2937,10 +2937,10 @@ The Foreign key object that this PseudoColumn is created based on
 | Name | Type | Description |
 | --- | --- | --- |
 | useDefault | <code>boolean</code> | whether we should use default heuristics or NotFoundError |
-| filenameColumn | <code>string</code> \| <code>null</code> | if it's string, then it is the name of column we want to store filename inside of it. |
-| byteCountColumn | <code>string</code> \| <code>null</code> | if it's string, then it is the name of column we want to store byte count inside of it. |
-| md5 | <code>string</code> \| <code>boolean</code> \| <code>null</code> | if it's string, then it is the name of column we want to store md5 inside of it. If it's true, that means we must use md5. |
-| sha256 | <code>string</code> \| <code>boolean</code> \| <code>null</code> | if it's string, then it is the name of column we want to store sha256 inside of it. If it's true, that means we must use sha256. |
+| filenameColumn | [<code>Column</code>](#ERMrest.Column) \| <code>null</code> | if it's string, then it is the name of column we want to store filename inside of it. |
+| byteCountColumn | [<code>Column</code>](#ERMrest.Column) \| <code>null</code> | if it's string, then it is the name of column we want to store byte count inside of it. |
+| md5 | [<code>Column</code>](#ERMrest.Column) \| <code>boolean</code> \| <code>null</code> | if it's string, then it is the name of column we want to store md5 inside of it. If it's true, that means we must use md5. |
+| sha256 | [<code>Column</code>](#ERMrest.Column) \| <code>boolean</code> \| <code>null</code> | if it's string, then it is the name of column we want to store sha256 inside of it. If it's true, that means we must use sha256. |
 | filenameExtFilter | <code>Array.&lt;string&gt;</code> \| <code>null</code> | set of filename extension filters for use by upload agents to indicate to the user the acceptable filename patterns. |
 
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -2063,7 +2063,7 @@ The logic is as follows:
          1.1.3 avoid duplicate foreign keys.
          1.1.4 make sure it is not hidden(+).
      1.2 otherwise find the corresponding column if exits and add it (avoid duplicate),
-         if the column has asset annotation, create an asset pseudo-column
+         apply *addColumn* heuristics explained below.
 
 2.otherwise go through list of table columns
      2.0 create a pseudo-column for key if context is not detailed, entry, entry/create, or entry/edit and we have key that is notnull and notHTML
@@ -2071,18 +2071,25 @@ The logic is as follows:
      2.2 hide the columns that are part of origFKR.
      2.3 if column is serial and part of a simple key hide it.
      2.4 if it's not part of any foreign keys
-         2.4.1 if it has asset annotation create an asset pseudo-column for it.
-         2.4.2 otherwise add the column.
+         apply *addColumn* heuristics explained below.
      2.5 go through all of the foreign keys that this column is part of.
          2.5.1 make sure it is not hidden(+).
          2.5.2 if it's simple fk, just create PseudoColumn
          2.5.3 otherwise add the column just once and append just one PseudoColumn (avoid duplicate)
 
+*addColumn* heuristics:
+ + If column doesn't have asset annotation, add a normal ReferenceColumn.
+ + Otherwise:
+     + If it has `url_pattern`: add AssetPseudoColumn.
+     + Otherwise:
+         - in entry context: remove it from the visible columns list.
+         - in other contexts: ignore the asset annotation, treat it as normal column.
+
 NOTE:
  + If asset annotation was used and context is entry,
-   we should remove the columns that are used as filename, byte, sha256, or md5.
+     we should remove the columns that are used as filename, byte, sha256, or md5.
  + If this reference is actually an inbound related reference,
-   we should hide the foreign key (and all of its columns) that created the link.
+     we should hide the foreign key (and all of its columns) that created the link.
 
 **Kind**: instance property of [<code>columns</code>](#ERMrest.Reference+columns)  
 <a name="ERMrest.Reference+isUnique"></a>
@@ -2936,7 +2943,7 @@ The Foreign key object that this PseudoColumn is created based on
 
 | Name | Type | Description |
 | --- | --- | --- |
-| useDefault | <code>boolean</code> | whether we should use default heuristics or NotFoundError |
+| urlPattern | <code>string</code> | A desired upload location can be derived by Pattern Expansion on pattern. |
 | filenameColumn | [<code>Column</code>](#ERMrest.Column) \| <code>null</code> | if it's string, then it is the name of column we want to store filename inside of it. |
 | byteCountColumn | [<code>Column</code>](#ERMrest.Column) \| <code>null</code> | if it's string, then it is the name of column we want to store byte count inside of it. |
 | md5 | [<code>Column</code>](#ERMrest.Column) \| <code>boolean</code> \| <code>null</code> | if it's string, then it is the name of column we want to store md5 inside of it. If it's true, that means we must use md5. |

--- a/js/core.js
+++ b/js/core.js
@@ -1893,7 +1893,7 @@ var ERMrest = (function (module) {
 
         /**
          * returns string representation of Column
-         * @retuns {string} string representation of Column
+         * @return {string} string representation of Column
          */
         toString: function() {
             return [module._fixedEncodeURIComponent(this.table.schema.name),
@@ -2370,7 +2370,7 @@ var ERMrest = (function (module) {
 
         /**
          * returns string representation of colset object: (s:t:c1,s:t:c2)
-         * @retuns {string} string representation of colset object
+         * @return {string} string representation of colset object
          */
         toString: function(){
             return "(" + this.columns.slice().sort(function(a,b){
@@ -2445,7 +2445,7 @@ var ERMrest = (function (module) {
 
         /**
          * returns string representation of Mapping object
-         * @retuns {string} string representation of Mapping object
+         * @return {string} string representation of Mapping object
          */
         toString: function() {
             // changing from and to to Colset, makes this easier.
@@ -2777,7 +2777,7 @@ var ERMrest = (function (module) {
         /**
          * returns string representation of ForeignKeyRef object
          * @param {boolean} [reverse] false: returns (keyCol1, keyCol2)=(s:t:FKCol1,FKCol2) true: returns (FKCol1, FKCol2)=(s:t:keyCol1,keyCol2)
-         * @retuns {string} string representation of ForeignKeyRef object
+         * @return {string} string representation of ForeignKeyRef object
          */
         toString: function (reverse){
             var leftString = "", rightString = "";

--- a/js/reference.js
+++ b/js/reference.js
@@ -2915,9 +2915,7 @@ var ERMrest = (function(module) {
          */
         get default() {
             if (this._default === undefined) {
-                this._default = this._baseCols.reduce(function (res, col, index) {
-                    return res + (index>0 ? ":" : "") + col.default;
-                }, "");
+                this._default = this._simple ? this._baseCols[0].default : null;
             }
             return this._default;
         },

--- a/js/reference.js
+++ b/js/reference.js
@@ -351,7 +351,7 @@ var ERMrest = (function(module) {
                                         // fk is in this table, avoid duplicate and it's not hidden.
                                         if (!(fkName in addedFKs) && fk._table == this._table && !hideFKR(fk)) {
                                             addedFKs[fkName] = true;
-                                            this._referenceColumns.push(new ReferenceColumn(this, (fk.simple ? fk.colset.columns[0] : null), {"foreignKey":fk}));
+                                            this._referenceColumns.push(new ForeignKeyPseudoColumn(this, fk));
                                         }
                                         break;
                                     case module._constraintTypes.KEY:
@@ -366,11 +366,11 @@ var ERMrest = (function(module) {
                                                     col = cols[j];
                                                     if (!(col.name in consideredColumns) && !hideColumn(col)) {
                                                         consideredColumns[col.name] = true;
-                                                        this._referenceColumns.push(new ReferenceColumn(this, cols[j]));
+                                                        this._referenceColumns.push(new ReferenceColumn(this, [cols[j]]));
                                                     }
                                                 }
                                             } else {
-                                                this._referenceColumns.push(new ReferenceColumn(this, (fk.simple ? fk.colset.columns[0] : null), {"key":fk}));
+                                                this._referenceColumns.push(new KeyPseudoColumn(this, fk));
                                             }
                                         }
                                         break;
@@ -390,7 +390,7 @@ var ERMrest = (function(module) {
                                     continue;
                             }
                             consideredColumns[col.name] = true;
-                            this._referenceColumns.push(new ReferenceColumn(this, col));
+                            this._referenceColumns.push(new ReferenceColumn(this, [col]));
                         }
                     }
                 }
@@ -401,7 +401,7 @@ var ERMrest = (function(module) {
                     if (!module._isEntryContext(this._context) && this._context != module._contexts.DETAILED ) {
                         var key = this._table._getDisplayKey(this._context);
                         if (key !== undefined) {
-                            this._referenceColumns.push(new ReferenceColumn(this, (key.simple ? key.colset.columns[0] : null), {"key": key}));
+                            this._referenceColumns.push(new KeyPseudoColumn(this, key));
 
                             // make sure key columns won't be added
                             columns = key.colset.columns;
@@ -429,7 +429,7 @@ var ERMrest = (function(module) {
 
                         // add the column if it's not part of any foreign keys
                         if (col.memberOfForeignKeys.length === 0) {
-                            this._referenceColumns.push(new ReferenceColumn(this, col));
+                            this._referenceColumns.push(new ReferenceColumn(this, [col]));
                         } else {
                             // sort foreign keys of a column
                             if (col.memberOfForeignKeys.length > 1) {
@@ -450,18 +450,18 @@ var ERMrest = (function(module) {
                                 if (fk.simple) { // simple FKR
                                     if (!(fkName in addedFKs)) { // if not duplicate add the foreign key
                                         addedFKs[fkName] = true;
-                                        this._referenceColumns.push(new ReferenceColumn(this, col, {"foreignKey":fk}));
+                                        this._referenceColumns.push(new ForeignKeyPseudoColumn(this, fk));
                                     }
                                 } else { // composite FKR
                                     // add the column if context is not entry and avoid duplicate
                                     if (!colAdded && !module._isEntryContext(this._context)) {
                                         colAdded = true;
-                                        this._referenceColumns.push(new ReferenceColumn(this, col));
+                                        this._referenceColumns.push(new ReferenceColumn(this, [col]));
                                     }
                                     // hold composite FKR
                                     if (!(fkName in addedFKs)) {
                                         addedFKs[fkName] = true;
-                                        compositeFKs.push(new ReferenceColumn(this, null, {"foreignKey":fk}));
+                                        compositeFKs.push(new ForeignKeyPseudoColumn(this, fk));
                                     }
                                 }
                             }
@@ -859,7 +859,7 @@ var ERMrest = (function(module) {
 
                         // use the sort columns instead of the actual column.
                         for (j = 0; j < sortCols.length; j++) {
-                            if (col.isPseudo && col._isForeignKey) {
+                            if (col.isPseudo && col.isForeignKey) {
                                 fkIndex = foreignKeys.all().indexOf(col.foreignKey);
                                 colName = "F" + (foreignKeys.length() + k++);
                                 sortMap[colName] = ["F" + (fkIndex+1) , module._fixedEncodeURIComponent(sortCols[j].name)].join(":");
@@ -1170,9 +1170,9 @@ var ERMrest = (function(module) {
                         if (column.isPseudo) {
                             var keyColumns = [];
 
-                            if (column._isKey) {
+                            if (column.isKey) {
                                 keyColumns = column.key.colset.columns;
-                            } else if (column._isForeignKey) {
+                            } else if (column.isForeignKey) {
                                 keyColumns =  column.foreignKey.colset.columns;
                             }
 
@@ -1866,7 +1866,7 @@ var ERMrest = (function(module) {
 
                 var newLocationString;
 
-                if (source._location.hasJoin && newTable._isAlternativeTable()) {
+                if (source._location.hasJoin) {
                     // returns true if join is on alternative shared key
                     var joinOnAlternativeKey = function () {
                         var joinCols = source._location.lastJoin.rightCols,
@@ -1911,22 +1911,26 @@ var ERMrest = (function(module) {
                         return "(" + currJoin.leftColsStr + ")=(" + newRightCols.join(",") + ")";
                     };
 
-                    // 2.1. if _altSharedKey is the same as the join
-                    if (joinOnAlternativeKey(source)) {
-                        // change to-columns of the join
-                        newLocationString =  source._location.compactUri;
+                    // going from =
+                    if (newTable._isAlternativeTable()) {
+                        // 2.1. if _altSharedKey is the same as the join
+                        if (joinOnAlternativeKey(source)) {
+                            // change to-columns of the join
+                            newLocationString =  source._location.compactUri;
 
-                        // remove the search
-                        if (source._location.searchFilter) {
-                            newLocationString = newLocationString.substring(0, newLocationString.lastIndexOf("/"));
+                            // remove the search
+                            if (source._location.searchFilter) {
+                                newLocationString = newLocationString.substring(0, newLocationString.lastIndexOf("/"));
+                            }
+
+                            // remove the last join
+                            newLocationString = newLocationString.substring(0, newLocationString.lastIndexOf("/") + 1);
+
+                            // add the new join
+                            newLocationString += generateJoin();
                         }
-
-                        // remove the last join
-                        newLocationString = newLocationString.substring(0, newLocationString.lastIndexOf("/") + 1);
-
-                        // add the new join
-                        newLocationString += generateJoin();
                     }
+
                 } else {
                     if (source._location.filter === undefined) {
                         // 3.1 no filter
@@ -2227,7 +2231,7 @@ var ERMrest = (function(module) {
                         }
 
                         for(j = 0; j < pseudoCol._sortColumns.length; j++) {
-                            if (pseudoCol._isForeignKey) {
+                            if (pseudoCol.isForeignKey) {
                                 data = this._linkedData[0][colName][pseudoCol._sortColumns[j].name];
                             } else {
                                 data = this._data[0][pseudoCol._sortColumns[j].name];
@@ -2294,7 +2298,7 @@ var ERMrest = (function(module) {
                             }
                         }
                         for(j = 0; j < pseudoCol._sortColumns.length; j++) {
-                            if (pseudoCol._isForeignKey) {
+                            if (pseudoCol.isForeignKey) {
                                 data = this._linkedData[this._linkedData.length-1][colName][pseudoCol._sortColumns[j].name];
                             } else {
                                 data = this._data[this._data.length-1][pseudoCol._sortColumns[j].name];
@@ -2605,7 +2609,7 @@ var ERMrest = (function(module) {
                     for (i = 0; i < this._pageRef.columns.length; i++) {
                         column = this._pageRef.columns[i];
                         if (column.isPseudo) {
-                            if (column._isKey) {
+                            if (column.isKey) {
                                 presentation = column.formatPresentation(this._data, { formattedValues: keyValues, context: this._pageRef._context});
                             } else {
                                 presentation = column.formatPresentation(this._linkedData[column._constraintName], {context: this._pageRef._context});
@@ -2627,7 +2631,7 @@ var ERMrest = (function(module) {
                     for (i = 0; i < this._pageRef.columns.length; i++) {
                         column = this._pageRef.columns[i];
                         if (column.isPseudo) {
-                            if (column._isKey) {
+                            if (column.isKey) {
                                 values[i] = column.formatPresentation(this._data, { formattedValues: keyValues, context: this._pageRef._context});
                             } else {
                                 values[i] = column.formatPresentation(this._linkedData[column._constraintName], {context: this._pageRef._context});
@@ -2763,18 +2767,14 @@ var ERMrest = (function(module) {
      * @memberof ERMrest
      * @constructor
      * @param {ERMrest.Reference} reference column's reference
-     * @param {?ERMrest.Column} base The column that this reference-column will be created based on.
-     * @param {?Object} kwargs if it's not empty then the column is being created based on foreignkey or key.
+     * @param {?ERMrest.Column[]} baseCols List of columns that this reference-column will be created based on.
      * @desc
      * Constructor for ReferenceColumn. This class is a wrapper for {@link ERMrest.Column}.
      */
-    function ReferenceColumn(reference, base, kwargs) {
-
+    function ReferenceColumn(reference, cols) {
         this._baseReference = reference;
-
         this._context = reference._context;
-
-        this._base = base;
+        this._baseCols = cols;
 
         /**
          * @type {boolean}
@@ -2782,78 +2782,14 @@ var ERMrest = (function(module) {
          */
         this.isPseudo = false;
 
-        if (typeof kwargs != 'undefined') {
-            if (kwargs.foreignKey !== undefined) {
-
-                this.isPseudo = true;
-
-                // create ermrest url using the location
-                var table = kwargs.foreignKey.key.table;
-                var ermrestURI = [
-                    table.schema.catalog.server.uri ,"catalog" ,
-                    module._fixedEncodeURIComponent(table.schema.catalog.id), "entity",
-                    [module._fixedEncodeURIComponent(table.schema.name),module._fixedEncodeURIComponent(table.name)].join(":")
-                ].join("/");
-
-                /**
-                 * @type {ERMrest.Reference}
-                 * @desc The reference object that represents the table of this PseudoColumn
-                 */
-                this.reference =  new Reference(module._parse(ermrestURI), table.schema.catalog);
-                this.reference.session = reference._session;
-
-                /**
-                 * @type {ERMrest.ForeignKeyRef}
-                 * @desc The Foreign key object that this PseudoColumn is created based on
-                 */
-                this.foreignKey = kwargs.foreignKey;
-
-                this._constraintName = this.foreignKey.constraint_names[0].join("_");
-
-                /**
-                 * @private
-                 * @type {boolean}
-                 * @desc Indicates that this ReferenceColumn is a Foreign key.
-                 */
-                this._isForeignKey = true;
-            } else if (kwargs.key !== undefined) {
-
-                this.isPseudo = true;
-
-                /**
-                 * @type {ERMrest.ForeignKeyRef}
-                 * @desc The Foreign key object that this PseudoColumn is created based on
-                 */
-                this.key = kwargs.key;
-
-                this._constraintName = kwargs.key.constraint_names[0].join("_");
-
-                /**
-                 * @private
-                 * @type {boolean}
-                 * @desc Indicates that this ReferenceColumn is a key.
-                 */
-                this._isKey = true;
-            }
-        }
-    }
-    ReferenceColumn.prototype = {
-
         /**
          * @type {ERMrest.Table}
          */
-        get table () {
-            if (this._table === undefined) {
-                if (!this.isPseudo && this._hasBase) {
-                    this._table = this._base.table;
-                } else if (this._isForeignKey) {
-                    this._table = this.foreignKey.key.table;
-                } else if (this._isKey) {
-                    this._table = this.key.table;
-                }
-            }
-            return this._table;
-        },
+        this.table = this._baseCols[0].table;
+
+    }
+
+    ReferenceColumn.prototype = {
 
         /**
          * @type {string}
@@ -2861,91 +2797,30 @@ var ERMrest = (function(module) {
          */
         get name () {
             if (this._name === undefined) {
-                if (!this.isPseudo) {
-                    this._name = this._base.name;
-                } else {
-                    this._name = module._generatePseudoColumnName(this._constraintName, this._isForeignKey ? this.foreignKey._table : this.table);
-                }
+                this._name = this._baseCols.reduce(function (res, col, index) {
+                    return res + (index>0 ? ", " : "") + col.name;
+                }, "");
             }
             return this._name;
         },
 
         /**
          * @type {string}
-         * @desc Preferred display name for user presentation only.
+         * @desc name of the column.
          */
         get displayname() {
             if (this._displayname === undefined) {
-                if (!this.isPseudo) {
-                    this._displayname = this._base.displayname;
-                } else if (this._isForeignKey){
-                    var foreignKey = this.foreignKey, value, isHTML, unformatted;
-                    if (foreignKey.to_name !== "") {
-                        value = unformatted = foreignKey.to_name;
-                        isHTML = false;
-                    } else if (foreignKey.simple) {
-                        value = this._base.displayname.value;
-                        isHTML = this._base.displayname.isHTML;
-                        unformatted = this._base.displayname.unformatted;
-
-                        if (this._base.memberOfForeignKeys.length > 1) { // disambiguate
-                            value += " ("  + foreignKey.key.table.displayname.value + ")";
-                            unformatted += " (" + foreignKey.key.table.displayname.unformatted + " )";
-                            if (!isHTML) {
-                                isHTML = foreignKey.key.table.displayname.isHTML;
-                            }
-                        }
-
-                    } else {
-                        value = foreignKey.key.table.displayname.value;
-                        isHTML = foreignKey.key.table.displayname.isHTML;
-                        unformatted = foreignKey.key.table.displayname.unformatted;
-
-                        // disambiguate
-                        var tableCount = foreignKey._table.foreignKeys.all().filter(function (fk) {
-                            return !fk.simple && fk.to_name === "" && fk.key.table == foreignKey.key.table;
-                        }).length;
-
-                        if (tableCount > 1) {
-                            var cols = foreignKey.colset.columns.slice().sort(function(a,b) {
-                                return a.name.localeCompare(b.name);
-                            });
-
-                             value += " (" + cols.map(function(col) {
-                                return col.displayname.value;
-                            }).join(", ")  + ")";
-
-                            unformatted += " (" + cols.map(function(col) {
-                                return col.displayname.unformatted;
-                            }).join(", ")  + ")";
-
-                            if (!isHTML) {
-                                isHTML = foreignKey.colset.columns.some(function (col) {
-                                    return col.displayname.isHTML;
-                                });
-                            }
-                        }
-                    }
-                    this._displayname = {"value": value, "isHTML": isHTML, "unformatted": unformatted};
-
-                } else if (this._isKey) {
-                    this._displayname = module._determineDisplayName(this.key, false);
-
-                    if (this._displayname.value === undefined || this._displayname.value.trim() === "") {
-                        this._displayname = {
-                            "value": this.key.colset.columns.reduce(function(prev, curr, index) {
-                                return prev + (index>0 ? ":" : "") + curr.displayname.value;
-                            }, ""),
-                            "isHTML": this.key.colset.columns.some(function (col) {
-                                return col.displayname.isHTML;
-                            }),
-                            "unformatted": this.key.colset.columns.reduce(function(prev, curr, index) {
-                                return prev + (index>0 ? ":" : "") + curr.displayname.unformatted;
-                            }, ""),
-                        };
-                    }
-
-                }
+                this._displayname = {
+                    "value": this._baseCols.reduce(function(prev, curr, index) {
+                        return prev + (index>0 ? ":" : "") + curr.displayname.value;
+                    }, ""),
+                    "isHTML": this._baseCols.some(function (col) {
+                        return col.displayname.isHTML;
+                    }),
+                    "unformatted": this._baseCols.reduce(function(prev, curr, index) {
+                        return prev + (index>0 ? ":" : "") + curr.displayname.unformatted;
+                    }, ""),
+                };
             }
             return this._displayname;
         },
@@ -2956,7 +2831,7 @@ var ERMrest = (function(module) {
          */
         get type() {
             if (this._type === undefined) {
-                this._type = this.isPseudo ? module._createType("markdown") : this._base.type;
+                this._type = (!this._simple || this.isPseudo) ? module._createType("markdown") : this._baseCols[0].type;
             }
             return this._type;
         },
@@ -2966,14 +2841,9 @@ var ERMrest = (function(module) {
          */
         get nullok() {
             if (this._nullok === undefined) {
-                if (!this.isPseudo) {
-                    this._nullok = this._base.nullok;
-                } else {
-                    var colset = this._isForeignKey ? this.foreignKey.colset : this.key.colset;
-                    this._nullok = !colset.columns.some(function (col) {
-                        return !col.nullok;
-                    });
-                }
+                this._nullok = !this._baseCols.some(function (col) {
+                    return !col.nullok;
+                });
             }
             return this._nullok;
         },
@@ -2982,48 +2852,14 @@ var ERMrest = (function(module) {
          * @desc Returns the default value
          * @type {string}
          */
-         get default() {
-             if (this._default === undefined) {
-                if (!this.isPseudo) {
-                    this._default = this._base.default;
-                } else if (this._isForeignKey) {
-                    var fkColumns = this.foreignKey.colset.columns,
-                        keyColumns = this.foreignKey.key.colset.columns,
-                        mapping = this.foreignKey.mapping,
-                        data = {},
-                        caption,
-                        isNull = false,
-                        i;
-
-                    for (i = 0; i < fkColumns.length; i++) {
-                        if (fkColumns[i].default === null || fkColumns[i].default === undefined) {
-                            isNull = true; //return null if one of them is null;
-                            break;
-                        }
-                        data[mapping.get(fkColumns[i]).name] = fkColumns[i].default;
-                    }
-
-                    if (isNull) {
-                        this._default = null;
-                    } else {
-                        // use row name as the caption
-                        caption = module._generateRowName(this.table, this._context, data).value;
-
-                        // use "col_1:col_2:col_3"
-                        if (caption.trim() === '') {
-                            var keyValues = [];
-                            for (i = 0; i < keyColumns.length; i++) {
-                                keyValues.push(keyColumns[i].formatvalue(data[keyColumns[i].name], {context: this._context}));
-                            }
-                            caption = keyValues.join(":");
-                        }
-
-                        this._default = caption.trim() !== '' ? caption : null;
-                    }
-                }
-             }
-             return this._default;
-         },
+        get default() {
+            if (this._default === undefined) {
+                this._default = this._baseCols.reduce(function (res, col, index) {
+                    return res + (index>0 ? ":" : "") + col.default;
+                }, "");
+            }
+            return this._default;
+        },
 
         /**
          * @desc Documentation for this reference-column
@@ -3031,16 +2867,9 @@ var ERMrest = (function(module) {
          */
         get comment() {
             if (this._comment === undefined) {
-                if (this._hasBase) {
-                    this._comment = this._base.comment;
-                } else if (this._isForeignKey) {
-                    this._comment = this.foreignKey.comment;
-                } else if (this._isKey) {
-                    this._comment = this.key.comment;
-                }
+                this._comment = this._simple ? this._baseCols[0].comment : null;
             }
             return this._comment;
-
         },
 
         /**
@@ -3062,20 +2891,10 @@ var ERMrest = (function(module) {
          * Heuristics are as follows:
          *
          * (first applicable rule from top to bottom)
-         *
-         * - column_order = false -> disable sort.
-         *
-         * - PseudoColumn
-         *      - column_order defined -> use it.
-         *      - Foreign key:
-         *          - table has row_order -> use it.
-         *          - simple fk -> use the column's
-         *      - Key:
-         *          - simple key -> use the column's
-         *      - disable it
-         * - Column:
-         *      - column_order defined -> use it.
-         *      - use column actual value.
+         * - multiple columns -> disable sort.
+         * - single column:
+         *  - column_order defined -> use it.
+         *  - use column actual value.
          *
          * @type {boolean}
          */
@@ -3112,23 +2931,19 @@ var ERMrest = (function(module) {
          */
         get _display() {
             if (this._display_cached === undefined) {
-                if (!this.isPseudo) {
-                    this._display_cached = this._base.getDisplay(this._context);
-                } else if (this._isForeignKey) {
-                    this._display_cached = this.foreignKey.getDisplay(this._context);
-                } else if (this._isKey) {
-                    this._display_cached = this.key.getDisplay(this._context);
-                }
+                this._display_cached = this._simple ? this._baseCols[0].getDisplay(this._context) : null;
             }
             return this._display_cached;
         },
 
         /**
-         * @desc returns the private value _isForeignKey
+         * @private
+         * @desc
+         * Indicates if this object is wrapping just one column or not
          * @type {boolean}
          */
-        get isForeignKey() {
-            return this._isForeignKey;
+        get _simple() {
+            return this._baseCols.length == 1;
         },
 
         /**
@@ -3137,34 +2952,10 @@ var ERMrest = (function(module) {
          * @returns {string} The formatted value.
          */
         formatvalue: function(data, options) {
-            if (this._hasBase) {
-                return this._base.formatvalue(data, options);
+            if (this._simple) {
+                return this._baseCols[0].formatvalue(data, options);
             }
             return data.toString();
-        },
-
-        /**
-         * This function takes in a tuple and generates a reference that is
-         * constrained based on the domain_filter_pattern annotation. If this
-         * annotation doesn't exist, it returns this (reference)
-         * `this` is the same as column.reference
-         * @param {ERMrest.ReferenceColumn} column - column that `this` is based on
-         * @param {Object} data - tuple data with potential constraints
-         * @returns {ERMrest.Reference} the constrained reference
-         */
-        filteredRef: function(data) {
-            var filteredRef,
-                uri = this.reference.uri;
-
-            if (this.foreignKey.annotations.contains(module._annotations.FOREIGN_KEY)){
-                var filterPattern = this.foreignKey.annotations.get(module._annotations.FOREIGN_KEY).content.domain_filter_pattern;
-                var uriFilter = module._renderTemplate(filterPattern, data);
-                // NOTE: should we check for (uriFilter.trim() !== '') ?
-                if (uriFilter !== null) uri += ('/' + uriFilter);
-            }
-
-            filteredRef = module._createReference(module._parse(uri), this.table.schema.catalog);
-            return filteredRef;
         },
 
         /**
@@ -3174,147 +2965,9 @@ var ERMrest = (function(module) {
          * @returns {Object} A key value pair containing value and isHTML that detemrines the presenation.
          */
         formatPresentation: function(data, options) {
-            if (!this.isPseudo) {
-                return this._base.formatPresentation(data, options);
-            }
-
-            var context = options ? options.context : undefined;
-            var nullValue = {isHTML: false, value: this._getNullValue(context)};
-
-            // if data is empty
-            if (typeof data === "undefined" || data === null || Object.keys(data).length === 0) {
-                return nullValue;
-            }
-
-            // used to create key pairs in uri
-            var createKeyPair = function (cols) {
-                 var keyPair = "", col;
-                for (i = 0; i < cols.length; i++) {
-                    col = cols[i].name;
-                    keyPair +=  module._fixedEncodeURIComponent(col) + "=" + module._fixedEncodeURIComponent(data[col]);
-                    if (i != cols.length - 1) {
-                        keyPair +="&";
-                    }
-                }
-                return keyPair;
-            };
-
-            // check if we have data for the given columns
-            var hasData = function (kCols) {
-                for (var i = 0; i < kCols.length; i++) {
-                    if (data[kCols[i].name] === undefined ||  data[kCols[i].name] === null) {
-                        return false;
-                    }
-                }
-                return true;
-            };
-
-            var value, caption, i;
-
-            if (this._isKey) {
-                var cols = this.key.colset.columns,
-                    addLink = true;
-
-                // if any of key columns don't have data, this link is not valid.
-                if (!hasData(cols)) {
-                    return nullValue;
-                }
-
-                // use the markdown_pattern that is defiend in key-display annotation
-                var display = this.key.getDisplay(context);
-                if (display.isMarkdownPattern) {
-                    caption = module._renderTemplate(display.markdownPattern, options.formattedValues);
-                    caption = caption === null || caption.trim() === '' ? "" : module._formatUtils.printMarkdown(caption, { inline: true });
-                    addLink = false;
-                } else {
-                    var values = [];
-
-                    // create the caption
-                    var presentation;
-                    for (i = 0; i < cols.length; i++) {
-                        try {
-                            presentation = cols[i].formatPresentation(options.formattedValues[cols[i].name], {context: context, formattedValues: options.formattedValues});
-                            values.push(presentation.value);
-                            // if one of the values isHTMl, should not add link
-                            addLink = addLink ? !presentation.isHTML : false;
-                        } catch (exception) {
-                            // the value doesn't exist
-                            return nullValue;
-                        }
-                    }
-                    caption = values.join(":");
-
-                    // if the caption is empty we cannot add any link to that.
-                    if (caption.trim() === '') {
-                        return nullValue;
-                    }
-                }
-
-                if (addLink) {
-                    var table = this.key.table;
-                    var refURI = [
-                        table.schema.catalog.server.uri ,"catalog" ,
-                        module._fixedEncodeURIComponent(table.schema.catalog.id), this._baseReference.location.api,
-                        [module._fixedEncodeURIComponent(table.schema.name),module._fixedEncodeURIComponent(table.name)].join(":"),
-                        createKeyPair(cols)
-                    ].join("/");
-                    var keyRef = new Reference(module._parse(refURI), table.schema.catalog);
-                    value = '<a href="' + keyRef.contextualize.detailed.appLink +'">' + caption + '</a>';
-                } else {
-                    value = caption;
-                }
-
-                return {isHTML: true, value: value};
-            }
-            // find value for foreign key:
-            else if (this._isForeignKey) {
-                var fkey = this.foreignKey.key; // the key that creates this PseudoColumn
-
-                // if any of key columns don't have data, this link is not valid.
-                if (!hasData(fkey.colset.columns)) {
-                    return nullValue;
-                }
-
-                // use row name as the caption
-                caption = module._generateRowName(this.table, context, data).value;
-
-                // use key for displayname: "col_1:col_2:col_3"
-                if (caption.trim() === '') {
-                    var formattedValues = module._getFormattedKeyValues(fkey.table.columns, context, data),
-                        keyCols = [],
-                        col;
-
-                    for (i = 0; i < fkey.colset.columns.length; i++) {
-                        col = fkey.colset.columns[i];
-                        keyCols.push(col.formatPresentation(formattedValues[col.name], {context: context, formattedValues: formattedValues}).value);
-                    }
-                    caption = keyCols.join(":");
-
-                    if (caption.trim() === '') {
-                        return nullValue;
-                    }
-                }
-
-                // if caption has a link, or context is EDIT: don't add the link.
-                if (caption.match(/<a/) || module._isEntryContext(context) ) {
-                    value = caption;
-                }
-                // create the link using reference.
-                else {
-
-                    // use the shortest key if it has data (for shorter url).
-                    var uriKey = hasData(this.table.shortestKey) ? this.table.shortestKey: fkey.colset.columns;
-
-                    // create a url that points to the current ReferenceColumn
-                    var uri = [this.reference.location.compactUri, createKeyPair(uriKey)].join("/");
-
-                    // create a reference to just this PseudoColumn to use for url
-                    var ref = new Reference(module._parse(uri), this.table.schema.catalog);
-
-                    value = '<a href="' + ref.contextualize.detailed.appLink +'">' + caption + '</a>';
-                }
-            }
-            return {isHTML: true, value: value};
+            return this._baseCols.reduce(function (res, col, index) {
+                return res + (index>0 ? ":" : "") + col.formatPresentation(data, options);
+            }, "");
         },
 
         /**
@@ -3322,6 +2975,7 @@ var ERMrest = (function(module) {
          * true: input must be disabled
          * false:  input can be enabled
          * object: input msut be disabled (show .message to user)
+         * TODO should be removed in favor of inputDisabled
          *
          * @type {boolean|object}
          */
@@ -3330,17 +2984,11 @@ var ERMrest = (function(module) {
         },
 
         _determineInputDisabled: function(context) {
-            if (this._hasBase) {
-                return this._base.getInputDisabled(context);
+            if (this._simple) {
+                return this._baseCols[0].getInputDisabled(context);
             }
 
-            var cols, generated, i;
-
-            if (this._isKey) {
-                cols = this.key.colset.columns;
-            } else {
-                cols = this.foreignKey.colset.columns;
-            }
+            var cols = this._baseCols, generated, i;
 
             if (context == module._contexts.CREATE) {
                 // if one is not generated
@@ -3376,18 +3024,207 @@ var ERMrest = (function(module) {
             return true;
         },
 
-        _getNullValue: function (context) {
-            if (this._hasBase) {
-                return this._base._getNullValue(context);
+        _determineSortable: function () {
+            this._sortColumns_cached = [];
+            this._sortable = false;
+
+            // disable if mutliple columns
+            if (!this._simple) return;
+
+            // use the column column_order
+            this._sortColumns_cached = this._baseCols[0]._getSortColumns(this._context); //might return undefined
+
+            if (typeof this._sortColumns_cached === 'undefined') {
+                // disable the sort
+                this._sortColumns_cached = [];
+            } else {
+                this._sortable = true;
             }
-            return module._getNullValue(this.table, context, [this.table, this.table.schema]);
+
         },
 
-        _determineSortable: function () {
+        _getNullValue: function (context) {
+            if (this._simple) {
+                return this._baseCols[0]._getNullValue(context);
+            }
+            return module._getNullValue(this.table, context, [this.table, this.table.schema]);
+        }
+    };
 
-            var display = this._display,
-                useColumn = !this.isPseudo,
-                baseCol = this._base;
+    /**
+     * @memberof ERMrest
+     * @constructor
+     * @param {ERMrest.Reference} reference column's reference
+     * @param {?ERMrest.ForeignKeyRef} fk the foreignkey
+     * @desc
+     * Constructor for ForeignKeyPseudoColumn. This class is a wrapper for {@link ERMrest.ForeignKeyRef}.
+     * This class extends the {@link ERMrest.ReferenceColumn}
+     */
+    function ForeignKeyPseudoColumn (reference, fk) {
+        // call the parent constructor
+        ForeignKeyPseudoColumn.superClass.call(this, reference, fk.colset.columns);
+
+        /**
+         * @type {boolean}
+         * @desc indicates this represents is a PseudoColumn or a Column.
+         */
+        this.isPseudo = true;
+
+        /**
+         * @type {boolean}
+         * @desc Indicates that this ReferenceColumn is a Foreign key.
+         */
+        this.isForeignKey = true;
+
+        // create ermrest url using the location
+        var table = fk.key.table;
+        var ermrestURI = [
+            table.schema.catalog.server.uri ,"catalog" ,
+            module._fixedEncodeURIComponent(table.schema.catalog.id), "entity",
+            [module._fixedEncodeURIComponent(table.schema.name),module._fixedEncodeURIComponent(table.name)].join(":")
+        ].join("/");
+
+        /**
+         * @type {ERMrest.Reference}
+         * @desc The reference object that represents the table of this PseudoColumn
+         */
+        this.reference =  new Reference(module._parse(ermrestURI), table.schema.catalog);
+        this.reference.session = reference._session;
+
+        /**
+         * @type {ERMrest.ForeignKeyRef}
+         * @desc The Foreign key object that this PseudoColumn is created based on
+         */
+        this.foreignKey = fk;
+
+        this._constraintName = this.foreignKey.constraint_names[0].join("_");
+
+        this.table = this.foreignKey.key.table;
+    }
+
+    // only the override or extra functions should be here.
+    ForeignKeyPseudoColumn.prototype = {
+        constructor: ForeignKeyPseudoColumn,
+
+        /**
+         * This function takes in a tuple and generates a reference that is
+         * constrained based on the domain_filter_pattern annotation. If this
+         * annotation doesn't exist, it returns this (reference)
+         * `this` is the same as column.reference
+         * @param {ERMrest.ReferenceColumn} column - column that `this` is based on
+         * @param {Object} data - tuple data with potential constraints
+         * @returns {ERMrest.Reference} the constrained reference
+         */
+        filteredRef: function(data) {
+            var filteredRef,
+                uri = this.reference.uri;
+
+            if (this.foreignKey.annotations.contains(module._annotations.FOREIGN_KEY)){
+                var filterPattern = this.foreignKey.annotations.get(module._annotations.FOREIGN_KEY).content.domain_filter_pattern;
+                var uriFilter = module._renderTemplate(filterPattern, data);
+                // NOTE: should we check for (uriFilter.trim() !== '') ?
+                if (uriFilter !== null) uri += ('/' + uriFilter);
+            }
+
+            filteredRef = module._createReference(module._parse(uri), this.table.schema.catalog);
+            return filteredRef;
+        },
+
+        /**
+         * Formats the presentation value corresponding to this reference-column definition.
+         * @param {String} data In case of pseudocolumn it's the raw data, otherwise'formatted' data value.
+         * @param {Object} options includes `context` and `formattedValues`
+         * @returns {Object} A key value pair containing value and isHTML that detemrines the presenation.
+         * @override
+         */
+        formatPresentation: function(data, options) {
+            var context = options ? options.context : undefined;
+            var nullValue = {isHTML: false, value: this._getNullValue(context)};
+
+            // if data is empty
+            if (typeof data === "undefined" || data === null || Object.keys(data).length === 0) {
+                return nullValue;
+            }
+
+            // used to create key pairs in uri
+            var createKeyPair = function (cols) {
+                 var keyPair = "", col;
+                for (i = 0; i < cols.length; i++) {
+                    col = cols[i].name;
+                    keyPair +=  module._fixedEncodeURIComponent(col) + "=" + module._fixedEncodeURIComponent(data[col]);
+                    if (i != cols.length - 1) {
+                        keyPair +="&";
+                    }
+                }
+                return keyPair;
+            };
+
+            // check if we have data for the given columns
+            var hasData = function (kCols) {
+                for (var i = 0; i < kCols.length; i++) {
+                    if (data[kCols[i].name] === undefined ||  data[kCols[i].name] === null) {
+                        return false;
+                    }
+                }
+                return true;
+            };
+
+            var value, caption, i;
+
+            var fkey = this.foreignKey.key; // the key that creates this PseudoColumn
+
+            // if any of key columns don't have data, this link is not valid.
+            if (!hasData(fkey.colset.columns)) {
+                return nullValue;
+            }
+
+            // use row name as the caption
+            caption = module._generateRowName(this.table, context, data).value;
+
+            // use key for displayname: "col_1:col_2:col_3"
+            if (caption.trim() === '') {
+                var formattedValues = module._getFormattedKeyValues(fkey.table.columns, context, data),
+                    keyCols = [],
+                    col;
+
+                for (i = 0; i < fkey.colset.columns.length; i++) {
+                    col = fkey.colset.columns[i];
+                    keyCols.push(col.formatPresentation(formattedValues[col.name], {context: context, formattedValues: formattedValues}).value);
+                }
+                caption = keyCols.join(":");
+
+                if (caption.trim() === '') {
+                    return nullValue;
+                }
+            }
+
+            // if caption has a link, or context is EDIT: don't add the link.
+            if (caption.match(/<a/) || module._isEntryContext(context) ) {
+                value = caption;
+            }
+            // create the link using reference.
+            else {
+
+                // use the shortest key if it has data (for shorter url).
+                var uriKey = hasData(this.table.shortestKey) ? this.table.shortestKey: fkey.colset.columns;
+
+                // create a url that points to the current ReferenceColumn
+                var uri = [this.reference.location.compactUri, createKeyPair(uriKey)].join("/");
+
+                // create a reference to just this PseudoColumn to use for url
+                var ref = new Reference(module._parse(uri), this.table.schema.catalog);
+
+                value = '<a href="' + ref.contextualize.detailed.appLink +'">' + caption + '</a>';
+            }
+
+            return {isHTML: true, value: value};
+        },
+
+        /**
+        * @override
+        */
+        _determineSortable: function () {
+            var display = this._display, useColumn = false, baseCol;
 
             this._sortColumns_cached = [];
             this._sortable = false;
@@ -3395,38 +3232,29 @@ var ERMrest = (function(module) {
             // disable the sort
             if (display !== undefined && display.columnOrder === false) return;
 
-            if (this.isPseudo) {
-                // use the column_order
-                if (display !== undefined && display.columnOrder !== undefined && display.columnOrder.length !== 0) {
-                    this._sortColumns_cached = display.columnOrder;
-                    this._sortable = true;
-                    return;
-                }
-
-                if (this._isForeignKey) {
-                    if (this.reference.display._rowOrder !== undefined) {
-                        var rowOrder = this.reference.display._rowOrder;
-                        for (var i = 0; i < rowOrder.length; i++) {
-                            try{
-                                this._sortColumns_cached.push(this.table.columns.get(rowOrder[i].column));
-                            } catch(exception) {}
-                        }
-                        this._sortable = true;
-                    } else if (this.foreignKey.simple) {
-                        baseCol = this.foreignKey.mapping.get(this._base);
-                        useColumn = true;
-                    }
-                } else if (this._isKey) {
-                    if (this.key.simple) {
-                        baseCol = this.key.colset.columns[0];
-                        useColumn = true;
-                    }
-                }
+            // use the column_order
+            if (display !== undefined && display.columnOrder !== undefined && display.columnOrder.length !== 0) {
+                this._sortColumns_cached = display.columnOrder;
+                this._sortable = true;
+                return;
             }
 
-            // its an actual column or a simple key/foreign key
-            if (useColumn) {
-                // use the column column_order
+            // use row-order of the table
+            if (this.reference.display._rowOrder !== undefined) {
+                var rowOrder = this.reference.display._rowOrder;
+                for (var i = 0; i < rowOrder.length; i++) {
+                    try{
+                        this._sortColumns_cached.push(this.table.columns.get(rowOrder[i].column));
+                    } catch(exception) {}
+                }
+                this._sortable = true;
+                return;
+            }
+
+            // if simple, use column
+            if (this.foreignKey.simple) {
+                baseCol = this.foreignKey.mapping.get(this._baseCols[0]);
+
                 this._sortColumns_cached = baseCol._getSortColumns(this._context); //might return undefined
 
                 if (typeof this._sortColumns_cached === 'undefined') {
@@ -3435,12 +3263,348 @@ var ERMrest = (function(module) {
                     this._sortable = true;
                 }
             }
-        },
+        }
 
-        get _hasBase() {
-            return this._base !== null && this._base !== undefined;
+    };
+
+    // extend the prototype
+    module._extends(ForeignKeyPseudoColumn, ReferenceColumn);
+
+    // properties to be overriden:
+    Object.defineProperty(ForeignKeyPseudoColumn.prototype, "name", {
+        get: function () {
+            if (this._name === undefined) {
+                this._name = module._generatePseudoColumnName(this._constraintName, this.foreignKey._table);
+            }
+            return this._name;
+        }
+    });
+    Object.defineProperty(ForeignKeyPseudoColumn.prototype, "displayname", {
+        get: function () {
+            if (this._displayname === undefined) {
+                var foreignKey = this.foreignKey, value, isHTML, unformatted;
+                if (foreignKey.to_name !== "") {
+                    value = unformatted = foreignKey.to_name;
+                    isHTML = false;
+                } else if (foreignKey.simple) {
+                    value = this._baseCols[0].displayname.value;
+                    isHTML = this._baseCols[0].displayname.isHTML;
+                    unformatted = this._baseCols[0].displayname.unformatted;
+
+                    if (this._baseCols[0].memberOfForeignKeys.length > 1) { // disambiguate
+                        value += " ("  + foreignKey.key.table.displayname.value + ")";
+                        unformatted += " (" + foreignKey.key.table.displayname.unformatted + " )";
+                        if (!isHTML) {
+                            isHTML = foreignKey.key.table.displayname.isHTML;
+                        }
+                    }
+
+                } else {
+                    value = foreignKey.key.table.displayname.value;
+                    isHTML = foreignKey.key.table.displayname.isHTML;
+                    unformatted = foreignKey.key.table.displayname.unformatted;
+
+                    // disambiguate
+                    var tableCount = foreignKey._table.foreignKeys.all().filter(function (fk) {
+                        return !fk.simple && fk.to_name === "" && fk.key.table == foreignKey.key.table;
+                    }).length;
+
+                    if (tableCount > 1) {
+                        var cols = foreignKey.colset.columns.slice().sort(function(a,b) {
+                            return a.name.localeCompare(b.name);
+                        });
+
+                         value += " (" + cols.map(function(col) {
+                            return col.displayname.value;
+                        }).join(", ")  + ")";
+
+                        unformatted += " (" + cols.map(function(col) {
+                            return col.displayname.unformatted;
+                        }).join(", ")  + ")";
+
+                        if (!isHTML) {
+                            isHTML = foreignKey.colset.columns.some(function (col) {
+                                return col.displayname.isHTML;
+                            });
+                        }
+                    }
+                }
+                this._displayname = {"value": value, "isHTML": isHTML, "unformatted": unformatted};
+            }
+            return this._displayname;
+        }
+    });
+    Object.defineProperty(ForeignKeyPseudoColumn.prototype, "default", {
+        get: function () {
+            if (this._default === undefined) {
+                var fkColumns = this.foreignKey.colset.columns,
+                    keyColumns = this.foreignKey.key.colset.columns,
+                    mapping = this.foreignKey.mapping,
+                    data = {},
+                    caption,
+                    isNull = false,
+                    i;
+
+                for (i = 0; i < fkColumns.length; i++) {
+                    if (fkColumns[i].default === null || fkColumns[i].default === undefined) {
+                        isNull = true; //return null if one of them is null;
+                        break;
+                    }
+                    data[mapping.get(fkColumns[i]).name] = fkColumns[i].default;
+                }
+
+                if (isNull) {
+                    this._default = null;
+                } else {
+                    // use row name as the caption
+                    caption = module._generateRowName(this.table, this._context, data).value;
+
+                    // use "col_1:col_2:col_3"
+                    if (caption.trim() === '') {
+                        var keyValues = [];
+                        for (i = 0; i < keyColumns.length; i++) {
+                            keyValues.push(keyColumns[i].formatvalue(data[keyColumns[i].name], {context: this._context}));
+                        }
+                        caption = keyValues.join(":");
+                    }
+
+                    this._default = caption.trim() !== '' ? caption : null;
+                }
+                return this._default;
+            }
+        }
+    });
+    Object.defineProperty(ForeignKeyPseudoColumn.prototype, "comment", {
+        get: function () {
+            if (this._comment === undefined) {
+                // calling the parent
+                Object.getOwnPropertyDescriptor(ForeignKeyPseudoColumn.super,"comment").get.call(this);
+                this._comment = (this._comment !== null) ? this._comment : this.foreignKey.comment;
+            }
+            return this._comment;
+        }
+    });
+    Object.defineProperty(ForeignKeyPseudoColumn.prototype, "_display", {
+        get: function () {
+            if (this._display_cached === undefined) {
+                this._display_cached = this.foreignKey.getDisplay(this._context);
+            }
+            return this._display_cached;
+        }
+    });
+
+    function KeyPseudoColumn (reference, key) {
+        // call the parent constructor
+        KeyPseudoColumn.superClass.call(this, reference, key.colset.columns);
+
+        /**
+         * @type {boolean}
+         * @desc indicates this represents is a PseudoColumn or a Column.
+         */
+        this.isPseudo = true;
+
+        /**
+         * @type {boolean}
+         * @desc Indicates that this ReferenceColumn is a key.
+         */
+        this.isKey = true;
+
+        /**
+         * @type {ERMrest.ForeignKeyRef}
+         * @desc The Foreign key object that this PseudoColumn is created based on
+         */
+        this.key = key;
+
+        this.table = this.key.table;
+
+        this._constraintName = key.constraint_names[0].join("_");
+    }
+
+    // only the override or extra functions should be here.
+    KeyPseudoColumn.prototype = {
+        constructor: KeyPseudoColumn,
+
+        /**
+         * Formats the presentation value corresponding to this reference-column definition.
+         * @param {String} data In case of pseudocolumn it's the raw data, otherwise'formatted' data value.
+         * @param {Object} options includes `context` and `formattedValues`
+         * @returns {Object} A key value pair containing value and isHTML that detemrines the presenation.
+         * @override
+         */
+         formatPresentation: function(data, options) {
+             var context = options ? options.context : undefined;
+             var nullValue = {isHTML: false, value: this._getNullValue(context)};
+
+             // if data is empty
+             if (typeof data === "undefined" || data === null || Object.keys(data).length === 0) {
+                 return nullValue;
+             }
+
+             // used to create key pairs in uri
+             var createKeyPair = function (cols) {
+                  var keyPair = "", col;
+                 for (i = 0; i < cols.length; i++) {
+                     col = cols[i].name;
+                     keyPair +=  module._fixedEncodeURIComponent(col) + "=" + module._fixedEncodeURIComponent(data[col]);
+                     if (i != cols.length - 1) {
+                         keyPair +="&";
+                     }
+                 }
+                 return keyPair;
+             };
+
+             // check if we have data for the given columns
+             var hasData = function (kCols) {
+                 for (var i = 0; i < kCols.length; i++) {
+                     if (data[kCols[i].name] === undefined ||  data[kCols[i].name] === null) {
+                         return false;
+                     }
+                 }
+                 return true;
+             };
+
+             var value, caption, i;
+             var cols = this.key.colset.columns,
+                 addLink = true;
+
+             // if any of key columns don't have data, this link is not valid.
+             if (!hasData(cols)) {
+                 return nullValue;
+             }
+
+             // use the markdown_pattern that is defiend in key-display annotation
+             var display = this.key.getDisplay(context);
+             if (display.isMarkdownPattern) {
+                 caption = module._renderTemplate(display.markdownPattern, options.formattedValues);
+                 caption = caption === null || caption.trim() === '' ? "" : module._formatUtils.printMarkdown(caption, { inline: true });
+                 addLink = false;
+             } else {
+                 var values = [];
+
+                 // create the caption
+                 var presentation;
+                 for (i = 0; i < cols.length; i++) {
+                     try {
+                         presentation = cols[i].formatPresentation(options.formattedValues[cols[i].name], {context: context, formattedValues: options.formattedValues});
+                         values.push(presentation.value);
+                         // if one of the values isHTMl, should not add link
+                         addLink = addLink ? !presentation.isHTML : false;
+                     } catch (exception) {
+                         // the value doesn't exist
+                         return nullValue;
+                     }
+                 }
+                 caption = values.join(":");
+
+                 // if the caption is empty we cannot add any link to that.
+                 if (caption.trim() === '') {
+                     return nullValue;
+                 }
+             }
+
+             if (addLink) {
+                 var table = this.key.table;
+                 var refURI = [
+                     table.schema.catalog.server.uri ,"catalog" ,
+                     module._fixedEncodeURIComponent(table.schema.catalog.id), this._baseReference.location.api,
+                     [module._fixedEncodeURIComponent(table.schema.name),module._fixedEncodeURIComponent(table.name)].join(":"),
+                     createKeyPair(cols)
+                 ].join("/");
+                 var keyRef = new Reference(module._parse(refURI), table.schema.catalog);
+                 value = '<a href="' + keyRef.contextualize.detailed.appLink +'">' + caption + '</a>';
+             } else {
+                 value = caption;
+             }
+
+             return {isHTML: true, value: value};
+         },
+
+
+        /**
+        * @override
+        */
+        _determineSortable: function () {
+            var display = this._display, useColumn = false, baseCol;
+
+            this._sortColumns_cached = [];
+            this._sortable = false;
+
+            // disable the sort
+            if (display !== undefined && display.columnOrder === false) return;
+
+            // use the column_order
+            if (display !== undefined && display.columnOrder !== undefined && display.columnOrder.length !== 0) {
+                this._sortColumns_cached = display.columnOrder;
+                this._sortable = true;
+                return;
+            }
+
+            // if simple, use column
+            if (this.key.simple) {
+                baseCol = this._baseCols[0];
+
+                this._sortColumns_cached = baseCol._getSortColumns(this._context); //might return undefined
+
+                if (typeof this._sortColumns_cached === 'undefined') {
+                    this._sortColumns_cached = [];
+                } else {
+                    this._sortable = true;
+                }
+            }
         }
     };
+
+    // extend the prototype
+    module._extends(KeyPseudoColumn, ReferenceColumn);
+
+    // properties to be overriden:
+    Object.defineProperty(KeyPseudoColumn.prototype, "name", {
+        get: function () {
+            if (this._name === undefined) {
+                this._name = module._generatePseudoColumnName(this._constraintName, this.table);
+            }
+            return this._name;
+        }
+    });
+    Object.defineProperty(KeyPseudoColumn.prototype, "displayname", {
+        get: function () {
+            if (this._displayname === undefined) {
+                this._displayname = module._determineDisplayName(this.key, false);
+
+                // if was undefined, fall back to default
+                if (this._displayname.value === undefined || this._displayname.value.trim() === "") {
+                    this._displayname = undefined;
+                    Object.getOwnPropertyDescriptor(KeyPseudoColumn.super,"displayname").get.call(this);
+                }
+
+            }
+            return this._displayname;
+        }
+    });
+    Object.defineProperty(KeyPseudoColumn.prototype, "comment", {
+        get: function () {
+            if (this._comment === undefined) {
+                // calling the parent
+                Object.getOwnPropertyDescriptor(KeyPseudoColumn.super,"comment").get.call(this);
+                this._comment = (this._comment !== null) ? this._comment : this.key.comment;
+            }
+            return this._comment;
+        }
+    });
+    Object.defineProperty(KeyPseudoColumn.prototype, "default", {
+        get: function () {
+            // default should be undefined in key
+            return undefined;
+        }
+    });
+    Object.defineProperty(KeyPseudoColumn.prototype, "_display", {
+        get: function () {
+            if (this._display_cached === undefined) {
+                this._display_cached = this.key.getDisplay(this._context);
+            }
+            return this._display_cached;
+        }
+    });
 
     return module;
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -349,16 +349,14 @@ var ERMrest = (function(module) {
 
                 // this function will take care of adding column and asset column
                 var addColumn = function (col) {
-                    var isAsset = col.annotations.contains(module._annotations.ASSET);
-
-                    if(isAsset) {
-                        if (("url_pattern" in annotations.get(module._annotations.ASSET).content)) {
+                    if(col.annotations.contains(module._annotations.ASSET)) {
+                        if (("url_pattern" in col.annotations.get(module._annotations.ASSET).content)) {
                             // add asset annotation
                             var assetCol = new AssetPseudoColumn(self, col);
                             assetColumns.push(assetCol);
                             self._referenceColumns.push(assetCol);
                             return;
-                        } else if (module._isEntryContext(this._context)) {
+                        } else if (module._isEntryContext(self._context)) {
                             // ignore the column
                             return;
                         }

--- a/js/reference.js
+++ b/js/reference.js
@@ -2968,9 +2968,15 @@ var ERMrest = (function(module) {
          * @returns {Object} A key value pair containing value and isHTML that detemrines the presenation.
          */
         formatPresentation: function(data, options) {
-            return this._baseCols.reduce(function (res, col, index) {
-                return res + (index>0 ? ":" : "") + col.formatPresentation(data, options);
-            }, "");
+            var isHTML = false, value = "", curr;
+            for (var i = 0; i < this._baseCols.length; i++) {
+                curr = this._baseCols[i].formatPresentation(data, options);
+                if (!isHTML && curr.isHTML) {
+                    isHTML = true;
+                }
+                value += (i>0 ? ":" : "") + curr.value;
+            }
+            return {isHTML: isHTML, value: value};
         },
 
         /**
@@ -3396,6 +3402,15 @@ var ERMrest = (function(module) {
         }
     });
 
+    /**
+     * @memberof ERMrest
+     * @constructor
+     * @param {ERMrest.Reference} reference column's reference
+     * @param {?ERMrest.Key} key the key
+     * @desc
+     * Constructor for KeyPseudoColumn. This class is a wrapper for {@link ERMrest.Key}.
+     * This class extends the {@link ERMrest.ReferenceColumn}
+     */
     function KeyPseudoColumn (reference, key) {
         // call the parent constructor
         KeyPseudoColumn.superClass.call(this, reference, key.colset.columns);

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -62,6 +62,29 @@ var ERMrest = (function(module) {
         return target.split(search).join(replacement);
     };
 
+    /**
+     * @private
+     * @param {Object} child child class
+     * @param {Object} parent parent class
+     * @desc
+     * This function should be called to extend a prototype with another one.
+     * Make sure to attach the right constructor to the prototypes after,
+     * and also call `child.superClass.call(this, arguments*)` in frist line of
+     * the child constructor with appropriate arguments.
+     * You can define the extra or overriden functions of child before calling _extends.
+     * This function will take care of copying those functions.
+     * *Must be called after defining parent prototype and child constructor*
+     */
+    module._extends = function (child, parent) {
+        var childFns = child.prototype;
+        child.prototype = Object.create(parent.prototype);
+        child.superClass = parent;
+        child.super = parent.prototype;
+        // copy all the functions
+        for(var fn in childFns) {
+            child.prototype[fn] = childFns[fn];
+        }
+    };
 
     /**
      * @function

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -78,12 +78,9 @@ var ERMrest = (function(module) {
     module._extends = function (child, parent) {
         var childFns = child.prototype;
         child.prototype = Object.create(parent.prototype);
+        child.prototype.constructor = child;
         child.superClass = parent;
         child.super = parent.prototype;
-        // copy all the functions
-        for(var fn in childFns) {
-            child.prototype[fn] = childFns[fn];
-        }
     };
 
     /**
@@ -1345,7 +1342,8 @@ var ERMrest = (function(module) {
         GENERATED: "tag:isrd.isi.edu,2016:generated",
         IMMUTABLE: "tag:isrd.isi.edu,2016:immutable",
         NON_DELETABLE: "tag:isrd.isi.edu,2016:non-deletable",
-        KEY_DISPLAY: "tag:isrd.isi.edu,2017:key-display"
+        KEY_DISPLAY: "tag:isrd.isi.edu,2017:key-display",
+        ASSET: "tag:isrd.isi.edu,2017:asset"
     });
 
     /**

--- a/test/specs/reference/conf/reference_schema/data/table_w_asset.json
+++ b/test/specs/reference/conf/reference_schema/data/table_w_asset.json
@@ -1,0 +1,13 @@
+[{
+    "id": "1",
+    "col_fk": "1",
+    "col_1": "1000",
+    "col_2": "10001",
+    "col_filename": "filename",
+    "col_byte": 1242,
+    "col_md5": "md5",
+    "col_sha256": "sha256",
+    "col_asset_1": null,
+    "col_asset_2": "https://dev.isrd.isi.edu",
+    "col_asset_3": "https://dev.isrd.isi.edu"
+}]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -1794,14 +1794,162 @@
                     "*": ["id", "position_type_col, int_value"]
                 }
             }
+        },
+        "table_w_asset": {
+            "comment": "table that has some columns with asset annotation",
+            "kind": "table",
+            "keys": [
+                {
+                    "names": [["reference_schema", "table_w_asset_key_1"]],
+                    "unique_columns": ["id"]
+                }
+            ],
+            "table_name": "table_w_asset",
+            "schema_name": "reference_schema",
+            "foreign_keys": [
+                {
+                    "names": [["reference_schema", "table_w_asset_fk_to_outbound"]],
+                    "foreign_key_columns": [
+                        {
+                            "schema_name": "reference_schema",
+                            "table_name": "table_w_asset",
+                            "column_name": "col_fk"
+                        }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "schema_name": "reference_schema",
+                            "table_name": "reference_table_outbound_fks",
+                            "column_name": "id"
+                        }
+                    ],
+                    "annotations": {}
+                }
+            ],
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "comment": "id, asset should be ignored",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2017:asset": {}
+                    }
+                },
+                {
+                    "name": "col_fk",
+                    "comment": "is fk to another table and has asset annotation",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2017:asset": {}
+                    }
+                },
+                {
+                    "name": "col_1",
+                    "comment": "column without any fk or asset annotation",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col_2",
+                    "comment": "column without any fk or asset annotation",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col_filename",
+                    "comment": "",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col_byte",
+                    "comment": "",
+                    "type": {
+                        "typename": "int"
+                    }
+                },
+                {
+                    "name": "col_md5",
+                    "comment": "",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col_sha256",
+                    "comment": "",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col_asset_1",
+                    "comment":"column with asset annotation",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2017:asset": {}
+                    }
+                },
+                {
+                    "name": "col_asset_2",
+                    "comment": "column with asset annotation that has invalid values",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2017:asset": {
+                            "filename_column": "no col",
+                            "byte_count_column": "no col",
+                            "md5": true,
+                            "sha256": true
+                        },
+                        "tag:isrd.isi.edu,2016:column-display" : {
+                            "*" : {
+                                "markdown_pattern" : "## {{col_filename}}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "col_asset_3",
+                    "comment": "column with asset annotation",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2017:asset": {
+                            "url_pattern": "{{col_asset_3}}",
+                            "filename_column": "col_filename",
+                            "byte_count_column": "col_byte",
+                            "md5": "col_md5",
+                            "sha256": "col_sha256",
+                            "filename_ext_filter": ["*.jpg"]
+                        }
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2016:visible-columns": {
+                    "entry/create": ["col_filename","col_byte","col_md5","col_sha256"],
+                    "entry/edit": ["col_asset_3", "col_filename","col_byte","col_md5","col_sha256"],
+                    "compact/brief": ["col_asset_3", "col_filename","col_byte","col_md5","col_sha256"]
+                }
+            }
         }
+
     },
-    "table_names": [
-        "reference_table",
-        "inbound_related_reference_table",
-        "sorted_table",
-        "reference_values_table"
-    ],
     "comment": null,
     "annotations": {}
 }

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -1841,7 +1841,9 @@
                         "typename": "text"
                     },
                     "annotations": {
-                        "tag:isrd.isi.edu,2017:asset": {}
+                        "tag:isrd.isi.edu,2017:asset": {
+                            "url_pattern": "{{id}}"
+                        }
                     }
                 },
                 {
@@ -1851,7 +1853,9 @@
                         "typename": "text"
                     },
                     "annotations": {
-                        "tag:isrd.isi.edu,2017:asset": {}
+                        "tag:isrd.isi.edu,2017:asset": {
+                            "url_pattern": "{{col_fk}}"
+                        }
                     }
                 },
                 {

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -956,7 +956,8 @@
                     },
                     "tag:isrd.isi.edu,2017:key-display": {
                         "*": {
-                            "markdown_pattern": "**{{col_4}}**"
+                            "markdown_pattern": "**{{col_4}}**",
+                            "column_order": ["col_1", "col_2"]
                         }
                     }
                 }
@@ -966,6 +967,11 @@
                 "annotations": {
                     "tag:misd.isi.edu,2015:display": {
                         "markdown_name": "**fourth key**"
+                    },
+                    "tag:isrd.isi.edu,2017:key-display": {
+                        "*": {
+                            "column_order": false
+                        }
                     }
                 }
             }],

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -1916,6 +1916,7 @@
                     },
                     "annotations": {
                         "tag:isrd.isi.edu,2017:asset": {
+                            "url_pattern": "{{col_asset_2}}",
                             "filename_column": "no col",
                             "byte_count_column": "no col",
                             "md5": true,

--- a/test/specs/reference/spec.js
+++ b/test/specs/reference/spec.js
@@ -14,8 +14,8 @@ require('./../../utils/starter.spec.js').runTests({
         "/reference/tests/11.delete.js",
         "/reference/tests/12.reference_values_edit.js",
         "/reference/tests/13.search.js",
-        "/reference/tests/14.outbound_fks.js",
-        "/reference/tests/15.reference_column.js"        
+        "/reference/tests/14.pseudo_columns.js",
+        "/reference/tests/15.reference_column.js"
 
     ],
     schemaConfigurations: [

--- a/test/specs/reference/tests/14.pseudo_columns.js
+++ b/test/specs/reference/tests/14.pseudo_columns.js
@@ -195,7 +195,7 @@ exports.execute = function (options) {
             '1000', '10001', 'filename', '1,242', 'md5', 'sha256',
             '',
             '<h2>filename</h2>\n',
-            '<a href="https://dev.isrd.isi.edu" download="" class="btn btn-primary" target="_blank">Download</a>'
+            '<a href="https://dev.isrd.isi.edu" download="">filename</a>'
         ];
 
         /**

--- a/test/specs/reference/tests/14.pseudo_columns.js
+++ b/test/specs/reference/tests/14.pseudo_columns.js
@@ -312,7 +312,7 @@ exports.execute = function (options) {
          */
 
         var compactRef, compactBriefRef, compactSelectRef, compactRef, entryRef, entryCreateRef, entryEditRef,
-            slashRef, assetRef, assetRefEntry, assetRefCompact, assetRefCompactCols, assetRefEntryCols,
+            slashRef, assetRef, assetRefEntry, assetRefCompact, assetRefCompactCols,
             compactColumns, compactSelectColumns, table2RefColumns;
 
         beforeAll(function (done) {
@@ -343,7 +343,6 @@ exports.execute = function (options) {
                 assetRefCompact = ref.contextualize.compact;
                 assetRefCompactCols = assetRefCompact.columns;
                 assetRefEntry = ref.contextualize.entry;
-                assetRefEntryCols = assetRefEntry.columns;
                 done();
             }).catch(function (err) {
                 console.dir(err);

--- a/test/specs/reference/tests/14.pseudo_columns.js
+++ b/test/specs/reference/tests/14.pseudo_columns.js
@@ -8,6 +8,7 @@ exports.execute = function (options) {
             tableWithSimpleKeyFK = "table_w_simple_key_fk",
             tableWithCompositeKey3 = "table_w_composite_key_3",
             tableWithSlash = "table_w_slash",
+            tableWithAsset = "table_w_asset",
             entityId = 1,
             limit = 1,
             entryContext = "entry",
@@ -32,6 +33,9 @@ exports.execute = function (options) {
 
         var singleEnitityUriWithSlash = options.url + "/catalog/" + catalog_id + "/entity/" +
             schemaName + ":" + tableWithSlash + "/id=" + entityId;
+
+        var singleEnitityUriWithAsset = options.url + "/catalog/" + catalog_id + "/entity/" +
+            schemaName + ":" + tableWithAsset + "/id=" + entityId;
 
         var chaiseURL = "https://dev.isrd.isi.edu/chaise";
         var recordURL = chaiseURL + "/record";
@@ -98,23 +102,23 @@ exports.execute = function (options) {
                 "reference_schema_outbound_fk_7": "13"
             }
         ];
-        
-        var compactRefExpectedPartialValue = [ 
-            '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:reference_table_outbound_fks/id=1">1</a>', 
-            '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:reference_table/id=9000">9000</a>', 
-            '', 
+
+        var compactRefExpectedPartialValue = [
+            '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:reference_table_outbound_fks/id=1">1</a>',
+            '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:reference_table/id=9000">9000</a>',
+            '',
             '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:reference_table/id=4000">4000</a>',
             '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:reference_values/id=4000">4000</a>',
             '4000',
             '4001',
             '4002',
             '4003',
-             '', 
-             '<p>12</p>\n', 
+             '',
+             '<p>12</p>\n',
              '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:table_w_composite_key/id_1=4000&id_2=4001">4000 , 4001</a>',
              '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:table_w_composite_key_2/id_1=4000&id_2=4003">4000:4003</a>',
              '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:table_w_composite_key/id_1=4002&id_2=4000">4002 , 4000</a>',
-             '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:table_w_composite_key/id_1=4002&id_2=4001">4002 , 4001</a>', 
+             '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:table_w_composite_key/id_1=4002&id_2=4001">4002 , 4001</a>',
              ''
         ];
 
@@ -179,11 +183,25 @@ exports.execute = function (options) {
             '2',
             '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:reference_table/id=9001">Harold</a>',
             '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:reference_table/id=9000">Hank</a>'
-        ]
+        ];
+
+        var assetEntryExpectedValue = [
+            '1', '1', '1000', '10001', '', '<h2>filename</h2>\n', 'https://dev.isrd.isi.edu'
+        ];
+
+        var assetCompactExpectedValue = [
+            '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:table_w_asset/id=1">1</a>',
+            '<a href="https://dev.isrd.isi.edu/chaise/record/reference_schema:reference_table_outbound_fks/id=1">1</a>',
+            '1000', '10001', 'filename', '1,242', 'md5', 'sha256',
+            '',
+            '<h2>filename</h2>\n',
+            '<a href="https://dev.isrd.isi.edu" download="" class="btn btn-primary" target="_blank">Download</a>'
+        ];
 
         /**
-         * This is the structure of the used table:
-         * reference_table_outbound_fks:
+         * This is the structure of the used tables:
+         *
+         * 1. reference_table_outbound_fks:
          * columns:
          *  id -> single key, not part of any fk
          *  col_1 -> has generated annotation
@@ -250,7 +268,7 @@ exports.execute = function (options) {
          * 7:   outbound_fk_9 (used for inputDisabled)
          *
          * contexts that are used:
-         *  
+         *
          *  compact: doesn't have visible-columns
          *  compact/brief: has visible-columns with three composite keys
          *  compact/select: has all of the columns in visible-columns + has some foreign keys too
@@ -258,9 +276,43 @@ exports.execute = function (options) {
          *  entry: doesn't have visible-columns
          *  entry/edit: has visible-columns annotation. (just key)
          *  entry/create: has all of the columns in visible-column + has some foreign keys too
+         *
+         *
+         * 2. table_w_asset:
+         *  ref.columns for detailed (no context present):
+         *  0: table_w_asset_key_1
+         *  1: table_w_asset_fk_to_outbound
+         *  2: col_1
+         *  3: col_2
+         *  4: col_filename
+         *  5: col_byte
+         *  6: col_md5
+         *  7: col_sha256
+         *  8: col_asset_1 (asset with default options) is null
+         *  9: col_asset_2 (asset with invalid options) has column-display
+         *  10: col_asset_3 (asset with valid options)
+         *
+         *  ref.columns for entry (no context present):
+         *  0: id
+         *  1: table_w_asset_fk_to_outbound
+         *  2: col_1
+         *  3: col_2
+         *  4: col_asset_1 (asset with default options)
+         *  5: col_asset_2 (asset with invalid options)
+         *  6: col_asset_3 (asset with valid options)
+         *
+         *
+         *  contexts that are used:
+         *  - compact: no visible-columns
+         *  - edit: no visible-columns
+         *  - entry/create: does not include col_asset_3 -> so no ignore
+         *  - entry/edit: includes col_asset_3 and all its contituent columns
+         *  - compact/brief: includes col_asset_3 and all its contituent columns
+         *
          */
 
-        var compactRef, compactBriefRef, compactSelectRef, compactRef, entryRef, entryCreateRef, entryEditRef, slashRef,
+        var compactRef, compactBriefRef, compactSelectRef, compactRef, entryRef, entryCreateRef, entryEditRef,
+            slashRef, assetRef, assetRefEntry, assetRefCompact, assetRefCompactCols, assetRefEntryCols,
             compactColumns, compactSelectColumns, table2RefColumns;
 
         beforeAll(function (done) {
@@ -282,14 +334,18 @@ exports.execute = function (options) {
                 compactColumns = compactRef.columns;
                 compactSelectColumns = compactSelectRef.columns;
 
-                options.ermRest.resolve(singleEnitityUriWithSlash, {cid:"test"}).then(function(ref) {
-                    slashRef = ref;
-                    done();
-                }, function (err) {
-                    console.dir(err);
-                    done.fail();
-                });
-            }, function (err) {
+                return options.ermRest.resolve(singleEnitityUriWithSlash, {cid:"test"});
+            }).then(function(ref){
+                slashRef = ref;
+                return options.ermRest.resolve(singleEnitityUriWithAsset, {cid:"test"});
+            }).then(function(ref){
+                assetRef = ref;
+                assetRefCompact = ref.contextualize.compact;
+                assetRefCompactCols = assetRefCompact.columns;
+                assetRefEntry = ref.contextualize.entry;
+                assetRefEntryCols = assetRefEntry.columns;
+                done();
+            }).catch(function (err) {
                 console.dir(err);
                 done.fail();
             });
@@ -320,31 +376,66 @@ exports.execute = function (options) {
                     }]);
                 });
 
-                it('should not apply heuristics and just return given list.', function() {
-                    expect(compactSelectColumns.length).toBe(13);
-                    checkReferenceColumns([{
-                        ref: compactSelectRef,
-                        expected: [
-                            "id", ["reference_schema", "outbound_fk_1"].join("_"),
-                            "col_1", "col_2", "col_3", "col_4","col 5", ["reference_schema","outbound_fk_3"].join("_"),
-                            "col_6", "col_7", ["reference_schema","outbound_fk_5"].join("_"),
-                            "reference_schema_outbound_fk_7", ["reference_schema","outbound_fk_7"].join("_") + "1"
-                        ]
-                    }]);
+                describe('for foreignKey columns,', function () {
+                    it('should not apply heuristics and just return given list.', function() {
+                        expect(compactSelectColumns.length).toBe(13);
+                        checkReferenceColumns([{
+                            ref: compactSelectRef,
+                            expected: [
+                                "id", ["reference_schema", "outbound_fk_1"].join("_"),
+                                "col_1", "col_2", "col_3", "col_4","col 5", ["reference_schema","outbound_fk_3"].join("_"),
+                                "col_6", "col_7", ["reference_schema","outbound_fk_5"].join("_"),
+                                "reference_schema_outbound_fk_7", ["reference_schema","outbound_fk_7"].join("_") + "1"
+                            ]
+                        }]);
+                    });
                 });
 
-                it('in entry contexts, instead of creating a PseudoColumn for key, should add its contituent columns (avoid duplicate).', function () {
-                    checkReferenceColumns([{
-                        ref: entryEditRef,
-                        expected: [
-                            "col_6", "id", "col_3",
-                            ["reference_schema", "outbound_fk_2"].join("_"),
-                            ["reference_schema", "outbound_fk_3"].join("_"),
-                            ["reference_schema", "outbound_fk_7"].join("_") + "1",
-                            ["reference_schema", "outbound_fk_8"].join("_"),
-                            ["reference_schema", "outbound_fk_9"].join("_")
-                        ]
-                    }]);
+                describe('for key columns,', function () {
+                    it('in entry contexts, instead of creating a PseudoColumn for key, should add its contituent columns (avoid duplicate).', function () {
+                        checkReferenceColumns([{
+                            ref: entryEditRef,
+                            expected: [
+                                "col_6", "id", "col_3",
+                                ["reference_schema", "outbound_fk_2"].join("_"),
+                                ["reference_schema", "outbound_fk_3"].join("_"),
+                                ["reference_schema", "outbound_fk_7"].join("_") + "1",
+                                ["reference_schema", "outbound_fk_8"].join("_"),
+                                ["reference_schema", "outbound_fk_9"].join("_")
+                            ]
+                        }]);
+                    });
+                });
+
+                describe('for asset columns,', function () {
+                    describe('filname, byte, md5, and sha256 columns', function() {
+                        it('should be ignored in edit context if the asset column is present.', function() {
+                            checkReferenceColumns([{
+                                ref: assetRef.contextualize.entryEdit,
+                                expected: [
+                                    "col_asset_3"
+                                ]
+                            }]);
+                        });
+
+                        it('should not be ignored in any contexts if the asset column is not present.', function() {
+                            checkReferenceColumns([{
+                                ref: assetRef.contextualize.entryCreate,
+                                expected: [
+                                    "col_filename","col_byte","col_md5","col_sha256"
+                                ]
+                            }]);
+                        });
+
+                        it('otherwise, should not be ignored.', function() {
+                            checkReferenceColumns([{
+                                ref: assetRef.contextualize.compactBrief,
+                                expected: [
+                                    "col_asset_3", "col_filename","col_byte","col_md5","col_sha256"
+                                ]
+                            }]);
+                        });
+                    });
                 });
 
                 if (!process.env.TRAVIS) {
@@ -385,7 +476,7 @@ exports.execute = function (options) {
                                 ref = ref.contextualize.detailed;
                                 expect(ref.columns[0].isPseudo).toBe(false);
                                 expect(ref.columns[0].name).toEqual("id");
-                                
+
                                 done();
                             }, function (err) {
                                 console.dir(err);
@@ -512,6 +603,42 @@ exports.execute = function (options) {
                     });
                 });
 
+                describe('for asset columns,', function () {
+                    describe('filname, byte, md5, and sha256 columns', function() {
+                        it('should be ignored in edit context.', function() {
+                            checkReferenceColumns([{
+                                ref: assetRefEntry,
+                                expected: [
+                                    "id",
+                                    ["reference_schema", "table_w_asset_fk_to_outbound"].join("_"),
+                                    "col_1", "col_2", "col_asset_1", "col_asset_2", "col_asset_3"
+                                ]
+                            }]);
+                        });
+
+                        it('should not be ignored in other contexts.', function() {
+                            expect(assetRefCompactCols.length).toBe(11);
+                            expect(assetRefCompactCols[4].name).toBe("col_filename");
+                            expect(assetRefCompactCols[4].isPseudo).toBe(false);
+                            expect(assetRefCompactCols[5].name).toBe("col_byte");
+                            expect(assetRefCompactCols[5].isPseudo).toBe(false);
+                            expect(assetRefCompactCols[6].name).toBe("col_md5");
+                            expect(assetRefCompactCols[6].isPseudo).toBe(false);
+                            expect(assetRefCompactCols[7].name).toBe("col_sha256");
+                            expect(assetRefCompactCols[7].isPseudo).toBe(false);
+                        });
+                    });
+
+                    it('if columns has been used as the keyReferenceColumn, should ignore the asset annotation.', function () {
+                        expect(assetRefCompactCols[0].name).toBe(["reference_schema", "table_w_asset_key_1"].join("_"));
+                        expect(assetRefCompactCols[0].isKey).toBe(true);
+                    });
+
+                    it('if column is part of any foreignkeys, should ignore the asset annotation.', function() {
+                        expect(assetRefCompactCols[1].name).toBe(["reference_schema", "table_w_asset_fk_to_outbound"].join("_"));
+                        expect(assetRefCompactCols[1].isForeignKey).toBe(true);
+                    });
+                });
 
                 if (!process.env.TRAVIS) {
                     it('should handle the columns with slash(`/`) in their names.', function () {
@@ -578,6 +705,30 @@ exports.execute = function (options) {
 
                     page = options.ermRest._createPage(entryCreateRef, null, referenceRawData, false, false);
                     expect(page.tuples[0].values).toEqual(entryCreateRefExpectedPartialValue);
+                });
+            });
+
+            describe('for tables with asset column, ', function () {
+                it('should return the underlying value in entry context.', function(done) {
+                    assetRefEntry.read(limit).then(function (page) {
+                        var tuples = page.tuples;
+                        expect(tuples[0].values).toEqual(assetEntryExpectedValue);
+                        done();
+                    }, function (err) {
+                        console.dir(err);
+                        done.fail();
+                    });
+                });
+
+                it('otherwise should return the download button.', function(done) {
+                    assetRefCompact.read(limit).then(function (page) {
+                        var tuples = page.tuples;
+                        expect(tuples[0].values).toEqual(assetCompactExpectedValue);
+                        done();
+                    }, function (err) {
+                        console.dir(err);
+                        done.fail();
+                    });
                 });
             });
 

--- a/test/specs/reference/tests/14.pseudo_columns.js
+++ b/test/specs/reference/tests/14.pseudo_columns.js
@@ -186,7 +186,7 @@ exports.execute = function (options) {
         ];
 
         var assetEntryExpectedValue = [
-            '1', '1', '1000', '10001', '', '<h2>filename</h2>\n', 'https://dev.isrd.isi.edu'
+            '1', '1', '1000', '10001', '<h2>filename</h2>\n', 'https://dev.isrd.isi.edu'
         ];
 
         var assetCompactExpectedValue = [
@@ -195,7 +195,7 @@ exports.execute = function (options) {
             '1000', '10001', 'filename', '1,242', 'md5', 'sha256',
             '',
             '<h2>filename</h2>\n',
-            '<a href="https://dev.isrd.isi.edu" download="">filename</a>'
+            '<a href="https://dev.isrd.isi.edu" download="" class="btn btn-primary">filename</a>'
         ];
 
         /**

--- a/test/specs/reference/tests/14.pseudo_columns.js
+++ b/test/specs/reference/tests/14.pseudo_columns.js
@@ -280,8 +280,8 @@ exports.execute = function (options) {
          *
          * 2. table_w_asset:
          *  ref.columns for detailed (no context present):
-         *  0: table_w_asset_key_1
-         *  1: table_w_asset_fk_to_outbound
+         *  0: table_w_asset_key_1 *KeyPseudoColumn*
+         *  1: table_w_asset_fk_to_outbound *ForeignKeyPseudoColumn*
          *  2: col_1
          *  3: col_2
          *  4: col_filename
@@ -289,17 +289,16 @@ exports.execute = function (options) {
          *  6: col_md5
          *  7: col_sha256
          *  8: col_asset_1 (asset with default options) is null
-         *  9: col_asset_2 (asset with invalid options) has column-display
-         *  10: col_asset_3 (asset with valid options)
+         *  9: col_asset_2 *AssetPseudoColumn* (asset with invalid options) has column-display
+         *  10: col_asset_3 *AssetPseudoColumn* (asset with valid options)
          *
          *  ref.columns for entry (no context present):
          *  0: id
-         *  1: table_w_asset_fk_to_outbound
+         *  1: table_w_asset_fk_to_outbound *ForeignKeyPseudoColumn*
          *  2: col_1
          *  3: col_2
-         *  4: col_asset_1 (asset with default options)
-         *  5: col_asset_2 (asset with invalid options)
-         *  6: col_asset_3 (asset with valid options)
+         *  4: col_asset_2 *AssetPseudoColumn*
+         *  5: col_asset_3 *AssetPseudoColumn*
          *
          *
          *  contexts that are used:
@@ -610,7 +609,7 @@ exports.execute = function (options) {
                                 expected: [
                                     "id",
                                     ["reference_schema", "table_w_asset_fk_to_outbound"].join("_"),
-                                    "col_1", "col_2", "col_asset_1", "col_asset_2", "col_asset_3"
+                                    "col_1", "col_2", "col_asset_2", "col_asset_3"
                                 ]
                             }]);
                         });
@@ -625,6 +624,16 @@ exports.execute = function (options) {
                             expect(assetRefCompactCols[6].isPseudo).toBe(false);
                             expect(assetRefCompactCols[7].name).toBe("col_sha256");
                             expect(assetRefCompactCols[7].isPseudo).toBe(false);
+                        });
+                    });
+
+                    describe('if column has asset annotation, but `no url_pattern`', function () {
+                        it('in edit context it should be removed from the visible-columns.', function (){
+                            //TODO
+                        });
+
+                        it('in other contexts it should be treated as a normal column.', function (){
+                            //TODO
                         });
                     });
 

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -174,9 +174,12 @@ exports.execute = function (options) {
             });
 
             it('for other columns should return the base column\'s table.', function () {
-                // TODO asset
                 for (var i = 5; i < 11; i++) {
                     expect(compactColumns[i].table.name).toBe(tableName);
+                }
+
+                for (var i = 8; i < 11; i++) {
+                    expect(assetRefCompactCols[i].table.name).toBe(tableWithAsset);
                 }
             });
         });
@@ -258,6 +261,9 @@ exports.execute = function (options) {
                 }
                 for (var i = 11; i < 16; i++) {
                     expect(compactColumns[i].type.name).toBe("markdown");
+                }
+                for (var i = 8; i < 11; i++) {
+                    expect(assetRefCompactCols[i].type.name).toBe('markdown');
                 }
             });
 
@@ -627,15 +633,18 @@ exports.execute = function (options) {
             });
 
             describe("for pseudoColumns that are key, ", function () {
-                // it('when key has `column_order:false` annotation, should return false.', function () {
-                //     // TODO should define column_order on keys
-                //     // TODO use table_w_composite_key_3
-                // });
+                it('when key has `column_order:false` annotation, should return false.', function () {
+                    expect(compactBriefRef.columns[2].sortable).toBe(false);
+                    expect(compactBriefRef.columns[2]._sortColumns.length).toBe(0);
+                });
 
-                // it("when key has a `column_order` annotation with value other than false, should return true and use those columns for sort.", function () {
-                //     // TODO should define column_order on keys
-                //     // TODO use table_w_composite_key_3
-                // });
+                it("when key has a `column_order` annotation with value other than false, should return true and use those columns for sort.", function () {
+                    expect(compactBriefRef.columns[1].sortable).toBe(true);
+                    expect(compactBriefRef.columns[1]._sortColumns.length).toBe(2);
+                    expect(compactBriefRef.columns[1]._sortColumns.map(function (col) {
+                        return col.name
+                    })).toEqual(['col_1', 'col_2']);
+                });
 
                 it("when key doesn't have any `column_order` annotation and is simple, should be based on the constituent column.", function () {
                     expect(compactColumns[0].sortable).toBe(true);

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -561,8 +561,8 @@ exports.execute = function (options) {
                     });
 
                     it("otherwise return a download link", function() {
-                        val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com"}).value;
-                        expect(val).toEqual('<a href="https://example.com" download="" class="btn btn-primary" target="_blank">Download</a>');
+                        val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com", "col_filename": "filename"}).value;
+                        expect(val).toEqual('<a href="https://example.com" download="">filename</a>');
                     });
                  });
 
@@ -710,8 +710,8 @@ exports.execute = function (options) {
                     expect(assetRefCompactCols[9].filenameColumn).toBe(null);
                 });
 
-                it('otherwise should return the column name.', function () {
-                    expect(assetRefCompactCols[10].filenameColumn).toBe("col_filename");
+                it('otherwise should return the column.', function () {
+                    expect(assetRefCompactCols[10].filenameColumn.name).toBe("col_filename");
                 });
             });
 
@@ -725,8 +725,8 @@ exports.execute = function (options) {
                     expect(assetRefCompactCols[9].byteCountColumn).toBe(null);
                 });
 
-                it('otherwise should return the column name.', function () {
-                    expect(assetRefCompactCols[10].byteCountColumn).toBe("col_byte");
+                it('otherwise should return the column.', function () {
+                    expect(assetRefCompactCols[10].byteCountColumn.name).toBe("col_byte");
                 });
             });
 
@@ -737,7 +737,7 @@ exports.execute = function (options) {
 
                 it('should return the md5 defined.', function () {
                     expect(assetRefCompactCols[9].md5).toBe(true);
-                    expect(assetRefCompactCols[10].md5).toBe("col_md5");
+                    expect(assetRefCompactCols[10].md5.name).toBe("col_md5");
                 });
             });
 
@@ -748,7 +748,7 @@ exports.execute = function (options) {
 
                 it('should return the sha256 defined.', function () {
                     expect(assetRefCompactCols[9].sha256).toBe(true);
-                    expect(assetRefCompactCols[10].sha256).toBe("col_sha256");
+                    expect(assetRefCompactCols[10].sha256.name).toBe("col_sha256");
                 });
             });
 

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -557,11 +557,6 @@ exports.execute = function (options) {
                         expect(val).toEqual("<h2>filename</h2>\n");
                     });
 
-                    it('if value is null, return the null value.', function() {
-                        val = assetRefCompactCols[8].formatPresentation({"col_filename": "filename"}, {context:"compact", "formattedValues":{"col_filename": "filename"}}).value;
-                        expect(val).toEqual('');
-                    });
-
                     it('if in entry context, return the original underlying data.', function() {
                         val = assetRefEntryCols[6].formatPresentation({"col_asset_3": "https://example.com"}, {context:"entry", "formattedValues":{"col_asset_3": "https://example.com"}}).value;
                         expect(val).toEqual("https://example.com");
@@ -689,19 +684,9 @@ exports.execute = function (options) {
         });
 
         describe('Asset related properties, ', function () {
-            describe('.useDefault', function() {
-                it('should return true if asset annotation is empty.', function (){
-                    expect(assetRefCompactCols[8].useDefault).toBe(true);
-                });
-                it('otherwise should return false.', function (){
-                    expect(assetRefCompactCols[9].useDefault).toBe(false);
-                    expect(assetRefCompactCols[10].useDefault).toBe(false);
-                });
-            });
 
             describe('.urlPattern', function() {
-                it('should return null if asset annotation is empty, or url_pattern is undefined.', function () {
-                    expect(assetRefCompactCols[8].urlPattern).toBe(null);
+                it('should return null if url_pattern is undefined.', function () {
                     expect(assetRefCompactCols[9].urlPattern).toBe(null);
                 });
 
@@ -711,12 +696,8 @@ exports.execute = function (options) {
             });
 
             describe('.filenameColumn', function() {
-                it('should return null if asset annotation is empty.', function () {
-                    expect(assetRefCompactCols[8].filenameColumn).toBe(null);
 
-                });
-
-                it('should return null if column is not valid.', function () {
+                it('should return null if column is not valid or not present.', function () {
                     expect(assetRefCompactCols[9].filenameColumn).toBe(null);
                 });
 
@@ -726,12 +707,7 @@ exports.execute = function (options) {
             });
 
             describe('.byteCountColumn', function() {
-                it('should return null if asset annotation is empty.', function () {
-                    expect(assetRefCompactCols[8].byteCountColumn).toBe(null);
-
-                });
-
-                it('should return null if column is not valid.', function () {
+                it('should return null if column is not valid or not present.', function () {
                     expect(assetRefCompactCols[9].byteCountColumn).toBe(null);
                 });
 
@@ -741,10 +717,6 @@ exports.execute = function (options) {
             });
 
             describe('.md5', function() {
-                it('should return null if asset annotation is empty.', function () {
-                    expect(assetRefCompactCols[8].md5).toBe(null);
-                });
-
                 it('should return the md5 defined.', function () {
                     expect(assetRefCompactCols[9].md5).toBe(true);
                     expect(assetRefCompactCols[10].md5.name).toBe("col_md5");
@@ -752,10 +724,6 @@ exports.execute = function (options) {
             });
 
             describe('.sha256', function() {
-                it('should return null if asset annotation is empty.', function () {
-                    expect(assetRefCompactCols[8].sha256).toBe(null);
-                });
-
                 it('should return the sha256 defined.', function () {
                     expect(assetRefCompactCols[9].sha256).toBe(true);
                     expect(assetRefCompactCols[10].sha256.name).toBe("col_sha256");
@@ -763,8 +731,7 @@ exports.execute = function (options) {
             });
 
             describe('.filenameExtFilter', function() {
-                it('should return null if asset annotation is empty.', function () {
-                    expect(assetRefCompactCols[8].filenameExtFilter).toBe(null);
+                it('should return null if file_name_ext is not present.', function () {
                     expect(assetRefCompactCols[9].filenameExtFilter).toBe(null);
                 });
 

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -101,7 +101,7 @@ exports.execute = function (options) {
                     expect(compactColumns[i].isPseudo).toBe(true);
                 }
 
-                for (var i = 8; i < 11; i++) {
+                for (var i = 9; i < 11; i++) {
                     expect(assetRefCompactCols[i].isPseudo).toBe(true);
                 }
             });
@@ -143,13 +143,13 @@ exports.execute = function (options) {
 
         describe('.isAsset, ', function () {
             it ('for PseudoColumns that are asset should return true.', function () {
-                for (var i = 8; i < 11; i++) {
+                for (var i = 9; i < 11; i++) {
                     expect(assetRefCompactCols[i].isAsset).toBe(true);
                 }
             });
 
             it ('for other columns should return undefined.', function () {
-                for (var i = 0; i < 8; i++) {
+                for (var i = 0; i < 9; i++) {
                     expect(assetRefCompactCols[i].isAsset).toBe(undefined);
                 }
             });
@@ -262,7 +262,7 @@ exports.execute = function (options) {
                 for (var i = 11; i < 16; i++) {
                     expect(compactColumns[i].type.name).toBe("markdown");
                 }
-                for (var i = 8; i < 11; i++) {
+                for (var i = 9; i < 11; i++) {
                     expect(assetRefCompactCols[i].type.name).toBe('markdown');
                 }
             });
@@ -558,13 +558,13 @@ exports.execute = function (options) {
                     });
 
                     it('if in entry context, return the original underlying data.', function() {
-                        val = assetRefEntryCols[6].formatPresentation({"col_asset_3": "https://example.com"}, {context:"entry", "formattedValues":{"col_asset_3": "https://example.com"}}).value;
+                        val = assetRefEntryCols[5].formatPresentation({"col_asset_3": "https://example.com"}, {context:"entry", "formattedValues":{"col_asset_3": "https://example.com"}}).value;
                         expect(val).toEqual("https://example.com");
                     });
 
                     it("otherwise return a download link", function() {
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com", "col_filename": "filename"}).value;
-                        expect(val).toEqual('<a href="https://example.com" download="">filename</a>');
+                        expect(val).toEqual('<a href="https://example.com" download="" class="btn btn-primary">filename</a>');
                     });
                  });
 
@@ -686,11 +686,8 @@ exports.execute = function (options) {
         describe('Asset related properties, ', function () {
 
             describe('.urlPattern', function() {
-                it('should return null if url_pattern is undefined.', function () {
-                    expect(assetRefCompactCols[9].urlPattern).toBe(null);
-                });
-
                 it('otherwise should return the defined url_pattern in annotation.', function () {
+                    expect(assetRefCompactCols[9].urlPattern).toBe("{{col_asset_2}}");
                     expect(assetRefCompactCols[10].urlPattern).toBe("{{col_asset_3}}");
                 });
             });

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -99,14 +99,14 @@ exports.execute = function (options) {
             });
         });
 
-        describe('._isKey, ', function () {
+        describe('.isKey, ', function () {
             it ('for PseudoColumns that are key should return true.', function () {
-                expect(compactColumns[0]._isKey).toBe(true);
+                expect(compactColumns[0].isKey).toBe(true);
             });
 
             it ('for other columns should return undefined.', function () {
                 for (var i = 1; i < 16; i++) {
-                    expect(compactColumns[i]._isKey).toBe(undefined);
+                    expect(compactColumns[i].isKey).toBe(undefined);
                 }
             });
         });

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -324,6 +324,7 @@ exports.execute = function (options) {
             it('for other columns should return the base column\'s default value.', function () {
                 expect(compactColumns[6].default).toEqual('col 4 default');
                 expect(compactColumns[7].default).toEqual('col 5 default');
+                expect(compactColumns[9].default).toEqual(null);
             });
         });
 


### PR DESCRIPTION
This PR addresses #379. It includes:

- Refactor `ReferenceColumn` implementation to have a base table that other pusedo-column classes (`KeyPseudoColumn`, `ForeignKeyPseudoColumn`, and `AssetPseudoColumn`) will extend it.
- `AssetPseudoColumn` implementation. Its specific properties are:
  - `useDefault`: It's mainly used internally, it only indicates whether all of other properties are null or not.
  - `filenameColumn`: `Column` object or null
  - `byteCountColumn`: `Column` object or null
  - `md5`: `Column` object, null, or true
  - `sha256`: `Column` object, null, or true
  - `filenameExtFilter`: Array of string or null
- Override `ReferenceColumn` functions for `AssetPseudoColumn`. It only includes the `formatPresentation` function which will take care of returning the value. This is how the value is generated:
  1. If Column has `column-display` annotation use it.
  2. If in edit context, just return the raw value.
  3. Otherwise, return a download link. The caption will be filename column formatted data (if available), or column's formatted data.

- Change `Reference.columns` logic to handle asset columns. The logic is as follows:
  - If we are in edit context, remove `filename`, `bytecount`, `md5`, and `sha256` from visible columns list.
  - When visible-columns annotation is not defined, if column is part of any foreign-keys ignore the asset annotation.

**Chaise test cases are passing with this branch.**


