### PR TITLE
Removed setting the hostname in file urls

### DIFF
--- a/test/specs/upload/tests/01.checksum.js
+++ b/test/specs/upload/tests/01.checksum.js
@@ -15,8 +15,6 @@ exports.execute = function (options) {
             ermRest,
             reference;
 
-        var baseUrl = options.url.replace("/ermrest", "");
-
         var files = [{
         	name: "testfile50MB.pdf",
         	size: 52428800,
@@ -121,7 +119,7 @@ exports.execute = function (options) {
 		        		uploadObj.hash = { md5_hex: file.hash };
 
 			        	//Note: Property uri.md5_hex is generated at runtime so we are setting it expliticly to test the function
-			        	expect(uploadObj.generateURL(validRow)).toBe(baseUrl + "/hatrac/ermrestjstest/800001/" + file.hash);
+			        	expect(uploadObj.generateURL(validRow)).toBe("/hatrac/ermrestjstest/800001/" + file.hash);
 			        });
 
 
@@ -134,7 +132,7 @@ exports.execute = function (options) {
 			        		
 			        		expect(uploaded).toBe(file.size, "File progress was not called for all checksum chunk calculation");
 			        		
-			        		expect(url).toBe(baseUrl + "/hatrac/ermrestjstest/800001/" + file.hash, "File generated url is not the same");
+			        		expect(url).toBe("/hatrac/ermrestjstest/800001/" + file.hash, "File generated url is not the same");
 
 			        		expect(validRow.filename).toBe(file.name);
 			        		expect(validRow.bytes).toBe(file.size);

--- a/test/specs/upload/tests/02.upload_process.js
+++ b/test/specs/upload/tests/02.upload_process.js
@@ -15,8 +15,6 @@ exports.execute = function (options) {
             ermRest,
             reference;
 
-        var baseUrl = options.url.replace("/ermrest", "");
-
         var files = [{
         	name: "testfile50MB.pdf",
         	size: 52428800,
@@ -118,7 +116,7 @@ exports.execute = function (options) {
 			        		
 			        		expect(uploaded).toBe(file.size, "File progress was not called for all checksum chunk calculation");
 			        		
-			        		expect(url).toBe(baseUrl + "/hatrac/ermrestjstest/" + fk_id + "/" + file.hash, "File generated url is not the same");
+			        		expect(url).toBe("/hatrac/ermrestjstest/" + fk_id + "/" + file.hash, "File generated url is not the same");
 
 			        		expect(validRow.filename).toBe(file.name);
 			        		expect(validRow.bytes).toBe(file.size);
@@ -168,7 +166,7 @@ exports.execute = function (options) {
 
 			        	uploadObj.start().then(function(url) {
 			        		expect(uploaded).toBe(file.size, "File progress was not called for all uploading");
-			        		expect(url).toBe(baseUrl + "/hatrac/ermrestjstest/" + fk_id + "/" + file.hash, "File  url is not the same");
+			        		expect(url).toBe("/hatrac/ermrestjstest/" + fk_id + "/" + file.hash, "File  url is not the same");
 			        		done();
 	                    }, function(e) {
 	                    	console.dir(e);
@@ -184,7 +182,7 @@ exports.execute = function (options) {
 			        it("should complete upload job and return final url", function(done) {
 
 			        	uploadObj.completeUpload().then(function(url) {
-			        		expect(url).toContain(baseUrl + "/hatrac/ermrestjstest/" + fk_id +"/" + file.hash, "File  url is not the same");
+			        		expect(url).toContain("/hatrac/ermrestjstest/" + fk_id +"/" + file.hash, "File  url is not the same");
 			        		done();
 	                    }, function(e) {
 	                    	console.dir(e);


### PR DESCRIPTION
This PR fixes issue mentioned here https://github.com/informatics-isi-edu/chaise/issues/1135, to not add the current hostname to the URLs it generates during fileupload.

Now the urls that are stored are relative. Can be tested here

https://dev.rebuildingakidney.org/~chirag/chaise/recordedit/#2/test:asset_test