### PR TITLE
Shallow Copy Tuple with de-referenced data

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -276,7 +276,7 @@ to use for ERMrest JavaScript agents.
         * [.update()](#ERMrest.Tuple+update) ⇒ <code>Promise</code>
         * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
         * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : <code>[Reference](#ERMrest.Reference)</code>
-        * [.shallowCopy()](#ERMrest.Tuple+shallowCopy)
+        * [.copy()](#ERMrest.Tuple+copy) ⇒ <code>[Tuple](#ERMrest.Tuple)</code>
     * [.ReferenceColumn](#ERMrest.ReferenceColumn)
         * [new ReferenceColumn(reference, baseCols)](#new_ERMrest.ReferenceColumn_new)
         * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
@@ -2532,7 +2532,7 @@ if (content) {
     * [.update()](#ERMrest.Tuple+update) ⇒ <code>Promise</code>
     * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
     * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : <code>[Reference](#ERMrest.Reference)</code>
-    * [.shallowCopy()](#ERMrest.Tuple+shallowCopy)
+    * [.copy()](#ERMrest.Tuple+copy) ⇒ <code>[Tuple](#ERMrest.Tuple)</code>
 
 <a name="new_ERMrest.Tuple_new"></a>
 
@@ -2701,10 +2701,14 @@ With origFKRData = {"k1": "1"} this function will return a reference
 to AssocitaitonTable with FK1 = "1"" and FK2 = "2".
 
 **Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
-<a name="ERMrest.Tuple+shallowCopy"></a>
+<a name="ERMrest.Tuple+copy"></a>
 
-#### tuple.shallowCopy()
+#### tuple.copy() ⇒ <code>[Tuple](#ERMrest.Tuple)</code>
+This function takes the current Tuple (this) and creates a shallow copy of it while de-referencing
+the _data attribute. This way _data can be modified in chaise without changing the originating Tuple
+
 **Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Returns**: <code>[Tuple](#ERMrest.Tuple)</code> - a shallow copy of _this_ tuple with it's _data de-referenced  
 <a name="ERMrest.ReferenceColumn"></a>
 
 ### ERMrest.ReferenceColumn

--- a/doc/api.md
+++ b/doc/api.md
@@ -37,7 +37,7 @@ to use for ERMrest JavaScript agents.
     * [.Server](#ERMrest.Server)
         * [new Server(uri)](#new_ERMrest.Server_new)
         * [.uri](#ERMrest.Server+uri) : <code>string</code>
-        * [.catalogs](#ERMrest.Server+catalogs) : [<code>Catalogs</code>](#ERMrest.Catalogs)
+        * [.catalogs](#ERMrest.Server+catalogs) : <code>[Catalogs](#ERMrest.Catalogs)</code>
     * [.Catalogs](#ERMrest.Catalogs)
         * [new Catalogs(server)](#new_ERMrest.Catalogs_new)
         * [.length()](#ERMrest.Catalogs+length) ⇒ <code>Number</code>
@@ -46,44 +46,44 @@ to use for ERMrest JavaScript agents.
     * [.Catalog](#ERMrest.Catalog)
         * [new Catalog(server, id)](#new_ERMrest.Catalog_new)
         * [.id](#ERMrest.Catalog+id) : <code>string</code>
-        * [.schemas](#ERMrest.Catalog+schemas) : [<code>Schemas</code>](#ERMrest.Schemas)
-        * [.constraintByNamePair(pair, subject)](#ERMrest.Catalog+constraintByNamePair) ⇒ <code>Object</code> \| <code>null</code>
+        * [.schemas](#ERMrest.Catalog+schemas) : <code>[Schemas](#ERMrest.Schemas)</code>
+        * [.constraintByNamePair(pair, subject)](#ERMrest.Catalog+constraintByNamePair) ⇒ <code>Object</code> &#124; <code>null</code>
     * [.Schemas](#ERMrest.Schemas)
         * [new Schemas()](#new_ERMrest.Schemas_new)
         * [.length()](#ERMrest.Schemas+length) ⇒ <code>Number</code>
         * [.all()](#ERMrest.Schemas+all) ⇒ <code>Array</code>
         * [.names()](#ERMrest.Schemas+names) ⇒ <code>Array</code>
-        * [.get(name)](#ERMrest.Schemas+get) ⇒ [<code>Schema</code>](#ERMrest.Schema)
+        * [.get(name)](#ERMrest.Schemas+get) ⇒ <code>[Schema](#ERMrest.Schema)</code>
         * [.has(name)](#ERMrest.Schemas+has) ⇒ <code>boolean</code>
     * [.Schema](#ERMrest.Schema)
         * [new Schema(catalog, jsonSchema)](#new_ERMrest.Schema_new)
-        * [.catalog](#ERMrest.Schema+catalog) : [<code>Catalog</code>](#ERMrest.Catalog)
+        * [.catalog](#ERMrest.Schema+catalog) : <code>[Catalog](#ERMrest.Catalog)</code>
         * [.name](#ERMrest.Schema+name)
         * [.ignore](#ERMrest.Schema+ignore) : <code>boolean</code>
-        * [.annotations](#ERMrest.Schema+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+        * [.annotations](#ERMrest.Schema+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
         * [.displayname](#ERMrest.Schema+displayname) : <code>object</code>
-        * [.tables](#ERMrest.Schema+tables) : [<code>Tables</code>](#ERMrest.Tables)
+        * [.tables](#ERMrest.Schema+tables) : <code>[Tables](#ERMrest.Tables)</code>
         * [.comment](#ERMrest.Schema+comment) : <code>string</code>
     * [.Tables](#ERMrest.Tables)
         * [new Tables()](#new_ERMrest.Tables_new)
         * [.all()](#ERMrest.Tables+all) ⇒ <code>Array</code>
         * [.length()](#ERMrest.Tables+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Tables+names) ⇒ <code>Array</code>
-        * [.get(name)](#ERMrest.Tables+get) ⇒ [<code>Table</code>](#ERMrest.Table)
+        * [.get(name)](#ERMrest.Tables+get) ⇒ <code>[Table](#ERMrest.Table)</code>
     * [.Table](#ERMrest.Table)
         * [new Table(schema, jsonTable)](#new_ERMrest.Table_new)
         * _instance_
-            * [.schema](#ERMrest.Table+schema) : [<code>Schema</code>](#ERMrest.Schema)
+            * [.schema](#ERMrest.Table+schema) : <code>[Schema](#ERMrest.Schema)</code>
             * [.name](#ERMrest.Table+name)
-            * [.entity](#ERMrest.Table+entity) : [<code>Entity</code>](#ERMrest.Table.Entity)
+            * [.entity](#ERMrest.Table+entity) : <code>[Entity](#ERMrest.Table.Entity)</code>
             * [.ignore](#ERMrest.Table+ignore) : <code>boolean</code>
-            * [._baseTable](#ERMrest.Table+_baseTable) : [<code>Table</code>](#ERMrest.Table)
-            * [.annotations](#ERMrest.Table+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+            * [._baseTable](#ERMrest.Table+_baseTable) : <code>[Table](#ERMrest.Table)</code>
+            * [.annotations](#ERMrest.Table+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
             * [.displayname](#ERMrest.Table+displayname) : <code>object</code>
-            * [.columns](#ERMrest.Table+columns) : [<code>Columns</code>](#ERMrest.Columns)
-            * [.keys](#ERMrest.Table+keys) : [<code>Keys</code>](#ERMrest.Keys)
-            * [.foreignKeys](#ERMrest.Table+foreignKeys) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
-            * [.referredBy](#ERMrest.Table+referredBy) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
+            * [.columns](#ERMrest.Table+columns) : <code>[Columns](#ERMrest.Columns)</code>
+            * [.keys](#ERMrest.Table+keys) : <code>[Keys](#ERMrest.Keys)</code>
+            * [.foreignKeys](#ERMrest.Table+foreignKeys) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
+            * [.referredBy](#ERMrest.Table+referredBy) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
             * [.comment](#ERMrest.Table+comment) : <code>string</code>
             * [.kind](#ERMrest.Table+kind) : <code>string</code>
             * [.shortestKey](#ERMrest.Table+shortestKey)
@@ -116,32 +116,32 @@ to use for ERMrest JavaScript agents.
         * [.length()](#ERMrest.Columns+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Columns+names) ⇒ <code>Array</code>
         * [.has(name)](#ERMrest.Columns+has) ⇒ <code>boolean</code>
-        * [.get(name)](#ERMrest.Columns+get) ⇒ [<code>Column</code>](#ERMrest.Column)
-        * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ [<code>Column</code>](#ERMrest.Column)
+        * [.get(name)](#ERMrest.Columns+get) ⇒ <code>[Column](#ERMrest.Column)</code>
+        * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ <code>[Column](#ERMrest.Column)</code>
     * [.Column](#ERMrest.Column)
         * [new Column(table, jsonColumn)](#new_ERMrest.Column_new)
         * [.position](#ERMrest.Column+position) : <code>number</code>
-        * [.table](#ERMrest.Column+table) : [<code>Table</code>](#ERMrest.Table)
+        * [.table](#ERMrest.Column+table) : <code>[Table](#ERMrest.Table)</code>
         * [.name](#ERMrest.Column+name) : <code>string</code>
-        * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
+        * [.type](#ERMrest.Column+type) : <code>[Type](#ERMrest.Type)</code>
         * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
         * [.default](#ERMrest.Column+default) : <code>string</code>
         * [.comment](#ERMrest.Column+comment) : <code>string</code>
         * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
-        * [.annotations](#ERMrest.Column+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+        * [.annotations](#ERMrest.Column+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
         * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
-        * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
-        * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+        * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : <code>[Array.&lt;Key&gt;](#ERMrest.Key)</code>
+        * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
         * [.formatvalue(data)](#ERMrest.Column+formatvalue) ⇒ <code>string</code>
         * [.formatPresentation(data, options)](#ERMrest.Column+formatPresentation) ⇒ <code>Object</code>
         * [.toString()](#ERMrest.Column+toString) ⇒ <code>string</code>
         * [.getDisplay(context)](#ERMrest.Column+getDisplay)
     * [.Annotations](#ERMrest.Annotations)
         * [new Annotations()](#new_ERMrest.Annotations_new)
-        * [.all()](#ERMrest.Annotations+all) ⇒ [<code>Array.&lt;Annotation&gt;</code>](#ERMrest.Annotation)
+        * [.all()](#ERMrest.Annotations+all) ⇒ <code>[Array.&lt;Annotation&gt;](#ERMrest.Annotation)</code>
         * [.length()](#ERMrest.Annotations+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Annotations+names) ⇒ <code>Array</code>
-        * [.get(uri)](#ERMrest.Annotations+get) ⇒ [<code>Annotation</code>](#ERMrest.Annotation)
+        * [.get(uri)](#ERMrest.Annotations+get) ⇒ <code>[Annotation](#ERMrest.Annotation)</code>
         * [.contains(uri)](#ERMrest.Annotations+contains) ⇒ <code>boolean</code>
     * [.Annotation](#ERMrest.Annotation)
         * [new Annotation(subject, uri, jsonAnnotation)](#new_ERMrest.Annotation_new)
@@ -151,13 +151,13 @@ to use for ERMrest JavaScript agents.
         * [new Keys()](#new_ERMrest.Keys_new)
         * [.all()](#ERMrest.Keys+all) ⇒ <code>Array.&lt;Key&gt;</code>
         * [.length()](#ERMrest.Keys+length) ⇒ <code>Number</code>
-        * [.colsets()](#ERMrest.Keys+colsets) ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
-        * [.get(colset)](#ERMrest.Keys+get) ⇒ [<code>Key</code>](#ERMrest.Key)
+        * [.colsets()](#ERMrest.Keys+colsets) ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
+        * [.get(colset)](#ERMrest.Keys+get) ⇒ <code>[Key](#ERMrest.Key)</code>
     * [.Key](#ERMrest.Key)
         * [new Key(table, jsonKey)](#new_ERMrest.Key_new)
         * [.table](#ERMrest.Key+table) : <code>Table</code>
-        * [.colset](#ERMrest.Key+colset) : [<code>ColSet</code>](#ERMrest.ColSet)
-        * [.annotations](#ERMrest.Key+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+        * [.colset](#ERMrest.Key+colset) : <code>[ColSet](#ERMrest.ColSet)</code>
+        * [.annotations](#ERMrest.Key+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
         * [.comment](#ERMrest.Key+comment) : <code>string</code>
         * [.constraint_names](#ERMrest.Key+constraint_names) : <code>Array</code>
         * [.simple](#ERMrest.Key+simple) : <code>boolean</code>
@@ -171,27 +171,27 @@ to use for ERMrest JavaScript agents.
         * [new Mapping(from, to)](#new_ERMrest.Mapping_new)
         * [.toString()](#ERMrest.Mapping+toString) ⇒ <code>string</code>
         * [.length()](#ERMrest.Mapping+length) ⇒ <code>Number</code>
-        * [.domain()](#ERMrest.Mapping+domain) ⇒ [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
-        * [.get(fromCol)](#ERMrest.Mapping+get) ⇒ [<code>Column</code>](#ERMrest.Column)
-        * [.getFromColumn(toCol)](#ERMrest.Mapping+getFromColumn) ⇒ [<code>Column</code>](#ERMrest.Column)
+        * [.domain()](#ERMrest.Mapping+domain) ⇒ <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
+        * [.get(fromCol)](#ERMrest.Mapping+get) ⇒ <code>[Column](#ERMrest.Column)</code>
+        * [.getFromColumn(toCol)](#ERMrest.Mapping+getFromColumn) ⇒ <code>[Column](#ERMrest.Column)</code>
     * [.InboundForeignKeys](#ERMrest.InboundForeignKeys)
         * [new InboundForeignKeys(table)](#new_ERMrest.InboundForeignKeys_new)
     * [.ForeignKeys](#ERMrest.ForeignKeys)
-        * [.all()](#ERMrest.ForeignKeys+all) ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
-        * [.colsets()](#ERMrest.ForeignKeys+colsets) ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
+        * [.all()](#ERMrest.ForeignKeys+all) ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
+        * [.colsets()](#ERMrest.ForeignKeys+colsets) ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
         * [.length()](#ERMrest.ForeignKeys+length) ⇒ <code>Number</code>
-        * [.mappings()](#ERMrest.ForeignKeys+mappings) ⇒ [<code>Array.&lt;Mapping&gt;</code>](#ERMrest.Mapping)
-        * [.get(colset)](#ERMrest.ForeignKeys+get) ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+        * [.mappings()](#ERMrest.ForeignKeys+mappings) ⇒ <code>[Array.&lt;Mapping&gt;](#ERMrest.Mapping)</code>
+        * [.get(colset)](#ERMrest.ForeignKeys+get) ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
     * [.ForeignKeyRef](#ERMrest.ForeignKeyRef)
         * [new ForeignKeyRef(table, jsonFKR)](#new_ERMrest.ForeignKeyRef_new)
-        * [.colset](#ERMrest.ForeignKeyRef+colset) : [<code>ColSet</code>](#ERMrest.ColSet)
-        * [.key](#ERMrest.ForeignKeyRef+key) : [<code>Key</code>](#ERMrest.Key)
-        * [.mapping](#ERMrest.ForeignKeyRef+mapping) : [<code>Mapping</code>](#ERMrest.Mapping)
+        * [.colset](#ERMrest.ForeignKeyRef+colset) : <code>[ColSet](#ERMrest.ColSet)</code>
+        * [.key](#ERMrest.ForeignKeyRef+key) : <code>[Key](#ERMrest.Key)</code>
+        * [.mapping](#ERMrest.ForeignKeyRef+mapping) : <code>[Mapping](#ERMrest.Mapping)</code>
         * [.constraint_names](#ERMrest.ForeignKeyRef+constraint_names) : <code>Array</code>
         * [.from_name](#ERMrest.ForeignKeyRef+from_name) : <code>string</code>
         * [.to_name](#ERMrest.ForeignKeyRef+to_name) : <code>string</code>
         * [.ignore](#ERMrest.ForeignKeyRef+ignore) : <code>boolean</code>
-        * [.annotations](#ERMrest.ForeignKeyRef+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+        * [.annotations](#ERMrest.ForeignKeyRef+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
         * [.comment](#ERMrest.ForeignKeyRef+comment) : <code>string</code>
         * [.simple](#ERMrest.ForeignKeyRef+simple) : <code>Boolean</code>
         * [.toString([reverse])](#ERMrest.ForeignKeyRef+toString) ⇒ <code>string</code>
@@ -233,17 +233,17 @@ to use for ERMrest JavaScript agents.
         * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
         * [.uri](#ERMrest.Reference+uri) : <code>string</code>
         * [.session](#ERMrest.Reference+session)
-        * [.table](#ERMrest.Reference+table) : [<code>Table</code>](#ERMrest.Table)
-        * [.columns](#ERMrest.Reference+columns) : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
+        * [.table](#ERMrest.Reference+table) : <code>[Table](#ERMrest.Table)</code>
+        * [.columns](#ERMrest.Reference+columns) : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
             * [._referenceColumns](#ERMrest.Reference+columns+_referenceColumns)
         * [.isUnique](#ERMrest.Reference+isUnique) : <code>boolean</code>
-        * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> \| <code>undefined</code>
-        * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> \| <code>undefined</code>
-        * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> \| <code>undefined</code>
-        * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> \| <code>undefined</code>
+        * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> &#124; <code>undefined</code>
+        * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> &#124; <code>undefined</code>
+        * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
+        * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
         * [.display](#ERMrest.Reference+display) : <code>Object</code>
         * [._related](#ERMrest.Reference+_related)
-        * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
+        * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : <code>[Reference](#ERMrest.Reference)</code>
         * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
         * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
             * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
@@ -251,99 +251,88 @@ to use for ERMrest JavaScript agents.
         * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
         * [.update(tuples)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
         * [.delete(tuples)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
-        * [.related([tuple])](#ERMrest.Reference+related) ⇒ [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
+        * [.related([tuple])](#ERMrest.Reference+related) ⇒ <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
         * [.search(term)](#ERMrest.Reference+search) ⇒ <code>Reference</code>
     * [.Page](#ERMrest.Page)
         * [new Page(reference, etag, data, hasNext, hasPrevious)](#new_ERMrest.Page_new)
-        * [.reference](#ERMrest.Page+reference) : [<code>Reference</code>](#ERMrest.Reference)
-        * [.tuples](#ERMrest.Page+tuples) : [<code>Array.&lt;Tuple&gt;</code>](#ERMrest.Tuple)
+        * [.reference](#ERMrest.Page+reference) : <code>[Reference](#ERMrest.Reference)</code>
+        * [.tuples](#ERMrest.Page+tuples) : <code>[Array.&lt;Tuple&gt;](#ERMrest.Tuple)</code>
         * [.hasPrevious](#ERMrest.Page+hasPrevious) ⇒ <code>boolean</code>
-        * [.previous](#ERMrest.Page+previous) : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
+        * [.previous](#ERMrest.Page+previous) : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
         * [.hasNext](#ERMrest.Page+hasNext) ⇒ <code>boolean</code>
-        * [.next](#ERMrest.Page+next) : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
-        * [.content](#ERMrest.Page+content) : <code>string</code> \| <code>null</code>
+        * [.next](#ERMrest.Page+next) : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
+        * [.content](#ERMrest.Page+content) : <code>string</code> &#124; <code>null</code>
     * [.Tuple](#ERMrest.Tuple)
         * [new Tuple(reference, page, data)](#new_ERMrest.Tuple_new)
-        * [.reference](#ERMrest.Tuple+reference) ⇒ [<code>Reference</code>](#ERMrest.Reference) \| <code>\*</code>
-        * [.page](#ERMrest.Tuple+page) ⇒ [<code>Page</code>](#ERMrest.Page) \| <code>\*</code>
+        * [.reference](#ERMrest.Tuple+reference) ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
+        * [.page](#ERMrest.Tuple+page) ⇒ <code>[Page](#ERMrest.Page)</code> &#124; <code>\*</code>
         * [.data](#ERMrest.Tuple+data) : <code>Object</code>
         * [.data](#ERMrest.Tuple+data)
-        * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> \| <code>undefined</code>
-        * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> \| <code>undefined</code>
+        * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
+        * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
         * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
         * [.isHTML](#ERMrest.Tuple+isHTML) : <code>Array.&lt;string&gt;</code>
         * [.displayname](#ERMrest.Tuple+displayname) : <code>string</code>
         * [.update()](#ERMrest.Tuple+update) ⇒ <code>Promise</code>
         * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
-        * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : [<code>Reference</code>](#ERMrest.Reference)
+        * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : <code>[Reference](#ERMrest.Reference)</code>
+        * [.shallowCopy()](#ERMrest.Tuple+shallowCopy)
     * [.ReferenceColumn](#ERMrest.ReferenceColumn)
         * [new ReferenceColumn(reference, baseCols)](#new_ERMrest.ReferenceColumn_new)
         * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
-<<<<<<< HEAD
-=======
-        * [.reference](#ERMrest.ReferenceColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
-        * [.foreignKey](#ERMrest.ReferenceColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
-        * [.key](#ERMrest.ReferenceColumn+key) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
-        * [.table](#ERMrest.ReferenceColumn+table) : [<code>Table</code>](#ERMrest.Table)
+        * [.table](#ERMrest.ReferenceColumn+table) : <code>[Table](#ERMrest.Table)</code>
         * [.name](#ERMrest.ReferenceColumn+name) : <code>string</code>
         * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>string</code>
-        * [.type](#ERMrest.ReferenceColumn+type) : [<code>Type</code>](#ERMrest.Type)
+        * [.type](#ERMrest.ReferenceColumn+type) : <code>[Type](#ERMrest.Type)</code>
         * [.nullok](#ERMrest.ReferenceColumn+nullok) : <code>Boolean</code>
         * [.default](#ERMrest.ReferenceColumn+default) : <code>string</code>
         * [.comment](#ERMrest.ReferenceColumn+comment) : <code>string</code>
-        * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> \| <code>object</code>
+        * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> &#124; <code>object</code>
         * [.sortable](#ERMrest.ReferenceColumn+sortable) : <code>boolean</code>
         * [.formatvalue(data)](#ERMrest.ReferenceColumn+formatvalue) ⇒ <code>string</code>
-<<<<<<< HEAD
         * [.formatPresentation(data, options)](#ERMrest.ReferenceColumn+formatPresentation) ⇒ <code>Object</code>
-        * [.getInputDisabled()](#ERMrest.ReferenceColumn+getInputDisabled) : <code>boolean</code> \| <code>object</code>
+        * [.getInputDisabled()](#ERMrest.ReferenceColumn+getInputDisabled) : <code>boolean</code> &#124; <code>object</code>
     * [.ForeignKeyPseudoColumn](#ERMrest.ForeignKeyPseudoColumn)
         * [new ForeignKeyPseudoColumn(reference, fk)](#new_ERMrest.ForeignKeyPseudoColumn_new)
         * [.isPseudo](#ERMrest.ForeignKeyPseudoColumn+isPseudo) : <code>boolean</code>
         * [.isForeignKey](#ERMrest.ForeignKeyPseudoColumn+isForeignKey) : <code>boolean</code>
-        * [.reference](#ERMrest.ForeignKeyPseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
-        * [.foreignKey](#ERMrest.ForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
-        * [.filteredRef(column, data)](#ERMrest.ForeignKeyPseudoColumn+filteredRef) ⇒ [<code>Reference</code>](#ERMrest.Reference)
+        * [.reference](#ERMrest.ForeignKeyPseudoColumn+reference) : <code>[Reference](#ERMrest.Reference)</code>
+        * [.foreignKey](#ERMrest.ForeignKeyPseudoColumn+foreignKey) : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
+        * [.filteredRef(column, data)](#ERMrest.ForeignKeyPseudoColumn+filteredRef) ⇒ <code>[Reference](#ERMrest.Reference)</code>
     * [.KeyPseudoColumn](#ERMrest.KeyPseudoColumn)
         * [new KeyPseudoColumn(reference, key)](#new_ERMrest.KeyPseudoColumn_new)
         * [.isPseudo](#ERMrest.KeyPseudoColumn+isPseudo) : <code>boolean</code>
         * [.isKey](#ERMrest.KeyPseudoColumn+isKey) : <code>boolean</code>
-        * [.key](#ERMrest.KeyPseudoColumn+key) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
+        * [.key](#ERMrest.KeyPseudoColumn+key) : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
     * [.AssetPseudoColumn](#ERMrest.AssetPseudoColumn)
         * [new AssetPseudoColumn(reference, column)](#new_ERMrest.AssetPseudoColumn_new)
         * [.isPseudo](#ERMrest.AssetPseudoColumn+isPseudo) : <code>boolean</code>
         * [.isAsset](#ERMrest.AssetPseudoColumn+isAsset) : <code>boolean</code>
-=======
-        * [.filteredRef(column, data)](#ERMrest.ReferenceColumn+filteredRef) ⇒ [<code>Reference</code>](#ERMrest.Reference)
-        * [.formatPresentation(data, options)](#ERMrest.ReferenceColumn+formatPresentation) ⇒ <code>Object</code>
-        * [.getInputDisabled()](#ERMrest.ReferenceColumn+getInputDisabled) : <code>boolean</code> \| <code>object</code>
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
     * [.Datapath](#ERMrest.Datapath) : <code>object</code>
         * [.DataPath](#ERMrest.Datapath.DataPath)
             * [new DataPath(table)](#new_ERMrest.Datapath.DataPath_new)
-            * [.catalog](#ERMrest.Datapath.DataPath+catalog) : [<code>Catalog</code>](#ERMrest.Catalog)
-            * [.context](#ERMrest.Datapath.DataPath+context) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+            * [.catalog](#ERMrest.Datapath.DataPath+catalog) : <code>[Catalog](#ERMrest.Catalog)</code>
+            * [.context](#ERMrest.Datapath.DataPath+context) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
             * [.entity](#ERMrest.Datapath.DataPath+entity)
                 * [.get()](#ERMrest.Datapath.DataPath+entity.get) ⇒ <code>Promise</code>
                 * [.delete(filter)](#ERMrest.Datapath.DataPath+entity.delete) ⇒ <code>Promise</code>
-            * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
-            * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+            * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
+            * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
         * [.PathTable](#ERMrest.Datapath.PathTable)
             * [new PathTable(table, datapath, alias)](#new_ERMrest.Datapath.PathTable_new)
-            * [.datapath](#ERMrest.Datapath.PathTable+datapath) : [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
-            * [.table](#ERMrest.Datapath.PathTable+table) : [<code>Table</code>](#ERMrest.Table)
+            * [.datapath](#ERMrest.Datapath.PathTable+datapath) : <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
+            * [.table](#ERMrest.Datapath.PathTable+table) : <code>[Table](#ERMrest.Table)</code>
             * [.alias](#ERMrest.Datapath.PathTable+alias) : <code>string</code>
-            * [.columns](#ERMrest.Datapath.PathTable+columns) : [<code>Columns</code>](#ERMrest.Datapath.Columns)
+            * [.columns](#ERMrest.Datapath.PathTable+columns) : <code>[Columns](#ERMrest.Datapath.Columns)</code>
             * [.toString()](#ERMrest.Datapath.PathTable+toString) ⇒ <code>string</code>
         * [.PathColumn](#ERMrest.Datapath.PathColumn)
             * [new PathColumn(column, pathtable)](#new_ERMrest.Datapath.PathColumn_new)
-            * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
-            * [.column](#ERMrest.Datapath.PathColumn+column) : [<code>Column</code>](#ERMrest.Column)
+            * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+            * [.column](#ERMrest.Datapath.PathColumn+column) : <code>[Column](#ERMrest.Column)</code>
         * [.Columns(table, pathtable)](#ERMrest.Datapath.Columns)
             * [.length()](#ERMrest.Datapath.Columns+length) ⇒ <code>Number</code>
             * [.names()](#ERMrest.Datapath.Columns+names) ⇒ <code>Array.&lt;String&gt;</code>
-            * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)
+            * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>
         * [.Operators()](#ERMrest.Datapath.Operators)
     * [.Filters](#ERMrest.Filters) : <code>object</code>
         * [.Negation](#ERMrest.Filters.Negation)
@@ -362,18 +351,18 @@ to use for ERMrest JavaScript agents.
             * [new BinaryPredicate(column, operator, rvalue)](#new_ERMrest.Filters.BinaryPredicate_new)
             * [.toUri()](#ERMrest.Filters.BinaryPredicate+toUri) ⇒ <code>string</code>
     * [.configure(http, q)](#ERMrest.configure)
-    * [.getServer(uri, [params])](#ERMrest.getServer) ⇒ [<code>Server</code>](#ERMrest.Server)
+    * [.getServer(uri, [params])](#ERMrest.getServer) ⇒ <code>[Server](#ERMrest.Server)</code>
     * [.resolve(uri, [params])](#ERMrest.resolve) ⇒ <code>Promise</code>
 
 <a name="ERMrest.Server"></a>
 
 ### ERMrest.Server
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Server](#ERMrest.Server)
     * [new Server(uri)](#new_ERMrest.Server_new)
     * [.uri](#ERMrest.Server+uri) : <code>string</code>
-    * [.catalogs](#ERMrest.Server+catalogs) : [<code>Catalogs</code>](#ERMrest.Catalogs)
+    * [.catalogs](#ERMrest.Server+catalogs) : <code>[Catalogs](#ERMrest.Catalogs)</code>
 
 <a name="new_ERMrest.Server_new"></a>
 
@@ -388,15 +377,15 @@ to use for ERMrest JavaScript agents.
 #### server.uri : <code>string</code>
 The URI of the ERMrest service
 
-**Kind**: instance property of [<code>Server</code>](#ERMrest.Server)  
+**Kind**: instance property of <code>[Server](#ERMrest.Server)</code>  
 <a name="ERMrest.Server+catalogs"></a>
 
-#### server.catalogs : [<code>Catalogs</code>](#ERMrest.Catalogs)
-**Kind**: instance property of [<code>Server</code>](#ERMrest.Server)  
+#### server.catalogs : <code>[Catalogs](#ERMrest.Catalogs)</code>
+**Kind**: instance property of <code>[Server](#ERMrest.Server)</code>  
 <a name="ERMrest.Catalogs"></a>
 
 ### ERMrest.Catalogs
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Catalogs](#ERMrest.Catalogs)
     * [new Catalogs(server)](#new_ERMrest.Catalogs_new)
@@ -412,24 +401,24 @@ Constructor for the Catalogs.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| server | [<code>Server</code>](#ERMrest.Server) | the server object. |
+| server | <code>[Server](#ERMrest.Server)</code> | the server object. |
 
 <a name="ERMrest.Catalogs+length"></a>
 
 #### catalogs.length() ⇒ <code>Number</code>
-**Kind**: instance method of [<code>Catalogs</code>](#ERMrest.Catalogs)  
+**Kind**: instance method of <code>[Catalogs](#ERMrest.Catalogs)</code>  
 **Returns**: <code>Number</code> - Returns the length of the catalogs.  
 <a name="ERMrest.Catalogs+names"></a>
 
 #### catalogs.names() ⇒ <code>Array</code>
-**Kind**: instance method of [<code>Catalogs</code>](#ERMrest.Catalogs)  
+**Kind**: instance method of <code>[Catalogs](#ERMrest.Catalogs)</code>  
 **Returns**: <code>Array</code> - Returns an array of names of catalogs.  
 <a name="ERMrest.Catalogs+get"></a>
 
 #### catalogs.get(id) ⇒ <code>Promise</code>
 Get a catalog by id. This call does catalog introspection.
 
-**Kind**: instance method of [<code>Catalogs</code>](#ERMrest.Catalogs)  
+**Kind**: instance method of <code>[Catalogs](#ERMrest.Catalogs)</code>  
 **Returns**: <code>Promise</code> - a promise that returns the catalog  if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [NotFoundError](#ERMrest.NotFoundError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
@@ -441,13 +430,13 @@ Get a catalog by id. This call does catalog introspection.
 <a name="ERMrest.Catalog"></a>
 
 ### ERMrest.Catalog
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Catalog](#ERMrest.Catalog)
     * [new Catalog(server, id)](#new_ERMrest.Catalog_new)
     * [.id](#ERMrest.Catalog+id) : <code>string</code>
-    * [.schemas](#ERMrest.Catalog+schemas) : [<code>Schemas</code>](#ERMrest.Schemas)
-    * [.constraintByNamePair(pair, subject)](#ERMrest.Catalog+constraintByNamePair) ⇒ <code>Object</code> \| <code>null</code>
+    * [.schemas](#ERMrest.Catalog+schemas) : <code>[Schemas](#ERMrest.Schemas)</code>
+    * [.constraintByNamePair(pair, subject)](#ERMrest.Catalog+constraintByNamePair) ⇒ <code>Object</code> &#124; <code>null</code>
 
 <a name="new_ERMrest.Catalog_new"></a>
 
@@ -457,7 +446,7 @@ Constructor for the Catalog.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| server | [<code>Server</code>](#ERMrest.Server) | the server object. |
+| server | <code>[Server](#ERMrest.Server)</code> | the server object. |
 | id | <code>string</code> | the catalog id. |
 
 <a name="ERMrest.Catalog+id"></a>
@@ -465,21 +454,21 @@ Constructor for the Catalog.
 #### catalog.id : <code>string</code>
 The catalog identifier.
 
-**Kind**: instance property of [<code>Catalog</code>](#ERMrest.Catalog)  
+**Kind**: instance property of <code>[Catalog](#ERMrest.Catalog)</code>  
 <a name="ERMrest.Catalog+schemas"></a>
 
-#### catalog.schemas : [<code>Schemas</code>](#ERMrest.Schemas)
-**Kind**: instance property of [<code>Catalog</code>](#ERMrest.Catalog)  
+#### catalog.schemas : <code>[Schemas](#ERMrest.Schemas)</code>
+**Kind**: instance property of <code>[Catalog](#ERMrest.Catalog)</code>  
 <a name="ERMrest.Catalog+constraintByNamePair"></a>
 
-#### catalog.constraintByNamePair(pair, subject) ⇒ <code>Object</code> \| <code>null</code>
+#### catalog.constraintByNamePair(pair, subject) ⇒ <code>Object</code> &#124; <code>null</code>
 returns the constraint object for the pair.
 
-**Kind**: instance method of [<code>Catalog</code>](#ERMrest.Catalog)  
-**Returns**: <code>Object</code> \| <code>null</code> - the constraint object. Null means the constraint name is not valid.  
+**Kind**: instance method of <code>[Catalog](#ERMrest.Catalog)</code>  
+**Returns**: <code>Object</code> &#124; <code>null</code> - the constraint object. Null means the constraint name is not valid.  
 **Throws**:
 
-- [<code>NotFoundError</code>](#ERMrest.NotFoundError) constraint not found
+- <code>[NotFoundError](#ERMrest.NotFoundError)</code> constraint not found
 
 
 | Param | Type | Description |
@@ -490,14 +479,14 @@ returns the constraint object for the pair.
 <a name="ERMrest.Schemas"></a>
 
 ### ERMrest.Schemas
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Schemas](#ERMrest.Schemas)
     * [new Schemas()](#new_ERMrest.Schemas_new)
     * [.length()](#ERMrest.Schemas+length) ⇒ <code>Number</code>
     * [.all()](#ERMrest.Schemas+all) ⇒ <code>Array</code>
     * [.names()](#ERMrest.Schemas+names) ⇒ <code>Array</code>
-    * [.get(name)](#ERMrest.Schemas+get) ⇒ [<code>Schema</code>](#ERMrest.Schema)
+    * [.get(name)](#ERMrest.Schemas+get) ⇒ <code>[Schema](#ERMrest.Schema)</code>
     * [.has(name)](#ERMrest.Schemas+has) ⇒ <code>boolean</code>
 
 <a name="new_ERMrest.Schemas_new"></a>
@@ -508,28 +497,28 @@ Constructor for the Schemas.
 <a name="ERMrest.Schemas+length"></a>
 
 #### schemas.length() ⇒ <code>Number</code>
-**Kind**: instance method of [<code>Schemas</code>](#ERMrest.Schemas)  
+**Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
 **Returns**: <code>Number</code> - number of schemas  
 <a name="ERMrest.Schemas+all"></a>
 
 #### schemas.all() ⇒ <code>Array</code>
-**Kind**: instance method of [<code>Schemas</code>](#ERMrest.Schemas)  
+**Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
 **Returns**: <code>Array</code> - Array of all schemas in the catalog  
 <a name="ERMrest.Schemas+names"></a>
 
 #### schemas.names() ⇒ <code>Array</code>
-**Kind**: instance method of [<code>Schemas</code>](#ERMrest.Schemas)  
+**Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
 **Returns**: <code>Array</code> - Array of schema names  
 <a name="ERMrest.Schemas+get"></a>
 
-#### schemas.get(name) ⇒ [<code>Schema</code>](#ERMrest.Schema)
+#### schemas.get(name) ⇒ <code>[Schema](#ERMrest.Schema)</code>
 get schema by schema name
 
-**Kind**: instance method of [<code>Schemas</code>](#ERMrest.Schemas)  
-**Returns**: [<code>Schema</code>](#ERMrest.Schema) - schema object  
+**Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
+**Returns**: <code>[Schema](#ERMrest.Schema)</code> - schema object  
 **Throws**:
 
-- [<code>NotFoundError</code>](#ERMrest.NotFoundError) schema not found
+- <code>[NotFoundError](#ERMrest.NotFoundError)</code> schema not found
 
 
 | Param | Type | Description |
@@ -541,7 +530,7 @@ get schema by schema name
 #### schemas.has(name) ⇒ <code>boolean</code>
 check for schema name existence
 
-**Kind**: instance method of [<code>Schemas</code>](#ERMrest.Schemas)  
+**Kind**: instance method of <code>[Schemas](#ERMrest.Schemas)</code>  
 **Returns**: <code>boolean</code> - if the schema exists or not  
 
 | Param | Type | Description |
@@ -551,16 +540,16 @@ check for schema name existence
 <a name="ERMrest.Schema"></a>
 
 ### ERMrest.Schema
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Schema](#ERMrest.Schema)
     * [new Schema(catalog, jsonSchema)](#new_ERMrest.Schema_new)
-    * [.catalog](#ERMrest.Schema+catalog) : [<code>Catalog</code>](#ERMrest.Catalog)
+    * [.catalog](#ERMrest.Schema+catalog) : <code>[Catalog](#ERMrest.Catalog)</code>
     * [.name](#ERMrest.Schema+name)
     * [.ignore](#ERMrest.Schema+ignore) : <code>boolean</code>
-    * [.annotations](#ERMrest.Schema+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+    * [.annotations](#ERMrest.Schema+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
     * [.displayname](#ERMrest.Schema+displayname) : <code>object</code>
-    * [.tables](#ERMrest.Schema+tables) : [<code>Tables</code>](#ERMrest.Tables)
+    * [.tables](#ERMrest.Schema+tables) : <code>[Tables](#ERMrest.Tables)</code>
     * [.comment](#ERMrest.Schema+comment) : <code>string</code>
 
 <a name="new_ERMrest.Schema_new"></a>
@@ -571,25 +560,25 @@ Constructor for the Catalog.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| catalog | [<code>Catalog</code>](#ERMrest.Catalog) | the catalog object. |
+| catalog | <code>[Catalog](#ERMrest.Catalog)</code> | the catalog object. |
 | jsonSchema | <code>string</code> | json of the schema. |
 
 <a name="ERMrest.Schema+catalog"></a>
 
-#### schema.catalog : [<code>Catalog</code>](#ERMrest.Catalog)
-**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
+#### schema.catalog : <code>[Catalog](#ERMrest.Catalog)</code>
+**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+name"></a>
 
 #### schema.name
-**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
+**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+ignore"></a>
 
 #### schema.ignore : <code>boolean</code>
-**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
+**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+annotations"></a>
 
-#### schema.annotations : [<code>Annotations</code>](#ERMrest.Annotations)
-**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
+#### schema.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
+**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+displayname"></a>
 
 #### schema.displayname : <code>object</code>
@@ -597,28 +586,28 @@ Preferred display name for user presentation only.
 this.displayname.isHTML will return true/false
 this.displayname.value has the value
 
-**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
+**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+tables"></a>
 
-#### schema.tables : [<code>Tables</code>](#ERMrest.Tables)
-**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
+#### schema.tables : <code>[Tables](#ERMrest.Tables)</code>
+**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Schema+comment"></a>
 
 #### schema.comment : <code>string</code>
 Documentation for this schema
 
-**Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
+**Kind**: instance property of <code>[Schema](#ERMrest.Schema)</code>  
 <a name="ERMrest.Tables"></a>
 
 ### ERMrest.Tables
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Tables](#ERMrest.Tables)
     * [new Tables()](#new_ERMrest.Tables_new)
     * [.all()](#ERMrest.Tables+all) ⇒ <code>Array</code>
     * [.length()](#ERMrest.Tables+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Tables+names) ⇒ <code>Array</code>
-    * [.get(name)](#ERMrest.Tables+get) ⇒ [<code>Table</code>](#ERMrest.Table)
+    * [.get(name)](#ERMrest.Tables+get) ⇒ <code>[Table](#ERMrest.Table)</code>
 
 <a name="new_ERMrest.Tables_new"></a>
 
@@ -628,28 +617,28 @@ Constructor for the Tables.
 <a name="ERMrest.Tables+all"></a>
 
 #### tables.all() ⇒ <code>Array</code>
-**Kind**: instance method of [<code>Tables</code>](#ERMrest.Tables)  
+**Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
 **Returns**: <code>Array</code> - array of tables  
 <a name="ERMrest.Tables+length"></a>
 
 #### tables.length() ⇒ <code>Number</code>
-**Kind**: instance method of [<code>Tables</code>](#ERMrest.Tables)  
+**Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
 **Returns**: <code>Number</code> - number of tables  
 <a name="ERMrest.Tables+names"></a>
 
 #### tables.names() ⇒ <code>Array</code>
-**Kind**: instance method of [<code>Tables</code>](#ERMrest.Tables)  
+**Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
 **Returns**: <code>Array</code> - Array of table names  
 <a name="ERMrest.Tables+get"></a>
 
-#### tables.get(name) ⇒ [<code>Table</code>](#ERMrest.Table)
+#### tables.get(name) ⇒ <code>[Table](#ERMrest.Table)</code>
 get table by table name
 
-**Kind**: instance method of [<code>Tables</code>](#ERMrest.Tables)  
-**Returns**: [<code>Table</code>](#ERMrest.Table) - table  
+**Kind**: instance method of <code>[Tables](#ERMrest.Tables)</code>  
+**Returns**: <code>[Table](#ERMrest.Table)</code> - table  
 **Throws**:
 
-- [<code>NotFoundError</code>](#ERMrest.NotFoundError) table not found
+- <code>[NotFoundError](#ERMrest.NotFoundError)</code> table not found
 
 
 | Param | Type | Description |
@@ -659,22 +648,22 @@ get table by table name
 <a name="ERMrest.Table"></a>
 
 ### ERMrest.Table
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Table](#ERMrest.Table)
     * [new Table(schema, jsonTable)](#new_ERMrest.Table_new)
     * _instance_
-        * [.schema](#ERMrest.Table+schema) : [<code>Schema</code>](#ERMrest.Schema)
+        * [.schema](#ERMrest.Table+schema) : <code>[Schema](#ERMrest.Schema)</code>
         * [.name](#ERMrest.Table+name)
-        * [.entity](#ERMrest.Table+entity) : [<code>Entity</code>](#ERMrest.Table.Entity)
+        * [.entity](#ERMrest.Table+entity) : <code>[Entity](#ERMrest.Table.Entity)</code>
         * [.ignore](#ERMrest.Table+ignore) : <code>boolean</code>
-        * [._baseTable](#ERMrest.Table+_baseTable) : [<code>Table</code>](#ERMrest.Table)
-        * [.annotations](#ERMrest.Table+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+        * [._baseTable](#ERMrest.Table+_baseTable) : <code>[Table](#ERMrest.Table)</code>
+        * [.annotations](#ERMrest.Table+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
         * [.displayname](#ERMrest.Table+displayname) : <code>object</code>
-        * [.columns](#ERMrest.Table+columns) : [<code>Columns</code>](#ERMrest.Columns)
-        * [.keys](#ERMrest.Table+keys) : [<code>Keys</code>](#ERMrest.Keys)
-        * [.foreignKeys](#ERMrest.Table+foreignKeys) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
-        * [.referredBy](#ERMrest.Table+referredBy) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
+        * [.columns](#ERMrest.Table+columns) : <code>[Columns](#ERMrest.Columns)</code>
+        * [.keys](#ERMrest.Table+keys) : <code>[Keys](#ERMrest.Keys)</code>
+        * [.foreignKeys](#ERMrest.Table+foreignKeys) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
+        * [.referredBy](#ERMrest.Table+referredBy) : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
         * [.comment](#ERMrest.Table+comment) : <code>string</code>
         * [.kind](#ERMrest.Table+kind) : <code>string</code>
         * [.shortestKey](#ERMrest.Table+shortestKey)
@@ -698,36 +687,36 @@ Constructor for Table.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| schema | [<code>Schema</code>](#ERMrest.Schema) | the schema object. |
+| schema | <code>[Schema](#ERMrest.Schema)</code> | the schema object. |
 | jsonTable | <code>string</code> | the json of the table. |
 
 <a name="ERMrest.Table+schema"></a>
 
-#### table.schema : [<code>Schema</code>](#ERMrest.Schema)
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+#### table.schema : <code>[Schema](#ERMrest.Schema)</code>
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+name"></a>
 
 #### table.name
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+entity"></a>
 
-#### table.entity : [<code>Entity</code>](#ERMrest.Table.Entity)
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+#### table.entity : <code>[Entity](#ERMrest.Table.Entity)</code>
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+ignore"></a>
 
 #### table.ignore : <code>boolean</code>
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+_baseTable"></a>
 
-#### table._baseTable : [<code>Table</code>](#ERMrest.Table)
+#### table._baseTable : <code>[Table](#ERMrest.Table)</code>
 this defaults to itself on the first pass of introspection
 then might be changed on the second pass if this is an alternative table
 
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+annotations"></a>
 
-#### table.annotations : [<code>Annotations</code>](#ERMrest.Annotations)
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+#### table.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+displayname"></a>
 
 #### table.displayname : <code>object</code>
@@ -735,50 +724,50 @@ Preferred display name for user presentation only.
 this.displayname.isHTML will return true/false
 this.displayname.value has the value
 
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+columns"></a>
 
-#### table.columns : [<code>Columns</code>](#ERMrest.Columns)
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+#### table.columns : <code>[Columns](#ERMrest.Columns)</code>
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+keys"></a>
 
-#### table.keys : [<code>Keys</code>](#ERMrest.Keys)
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+#### table.keys : <code>[Keys](#ERMrest.Keys)</code>
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+foreignKeys"></a>
 
-#### table.foreignKeys : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+#### table.foreignKeys : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+referredBy"></a>
 
-#### table.referredBy : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
+#### table.referredBy : <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>
 All the FKRs to this table.
 
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+comment"></a>
 
 #### table.comment : <code>string</code>
 Documentation for this table
 
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+kind"></a>
 
 #### table.kind : <code>string</code>
 The type of this table
 
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 <a name="ERMrest.Table+shortestKey"></a>
 
 #### table.shortestKey
 The columns that create the shortest key
 
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+**Kind**: instance property of <code>[Table](#ERMrest.Table)</code>  
 **Type{column[]}**:   
 <a name="ERMrest.Table+_getDisplayKey"></a>
 
 #### table._getDisplayKey(context)
 returns the key that can be used for display purposes.
 
-**Kind**: instance method of [<code>Table</code>](#ERMrest.Table)  
+**Kind**: instance method of <code>[Table](#ERMrest.Table)</code>  
 **Returns{column[]|undefined}**: list of columns. If couldn't find a suitable columns will return undefined.  
 
 | Param | Type | Description |
@@ -788,7 +777,7 @@ returns the key that can be used for display purposes.
 <a name="ERMrest.Table.Entity"></a>
 
 #### Table.Entity
-**Kind**: static class of [<code>Table</code>](#ERMrest.Table)  
+**Kind**: static class of <code>[Table](#ERMrest.Table)</code>  
 
 * [.Entity](#ERMrest.Table.Entity)
     * [new Entity(server, table)](#new_ERMrest.Table.Entity_new)
@@ -808,22 +797,22 @@ Constructor for Entity. This is a container in Table
 
 | Param | Type |
 | --- | --- |
-| server | [<code>Server</code>](#ERMrest.Server) | 
-| table | [<code>Table</code>](#ERMrest.Table) | 
+| server | <code>[Server](#ERMrest.Server)</code> | 
+| table | <code>[Table](#ERMrest.Table)</code> | 
 
 <a name="ERMrest.Table.Entity+count"></a>
 
 ##### entity.count([filter]) ⇒ <code>Promise</code>
 get the number of rows
 
-**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
+**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
 **Returns**: <code>Promise</code> - promise returning number of count if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
 
 | Param | Type |
 | --- | --- |
-| [filter] | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) | 
+| [filter] | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
 
 <a name="ERMrest.Table.Entity+get"></a>
 
@@ -832,16 +821,16 @@ get table rows with option filter, row limit and selected columns (in this order
 In order to use before & after on a Rows, limit must be speficied,
 output columns and sortby needs to have columns of a key
 
-**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
+**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
 **Returns**: <code>Promise</code> - promise returning rowset if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     ERMrest.Conflict, ERMrest.ForbiddenError or ERMrest.Unauthorized if rejected  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [filter] | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) |  |
+| [filter] | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> |  |
 | [limit] | <code>Number</code> | Number of rows |
-| [columns] | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) \| <code>Array.&lt;string&gt;</code> | Array of column names or Column objects output |
+| [columns] | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> &#124; <code>Array.&lt;string&gt;</code> | Array of column names or Column objects output |
 | [sortby] | <code>Array.&lt;Object&gt;</code> | An ordered array of {column, order} where column is column name or Column object, order is null (default), 'asc' or 'desc' |
 
 <a name="ERMrest.Table.Entity+getBefore"></a>
@@ -851,16 +840,16 @@ get a page of rows before a specific row
 In order to use before & after on a Rows, limit must be speficied,
 output columns and sortby needs to have columns of a key
 
-**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
+**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
 **Returns**: <code>Promise</code> - promise returning rowset if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     ERMrest.Conflict, ERMrest.ForbiddenError or ERMrest.Unauthorized if rejected  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) \| <code>null</code> | null if not being used |
+| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> &#124; <code>null</code> | null if not being used |
 | limit | <code>Number</code> | Required. Number of rows |
-| [columns] | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) \| <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
+| [columns] | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> &#124; <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
 | [sortby] | <code>Array.&lt;Object&gt;</code> | ordered array of {column, order} where column is column name or Column object, order is null (default), 'asc' or 'desc' |
 | row | <code>Object</code> | json row data used to getBefore |
 
@@ -869,16 +858,16 @@ output columns and sortby needs to have columns of a key
 ##### entity.getAfter(filter, limit, [columns], [sortby], row) ⇒ <code>Promise</code>
 get a page of rows after a specific row
 
-**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
+**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
 **Returns**: <code>Promise</code> - promise returning rowset if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     ERMrest.Conflict, ERMrest.ForbiddenError or ERMrest.Unauthorized if rejected  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) \| <code>null</code> | null is not being used |
+| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> &#124; <code>null</code> | null is not being used |
 | limit | <code>Number</code> | Required. Number of rows |
-| [columns] | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) \| <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
+| [columns] | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> &#124; <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
 | [sortby] | <code>Array.&lt;Object&gt;</code> | ordered array of {column, order} where column is column name or Column object, order is null (default), 'asc' or 'desc' |
 | row | <code>Object</code> | json row data used to getAfter |
 
@@ -887,19 +876,19 @@ get a page of rows after a specific row
 ##### entity.delete(filter) ⇒ <code>Promise</code>
 Delete rows from table based on the filter
 
-**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
+**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
 **Returns**: <code>Promise</code> - Promise that returns the json row data deleted if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
 
 | Param | Type |
 | --- | --- |
-| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) | 
+| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
 
 <a name="ERMrest.Table.Entity+put"></a>
 
 ##### entity.put(rows) ⇒ <code>Promise</code>
-**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
+**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
 **Returns**: <code>Promise</code> - Promise that returns the rows updated if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected
@@ -914,7 +903,7 @@ Update rows in the table
 ##### entity.post(rows, defaults) ⇒ <code>Promise</code>
 Create new entities
 
-**Kind**: instance method of [<code>Entity</code>](#ERMrest.Table.Entity)  
+**Kind**: instance method of <code>[Entity](#ERMrest.Table.Entity)</code>  
 **Returns**: <code>Promise</code> - Promise that returns the rows created if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [BadRequestError](#ERMrest.BadRequestError), [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
@@ -927,7 +916,7 @@ Create new entities
 <a name="ERMrest.Rows"></a>
 
 ### ERMrest.Rows
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Rows](#ERMrest.Rows)
     * [new Rows(table, jsonRows, filter, limit, columns, [sortby])](#new_ERMrest.Rows_new)
@@ -943,11 +932,11 @@ Create new entities
 
 | Param | Type | Description |
 | --- | --- | --- |
-| table | [<code>Table</code>](#ERMrest.Table) |  |
+| table | <code>[Table](#ERMrest.Table)</code> |  |
 | jsonRows | <code>Object</code> |  |
-| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) \| <code>null</code> | null if not being used |
+| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> &#124; <code>null</code> | null if not being used |
 | limit | <code>Number</code> | Number of rows |
-| columns | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) \| <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
+| columns | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> &#124; <code>Array.&lt;String&gt;</code> | Array of column names or Column objects output |
 | [sortby] | <code>Array.&lt;Object&gt;</code> | An ordered array of {column, order} where column is column name or Column object, order is null/'' (default), 'asc' or 'desc' |
 
 <a name="ERMrest.Rows+data"></a>
@@ -957,21 +946,21 @@ The set of rows returns from the server. It is an Array of
 Objects that has keys and values based on the query that produced
 the Rows.
 
-**Kind**: instance property of [<code>Rows</code>](#ERMrest.Rows)  
+**Kind**: instance property of <code>[Rows](#ERMrest.Rows)</code>  
 <a name="ERMrest.Rows+length"></a>
 
 #### rows.length() ⇒ <code>number</code>
-**Kind**: instance method of [<code>Rows</code>](#ERMrest.Rows)  
+**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
 <a name="ERMrest.Rows+get"></a>
 
 #### rows.get() ⇒ <code>Row</code>
-**Kind**: instance method of [<code>Rows</code>](#ERMrest.Rows)  
+**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
 <a name="ERMrest.Rows+after"></a>
 
 #### rows.after() ⇒ <code>Promise</code>
 get the rows of the next page
 
-**Kind**: instance method of [<code>Rows</code>](#ERMrest.Rows)  
+**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
 **Returns**: <code>Promise</code> - promise that returns the rows if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
@@ -980,14 +969,14 @@ get the rows of the next page
 #### rows.before() ⇒ <code>Promise</code>
 get the rowset of the previous page
 
-**Kind**: instance method of [<code>Rows</code>](#ERMrest.Rows)  
+**Kind**: instance method of <code>[Rows](#ERMrest.Rows)</code>  
 **Returns**: <code>Promise</code> - promise that returns a rowset if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
 <a name="ERMrest.Row"></a>
 
 ### ERMrest.Row
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Row](#ERMrest.Row)
     * [new Row(jsonRow)](#new_ERMrest.Row_new)
@@ -1008,16 +997,16 @@ get the rowset of the previous page
 #### row.data : <code>Object</code>
 The row returned from the ith result in the Rows.data.
 
-**Kind**: instance property of [<code>Row</code>](#ERMrest.Row)  
+**Kind**: instance property of <code>[Row](#ERMrest.Row)</code>  
 <a name="ERMrest.Row+names"></a>
 
 #### row.names() ⇒ <code>Array</code>
-**Kind**: instance method of [<code>Row</code>](#ERMrest.Row)  
+**Kind**: instance method of <code>[Row](#ERMrest.Row)</code>  
 **Returns**: <code>Array</code> - Array of column names  
 <a name="ERMrest.Row+get"></a>
 
 #### row.get(name) ⇒ <code>Object</code>
-**Kind**: instance method of [<code>Row</code>](#ERMrest.Row)  
+**Kind**: instance method of <code>[Row](#ERMrest.Row)</code>  
 **Returns**: <code>Object</code> - column value  
 
 | Param | Type | Description |
@@ -1027,7 +1016,7 @@ The row returned from the ith result in the Rows.data.
 <a name="ERMrest.Columns"></a>
 
 ### ERMrest.Columns
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Columns](#ERMrest.Columns)
     * [new Columns(table)](#new_ERMrest.Columns_new)
@@ -1035,8 +1024,8 @@ The row returned from the ith result in the Rows.data.
     * [.length()](#ERMrest.Columns+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Columns+names) ⇒ <code>Array</code>
     * [.has(name)](#ERMrest.Columns+has) ⇒ <code>boolean</code>
-    * [.get(name)](#ERMrest.Columns+get) ⇒ [<code>Column</code>](#ERMrest.Column)
-    * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ [<code>Column</code>](#ERMrest.Column)
+    * [.get(name)](#ERMrest.Columns+get) ⇒ <code>[Column](#ERMrest.Column)</code>
+    * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ <code>[Column](#ERMrest.Column)</code>
 
 <a name="new_ERMrest.Columns_new"></a>
 
@@ -1051,22 +1040,22 @@ Constructor for Columns.
 <a name="ERMrest.Columns+all"></a>
 
 #### columns.all() ⇒ <code>Array</code>
-**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
+**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
 **Returns**: <code>Array</code> - array of all columns  
 <a name="ERMrest.Columns+length"></a>
 
 #### columns.length() ⇒ <code>Number</code>
-**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
+**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
 **Returns**: <code>Number</code> - number of columns  
 <a name="ERMrest.Columns+names"></a>
 
 #### columns.names() ⇒ <code>Array</code>
-**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
+**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
 **Returns**: <code>Array</code> - names of columns  
 <a name="ERMrest.Columns+has"></a>
 
 #### columns.has(name) ⇒ <code>boolean</code>
-**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
+**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
 **Returns**: <code>boolean</code> - whether Columns has this column or not  
 
 | Param | Type | Description |
@@ -1075,9 +1064,9 @@ Constructor for Columns.
 
 <a name="ERMrest.Columns+get"></a>
 
-#### columns.get(name) ⇒ [<code>Column</code>](#ERMrest.Column)
-**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
-**Returns**: [<code>Column</code>](#ERMrest.Column) - column  
+#### columns.get(name) ⇒ <code>[Column](#ERMrest.Column)</code>
+**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
+**Returns**: <code>[Column](#ERMrest.Column)</code> - column  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1085,8 +1074,8 @@ Constructor for Columns.
 
 <a name="ERMrest.Columns+getByPosition"></a>
 
-#### columns.getByPosition(pos) ⇒ [<code>Column</code>](#ERMrest.Column)
-**Kind**: instance method of [<code>Columns</code>](#ERMrest.Columns)  
+#### columns.getByPosition(pos) ⇒ <code>[Column](#ERMrest.Column)</code>
+**Kind**: instance method of <code>[Columns](#ERMrest.Columns)</code>  
 
 | Param | Type |
 | --- | --- |
@@ -1095,22 +1084,22 @@ Constructor for Columns.
 <a name="ERMrest.Column"></a>
 
 ### ERMrest.Column
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Column](#ERMrest.Column)
     * [new Column(table, jsonColumn)](#new_ERMrest.Column_new)
     * [.position](#ERMrest.Column+position) : <code>number</code>
-    * [.table](#ERMrest.Column+table) : [<code>Table</code>](#ERMrest.Table)
+    * [.table](#ERMrest.Column+table) : <code>[Table](#ERMrest.Table)</code>
     * [.name](#ERMrest.Column+name) : <code>string</code>
-    * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
+    * [.type](#ERMrest.Column+type) : <code>[Type](#ERMrest.Type)</code>
     * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
     * [.default](#ERMrest.Column+default) : <code>string</code>
     * [.comment](#ERMrest.Column+comment) : <code>string</code>
     * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
-    * [.annotations](#ERMrest.Column+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+    * [.annotations](#ERMrest.Column+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
     * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
-    * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
-    * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+    * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : <code>[Array.&lt;Key&gt;](#ERMrest.Key)</code>
+    * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
     * [.formatvalue(data)](#ERMrest.Column+formatvalue) ⇒ <code>string</code>
     * [.formatPresentation(data, options)](#ERMrest.Column+formatPresentation) ⇒ <code>Object</code>
     * [.toString()](#ERMrest.Column+toString) ⇒ <code>string</code>
@@ -1128,7 +1117,7 @@ a Column _may not_ be a part of a Table.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| table | [<code>Table</code>](#ERMrest.Table) | the table object. |
+| table | <code>[Table](#ERMrest.Table)</code> | the table object. |
 | jsonColumn | <code>string</code> | the json column. |
 
 <a name="ERMrest.Column+position"></a>
@@ -1138,41 +1127,41 @@ The ordinal number or position of this column relative to other
 columns within the same scope.
 TODO: to be implemented
 
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+table"></a>
 
-#### column.table : [<code>Table</code>](#ERMrest.Table)
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+#### column.table : <code>[Table](#ERMrest.Table)</code>
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+name"></a>
 
 #### column.name : <code>string</code>
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+type"></a>
 
-#### column.type : [<code>Type</code>](#ERMrest.Type)
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+#### column.type : <code>[Type](#ERMrest.Type)</code>
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+nullok"></a>
 
 #### column.nullok : <code>Boolean</code>
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+default"></a>
 
 #### column.default : <code>string</code>
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+comment"></a>
 
 #### column.comment : <code>string</code>
 Documentation for this column
 
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+ignore"></a>
 
 #### column.ignore : <code>boolean</code>
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+annotations"></a>
 
-#### column.annotations : [<code>Annotations</code>](#ERMrest.Annotations)
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+#### column.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+displayname"></a>
 
 #### column.displayname : <code>object</code>
@@ -1180,25 +1169,25 @@ Preferred display name for user presentation only.
 this.displayname.isHTML will return true/false
 this.displayname.value has the value
 
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+memberOfKeys"></a>
 
-#### column.memberOfKeys : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
+#### column.memberOfKeys : <code>[Array.&lt;Key&gt;](#ERMrest.Key)</code>
 keys that this column is a member of
 
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+memberOfForeignKeys"></a>
 
-#### column.memberOfForeignKeys : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+#### column.memberOfForeignKeys : <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
 foreign key that this column is a member of
 
-**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance property of <code>[Column](#ERMrest.Column)</code>  
 <a name="ERMrest.Column+formatvalue"></a>
 
 #### column.formatvalue(data) ⇒ <code>string</code>
 Formats a value corresponding to this column definition.
 
-**Kind**: instance method of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance method of <code>[Column](#ERMrest.Column)</code>  
 **Returns**: <code>string</code> - The formatted value.  
 
 | Param | Type | Description |
@@ -1210,7 +1199,7 @@ Formats a value corresponding to this column definition.
 #### column.formatPresentation(data, options) ⇒ <code>Object</code>
 Formats the presentation value corresponding to this column definition.
 
-**Kind**: instance method of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance method of <code>[Column](#ERMrest.Column)</code>  
 **Returns**: <code>Object</code> - A key value pair containing value and isHTML that detemrines the presenation.  
 
 | Param | Type | Description |
@@ -1223,18 +1212,14 @@ Formats the presentation value corresponding to this column definition.
 #### column.toString() ⇒ <code>string</code>
 returns string representation of Column
 
-**Kind**: instance method of [<code>Column</code>](#ERMrest.Column)  
-<<<<<<< HEAD
+**Kind**: instance method of <code>[Column](#ERMrest.Column)</code>  
 **Returns**: <code>string</code> - string representation of Column  
-=======
-**Retuns**: <code>string</code> string representation of Column  
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
 <a name="ERMrest.Column+getDisplay"></a>
 
 #### column.getDisplay(context)
 display object for the column
 
-**Kind**: instance method of [<code>Column</code>](#ERMrest.Column)  
+**Kind**: instance method of <code>[Column](#ERMrest.Column)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1243,14 +1228,14 @@ display object for the column
 <a name="ERMrest.Annotations"></a>
 
 ### ERMrest.Annotations
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Annotations](#ERMrest.Annotations)
     * [new Annotations()](#new_ERMrest.Annotations_new)
-    * [.all()](#ERMrest.Annotations+all) ⇒ [<code>Array.&lt;Annotation&gt;</code>](#ERMrest.Annotation)
+    * [.all()](#ERMrest.Annotations+all) ⇒ <code>[Array.&lt;Annotation&gt;](#ERMrest.Annotation)</code>
     * [.length()](#ERMrest.Annotations+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Annotations+names) ⇒ <code>Array</code>
-    * [.get(uri)](#ERMrest.Annotations+get) ⇒ [<code>Annotation</code>](#ERMrest.Annotation)
+    * [.get(uri)](#ERMrest.Annotations+get) ⇒ <code>[Annotation](#ERMrest.Annotation)</code>
     * [.contains(uri)](#ERMrest.Annotations+contains) ⇒ <code>boolean</code>
 
 <a name="new_ERMrest.Annotations_new"></a>
@@ -1260,29 +1245,29 @@ Constructor for Annotations.
 
 <a name="ERMrest.Annotations+all"></a>
 
-#### annotations.all() ⇒ [<code>Array.&lt;Annotation&gt;</code>](#ERMrest.Annotation)
-**Kind**: instance method of [<code>Annotations</code>](#ERMrest.Annotations)  
-**Returns**: [<code>Array.&lt;Annotation&gt;</code>](#ERMrest.Annotation) - list of all annotations  
+#### annotations.all() ⇒ <code>[Array.&lt;Annotation&gt;](#ERMrest.Annotation)</code>
+**Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
+**Returns**: <code>[Array.&lt;Annotation&gt;](#ERMrest.Annotation)</code> - list of all annotations  
 <a name="ERMrest.Annotations+length"></a>
 
 #### annotations.length() ⇒ <code>Number</code>
-**Kind**: instance method of [<code>Annotations</code>](#ERMrest.Annotations)  
+**Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
 **Returns**: <code>Number</code> - number of annotations  
 <a name="ERMrest.Annotations+names"></a>
 
 #### annotations.names() ⇒ <code>Array</code>
-**Kind**: instance method of [<code>Annotations</code>](#ERMrest.Annotations)  
+**Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
 **Returns**: <code>Array</code> - array of annotation names  
 <a name="ERMrest.Annotations+get"></a>
 
-#### annotations.get(uri) ⇒ [<code>Annotation</code>](#ERMrest.Annotation)
+#### annotations.get(uri) ⇒ <code>[Annotation](#ERMrest.Annotation)</code>
 get annotation by URI
 
-**Kind**: instance method of [<code>Annotations</code>](#ERMrest.Annotations)  
-**Returns**: [<code>Annotation</code>](#ERMrest.Annotation) - annotation  
+**Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
+**Returns**: <code>[Annotation](#ERMrest.Annotation)</code> - annotation  
 **Throws**:
 
-- [<code>NotFoundError</code>](#ERMrest.NotFoundError) annotation not found
+- <code>[NotFoundError](#ERMrest.NotFoundError)</code> annotation not found
 
 
 | Param | Type | Description |
@@ -1292,7 +1277,7 @@ get annotation by URI
 <a name="ERMrest.Annotations+contains"></a>
 
 #### annotations.contains(uri) ⇒ <code>boolean</code>
-**Kind**: instance method of [<code>Annotations</code>](#ERMrest.Annotations)  
+**Kind**: instance method of <code>[Annotations](#ERMrest.Annotations)</code>  
 **Returns**: <code>boolean</code> - whether or not annotation exists  
 
 | Param | Type | Description |
@@ -1302,7 +1287,7 @@ get annotation by URI
 <a name="ERMrest.Annotation"></a>
 
 ### ERMrest.Annotation
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Annotation](#ERMrest.Annotation)
     * [new Annotation(subject, uri, jsonAnnotation)](#new_ERMrest.Annotation_new)
@@ -1326,24 +1311,24 @@ Constructor for Annotation.
 #### annotation.subject : <code>string</code>
 One of schema,table,column,key,foreignkeyref
 
-**Kind**: instance property of [<code>Annotation</code>](#ERMrest.Annotation)  
+**Kind**: instance property of <code>[Annotation](#ERMrest.Annotation)</code>  
 <a name="ERMrest.Annotation+content"></a>
 
 #### annotation.content : <code>string</code>
 json content
 
-**Kind**: instance property of [<code>Annotation</code>](#ERMrest.Annotation)  
+**Kind**: instance property of <code>[Annotation](#ERMrest.Annotation)</code>  
 <a name="ERMrest.Keys"></a>
 
 ### ERMrest.Keys
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Keys](#ERMrest.Keys)
     * [new Keys()](#new_ERMrest.Keys_new)
     * [.all()](#ERMrest.Keys+all) ⇒ <code>Array.&lt;Key&gt;</code>
     * [.length()](#ERMrest.Keys+length) ⇒ <code>Number</code>
-    * [.colsets()](#ERMrest.Keys+colsets) ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
-    * [.get(colset)](#ERMrest.Keys+get) ⇒ [<code>Key</code>](#ERMrest.Key)
+    * [.colsets()](#ERMrest.Keys+colsets) ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
+    * [.get(colset)](#ERMrest.Keys+get) ⇒ <code>[Key](#ERMrest.Key)</code>
 
 <a name="new_ERMrest.Keys_new"></a>
 
@@ -1353,44 +1338,44 @@ Constructor for Keys.
 <a name="ERMrest.Keys+all"></a>
 
 #### keys.all() ⇒ <code>Array.&lt;Key&gt;</code>
-**Kind**: instance method of [<code>Keys</code>](#ERMrest.Keys)  
+**Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
 **Returns**: <code>Array.&lt;Key&gt;</code> - a list of all Keys  
 <a name="ERMrest.Keys+length"></a>
 
 #### keys.length() ⇒ <code>Number</code>
-**Kind**: instance method of [<code>Keys</code>](#ERMrest.Keys)  
+**Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
 **Returns**: <code>Number</code> - number of keys  
 <a name="ERMrest.Keys+colsets"></a>
 
-#### keys.colsets() ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
-**Kind**: instance method of [<code>Keys</code>](#ERMrest.Keys)  
-**Returns**: [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet) - array of colsets  
+#### keys.colsets() ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
+**Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
+**Returns**: <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code> - array of colsets  
 <a name="ERMrest.Keys+get"></a>
 
-#### keys.get(colset) ⇒ [<code>Key</code>](#ERMrest.Key)
+#### keys.get(colset) ⇒ <code>[Key](#ERMrest.Key)</code>
 get the key by the column set
 
-**Kind**: instance method of [<code>Keys</code>](#ERMrest.Keys)  
-**Returns**: [<code>Key</code>](#ERMrest.Key) - key of the colset  
+**Kind**: instance method of <code>[Keys](#ERMrest.Keys)</code>  
+**Returns**: <code>[Key](#ERMrest.Key)</code> - key of the colset  
 **Throws**:
 
-- [<code>NotFoundError</code>](#ERMrest.NotFoundError) Key not found
+- <code>[NotFoundError](#ERMrest.NotFoundError)</code> Key not found
 
 
 | Param | Type |
 | --- | --- |
-| colset | [<code>ColSet</code>](#ERMrest.ColSet) | 
+| colset | <code>[ColSet](#ERMrest.ColSet)</code> | 
 
 <a name="ERMrest.Key"></a>
 
 ### ERMrest.Key
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Key](#ERMrest.Key)
     * [new Key(table, jsonKey)](#new_ERMrest.Key_new)
     * [.table](#ERMrest.Key+table) : <code>Table</code>
-    * [.colset](#ERMrest.Key+colset) : [<code>ColSet</code>](#ERMrest.ColSet)
-    * [.annotations](#ERMrest.Key+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+    * [.colset](#ERMrest.Key+colset) : <code>[ColSet](#ERMrest.ColSet)</code>
+    * [.annotations](#ERMrest.Key+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
     * [.comment](#ERMrest.Key+comment) : <code>string</code>
     * [.constraint_names](#ERMrest.Key+constraint_names) : <code>Array</code>
     * [.simple](#ERMrest.Key+simple) : <code>boolean</code>
@@ -1404,7 +1389,7 @@ Constructor for Key.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| table | [<code>Table</code>](#ERMrest.Table) | the table object. |
+| table | <code>[Table](#ERMrest.Table)</code> | the table object. |
 | jsonKey | <code>string</code> | json key. |
 
 <a name="ERMrest.Key+table"></a>
@@ -1412,48 +1397,48 @@ Constructor for Key.
 #### key.table : <code>Table</code>
 Reference to the table that this Key belongs to.
 
-**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
+**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.Key+colset"></a>
 
-#### key.colset : [<code>ColSet</code>](#ERMrest.ColSet)
-**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
+#### key.colset : <code>[ColSet](#ERMrest.ColSet)</code>
+**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.Key+annotations"></a>
 
-#### key.annotations : [<code>Annotations</code>](#ERMrest.Annotations)
-**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
+#### key.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
+**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.Key+comment"></a>
 
 #### key.comment : <code>string</code>
 Documentation for this key
 
-**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
+**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.Key+constraint_names"></a>
 
 #### key.constraint_names : <code>Array</code>
 The exact `names` array in key definition
 
-**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
+**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.Key+simple"></a>
 
 #### key.simple : <code>boolean</code>
 Indicates if the key is simple (not composite)
 
-**Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
+**Kind**: instance property of <code>[Key](#ERMrest.Key)</code>  
 <a name="ERMrest.Key+containsColumn"></a>
 
 #### key.containsColumn(column) ⇒ <code>boolean</code>
 whether key has a column
 
-**Kind**: instance method of [<code>Key</code>](#ERMrest.Key)  
+**Kind**: instance method of <code>[Key](#ERMrest.Key)</code>  
 
 | Param | Type |
 | --- | --- |
-| column | [<code>Column</code>](#ERMrest.Column) | 
+| column | <code>[Column](#ERMrest.Column)</code> | 
 
 <a name="ERMrest.ColSet"></a>
 
 ### ERMrest.ColSet
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.ColSet](#ERMrest.ColSet)
     * [new ColSet(columns)](#new_ERMrest.ColSet_new)
@@ -1474,35 +1459,31 @@ Constructor for ColSet, a set of Column objects.
 <a name="ERMrest.ColSet+columns"></a>
 
 #### colSet.columns : <code>Array</code>
-**Kind**: instance property of [<code>ColSet</code>](#ERMrest.ColSet)  
+**Kind**: instance property of <code>[ColSet](#ERMrest.ColSet)</code>  
 <a name="ERMrest.ColSet+toString"></a>
 
 #### colSet.toString() ⇒ <code>string</code>
 returns string representation of colset object: (s:t:c1,s:t:c2)
 
-**Kind**: instance method of [<code>ColSet</code>](#ERMrest.ColSet)  
-<<<<<<< HEAD
+**Kind**: instance method of <code>[ColSet](#ERMrest.ColSet)</code>  
 **Returns**: <code>string</code> - string representation of colset object  
-=======
-**Retuns**: <code>string</code> string representation of colset object  
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
 <a name="ERMrest.ColSet+length"></a>
 
 #### colSet.length() ⇒ <code>Number</code>
-**Kind**: instance method of [<code>ColSet</code>](#ERMrest.ColSet)  
+**Kind**: instance method of <code>[ColSet](#ERMrest.ColSet)</code>  
 **Returns**: <code>Number</code> - number of columns  
 <a name="ERMrest.Mapping"></a>
 
 ### ERMrest.Mapping
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Mapping](#ERMrest.Mapping)
     * [new Mapping(from, to)](#new_ERMrest.Mapping_new)
     * [.toString()](#ERMrest.Mapping+toString) ⇒ <code>string</code>
     * [.length()](#ERMrest.Mapping+length) ⇒ <code>Number</code>
-    * [.domain()](#ERMrest.Mapping+domain) ⇒ [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
-    * [.get(fromCol)](#ERMrest.Mapping+get) ⇒ [<code>Column</code>](#ERMrest.Column)
-    * [.getFromColumn(toCol)](#ERMrest.Mapping+getFromColumn) ⇒ [<code>Column</code>](#ERMrest.Column)
+    * [.domain()](#ERMrest.Mapping+domain) ⇒ <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
+    * [.get(fromCol)](#ERMrest.Mapping+get) ⇒ <code>[Column](#ERMrest.Column)</code>
+    * [.getFromColumn(toCol)](#ERMrest.Mapping+getFromColumn) ⇒ <code>[Column](#ERMrest.Column)</code>
 
 <a name="new_ERMrest.Mapping_new"></a>
 
@@ -1510,66 +1491,62 @@ returns string representation of colset object: (s:t:c1,s:t:c2)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| from | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) | array of from Columns |
-| to | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) | array of to Columns |
+| from | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> | array of from Columns |
+| to | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> | array of to Columns |
 
 <a name="ERMrest.Mapping+toString"></a>
 
 #### mapping.toString() ⇒ <code>string</code>
 returns string representation of Mapping object
 
-**Kind**: instance method of [<code>Mapping</code>](#ERMrest.Mapping)  
-<<<<<<< HEAD
+**Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
 **Returns**: <code>string</code> - string representation of Mapping object  
-=======
-**Retuns**: <code>string</code> string representation of Mapping object  
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
 <a name="ERMrest.Mapping+length"></a>
 
 #### mapping.length() ⇒ <code>Number</code>
-**Kind**: instance method of [<code>Mapping</code>](#ERMrest.Mapping)  
+**Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
 **Returns**: <code>Number</code> - number of mapping columns  
 <a name="ERMrest.Mapping+domain"></a>
 
-#### mapping.domain() ⇒ [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
-**Kind**: instance method of [<code>Mapping</code>](#ERMrest.Mapping)  
-**Returns**: [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) - the from columns  
+#### mapping.domain() ⇒ <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
+**Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
+**Returns**: <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> - the from columns  
 <a name="ERMrest.Mapping+get"></a>
 
-#### mapping.get(fromCol) ⇒ [<code>Column</code>](#ERMrest.Column)
+#### mapping.get(fromCol) ⇒ <code>[Column](#ERMrest.Column)</code>
 get the mapping column given the from column
 
-**Kind**: instance method of [<code>Mapping</code>](#ERMrest.Mapping)  
-**Returns**: [<code>Column</code>](#ERMrest.Column) - mapping column  
+**Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
+**Returns**: <code>[Column](#ERMrest.Column)</code> - mapping column  
 **Throws**:
 
-- [<code>NotFoundError</code>](#ERMrest.NotFoundError) no mapping column found
+- <code>[NotFoundError](#ERMrest.NotFoundError)</code> no mapping column found
 
 
 | Param | Type |
 | --- | --- |
-| fromCol | [<code>Column</code>](#ERMrest.Column) | 
+| fromCol | <code>[Column](#ERMrest.Column)</code> | 
 
 <a name="ERMrest.Mapping+getFromColumn"></a>
 
-#### mapping.getFromColumn(toCol) ⇒ [<code>Column</code>](#ERMrest.Column)
+#### mapping.getFromColumn(toCol) ⇒ <code>[Column](#ERMrest.Column)</code>
 get the mapping column given the to column
 
-**Kind**: instance method of [<code>Mapping</code>](#ERMrest.Mapping)  
-**Returns**: [<code>Column</code>](#ERMrest.Column) - mapping column  
+**Kind**: instance method of <code>[Mapping](#ERMrest.Mapping)</code>  
+**Returns**: <code>[Column](#ERMrest.Column)</code> - mapping column  
 **Throws**:
 
-- [<code>NotFoundError</code>](#ERMrest.NotFoundError) no mapping column found
+- <code>[NotFoundError](#ERMrest.NotFoundError)</code> no mapping column found
 
 
 | Param | Type |
 | --- | --- |
-| toCol | [<code>Column</code>](#ERMrest.Column) | 
+| toCol | <code>[Column](#ERMrest.Column)</code> | 
 
 <a name="ERMrest.InboundForeignKeys"></a>
 
 ### ERMrest.InboundForeignKeys
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.InboundForeignKeys_new"></a>
 
 #### new InboundForeignKeys(table)
@@ -1578,71 +1555,71 @@ holds inbound foreignkeys of a table.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| table | [<code>Table</code>](#ERMrest.Table) | the table that this object is for |
+| table | <code>[Table](#ERMrest.Table)</code> | the table that this object is for |
 
 <a name="ERMrest.ForeignKeys"></a>
 
 ### ERMrest.ForeignKeys
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.ForeignKeys](#ERMrest.ForeignKeys)
-    * [.all()](#ERMrest.ForeignKeys+all) ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
-    * [.colsets()](#ERMrest.ForeignKeys+colsets) ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
+    * [.all()](#ERMrest.ForeignKeys+all) ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
+    * [.colsets()](#ERMrest.ForeignKeys+colsets) ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
     * [.length()](#ERMrest.ForeignKeys+length) ⇒ <code>Number</code>
-    * [.mappings()](#ERMrest.ForeignKeys+mappings) ⇒ [<code>Array.&lt;Mapping&gt;</code>](#ERMrest.Mapping)
-    * [.get(colset)](#ERMrest.ForeignKeys+get) ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+    * [.mappings()](#ERMrest.ForeignKeys+mappings) ⇒ <code>[Array.&lt;Mapping&gt;](#ERMrest.Mapping)</code>
+    * [.get(colset)](#ERMrest.ForeignKeys+get) ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
 
 <a name="ERMrest.ForeignKeys+all"></a>
 
-#### foreignKeys.all() ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
-**Kind**: instance method of [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)  
-**Returns**: [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef) - an array of all foreign key references  
+#### foreignKeys.all() ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
+**Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
+**Returns**: <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code> - an array of all foreign key references  
 <a name="ERMrest.ForeignKeys+colsets"></a>
 
-#### foreignKeys.colsets() ⇒ [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet)
-**Kind**: instance method of [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)  
-**Returns**: [<code>Array.&lt;ColSet&gt;</code>](#ERMrest.ColSet) - an array of the foreign keys' colsets  
+#### foreignKeys.colsets() ⇒ <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code>
+**Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
+**Returns**: <code>[Array.&lt;ColSet&gt;](#ERMrest.ColSet)</code> - an array of the foreign keys' colsets  
 <a name="ERMrest.ForeignKeys+length"></a>
 
 #### foreignKeys.length() ⇒ <code>Number</code>
-**Kind**: instance method of [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)  
+**Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
 **Returns**: <code>Number</code> - number of foreign keys  
 <a name="ERMrest.ForeignKeys+mappings"></a>
 
-#### foreignKeys.mappings() ⇒ [<code>Array.&lt;Mapping&gt;</code>](#ERMrest.Mapping)
-**Kind**: instance method of [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)  
-**Returns**: [<code>Array.&lt;Mapping&gt;</code>](#ERMrest.Mapping) - mappings  
+#### foreignKeys.mappings() ⇒ <code>[Array.&lt;Mapping&gt;](#ERMrest.Mapping)</code>
+**Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
+**Returns**: <code>[Array.&lt;Mapping&gt;](#ERMrest.Mapping)</code> - mappings  
 <a name="ERMrest.ForeignKeys+get"></a>
 
-#### foreignKeys.get(colset) ⇒ [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+#### foreignKeys.get(colset) ⇒ <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code>
 get the foreign key of the given column set
 
-**Kind**: instance method of [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)  
-**Returns**: [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef) - foreign key reference of the colset  
+**Kind**: instance method of <code>[ForeignKeys](#ERMrest.ForeignKeys)</code>  
+**Returns**: <code>[Array.&lt;ForeignKeyRef&gt;](#ERMrest.ForeignKeyRef)</code> - foreign key reference of the colset  
 **Throws**:
 
-- [<code>NotFoundError</code>](#ERMrest.NotFoundError) foreign key not found
+- <code>[NotFoundError](#ERMrest.NotFoundError)</code> foreign key not found
 
 
 | Param | Type |
 | --- | --- |
-| colset | [<code>ColSet</code>](#ERMrest.ColSet) | 
+| colset | <code>[ColSet](#ERMrest.ColSet)</code> | 
 
 <a name="ERMrest.ForeignKeyRef"></a>
 
 ### ERMrest.ForeignKeyRef
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.ForeignKeyRef](#ERMrest.ForeignKeyRef)
     * [new ForeignKeyRef(table, jsonFKR)](#new_ERMrest.ForeignKeyRef_new)
-    * [.colset](#ERMrest.ForeignKeyRef+colset) : [<code>ColSet</code>](#ERMrest.ColSet)
-    * [.key](#ERMrest.ForeignKeyRef+key) : [<code>Key</code>](#ERMrest.Key)
-    * [.mapping](#ERMrest.ForeignKeyRef+mapping) : [<code>Mapping</code>](#ERMrest.Mapping)
+    * [.colset](#ERMrest.ForeignKeyRef+colset) : <code>[ColSet](#ERMrest.ColSet)</code>
+    * [.key](#ERMrest.ForeignKeyRef+key) : <code>[Key](#ERMrest.Key)</code>
+    * [.mapping](#ERMrest.ForeignKeyRef+mapping) : <code>[Mapping](#ERMrest.Mapping)</code>
     * [.constraint_names](#ERMrest.ForeignKeyRef+constraint_names) : <code>Array</code>
     * [.from_name](#ERMrest.ForeignKeyRef+from_name) : <code>string</code>
     * [.to_name](#ERMrest.ForeignKeyRef+to_name) : <code>string</code>
     * [.ignore](#ERMrest.ForeignKeyRef+ignore) : <code>boolean</code>
-    * [.annotations](#ERMrest.ForeignKeyRef+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+    * [.annotations](#ERMrest.ForeignKeyRef+annotations) : <code>[Annotations](#ERMrest.Annotations)</code>
     * [.comment](#ERMrest.ForeignKeyRef+comment) : <code>string</code>
     * [.simple](#ERMrest.ForeignKeyRef+simple) : <code>Boolean</code>
     * [.toString([reverse])](#ERMrest.ForeignKeyRef+toString) ⇒ <code>string</code>
@@ -1654,70 +1631,66 @@ get the foreign key of the given column set
 
 | Param | Type |
 | --- | --- |
-| table | [<code>Table</code>](#ERMrest.Table) | 
+| table | <code>[Table](#ERMrest.Table)</code> | 
 | jsonFKR | <code>Object</code> | 
 
 <a name="ERMrest.ForeignKeyRef+colset"></a>
 
-#### foreignKeyRef.colset : [<code>ColSet</code>](#ERMrest.ColSet)
-**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+#### foreignKeyRef.colset : <code>[ColSet](#ERMrest.ColSet)</code>
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+key"></a>
 
-#### foreignKeyRef.key : [<code>Key</code>](#ERMrest.Key)
+#### foreignKeyRef.key : <code>[Key](#ERMrest.Key)</code>
 find key from referencedCols
 use index 0 since all refCols should be of the same schema:table
 
-**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+mapping"></a>
 
-#### foreignKeyRef.mapping : [<code>Mapping</code>](#ERMrest.Mapping)
-**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+#### foreignKeyRef.mapping : <code>[Mapping](#ERMrest.Mapping)</code>
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+constraint_names"></a>
 
 #### foreignKeyRef.constraint_names : <code>Array</code>
 The exact `names` array in foreign key definition
 TODO: it may need to change based on its usage
 
-**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+from_name"></a>
 
 #### foreignKeyRef.from_name : <code>string</code>
-**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+to_name"></a>
 
 #### foreignKeyRef.to_name : <code>string</code>
-**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+ignore"></a>
 
 #### foreignKeyRef.ignore : <code>boolean</code>
-**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+annotations"></a>
 
-#### foreignKeyRef.annotations : [<code>Annotations</code>](#ERMrest.Annotations)
-**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+#### foreignKeyRef.annotations : <code>[Annotations](#ERMrest.Annotations)</code>
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+comment"></a>
 
 #### foreignKeyRef.comment : <code>string</code>
 Documentation for this foreign key reference
 
-**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+simple"></a>
 
 #### foreignKeyRef.simple : <code>Boolean</code>
 Indicates if the foreign key is simple (not composite)
 
-**Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+**Kind**: instance property of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 <a name="ERMrest.ForeignKeyRef+toString"></a>
 
 #### foreignKeyRef.toString([reverse]) ⇒ <code>string</code>
 returns string representation of ForeignKeyRef object
 
-**Kind**: instance method of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
-<<<<<<< HEAD
+**Kind**: instance method of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 **Returns**: <code>string</code> - string representation of ForeignKeyRef object  
-=======
-**Retuns**: <code>string</code> string representation of ForeignKeyRef object  
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1726,7 +1699,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.ForeignKeyRef+getDomainValues"></a>
 
 #### foreignKeyRef.getDomainValues(limit) ⇒ <code>Promise</code>
-**Kind**: instance method of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
+**Kind**: instance method of <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>  
 **Returns**: <code>Promise</code> - promise that returns a rowset of the referenced key's table if resolved or
     [TimedOutError](#ERMrest.TimedOutError), [InternalServerError](#ERMrest.InternalServerError), [ServiceUnavailableError](#ERMrest.ServiceUnavailableError),
     [ConflictError](#ERMrest.ConflictError), [ForbiddenError](#ERMrest.ForbiddenError) or [UnauthorizedError](#ERMrest.UnauthorizedError) if rejected  
@@ -1738,7 +1711,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.Type"></a>
 
 ### ERMrest.Type
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Type](#ERMrest.Type)
     * [new Type(name)](#new_ERMrest.Type_new)
@@ -1755,11 +1728,11 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.Type+name"></a>
 
 #### type.name
-**Kind**: instance property of [<code>Type</code>](#ERMrest.Type)  
+**Kind**: instance property of <code>[Type](#ERMrest.Type)</code>  
 <a name="ERMrest.TimedOutError"></a>
 
 ### ERMrest.TimedOutError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.TimedOutError_new"></a>
 
 #### new TimedOutError(status, message)
@@ -1772,7 +1745,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.BadRequestError"></a>
 
 ### ERMrest.BadRequestError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.BadRequestError_new"></a>
 
 #### new BadRequestError(status, message)
@@ -1785,7 +1758,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.UnauthorizedError"></a>
 
 ### ERMrest.UnauthorizedError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.UnauthorizedError_new"></a>
 
 #### new UnauthorizedError(status, message)
@@ -1798,7 +1771,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.ForbiddenError"></a>
 
 ### ERMrest.ForbiddenError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.ForbiddenError_new"></a>
 
 #### new ForbiddenError(status, message)
@@ -1811,7 +1784,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.NotFoundError"></a>
 
 ### ERMrest.NotFoundError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.NotFoundError_new"></a>
 
 #### new NotFoundError(status, message)
@@ -1824,7 +1797,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.ConflictError"></a>
 
 ### ERMrest.ConflictError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.ConflictError_new"></a>
 
 #### new ConflictError(status, message)
@@ -1837,7 +1810,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.PreconditionFailedError"></a>
 
 ### ERMrest.PreconditionFailedError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.PreconditionFailedError_new"></a>
 
 #### new PreconditionFailedError(status, message)
@@ -1850,7 +1823,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.InternalServerError"></a>
 
 ### ERMrest.InternalServerError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.InternalServerError_new"></a>
 
 #### new InternalServerError(status, message)
@@ -1863,7 +1836,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.ServiceUnavailableError"></a>
 
 ### ERMrest.ServiceUnavailableError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.ServiceUnavailableError_new"></a>
 
 #### new ServiceUnavailableError(status, message)
@@ -1876,7 +1849,7 @@ returns string representation of ForeignKeyRef object
 <a name="ERMrest.InvalidFilterOperatorError"></a>
 
 ### ERMrest.InvalidFilterOperatorError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.InvalidFilterOperatorError_new"></a>
 
 #### new InvalidFilterOperatorError(message)
@@ -1890,7 +1863,7 @@ An invalid filter operator
 <a name="ERMrest.InvalidInputError"></a>
 
 ### ERMrest.InvalidInputError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.InvalidInputError_new"></a>
 
 #### new InvalidInputError(message)
@@ -1904,7 +1877,7 @@ An invalid input
 <a name="ERMrest.MalformedURIError"></a>
 
 ### ERMrest.MalformedURIError
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 <a name="new_ERMrest.MalformedURIError_new"></a>
 
 #### new MalformedURIError(message)
@@ -1918,7 +1891,7 @@ A malformed URI was passed to the API.
 <a name="ERMrest.ParsedFilter"></a>
 
 ### ERMrest.ParsedFilter
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.ParsedFilter](#ERMrest.ParsedFilter)
     * [new ParsedFilter(type)](#new_ERMrest.ParsedFilter_new)
@@ -1938,7 +1911,7 @@ Constructor for a ParsedFilter.
 <a name="ERMrest.ParsedFilter+setFilters"></a>
 
 #### parsedFilter.setFilters(filters)
-**Kind**: instance method of [<code>ParsedFilter</code>](#ERMrest.ParsedFilter)  
+**Kind**: instance method of <code>[ParsedFilter](#ERMrest.ParsedFilter)</code>  
 
 | Param | Description |
 | --- | --- |
@@ -1947,7 +1920,7 @@ Constructor for a ParsedFilter.
 <a name="ERMrest.ParsedFilter+setBinaryPredicate"></a>
 
 #### parsedFilter.setBinaryPredicate(colname, operator, value)
-**Kind**: instance method of [<code>ParsedFilter</code>](#ERMrest.ParsedFilter)  
+**Kind**: instance method of <code>[ParsedFilter](#ERMrest.ParsedFilter)</code>  
 
 | Param | Description |
 | --- | --- |
@@ -1958,7 +1931,7 @@ Constructor for a ParsedFilter.
 <a name="ERMrest.Reference"></a>
 
 ### ERMrest.Reference
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Reference](#ERMrest.Reference)
     * [new Reference(location, catalog)](#new_ERMrest.Reference_new)
@@ -1966,17 +1939,17 @@ Constructor for a ParsedFilter.
     * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
     * [.uri](#ERMrest.Reference+uri) : <code>string</code>
     * [.session](#ERMrest.Reference+session)
-    * [.table](#ERMrest.Reference+table) : [<code>Table</code>](#ERMrest.Table)
-    * [.columns](#ERMrest.Reference+columns) : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
+    * [.table](#ERMrest.Reference+table) : <code>[Table](#ERMrest.Table)</code>
+    * [.columns](#ERMrest.Reference+columns) : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
         * [._referenceColumns](#ERMrest.Reference+columns+_referenceColumns)
     * [.isUnique](#ERMrest.Reference+isUnique) : <code>boolean</code>
-    * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> \| <code>undefined</code>
-    * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> \| <code>undefined</code>
-    * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> \| <code>undefined</code>
-    * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> \| <code>undefined</code>
+    * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> &#124; <code>undefined</code>
+    * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> &#124; <code>undefined</code>
+    * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
+    * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
     * [.display](#ERMrest.Reference+display) : <code>Object</code>
     * [._related](#ERMrest.Reference+_related)
-    * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
+    * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : <code>[Reference](#ERMrest.Reference)</code>
     * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
     * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
         * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
@@ -1984,7 +1957,7 @@ Constructor for a ParsedFilter.
     * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
     * [.update(tuples)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
     * [.delete(tuples)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
-    * [.related([tuple])](#ERMrest.Reference+related) ⇒ [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
+    * [.related([tuple])](#ERMrest.Reference+related) ⇒ <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
     * [.search(term)](#ERMrest.Reference+search) ⇒ <code>Reference</code>
 
 <a name="new_ERMrest.Reference_new"></a>
@@ -2006,7 +1979,7 @@ Usage:
 | Param | Type | Description |
 | --- | --- | --- |
 | location | <code>ERMrest.Location</code> | The location object generated from parsing the URI |
-| catalog | [<code>Catalog</code>](#ERMrest.Catalog) | The catalog object. Since location.catalog is just an id, we need the actual catalog object too. |
+| catalog | <code>[Catalog](#ERMrest.Catalog)</code> | The catalog object. Since location.catalog is just an id, we need the actual catalog object too. |
 
 <a name="ERMrest.Reference+contextualize"></a>
 
@@ -2026,7 +1999,7 @@ The `reference` is unchanged, while `recordref` now represents a
 reconfigured reference. For instance, `recordref.columns` may be
 different compared to `reference.columns`.
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+displayname"></a>
 
 #### reference.displayname : <code>object</code>
@@ -2034,19 +2007,19 @@ The display name for this reference.
 displayname.isHTML will return true/false
 displayname.value has the value
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+uri"></a>
 
 #### reference.uri : <code>string</code>
 The string form of the `URI` for this reference.
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+session"></a>
 
 #### reference.session
 The session object from the server
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2054,13 +2027,13 @@ The session object from the server
 
 <a name="ERMrest.Reference+table"></a>
 
-#### reference.table : [<code>Table</code>](#ERMrest.Table)
+#### reference.table : <code>[Table](#ERMrest.Table)</code>
 The table object for this reference
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+columns"></a>
 
-#### reference.columns : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
+#### reference.columns : <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code>
 The array of column definitions which represent the model of
 the resources accessible via this reference.
 
@@ -2078,7 +2051,7 @@ for (var i=0, len=reference.columns.length; i<len; i++) {
 }
 ```
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+columns+_referenceColumns"></a>
 
 ##### columns._referenceColumns
@@ -2119,7 +2092,7 @@ NOTE:
  + If this reference is actually an inbound related reference,
      we should hide the foreign key (and all of its columns) that created the link.
 
-**Kind**: instance property of [<code>columns</code>](#ERMrest.Reference+columns)  
+**Kind**: instance property of <code>[columns](#ERMrest.Reference+columns)</code>  
 <a name="ERMrest.Reference+isUnique"></a>
 
 #### reference.isUnique : <code>boolean</code>
@@ -2146,39 +2119,39 @@ Usage:
 console.log("This reference is unique?", (reference.isUnique ? 'yes' : 'no'));
 ```
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+canCreate"></a>
 
-#### reference.canCreate : <code>boolean</code> \| <code>undefined</code>
+#### reference.canCreate : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client has the permission to _create_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+canRead"></a>
 
-#### reference.canRead : <code>boolean</code> \| <code>undefined</code>
+#### reference.canRead : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client has the permission to _read_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+canUpdate"></a>
 
-#### reference.canUpdate : <code>boolean</code> \| <code>undefined</code>
+#### reference.canUpdate : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client has the permission to _update_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+canDelete"></a>
 
-#### reference.canDelete : <code>boolean</code> \| <code>undefined</code>
+#### reference.canDelete : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client has the permission to _delete_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+display"></a>
 
 #### reference.display : <code>Object</code>
@@ -2216,7 +2189,7 @@ if ( displayType === 'table') {
 }
 ```
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+_related"></a>
 
 #### reference._related
@@ -2254,19 +2227,19 @@ The logic for are sorted based on following attributes:
  2. position of key columns that are involved in the foreignkey
  3. position of columns that are involved in the foreignkey
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+unfilteredReference"></a>
 
-#### reference.unfilteredReference : [<code>Reference</code>](#ERMrest.Reference)
+#### reference.unfilteredReference : <code>[Reference](#ERMrest.Reference)</code>
 This will generate a new unfiltered reference each time.
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 <a name="ERMrest.Reference+appLink"></a>
 
 #### reference.appLink : <code>String</code>
 App-specific URL
 
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance property of <code>[Reference](#ERMrest.Reference)</code>  
 **Throws**:
 
 - <code>Error</code> if `_appLinkFn` is not defined.
@@ -2279,7 +2252,7 @@ operation sets the `defaults` list according to the table
 specification, and not according to the contents of in the input
 tuple.
 
-**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
 **Returns**: <code>Promise</code> - A promise resolved w ith [Page](#ERMrest.Page) of results,
 or rejected with any of the following errors:
 - [InvalidInputError](#ERMrest.InvalidInputError): If `data` is not valid, or reference is not in `entry/create` context.
@@ -2299,7 +2272,7 @@ and subtrahend is [4,5,6]
 the difference is [1,2,3]
 The 6 is ignored because we only want to know what's in the minuend that is not in the subtrahend
 
-**Kind**: inner method of [<code>create</code>](#ERMrest.Reference+create)  
+**Kind**: inner method of <code>[create](#ERMrest.Reference+create)</code>  
 <a name="ERMrest.Reference+read"></a>
 
 #### reference.read(limit) ⇒ <code>Promise</code>
@@ -2322,7 +2295,7 @@ reference.read(10).then(
   });
 ```
 
-**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
 **Returns**: <code>Promise</code> - A promise resolved with [Page](#ERMrest.Page) of results,
 or rejected with any of these errors:
 - [InvalidInputError](#ERMrest.InvalidInputError): If `limit` is invalid.
@@ -2339,7 +2312,7 @@ or rejected with any of these errors:
 #### reference.sort(sort) ⇒ <code>Reference</code>
 Return a new Reference with the new sorting
 
-**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
 **Returns**: <code>Reference</code> - A new reference with the new sorting  
 **Throws**:
 
@@ -2355,7 +2328,7 @@ Return a new Reference with the new sorting
 #### reference.update(tuples) ⇒ <code>Promise</code>
 Updates a set of resources.
 
-**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
 **Returns**: <code>Promise</code> - A promise resolved with [Page](#ERMrest.Page) of results,
 or rejected with any of these errors:
 - [InvalidInputError](#ERMrest.InvalidInputError): If `limit` is invalid or reference is not in `entry/edit` context.
@@ -2370,7 +2343,7 @@ or rejected with any of these errors:
 #### reference.delete(tuples) ⇒ <code>Promise</code>
 Deletes the referenced resources.
 
-**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
 **Returns**: <code>Promise</code> - A promise resolved with empty object or rejected with any of these errors:
 - [InvalidInputError](#ERMrest.InvalidInputError): If `limit` is invalid.
 - ERMrestjs corresponding http errors, if ERMrest returns http error.  
@@ -2381,7 +2354,7 @@ Deletes the referenced resources.
 
 <a name="ERMrest.Reference+related"></a>
 
-#### reference.related([tuple]) ⇒ [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
+#### reference.related([tuple]) ⇒ <code>[Array.&lt;Reference&gt;](#ERMrest.Reference)</code>
 The "related" references. Relationships are defined by foreign key
 references between [Table](#ERMrest.Table)s. Those references can be
 considered "outbound" where the table has FKRs to other entities or
@@ -2395,11 +2368,11 @@ ignore `B` and think of this relationship as `A <-> C`, unless `B`
 has other moderating attributes, for instance that indicate the
 `type` of relationship, but this is a model-depenent detail.
 
-**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| [tuple] | [<code>Tuple</code>](#ERMrest.Tuple) | the current tuple |
+| [tuple] | <code>[Tuple](#ERMrest.Tuple)</code> | the current tuple |
 
 <a name="ERMrest.Reference+search"></a>
 
@@ -2411,7 +2384,7 @@ a) A string with no space: single term or regular expression
 b) A single term with space using ""
 c) use space for conjunction of terms
 
-**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
+**Kind**: instance method of <code>[Reference](#ERMrest.Reference)</code>  
 **Returns**: <code>Reference</code> - A new reference with the new search  
 **Throws**:
 
@@ -2425,17 +2398,17 @@ c) use space for conjunction of terms
 <a name="ERMrest.Page"></a>
 
 ### ERMrest.Page
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Page](#ERMrest.Page)
     * [new Page(reference, etag, data, hasNext, hasPrevious)](#new_ERMrest.Page_new)
-    * [.reference](#ERMrest.Page+reference) : [<code>Reference</code>](#ERMrest.Reference)
-    * [.tuples](#ERMrest.Page+tuples) : [<code>Array.&lt;Tuple&gt;</code>](#ERMrest.Tuple)
+    * [.reference](#ERMrest.Page+reference) : <code>[Reference](#ERMrest.Reference)</code>
+    * [.tuples](#ERMrest.Page+tuples) : <code>[Array.&lt;Tuple&gt;](#ERMrest.Tuple)</code>
     * [.hasPrevious](#ERMrest.Page+hasPrevious) ⇒ <code>boolean</code>
-    * [.previous](#ERMrest.Page+previous) : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
+    * [.previous](#ERMrest.Page+previous) : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
     * [.hasNext](#ERMrest.Page+hasNext) ⇒ <code>boolean</code>
-    * [.next](#ERMrest.Page+next) : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
-    * [.content](#ERMrest.Page+content) : <code>string</code> \| <code>null</code>
+    * [.next](#ERMrest.Page+next) : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
+    * [.content](#ERMrest.Page+content) : <code>string</code> &#124; <code>null</code>
 
 <a name="new_ERMrest.Page_new"></a>
 
@@ -2454,7 +2427,7 @@ Usage:
 
 | Param | Type | Description |
 | --- | --- | --- |
-| reference | [<code>Reference</code>](#ERMrest.Reference) | The reference object from which this data was acquired. |
+| reference | <code>[Reference](#ERMrest.Reference)</code> | The reference object from which this data was acquired. |
 | etag | <code>String</code> | The etag from the reference object that produced this page |
 | data | <code>Array.&lt;Object&gt;</code> | The data returned from ERMrest. |
 | hasNext | <code>boolean</code> | Whether there is more data before this Page |
@@ -2462,13 +2435,13 @@ Usage:
 
 <a name="ERMrest.Page+reference"></a>
 
-#### page.reference : [<code>Reference</code>](#ERMrest.Reference)
+#### page.reference : <code>[Reference](#ERMrest.Reference)</code>
 The page's associated reference.
 
-**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
+**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
 <a name="ERMrest.Page+tuples"></a>
 
-#### page.tuples : [<code>Array.&lt;Tuple&gt;</code>](#ERMrest.Tuple)
+#### page.tuples : <code>[Array.&lt;Tuple&gt;](#ERMrest.Tuple)</code>
 An array of processed tuples. The results will be processed
 according to the contextualized scheme (model) of this reference.
 
@@ -2480,16 +2453,16 @@ for (var i=0, len=page.tuples.length; i<len; i++) {
 }
 ```
 
-**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
+**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
 <a name="ERMrest.Page+hasPrevious"></a>
 
 #### page.hasPrevious ⇒ <code>boolean</code>
 Whether there is more entities before this page
 
-**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
+**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
 <a name="ERMrest.Page+previous"></a>
 
-#### page.previous : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
+#### page.previous : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
 A reference to the previous set of results.
 
 Usage:
@@ -2502,16 +2475,16 @@ if (reference.previous) {
 }
 ```
 
-**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
+**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
 <a name="ERMrest.Page+hasNext"></a>
 
 #### page.hasNext ⇒ <code>boolean</code>
 Whether there is more entities after this page
 
-**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
+**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
 <a name="ERMrest.Page+next"></a>
 
-#### page.next : [<code>Reference</code>](#ERMrest.Reference) \| <code>undefined</code>
+#### page.next : <code>[Reference](#ERMrest.Reference)</code> &#124; <code>undefined</code>
 A reference to the next set of results.
 
 Usage:
@@ -2524,10 +2497,10 @@ if (reference.next) {
 }
 ```
 
-**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
+**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
 <a name="ERMrest.Page+content"></a>
 
-#### page.content : <code>string</code> \| <code>null</code>
+#### page.content : <code>string</code> &#124; <code>null</code>
 HTML representation of the whole page which uses table-display annotation.
 For more info you can refer {ERM.reference.display}
 
@@ -2539,26 +2512,27 @@ if (content) {
 }
 ```
 
-**Kind**: instance property of [<code>Page</code>](#ERMrest.Page)  
+**Kind**: instance property of <code>[Page](#ERMrest.Page)</code>  
 <a name="ERMrest.Tuple"></a>
 
 ### ERMrest.Tuple
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Tuple](#ERMrest.Tuple)
     * [new Tuple(reference, page, data)](#new_ERMrest.Tuple_new)
-    * [.reference](#ERMrest.Tuple+reference) ⇒ [<code>Reference</code>](#ERMrest.Reference) \| <code>\*</code>
-    * [.page](#ERMrest.Tuple+page) ⇒ [<code>Page</code>](#ERMrest.Page) \| <code>\*</code>
+    * [.reference](#ERMrest.Tuple+reference) ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
+    * [.page](#ERMrest.Tuple+page) ⇒ <code>[Page](#ERMrest.Page)</code> &#124; <code>\*</code>
     * [.data](#ERMrest.Tuple+data) : <code>Object</code>
     * [.data](#ERMrest.Tuple+data)
-    * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> \| <code>undefined</code>
-    * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> \| <code>undefined</code>
+    * [.canUpdate](#ERMrest.Tuple+canUpdate) : <code>boolean</code> &#124; <code>undefined</code>
+    * [.canDelete](#ERMrest.Tuple+canDelete) : <code>boolean</code> &#124; <code>undefined</code>
     * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
     * [.isHTML](#ERMrest.Tuple+isHTML) : <code>Array.&lt;string&gt;</code>
     * [.displayname](#ERMrest.Tuple+displayname) : <code>string</code>
     * [.update()](#ERMrest.Tuple+update) ⇒ <code>Promise</code>
     * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
-    * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : [<code>Reference</code>](#ERMrest.Reference)
+    * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : <code>[Reference](#ERMrest.Reference)</code>
+    * [.shallowCopy()](#ERMrest.Tuple+shallowCopy)
 
 <a name="new_ERMrest.Tuple_new"></a>
 
@@ -2573,24 +2547,24 @@ Usage:
 
 | Param | Type | Description |
 | --- | --- | --- |
-| reference | [<code>Reference</code>](#ERMrest.Reference) | The reference object from which this data was acquired. |
-| page | [<code>Page</code>](#ERMrest.Page) | The Page object from which this data was acquired. |
+| reference | <code>[Reference](#ERMrest.Reference)</code> | The reference object from which this data was acquired. |
+| page | <code>[Page](#ERMrest.Page)</code> | The Page object from which this data was acquired. |
 | data | <code>Object</code> | The unprocessed tuple of data returned from ERMrest. |
 
 <a name="ERMrest.Tuple+reference"></a>
 
-#### tuple.reference ⇒ [<code>Reference</code>](#ERMrest.Reference) \| <code>\*</code>
+#### tuple.reference ⇒ <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code>
 This is the reference of the Tuple
 
-**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
-**Returns**: [<code>Reference</code>](#ERMrest.Reference) \| <code>\*</code> - reference of the Tuple  
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Returns**: <code>[Reference](#ERMrest.Reference)</code> &#124; <code>\*</code> - reference of the Tuple  
 <a name="ERMrest.Tuple+page"></a>
 
-#### tuple.page ⇒ [<code>Page</code>](#ERMrest.Page) \| <code>\*</code>
+#### tuple.page ⇒ <code>[Page](#ERMrest.Page)</code> &#124; <code>\*</code>
 This is the page of the Tuple
 
-**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
-**Returns**: [<code>Page</code>](#ERMrest.Page) \| <code>\*</code> - page of the Tuple  
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
+**Returns**: <code>[Page](#ERMrest.Page)</code> &#124; <code>\*</code> - page of the Tuple  
 <a name="ERMrest.Tuple+data"></a>
 
 #### tuple.data : <code>Object</code>
@@ -2604,11 +2578,11 @@ track of so that the column projections for the uri can be properly created
 and both the old and new value for the modified key are submitted together
 for proper updating.
 
-**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+data"></a>
 
 #### tuple.data
-**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2616,7 +2590,7 @@ for proper updating.
 
 <a name="ERMrest.Tuple+canUpdate"></a>
 
-#### tuple.canUpdate : <code>boolean</code> \| <code>undefined</code>
+#### tuple.canUpdate : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client can update this tuple. Because
 some policies may be undecidable until query execution, this
 property may also be `undefined`.
@@ -2634,17 +2608,17 @@ else {
 }
 ```
 
-**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+canDelete"></a>
 
-#### tuple.canDelete : <code>boolean</code> \| <code>undefined</code>
+#### tuple.canDelete : <code>boolean</code> &#124; <code>undefined</code>
 Indicates whether the client can delete this tuple. Because
 some policies may be undecidable until query execution, this
 property may also be `undefined`.
 
 See [canUpdate](#ERMrest.Tuple+canUpdate) for a usage example.
 
-**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+values"></a>
 
 #### tuple.values : <code>Array.&lt;string&gt;</code>
@@ -2667,7 +2641,7 @@ console.log(tuple.displayname, "has a", column.displayname,
     "with value", tuple.values[column.position]);
 ```
 
-**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+isHTML"></a>
 
 #### tuple.isHTML : <code>Array.&lt;string&gt;</code>
@@ -2682,7 +2656,7 @@ for (var i=0; len=reference.columns.length; i<len; i++) {
 }
 ```
 
-**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+displayname"></a>
 
 #### tuple.displayname : <code>string</code>
@@ -2696,14 +2670,14 @@ Usage:
 console.log("This tuple has a displayable name of ", tuple.displayname.value);
 ```
 
-**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Kind**: instance property of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.Tuple+update"></a>
 
 #### tuple.update() ⇒ <code>Promise</code>
 Attempts to update this tuple. This is a server side transaction,
 and therefore an asynchronous operation that returns a promise.
 
-**Kind**: instance method of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
 **Returns**: <code>Promise</code> - a promise (TBD the result object)  
 <a name="ERMrest.Tuple+delete"></a>
 
@@ -2711,11 +2685,11 @@ and therefore an asynchronous operation that returns a promise.
 Attempts to delete this tuple. This is a server side transaction,
 and therefore an asynchronous operation that returns a promise.
 
-**Kind**: instance method of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
 **Returns**: <code>Promise</code> - a promise (TBD the result object)  
 <a name="ERMrest.Tuple+getAssociationRef"></a>
 
-#### tuple.getAssociationRef() : [<code>Reference</code>](#ERMrest.Reference)
+#### tuple.getAssociationRef() : <code>[Reference](#ERMrest.Reference)</code>
 If the Tuple is derived from an association related table,
 this function will return a reference to the corresponding
 entity of this tuple's association table.
@@ -2726,37 +2700,31 @@ and current tuple is from Table2 with k2 = "2".
 With origFKRData = {"k1": "1"} this function will return a reference
 to AssocitaitonTable with FK1 = "1"" and FK2 = "2".
 
-**Kind**: instance method of [<code>Tuple</code>](#ERMrest.Tuple)  
+**Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
+<a name="ERMrest.Tuple+shallowCopy"></a>
+
+#### tuple.shallowCopy()
+**Kind**: instance method of <code>[Tuple](#ERMrest.Tuple)</code>  
 <a name="ERMrest.ReferenceColumn"></a>
 
 ### ERMrest.ReferenceColumn
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.ReferenceColumn](#ERMrest.ReferenceColumn)
     * [new ReferenceColumn(reference, baseCols)](#new_ERMrest.ReferenceColumn_new)
     * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
-<<<<<<< HEAD
-=======
-    * [.reference](#ERMrest.ReferenceColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
-    * [.foreignKey](#ERMrest.ReferenceColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
-    * [.key](#ERMrest.ReferenceColumn+key) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
-    * [.table](#ERMrest.ReferenceColumn+table) : [<code>Table</code>](#ERMrest.Table)
+    * [.table](#ERMrest.ReferenceColumn+table) : <code>[Table](#ERMrest.Table)</code>
     * [.name](#ERMrest.ReferenceColumn+name) : <code>string</code>
     * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>string</code>
-    * [.type](#ERMrest.ReferenceColumn+type) : [<code>Type</code>](#ERMrest.Type)
+    * [.type](#ERMrest.ReferenceColumn+type) : <code>[Type](#ERMrest.Type)</code>
     * [.nullok](#ERMrest.ReferenceColumn+nullok) : <code>Boolean</code>
     * [.default](#ERMrest.ReferenceColumn+default) : <code>string</code>
     * [.comment](#ERMrest.ReferenceColumn+comment) : <code>string</code>
-    * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> \| <code>object</code>
+    * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> &#124; <code>object</code>
     * [.sortable](#ERMrest.ReferenceColumn+sortable) : <code>boolean</code>
     * [.formatvalue(data)](#ERMrest.ReferenceColumn+formatvalue) ⇒ <code>string</code>
-<<<<<<< HEAD
-=======
-    * [.filteredRef(column, data)](#ERMrest.ReferenceColumn+filteredRef) ⇒ [<code>Reference</code>](#ERMrest.Reference)
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
     * [.formatPresentation(data, options)](#ERMrest.ReferenceColumn+formatPresentation) ⇒ <code>Object</code>
-    * [.getInputDisabled()](#ERMrest.ReferenceColumn+getInputDisabled) : <code>boolean</code> \| <code>object</code>
+    * [.getInputDisabled()](#ERMrest.ReferenceColumn+getInputDisabled) : <code>boolean</code> &#124; <code>object</code>
 
 <a name="new_ERMrest.ReferenceColumn_new"></a>
 
@@ -2766,86 +2734,60 @@ Constructor for ReferenceColumn. This class is a wrapper for [Column](#ERMrest.C
 
 | Param | Type | Description |
 | --- | --- | --- |
-| reference | [<code>Reference</code>](#ERMrest.Reference) | column's reference |
-<<<<<<< HEAD
-| baseCols | [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column) | List of columns that this reference-column will be created based on. |
-=======
-| base | [<code>Column</code>](#ERMrest.Column) | The column that this reference-column will be created based on. |
-| kwargs | <code>Object</code> | if it's not empty then the column is being created based on foreignkey or key. |
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
+| reference | <code>[Reference](#ERMrest.Reference)</code> | column's reference |
+| baseCols | <code>[Array.&lt;Column&gt;](#ERMrest.Column)</code> | List of columns that this reference-column will be created based on. |
 
 <a name="ERMrest.ReferenceColumn+isPseudo"></a>
 
 #### referenceColumn.isPseudo : <code>boolean</code>
 indicates this represents is a PseudoColumn or a Column.
 
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
-<<<<<<< HEAD
-=======
-<a name="ERMrest.ReferenceColumn+reference"></a>
-
-#### referenceColumn.reference : [<code>Reference</code>](#ERMrest.Reference)
-The reference object that represents the table of this PseudoColumn
-
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
-<a name="ERMrest.ReferenceColumn+foreignKey"></a>
-
-#### referenceColumn.foreignKey : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
-The Foreign key object that this PseudoColumn is created based on
-
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
-<a name="ERMrest.ReferenceColumn+key"></a>
-
-#### referenceColumn.key : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
-The Foreign key object that this PseudoColumn is created based on
-
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+table"></a>
 
-#### referenceColumn.table : [<code>Table</code>](#ERMrest.Table)
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+#### referenceColumn.table : <code>[Table](#ERMrest.Table)</code>
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+name"></a>
 
 #### referenceColumn.name : <code>string</code>
 name of the column.
 
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+displayname"></a>
 
 #### referenceColumn.displayname : <code>string</code>
 name of the column.
 
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+type"></a>
 
-#### referenceColumn.type : [<code>Type</code>](#ERMrest.Type)
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+#### referenceColumn.type : <code>[Type](#ERMrest.Type)</code>
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+nullok"></a>
 
 #### referenceColumn.nullok : <code>Boolean</code>
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+default"></a>
 
 #### referenceColumn.default : <code>string</code>
 Returns the default value
 
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+comment"></a>
 
 #### referenceColumn.comment : <code>string</code>
 Documentation for this reference-column
 
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+inputDisabled"></a>
 
-#### referenceColumn.inputDisabled : <code>boolean</code> \| <code>object</code>
+#### referenceColumn.inputDisabled : <code>boolean</code> &#124; <code>object</code>
 Indicates if the input should be disabled
 true: input must be disabled
 false:  input can be enabled
 object: input msut be disabled (show .message to user)
 
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+sortable"></a>
 
 #### referenceColumn.sortable : <code>boolean</code>
@@ -2857,67 +2799,25 @@ Heuristics are as follows:
  - column_order defined -> use it.
  - use column actual value.
 
-<<<<<<< HEAD
-=======
-- column_order = false -> disable sort.
-
-- PseudoColumn
-     - column_order defined -> use it.
-     - Foreign key:
-         - table has row_order -> use it.
-         - simple fk -> use the column's
-     - Key:
-         - simple key -> use the column's
-     - disable it
-- Column:
-     - column_order defined -> use it.
-     - use column actual value.
-
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
-<a name="ERMrest.ReferenceColumn+isForeignKey"></a>
-
-#### referenceColumn.isForeignKey : <code>boolean</code>
-returns the private value _isForeignKey
-
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Kind**: instance property of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ReferenceColumn+formatvalue"></a>
 
 #### referenceColumn.formatvalue(data) ⇒ <code>string</code>
 Formats a value corresponding to this reference-column definition.
 
-**Kind**: instance method of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Kind**: instance method of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 **Returns**: <code>string</code> - The formatted value.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | data | <code>Object</code> | The 'raw' data value. |
 
-<<<<<<< HEAD
-=======
-<a name="ERMrest.ReferenceColumn+filteredRef"></a>
-
-#### referenceColumn.filteredRef(column, data) ⇒ [<code>Reference</code>](#ERMrest.Reference)
-This function takes in a tuple and generates a reference that is
-constrained based on the domain_filter_pattern annotation. If this
-annotation doesn't exist, it returns this (reference)
-`this` is the same as column.reference
-
-**Kind**: instance method of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
-**Returns**: [<code>Reference</code>](#ERMrest.Reference) - the constrained reference  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| column | [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn) | column that `this` is based on |
-| data | <code>Object</code> | tuple data with potential constraints |
-
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
 <a name="ERMrest.ReferenceColumn+formatPresentation"></a>
 
 #### referenceColumn.formatPresentation(data, options) ⇒ <code>Object</code>
 Formats the presentation value corresponding to this reference-column definition.
 
-**Kind**: instance method of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Kind**: instance method of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 **Returns**: <code>Object</code> - A key value pair containing value and isHTML that detemrines the presenation.  
 
 | Param | Type | Description |
@@ -2927,26 +2827,26 @@ Formats the presentation value corresponding to this reference-column definition
 
 <a name="ERMrest.ReferenceColumn+getInputDisabled"></a>
 
-#### referenceColumn.getInputDisabled() : <code>boolean</code> \| <code>object</code>
+#### referenceColumn.getInputDisabled() : <code>boolean</code> &#124; <code>object</code>
 Indicates if the input should be disabled, in different contexts
 true: input must be disabled
 false:  input can be enabled
 object: input msut be disabled (show .message to user)
 TODO should be removed in favor of inputDisabled
 
-**Kind**: instance method of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Kind**: instance method of <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code>  
 <a name="ERMrest.ForeignKeyPseudoColumn"></a>
 
 ### ERMrest.ForeignKeyPseudoColumn
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.ForeignKeyPseudoColumn](#ERMrest.ForeignKeyPseudoColumn)
     * [new ForeignKeyPseudoColumn(reference, fk)](#new_ERMrest.ForeignKeyPseudoColumn_new)
     * [.isPseudo](#ERMrest.ForeignKeyPseudoColumn+isPseudo) : <code>boolean</code>
     * [.isForeignKey](#ERMrest.ForeignKeyPseudoColumn+isForeignKey) : <code>boolean</code>
-    * [.reference](#ERMrest.ForeignKeyPseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
-    * [.foreignKey](#ERMrest.ForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
-    * [.filteredRef(column, data)](#ERMrest.ForeignKeyPseudoColumn+filteredRef) ⇒ [<code>Reference</code>](#ERMrest.Reference)
+    * [.reference](#ERMrest.ForeignKeyPseudoColumn+reference) : <code>[Reference](#ERMrest.Reference)</code>
+    * [.foreignKey](#ERMrest.ForeignKeyPseudoColumn+foreignKey) : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
+    * [.filteredRef(column, data)](#ERMrest.ForeignKeyPseudoColumn+filteredRef) ⇒ <code>[Reference](#ERMrest.Reference)</code>
 
 <a name="new_ERMrest.ForeignKeyPseudoColumn_new"></a>
 
@@ -2957,59 +2857,59 @@ This class extends the [ReferenceColumn](#ERMrest.ReferenceColumn)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| reference | [<code>Reference</code>](#ERMrest.Reference) | column's reference |
-| fk | [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef) | the foreignkey |
+| reference | <code>[Reference](#ERMrest.Reference)</code> | column's reference |
+| fk | <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code> | the foreignkey |
 
 <a name="ERMrest.ForeignKeyPseudoColumn+isPseudo"></a>
 
 #### foreignKeyPseudoColumn.isPseudo : <code>boolean</code>
 indicates this represents is a PseudoColumn or a Column.
 
-**Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+**Kind**: instance property of <code>[ForeignKeyPseudoColumn](#ERMrest.ForeignKeyPseudoColumn)</code>  
 <a name="ERMrest.ForeignKeyPseudoColumn+isForeignKey"></a>
 
 #### foreignKeyPseudoColumn.isForeignKey : <code>boolean</code>
 Indicates that this ReferenceColumn is a Foreign key.
 
-**Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+**Kind**: instance property of <code>[ForeignKeyPseudoColumn](#ERMrest.ForeignKeyPseudoColumn)</code>  
 <a name="ERMrest.ForeignKeyPseudoColumn+reference"></a>
 
-#### foreignKeyPseudoColumn.reference : [<code>Reference</code>](#ERMrest.Reference)
+#### foreignKeyPseudoColumn.reference : <code>[Reference](#ERMrest.Reference)</code>
 The reference object that represents the table of this PseudoColumn
 
-**Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+**Kind**: instance property of <code>[ForeignKeyPseudoColumn](#ERMrest.ForeignKeyPseudoColumn)</code>  
 <a name="ERMrest.ForeignKeyPseudoColumn+foreignKey"></a>
 
-#### foreignKeyPseudoColumn.foreignKey : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
+#### foreignKeyPseudoColumn.foreignKey : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
 The Foreign key object that this PseudoColumn is created based on
 
-**Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+**Kind**: instance property of <code>[ForeignKeyPseudoColumn](#ERMrest.ForeignKeyPseudoColumn)</code>  
 <a name="ERMrest.ForeignKeyPseudoColumn+filteredRef"></a>
 
-#### foreignKeyPseudoColumn.filteredRef(column, data) ⇒ [<code>Reference</code>](#ERMrest.Reference)
+#### foreignKeyPseudoColumn.filteredRef(column, data) ⇒ <code>[Reference](#ERMrest.Reference)</code>
 This function takes in a tuple and generates a reference that is
 constrained based on the domain_filter_pattern annotation. If this
 annotation doesn't exist, it returns this (reference)
 `this` is the same as column.reference
 
-**Kind**: instance method of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
-**Returns**: [<code>Reference</code>](#ERMrest.Reference) - the constrained reference  
+**Kind**: instance method of <code>[ForeignKeyPseudoColumn](#ERMrest.ForeignKeyPseudoColumn)</code>  
+**Returns**: <code>[Reference](#ERMrest.Reference)</code> - the constrained reference  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| column | [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn) | column that `this` is based on |
+| column | <code>[ReferenceColumn](#ERMrest.ReferenceColumn)</code> | column that `this` is based on |
 | data | <code>Object</code> | tuple data with potential constraints |
 
 <a name="ERMrest.KeyPseudoColumn"></a>
 
 ### ERMrest.KeyPseudoColumn
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 
 * [.KeyPseudoColumn](#ERMrest.KeyPseudoColumn)
     * [new KeyPseudoColumn(reference, key)](#new_ERMrest.KeyPseudoColumn_new)
     * [.isPseudo](#ERMrest.KeyPseudoColumn+isPseudo) : <code>boolean</code>
     * [.isKey](#ERMrest.KeyPseudoColumn+isKey) : <code>boolean</code>
-    * [.key](#ERMrest.KeyPseudoColumn+key) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
+    * [.key](#ERMrest.KeyPseudoColumn+key) : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
 
 <a name="new_ERMrest.KeyPseudoColumn_new"></a>
 
@@ -3020,41 +2920,41 @@ This class extends the [ReferenceColumn](#ERMrest.ReferenceColumn)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| reference | [<code>Reference</code>](#ERMrest.Reference) | column's reference |
-| key | [<code>Key</code>](#ERMrest.Key) | the key |
+| reference | <code>[Reference](#ERMrest.Reference)</code> | column's reference |
+| key | <code>[Key](#ERMrest.Key)</code> | the key |
 
 <a name="ERMrest.KeyPseudoColumn+isPseudo"></a>
 
 #### keyPseudoColumn.isPseudo : <code>boolean</code>
 indicates this represents is a PseudoColumn or a Column.
 
-**Kind**: instance property of [<code>KeyPseudoColumn</code>](#ERMrest.KeyPseudoColumn)  
+**Kind**: instance property of <code>[KeyPseudoColumn](#ERMrest.KeyPseudoColumn)</code>  
 <a name="ERMrest.KeyPseudoColumn+isKey"></a>
 
 #### keyPseudoColumn.isKey : <code>boolean</code>
 Indicates that this ReferenceColumn is a key.
 
-**Kind**: instance property of [<code>KeyPseudoColumn</code>](#ERMrest.KeyPseudoColumn)  
+**Kind**: instance property of <code>[KeyPseudoColumn](#ERMrest.KeyPseudoColumn)</code>  
 <a name="ERMrest.KeyPseudoColumn+key"></a>
 
-#### keyPseudoColumn.key : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
+#### keyPseudoColumn.key : <code>[ForeignKeyRef](#ERMrest.ForeignKeyRef)</code>
 The Foreign key object that this PseudoColumn is created based on
 
-**Kind**: instance property of [<code>KeyPseudoColumn</code>](#ERMrest.KeyPseudoColumn)  
+**Kind**: instance property of <code>[KeyPseudoColumn](#ERMrest.KeyPseudoColumn)</code>  
 <a name="ERMrest.AssetPseudoColumn"></a>
 
 ### ERMrest.AssetPseudoColumn
-**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static class of <code>[ERMrest](#ERMrest)</code>  
 **Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
 | urlPattern | <code>string</code> | A desired upload location can be derived by Pattern Expansion on pattern. |
-| filenameColumn | [<code>Column</code>](#ERMrest.Column) \| <code>null</code> | if it's string, then it is the name of column we want to store filename inside of it. |
-| byteCountColumn | [<code>Column</code>](#ERMrest.Column) \| <code>null</code> | if it's string, then it is the name of column we want to store byte count inside of it. |
-| md5 | [<code>Column</code>](#ERMrest.Column) \| <code>boolean</code> \| <code>null</code> | if it's string, then it is the name of column we want to store md5 inside of it. If it's true, that means we must use md5. |
-| sha256 | [<code>Column</code>](#ERMrest.Column) \| <code>boolean</code> \| <code>null</code> | if it's string, then it is the name of column we want to store sha256 inside of it. If it's true, that means we must use sha256. |
-| filenameExtFilter | <code>Array.&lt;string&gt;</code> \| <code>null</code> | set of filename extension filters for use by upload agents to indicate to the user the acceptable filename patterns. |
+| filenameColumn | <code>[Column](#ERMrest.Column)</code> &#124; <code>null</code> | if it's string, then it is the name of column we want to store filename inside of it. |
+| byteCountColumn | <code>[Column](#ERMrest.Column)</code> &#124; <code>null</code> | if it's string, then it is the name of column we want to store byte count inside of it. |
+| md5 | <code>[Column](#ERMrest.Column)</code> &#124; <code>boolean</code> &#124; <code>null</code> | if it's string, then it is the name of column we want to store md5 inside of it. If it's true, that means we must use md5. |
+| sha256 | <code>[Column](#ERMrest.Column)</code> &#124; <code>boolean</code> &#124; <code>null</code> | if it's string, then it is the name of column we want to store sha256 inside of it. If it's true, that means we must use sha256. |
+| filenameExtFilter | <code>Array.&lt;string&gt;</code> &#124; <code>null</code> | set of filename extension filters for use by upload agents to indicate to the user the acceptable filename patterns. |
 
 
 * [.AssetPseudoColumn](#ERMrest.AssetPseudoColumn)
@@ -3072,71 +2972,67 @@ This class extends the [ReferenceColumn](#ERMrest.ReferenceColumn)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| reference | [<code>Reference</code>](#ERMrest.Reference) | column's reference |
-| column | [<code>Column</code>](#ERMrest.Column) | the asset column |
+| reference | <code>[Reference](#ERMrest.Reference)</code> | column's reference |
+| column | <code>[Column](#ERMrest.Column)</code> | the asset column |
 
 <a name="ERMrest.AssetPseudoColumn+isPseudo"></a>
 
 #### assetPseudoColumn.isPseudo : <code>boolean</code>
 indicates this represents is a PseudoColumn or a Column.
 
-**Kind**: instance property of [<code>AssetPseudoColumn</code>](#ERMrest.AssetPseudoColumn)  
+**Kind**: instance property of <code>[AssetPseudoColumn](#ERMrest.AssetPseudoColumn)</code>  
 <a name="ERMrest.AssetPseudoColumn+isAsset"></a>
 
 #### assetPseudoColumn.isAsset : <code>boolean</code>
 Indicates that this ReferenceColumn is an asset.
 
-<<<<<<< HEAD
-**Kind**: instance property of [<code>AssetPseudoColumn</code>](#ERMrest.AssetPseudoColumn)  
-=======
-**Kind**: instance method of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
->>>>>>> 638d3729cc72fccc606e4c48982099a07ddbec30
+**Kind**: instance property of <code>[AssetPseudoColumn](#ERMrest.AssetPseudoColumn)</code>  
 <a name="ERMrest.Datapath"></a>
 
 ### ERMrest.Datapath : <code>object</code>
-**Kind**: static namespace of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static namespace of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Datapath](#ERMrest.Datapath) : <code>object</code>
     * [.DataPath](#ERMrest.Datapath.DataPath)
         * [new DataPath(table)](#new_ERMrest.Datapath.DataPath_new)
-        * [.catalog](#ERMrest.Datapath.DataPath+catalog) : [<code>Catalog</code>](#ERMrest.Catalog)
-        * [.context](#ERMrest.Datapath.DataPath+context) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+        * [.catalog](#ERMrest.Datapath.DataPath+catalog) : <code>[Catalog](#ERMrest.Catalog)</code>
+        * [.context](#ERMrest.Datapath.DataPath+context) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
         * [.entity](#ERMrest.Datapath.DataPath+entity)
             * [.get()](#ERMrest.Datapath.DataPath+entity.get) ⇒ <code>Promise</code>
             * [.delete(filter)](#ERMrest.Datapath.DataPath+entity.delete) ⇒ <code>Promise</code>
-        * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
-        * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+        * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
+        * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
     * [.PathTable](#ERMrest.Datapath.PathTable)
         * [new PathTable(table, datapath, alias)](#new_ERMrest.Datapath.PathTable_new)
-        * [.datapath](#ERMrest.Datapath.PathTable+datapath) : [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
-        * [.table](#ERMrest.Datapath.PathTable+table) : [<code>Table</code>](#ERMrest.Table)
+        * [.datapath](#ERMrest.Datapath.PathTable+datapath) : <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
+        * [.table](#ERMrest.Datapath.PathTable+table) : <code>[Table](#ERMrest.Table)</code>
         * [.alias](#ERMrest.Datapath.PathTable+alias) : <code>string</code>
-        * [.columns](#ERMrest.Datapath.PathTable+columns) : [<code>Columns</code>](#ERMrest.Datapath.Columns)
+        * [.columns](#ERMrest.Datapath.PathTable+columns) : <code>[Columns](#ERMrest.Datapath.Columns)</code>
         * [.toString()](#ERMrest.Datapath.PathTable+toString) ⇒ <code>string</code>
     * [.PathColumn](#ERMrest.Datapath.PathColumn)
         * [new PathColumn(column, pathtable)](#new_ERMrest.Datapath.PathColumn_new)
-        * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
-        * [.column](#ERMrest.Datapath.PathColumn+column) : [<code>Column</code>](#ERMrest.Column)
+        * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+        * [.column](#ERMrest.Datapath.PathColumn+column) : <code>[Column](#ERMrest.Column)</code>
     * [.Columns(table, pathtable)](#ERMrest.Datapath.Columns)
         * [.length()](#ERMrest.Datapath.Columns+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Datapath.Columns+names) ⇒ <code>Array.&lt;String&gt;</code>
-        * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)
+        * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>
     * [.Operators()](#ERMrest.Datapath.Operators)
 
 <a name="ERMrest.Datapath.DataPath"></a>
 
 #### Datapath.DataPath
-**Kind**: static class of [<code>Datapath</code>](#ERMrest.Datapath)  
+**Kind**: static class of <code>[Datapath](#ERMrest.Datapath)</code>  
 
 * [.DataPath](#ERMrest.Datapath.DataPath)
     * [new DataPath(table)](#new_ERMrest.Datapath.DataPath_new)
-    * [.catalog](#ERMrest.Datapath.DataPath+catalog) : [<code>Catalog</code>](#ERMrest.Catalog)
-    * [.context](#ERMrest.Datapath.DataPath+context) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+    * [.catalog](#ERMrest.Datapath.DataPath+catalog) : <code>[Catalog](#ERMrest.Catalog)</code>
+    * [.context](#ERMrest.Datapath.DataPath+context) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
     * [.entity](#ERMrest.Datapath.DataPath+entity)
         * [.get()](#ERMrest.Datapath.DataPath+entity.get) ⇒ <code>Promise</code>
         * [.delete(filter)](#ERMrest.Datapath.DataPath+entity.delete) ⇒ <code>Promise</code>
-    * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
-    * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+    * [.filter(filter)](#ERMrest.Datapath.DataPath+filter) ⇒ <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
+    * [.extend(table, context, link)](#ERMrest.Datapath.DataPath+extend) ⇒ <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
 
 <a name="new_ERMrest.Datapath.DataPath_new"></a>
 
@@ -3144,22 +3040,22 @@ Indicates that this ReferenceColumn is an asset.
 
 | Param | Type |
 | --- | --- |
-| table | [<code>Table</code>](#ERMrest.Table) | 
+| table | <code>[Table](#ERMrest.Table)</code> | 
 
 <a name="ERMrest.Datapath.DataPath+catalog"></a>
 
-##### dataPath.catalog : [<code>Catalog</code>](#ERMrest.Catalog)
-**Kind**: instance property of [<code>DataPath</code>](#ERMrest.Datapath.DataPath)  
+##### dataPath.catalog : <code>[Catalog](#ERMrest.Catalog)</code>
+**Kind**: instance property of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
 <a name="ERMrest.Datapath.DataPath+context"></a>
 
-##### dataPath.context : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
-**Kind**: instance property of [<code>DataPath</code>](#ERMrest.Datapath.DataPath)  
+##### dataPath.context : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+**Kind**: instance property of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
 <a name="ERMrest.Datapath.DataPath+entity"></a>
 
 ##### dataPath.entity
 entity container
 
-**Kind**: instance property of [<code>DataPath</code>](#ERMrest.Datapath.DataPath)  
+**Kind**: instance property of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
 
 * [.entity](#ERMrest.Datapath.DataPath+entity)
     * [.get()](#ERMrest.Datapath.DataPath+entity.get) ⇒ <code>Promise</code>
@@ -3168,7 +3064,7 @@ entity container
 <a name="ERMrest.Datapath.DataPath+entity.get"></a>
 
 ###### entity.get() ⇒ <code>Promise</code>
-**Kind**: static method of [<code>entity</code>](#ERMrest.Datapath.DataPath+entity)  
+**Kind**: static method of <code>[entity](#ERMrest.Datapath.DataPath+entity)</code>  
 **Returns**: <code>Promise</code> - promise that returns a row data if resolved or
     [ERMrest.Errors.TimedOutError](ERMrest.Errors.TimedOutError), [ERMrest.Errors.InternalServerError](ERMrest.Errors.InternalServerError), [ERMrest.Errors.ServiceUnavailableError](ERMrest.Errors.ServiceUnavailableError),
     [ERMrest.Errors.ConflictError](ERMrest.Errors.ConflictError), [ERMrest.Errors.ForbiddenError](ERMrest.Errors.ForbiddenError) or [ERMrest.Errors.UnauthorizedError](ERMrest.Errors.UnauthorizedError) if rejected  
@@ -3177,51 +3073,51 @@ entity container
 ###### entity.delete(filter) ⇒ <code>Promise</code>
 delete entities
 
-**Kind**: static method of [<code>entity</code>](#ERMrest.Datapath.DataPath+entity)  
+**Kind**: static method of <code>[entity](#ERMrest.Datapath.DataPath+entity)</code>  
 **Returns**: <code>Promise</code> - promise that returns deleted entities if resolved or
     [ERMrest.Errors.TimedOutError](ERMrest.Errors.TimedOutError), [ERMrest.Errors.InternalServerError](ERMrest.Errors.InternalServerError), [ERMrest.Errors.ServiceUnavailableError](ERMrest.Errors.ServiceUnavailableError),
     [ERMrest.Errors.ConflictError](ERMrest.Errors.ConflictError), [ERMrest.Errors.ForbiddenError](ERMrest.Errors.ForbiddenError) or [ERMrest.Errors.UnauthorizedError](ERMrest.Errors.UnauthorizedError) if rejected  
 
 | Param | Type |
 | --- | --- |
-| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) | 
+| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
 
 <a name="ERMrest.Datapath.DataPath+filter"></a>
 
-##### dataPath.filter(filter) ⇒ [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
+##### dataPath.filter(filter) ⇒ <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
 this datapath is not modified
 
-**Kind**: instance method of [<code>DataPath</code>](#ERMrest.Datapath.DataPath)  
-**Returns**: [<code>DataPath</code>](#ERMrest.Datapath.DataPath) - a shallow copy of this datapath with filter  
+**Kind**: instance method of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
+**Returns**: <code>[DataPath](#ERMrest.Datapath.DataPath)</code> - a shallow copy of this datapath with filter  
 
 | Param | Type |
 | --- | --- |
-| filter | [<code>Negation</code>](#ERMrest.Filters.Negation) \| [<code>Conjunction</code>](#ERMrest.Filters.Conjunction) \| [<code>Disjunction</code>](#ERMrest.Filters.Disjunction) \| [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate) \| [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate) | 
+| filter | <code>[Negation](#ERMrest.Filters.Negation)</code> &#124; <code>[Conjunction](#ERMrest.Filters.Conjunction)</code> &#124; <code>[Disjunction](#ERMrest.Filters.Disjunction)</code> &#124; <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code> &#124; <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code> | 
 
 <a name="ERMrest.Datapath.DataPath+extend"></a>
 
-##### dataPath.extend(table, context, link) ⇒ [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
+##### dataPath.extend(table, context, link) ⇒ <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
 extend the Datapath with table
 
-**Kind**: instance method of [<code>DataPath</code>](#ERMrest.Datapath.DataPath)  
+**Kind**: instance method of <code>[DataPath](#ERMrest.Datapath.DataPath)</code>  
 
 | Param | Type |
 | --- | --- |
-| table | [<code>Table</code>](#ERMrest.Table) | 
+| table | <code>[Table](#ERMrest.Table)</code> | 
 | context |  | 
 | link |  | 
 
 <a name="ERMrest.Datapath.PathTable"></a>
 
 #### Datapath.PathTable
-**Kind**: static class of [<code>Datapath</code>](#ERMrest.Datapath)  
+**Kind**: static class of <code>[Datapath](#ERMrest.Datapath)</code>  
 
 * [.PathTable](#ERMrest.Datapath.PathTable)
     * [new PathTable(table, datapath, alias)](#new_ERMrest.Datapath.PathTable_new)
-    * [.datapath](#ERMrest.Datapath.PathTable+datapath) : [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
-    * [.table](#ERMrest.Datapath.PathTable+table) : [<code>Table</code>](#ERMrest.Table)
+    * [.datapath](#ERMrest.Datapath.PathTable+datapath) : <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
+    * [.table](#ERMrest.Datapath.PathTable+table) : <code>[Table](#ERMrest.Table)</code>
     * [.alias](#ERMrest.Datapath.PathTable+alias) : <code>string</code>
-    * [.columns](#ERMrest.Datapath.PathTable+columns) : [<code>Columns</code>](#ERMrest.Datapath.Columns)
+    * [.columns](#ERMrest.Datapath.PathTable+columns) : <code>[Columns](#ERMrest.Datapath.Columns)</code>
     * [.toString()](#ERMrest.Datapath.PathTable+toString) ⇒ <code>string</code>
 
 <a name="new_ERMrest.Datapath.PathTable_new"></a>
@@ -3230,40 +3126,40 @@ extend the Datapath with table
 
 | Param | Type |
 | --- | --- |
-| table | [<code>Table</code>](#ERMrest.Table) | 
-| datapath | [<code>DataPath</code>](#ERMrest.Datapath.DataPath) | 
+| table | <code>[Table](#ERMrest.Table)</code> | 
+| datapath | <code>[DataPath](#ERMrest.Datapath.DataPath)</code> | 
 | alias | <code>string</code> | 
 
 <a name="ERMrest.Datapath.PathTable+datapath"></a>
 
-##### pathTable.datapath : [<code>DataPath</code>](#ERMrest.Datapath.DataPath)
-**Kind**: instance property of [<code>PathTable</code>](#ERMrest.Datapath.PathTable)  
+##### pathTable.datapath : <code>[DataPath](#ERMrest.Datapath.DataPath)</code>
+**Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
 <a name="ERMrest.Datapath.PathTable+table"></a>
 
-##### pathTable.table : [<code>Table</code>](#ERMrest.Table)
-**Kind**: instance property of [<code>PathTable</code>](#ERMrest.Datapath.PathTable)  
+##### pathTable.table : <code>[Table](#ERMrest.Table)</code>
+**Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
 <a name="ERMrest.Datapath.PathTable+alias"></a>
 
 ##### pathTable.alias : <code>string</code>
-**Kind**: instance property of [<code>PathTable</code>](#ERMrest.Datapath.PathTable)  
+**Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
 <a name="ERMrest.Datapath.PathTable+columns"></a>
 
-##### pathTable.columns : [<code>Columns</code>](#ERMrest.Datapath.Columns)
-**Kind**: instance property of [<code>PathTable</code>](#ERMrest.Datapath.PathTable)  
+##### pathTable.columns : <code>[Columns](#ERMrest.Datapath.Columns)</code>
+**Kind**: instance property of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
 <a name="ERMrest.Datapath.PathTable+toString"></a>
 
 ##### pathTable.toString() ⇒ <code>string</code>
-**Kind**: instance method of [<code>PathTable</code>](#ERMrest.Datapath.PathTable)  
+**Kind**: instance method of <code>[PathTable](#ERMrest.Datapath.PathTable)</code>  
 **Returns**: <code>string</code> - uri of the PathTable  
 <a name="ERMrest.Datapath.PathColumn"></a>
 
 #### Datapath.PathColumn
-**Kind**: static class of [<code>Datapath</code>](#ERMrest.Datapath)  
+**Kind**: static class of <code>[Datapath](#ERMrest.Datapath)</code>  
 
 * [.PathColumn](#ERMrest.Datapath.PathColumn)
     * [new PathColumn(column, pathtable)](#new_ERMrest.Datapath.PathColumn_new)
-    * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
-    * [.column](#ERMrest.Datapath.PathColumn+column) : [<code>Column</code>](#ERMrest.Column)
+    * [.pathtable](#ERMrest.Datapath.PathColumn+pathtable) : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+    * [.column](#ERMrest.Datapath.PathColumn+column) : <code>[Column](#ERMrest.Column)</code>
 
 <a name="new_ERMrest.Datapath.PathColumn_new"></a>
 
@@ -3271,50 +3167,50 @@ extend the Datapath with table
 
 | Param | Type |
 | --- | --- |
-| column | [<code>Column</code>](#ERMrest.Column) | 
-| pathtable | [<code>PathTable</code>](#ERMrest.Datapath.PathTable) | 
+| column | <code>[Column](#ERMrest.Column)</code> | 
+| pathtable | <code>[PathTable](#ERMrest.Datapath.PathTable)</code> | 
 
 <a name="ERMrest.Datapath.PathColumn+pathtable"></a>
 
-##### pathColumn.pathtable : [<code>PathTable</code>](#ERMrest.Datapath.PathTable)
-**Kind**: instance property of [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)  
+##### pathColumn.pathtable : <code>[PathTable](#ERMrest.Datapath.PathTable)</code>
+**Kind**: instance property of <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>  
 <a name="ERMrest.Datapath.PathColumn+column"></a>
 
-##### pathColumn.column : [<code>Column</code>](#ERMrest.Column)
-**Kind**: instance property of [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)  
+##### pathColumn.column : <code>[Column](#ERMrest.Column)</code>
+**Kind**: instance property of <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>  
 <a name="ERMrest.Datapath.Columns"></a>
 
 #### Datapath.Columns(table, pathtable)
-**Kind**: static method of [<code>Datapath</code>](#ERMrest.Datapath)  
+**Kind**: static method of <code>[Datapath](#ERMrest.Datapath)</code>  
 
 | Param | Type |
 | --- | --- |
-| table | [<code>Table</code>](#ERMrest.Table) | 
-| pathtable | [<code>PathTable</code>](#ERMrest.Datapath.PathTable) | 
+| table | <code>[Table](#ERMrest.Table)</code> | 
+| pathtable | <code>[PathTable](#ERMrest.Datapath.PathTable)</code> | 
 
 
 * [.Columns(table, pathtable)](#ERMrest.Datapath.Columns)
     * [.length()](#ERMrest.Datapath.Columns+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Datapath.Columns+names) ⇒ <code>Array.&lt;String&gt;</code>
-    * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)
+    * [.get(colName)](#ERMrest.Datapath.Columns+get) ⇒ <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>
 
 <a name="ERMrest.Datapath.Columns+length"></a>
 
 ##### columns.length() ⇒ <code>Number</code>
-**Kind**: instance method of [<code>Columns</code>](#ERMrest.Datapath.Columns)  
+**Kind**: instance method of <code>[Columns](#ERMrest.Datapath.Columns)</code>  
 **Returns**: <code>Number</code> - number of path columns  
 <a name="ERMrest.Datapath.Columns+names"></a>
 
 ##### columns.names() ⇒ <code>Array.&lt;String&gt;</code>
-**Kind**: instance method of [<code>Columns</code>](#ERMrest.Datapath.Columns)  
+**Kind**: instance method of <code>[Columns](#ERMrest.Datapath.Columns)</code>  
 **Returns**: <code>Array.&lt;String&gt;</code> - a list of pathcolumn names  
 <a name="ERMrest.Datapath.Columns+get"></a>
 
-##### columns.get(colName) ⇒ [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn)
+##### columns.get(colName) ⇒ <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code>
 get PathColumn object by column name
 
-**Kind**: instance method of [<code>Columns</code>](#ERMrest.Datapath.Columns)  
-**Returns**: [<code>PathColumn</code>](#ERMrest.Datapath.PathColumn) - returns the PathColumn  
+**Kind**: instance method of <code>[Columns](#ERMrest.Datapath.Columns)</code>  
+**Returns**: <code>[PathColumn](#ERMrest.Datapath.PathColumn)</code> - returns the PathColumn  
 **Throws**:
 
 - <code>ERMrest.Errors.NotFoundError</code> column not found
@@ -3327,11 +3223,11 @@ get PathColumn object by column name
 <a name="ERMrest.Datapath.Operators"></a>
 
 #### Datapath.Operators()
-**Kind**: static method of [<code>Datapath</code>](#ERMrest.Datapath)  
+**Kind**: static method of <code>[Datapath](#ERMrest.Datapath)</code>  
 <a name="ERMrest.Filters"></a>
 
 ### ERMrest.Filters : <code>object</code>
-**Kind**: static namespace of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static namespace of <code>[ERMrest](#ERMrest)</code>  
 
 * [.Filters](#ERMrest.Filters) : <code>object</code>
     * [.Negation](#ERMrest.Filters.Negation)
@@ -3353,7 +3249,7 @@ get PathColumn object by column name
 <a name="ERMrest.Filters.Negation"></a>
 
 #### Filters.Negation
-**Kind**: static class of [<code>Filters</code>](#ERMrest.Filters)  
+**Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
 
 * [.Negation](#ERMrest.Filters.Negation)
     * [new Negation(filter)](#new_ERMrest.Filters.Negation_new)
@@ -3370,12 +3266,12 @@ get PathColumn object by column name
 <a name="ERMrest.Filters.Negation+toUri"></a>
 
 ##### negation.toUri() ⇒ <code>string</code>
-**Kind**: instance method of [<code>Negation</code>](#ERMrest.Filters.Negation)  
+**Kind**: instance method of <code>[Negation](#ERMrest.Filters.Negation)</code>  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.Conjunction"></a>
 
 #### Filters.Conjunction
-**Kind**: static class of [<code>Filters</code>](#ERMrest.Filters)  
+**Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
 
 * [.Conjunction](#ERMrest.Filters.Conjunction)
     * [new Conjunction(filters)](#new_ERMrest.Filters.Conjunction_new)
@@ -3392,12 +3288,12 @@ get PathColumn object by column name
 <a name="ERMrest.Filters.Conjunction+toUri"></a>
 
 ##### conjunction.toUri() ⇒ <code>string</code>
-**Kind**: instance method of [<code>Conjunction</code>](#ERMrest.Filters.Conjunction)  
+**Kind**: instance method of <code>[Conjunction](#ERMrest.Filters.Conjunction)</code>  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.Disjunction"></a>
 
 #### Filters.Disjunction
-**Kind**: static class of [<code>Filters</code>](#ERMrest.Filters)  
+**Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
 
 * [.Disjunction](#ERMrest.Filters.Disjunction)
     * [new Disjunction(filters)](#new_ERMrest.Filters.Disjunction_new)
@@ -3414,12 +3310,12 @@ get PathColumn object by column name
 <a name="ERMrest.Filters.Disjunction+toUri"></a>
 
 ##### disjunction.toUri() ⇒ <code>string</code>
-**Kind**: instance method of [<code>Disjunction</code>](#ERMrest.Filters.Disjunction)  
+**Kind**: instance method of <code>[Disjunction](#ERMrest.Filters.Disjunction)</code>  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.UnaryPredicate"></a>
 
 #### Filters.UnaryPredicate
-**Kind**: static class of [<code>Filters</code>](#ERMrest.Filters)  
+**Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
 
 * [.UnaryPredicate](#ERMrest.Filters.UnaryPredicate)
     * [new UnaryPredicate(column, operator)](#new_ERMrest.Filters.UnaryPredicate_new)
@@ -3435,18 +3331,18 @@ get PathColumn object by column name
 
 | Param | Type |
 | --- | --- |
-| column | [<code>Column</code>](#ERMrest.Column) | 
+| column | <code>[Column](#ERMrest.Column)</code> | 
 | operator | <code>ERMrest.Filters.OPERATOR</code> | 
 
 <a name="ERMrest.Filters.UnaryPredicate+toUri"></a>
 
 ##### unaryPredicate.toUri() ⇒ <code>string</code>
-**Kind**: instance method of [<code>UnaryPredicate</code>](#ERMrest.Filters.UnaryPredicate)  
+**Kind**: instance method of <code>[UnaryPredicate](#ERMrest.Filters.UnaryPredicate)</code>  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.Filters.BinaryPredicate"></a>
 
 #### Filters.BinaryPredicate
-**Kind**: static class of [<code>Filters</code>](#ERMrest.Filters)  
+**Kind**: static class of <code>[Filters](#ERMrest.Filters)</code>  
 
 * [.BinaryPredicate](#ERMrest.Filters.BinaryPredicate)
     * [new BinaryPredicate(column, operator, rvalue)](#new_ERMrest.Filters.BinaryPredicate_new)
@@ -3462,21 +3358,21 @@ get PathColumn object by column name
 
 | Param | Type |
 | --- | --- |
-| column | [<code>Column</code>](#ERMrest.Column) | 
+| column | <code>[Column](#ERMrest.Column)</code> | 
 | operator | <code>ERMrest.Filters.OPERATOR</code> | 
-| rvalue | <code>String</code> \| <code>Number</code> | 
+| rvalue | <code>String</code> &#124; <code>Number</code> | 
 
 <a name="ERMrest.Filters.BinaryPredicate+toUri"></a>
 
 ##### binaryPredicate.toUri() ⇒ <code>string</code>
-**Kind**: instance method of [<code>BinaryPredicate</code>](#ERMrest.Filters.BinaryPredicate)  
+**Kind**: instance method of <code>[BinaryPredicate](#ERMrest.Filters.BinaryPredicate)</code>  
 **Returns**: <code>string</code> - URI of the filter  
 <a name="ERMrest.configure"></a>
 
 ### ERMrest.configure(http, q)
 This function is used to configure the module
 
-**Kind**: static method of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static method of <code>[ERMrest](#ERMrest)</code>  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3485,16 +3381,16 @@ This function is used to configure the module
 
 <a name="ERMrest.getServer"></a>
 
-### ERMrest.getServer(uri, [params]) ⇒ [<code>Server</code>](#ERMrest.Server)
+### ERMrest.getServer(uri, [params]) ⇒ <code>[Server](#ERMrest.Server)</code>
 ERMrest server factory creates or reuses ERMrest.Server instances. The
 URI should be to the ERMrest _service_. For example,
 `https://www.example.org/ermrest`.
 
-**Kind**: static method of [<code>ERMrest</code>](#ERMrest)  
-**Returns**: [<code>Server</code>](#ERMrest.Server) - Returns a server instance.  
+**Kind**: static method of <code>[ERMrest](#ERMrest)</code>  
+**Returns**: <code>[Server](#ERMrest.Server)</code> - Returns a server instance.  
 **Throws**:
 
-- [<code>InvalidInputError</code>](#ERMrest.InvalidInputError) URI is missing
+- <code>[InvalidInputError](#ERMrest.InvalidInputError)</code> URI is missing
 
 
 | Param | Type | Default | Description |
@@ -3528,7 +3424,7 @@ ERMrest.resolve('https://example.org/catalog/42/entity/s:t/k=123').then(
   });
 ```
 
-**Kind**: static method of [<code>ERMrest</code>](#ERMrest)  
+**Kind**: static method of <code>[ERMrest](#ERMrest)</code>  
 **Returns**: <code>Promise</code> - Promise when resolved passes the
 [Reference](#ERMrest.Reference) object. If rejected, passes one of:
 [MalformedURIError](#ERMrest.MalformedURIError)
@@ -3553,7 +3449,7 @@ set callback function which will be called when a HTTP 401 Error occurs
 
 | Param | Type | Description |
 | --- | --- | --- |
-| fn | [<code>httpUnauthorizedFn</code>](#httpUnauthorizedFn) | callback function |
+| fn | <code>[httpUnauthorizedFn](#httpUnauthorizedFn)</code> | callback function |
 
 <a name="appLinkFn"></a>
 
@@ -3564,5 +3460,5 @@ set callback function that converts app tag to app URL
 
 | Param | Type | Description |
 | --- | --- | --- |
-| fn | [<code>appLinkFn</code>](#appLinkFn) | callback function |
+| fn | <code>[appLinkFn](#appLinkFn)</code> | callback function |
 

--- a/js/datapath.js
+++ b/js/datapath.js
@@ -47,7 +47,7 @@ var ERMrest = (function(module) {
 
         _copy: function() { // shallow copy
             var dp = Object.create(DataPath.prototype);
-            module._clone(dp, this);
+            module._shallowCopy(dp, this);
             dp.entity._bind(dp);
             return dp;
         },

--- a/js/reference.js
+++ b/js/reference.js
@@ -2832,7 +2832,27 @@ var ERMrest = (function(module) {
                 return null;
             }
 
-        }
+        },
+
+        /**
+         * @desc
+         * This function takes the current Tuple (this) and creates a shallow copy of it while de-referencing
+         * the _data attribute. This way _data can be modified in chaise without changing the originating Tuple
+         * @returns {ERMrest.Tuple} a shallow copy of _this_ tuple with it's _data de-referenced
+         */
+         deepCopyData: function() {
+             var newTuple = Object.create(Tuple.prototype);
+             module._clone(newTuple, this);
+             newTuple._data = {};
+
+             //change _data though
+             var keys = Object.keys(this._data);
+             for (var i = 0; i < keys.length; i++) {
+                 newTuple._data[keys[i]] = this._data[keys[i]];
+             }
+
+             return newTuple;
+         }
 
 
     };

--- a/js/reference.js
+++ b/js/reference.js
@@ -1824,7 +1824,7 @@ var ERMrest = (function(module) {
     function _referenceCopy(source) {
         var referenceCopy = Object.create(Reference.prototype);
         // referenceCopy must be defined before _clone can copy values from source to referenceCopy
-        module._clone(referenceCopy, source);
+        module._shallowCopy(referenceCopy, source);
 
         referenceCopy.contextualize = new Contextualize(referenceCopy);
         return referenceCopy;
@@ -2840,9 +2840,9 @@ var ERMrest = (function(module) {
          * the _data attribute. This way _data can be modified in chaise without changing the originating Tuple
          * @returns {ERMrest.Tuple} a shallow copy of _this_ tuple with it's _data de-referenced
          */
-         deepCopyData: function() {
+         copy: function() {
              var newTuple = Object.create(Tuple.prototype);
-             module._clone(newTuple, this);
+             module._shallowCopy(newTuple, this);
              newTuple._data = {};
 
              //change _data though

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -90,7 +90,7 @@ var ERMrest = (function(module) {
      * @desc
      * This private utility function does a shallow copy between objects.
      */
-    module._clone = function (copyTo, copyFrom) {
+    module._shallowCopy = function (copyTo, copyFrom) {
         for (var key in copyFrom) {
             // only copy those properties that were set in the object, this
             // will skip properties from the source object's prototype

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -77,7 +77,7 @@ exports.execute = function (options) {
 
             it("should return error if reference is not contextualized for create.", function(done) {
                 var rows = [{ id: 9999, name: "Paula", value: 5 }];
-                
+
                 reference.create(rows).then(function(response) {
                     throw new Error("Did not return any errors");
                 }).catch(function (err) {
@@ -261,6 +261,18 @@ exports.execute = function (options) {
 
             it('tuples should have methods properly defined.', function() {
                 expect(tuple.values).toBeDefined();
+            });
+
+            it('tuple.deepCopyData should create a shallow copy of the tuple except for the data.', function() {
+                var newTuple = tuple.deepCopyData();
+
+                // The original and new Tuple should not be the same object, neither should the _data
+                expect(newTuple).not.toBe(tuple);
+                expect(newTuple._data).not.toBe(tuple._data);
+
+                // All other objects of tuple should be the same object
+                // newTuple should have references to the original objects in tuple
+                expect(newTuple._pageRef).toBe(tuple._pageRef);
             });
 
             it('values should return only the values of the tuple.', function() {

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -263,12 +263,18 @@ exports.execute = function (options) {
                 expect(tuple.values).toBeDefined();
             });
 
-            it('tuple.deepCopyData should create a shallow copy of the tuple except for the data.', function() {
-                var newTuple = tuple.deepCopyData();
+            it('tuple.copy should create a shallow copy of the tuple except for the data.', function() {
+                var key;
+                var newTuple = tuple.copy();
 
                 // The original and new Tuple should not be the same object, neither should the _data
                 expect(newTuple).not.toBe(tuple);
                 expect(newTuple._data).not.toBe(tuple._data);
+                var keys = Object.keys(tuple._data);
+                for (var i = 0; i < keys.length; i++) {
+                    key = keys[i];
+                    expect(newTuple._data[key]).toBe(tuple._data[key]);
+                }
 
                 // All other objects of tuple should be the same object
                 // newTuple should have references to the original objects in tuple


### PR DESCRIPTION
This PR addresses issue [#1102](https://github.com/informatics-isi-edu/chaise/issues/1102) in chaise. The function I added to the `Tuple` object's prototype allows the user to make a _shallow_ copy of the `Tuple` while de-referencing the private `_data` object. This is so when changes are made to the new `Tuple`, it doesn't modify the originating `Tuple`.

This PR needs to be merged before [this](https://github.com/informatics-isi-edu/chaise/pull/1112) one in `Chaise`.