### PR TITLE
Change Update and Create

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -2281,7 +2281,8 @@ specification, and not according to the contents of in the input
 tuple.
 
 **Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
-**Returns**: <code>Promise</code> - A promise resolved w ith [Page](#ERMrest.Page) of results,
+**Returns**: <code>Promise</code> - A promise resolved with a object containing `successful` and `failure` attributes.
+Both are [Page](#ERMrest.Page) of results.
 or rejected with any of the following errors:
 - [InvalidInputError](#ERMrest.InvalidInputError): If `data` is not valid, or reference is not in `entry/create` context.
 - [InvalidInputError](#ERMrest.InvalidInputError): If `limit` is invalid.
@@ -2357,7 +2358,8 @@ Return a new Reference with the new sorting
 Updates a set of resources.
 
 **Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
-**Returns**: <code>Promise</code> - A promise resolved with [Page](#ERMrest.Page) of results,
+**Returns**: <code>Promise</code> - A promise resolved with a object containing `successful` and `failure` attributes.
+Both are [Page](#ERMrest.Page) of results.
 or rejected with any of these errors:
 - [InvalidInputError](#ERMrest.InvalidInputError): If `limit` is invalid or reference is not in `entry/edit` context.
 - ERMrestjs corresponding http errors, if ERMrest returns http error.  

--- a/js/reference.js
+++ b/js/reference.js
@@ -772,7 +772,7 @@ var ERMrest = (function(module) {
 
                     var ref = new Reference(module._parse(uri), self._table.schema.catalog);
                     //  make a page of tuples of the results (unless error)
-                    var page = new Page(ref, etag, response.data, false, false);
+                    var page = new Page(ref.contextualize.compact, etag, response.data, false, false);
 
                     //  resolve the promise, passing back the page
                     return defer.resolve(page);
@@ -1380,7 +1380,7 @@ var ERMrest = (function(module) {
                         }
                     }
                     var ref = new Reference(module._parse(uri), self._table.schema.catalog);
-                    page = new Page(ref, etag, pageData, false, false);
+                    page = new Page(ref.contextualize.compact, etag, pageData, false, false);
 
                     defer.resolve(page);
                 }, function error(response) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -718,7 +718,8 @@ var ERMrest = (function(module) {
          * specification, and not according to the contents of in the input
          * tuple.
          * @param {!Array} data The array of data to be created as new tuples.
-         * @returns {Promise} A promise resolved w ith {@link ERMrest.Page} of results,
+         * @returns {Promise} A promise resolved with a object containing `successful` and `failure` attributes.
+         * Both are {@link ERMrest.Page} of results.
          * or rejected with any of the following errors:
          * - {@link ERMrest.InvalidInputError}: If `data` is not valid, or reference is not in `entry/create` context.
          * - {@link ERMrest.InvalidInputError}: If `limit` is invalid.
@@ -775,7 +776,10 @@ var ERMrest = (function(module) {
                     var page = new Page(ref.contextualize.compact, etag, response.data, false, false);
 
                     //  resolve the promise, passing back the page
-                    return defer.resolve(page);
+                    return defer.resolve({
+                      "successful": page,
+                      "failed": null
+                    });
                 }, function error(response) {
                     var error = module._responseToError(response);
                     return defer.reject(error);
@@ -1164,7 +1168,8 @@ var ERMrest = (function(module) {
          * @param {Array} tuples array of tuple objects so that the new data nd old data can be used to determine key changes.
          * tuple.data has the new data
          * tuple._oldData has the data before changes were made
-         * @returns {Promise} A promise resolved with {@link ERMrest.Page} of results,
+         * @returns {Promise} A promise resolved with a object containing `successful` and `failure` attributes.
+         * Both are {@link ERMrest.Page} of results.
          * or rejected with any of these errors:
          * - {@link ERMrest.InvalidInputError}: If `limit` is invalid or reference is not in `entry/edit` context.
          * - ERMrestjs corresponding http errors, if ERMrest returns http error.
@@ -1188,6 +1193,8 @@ var ERMrest = (function(module) {
                     keyWasModified = false,
                     tuple, oldData, allOldData = [], newData, allNewData = [], keyName;
 
+                var i, j, k;
+
                 // add column name into list of column projections and data into the submission data
                 var addProjectionAndKeyData = function(index, colName) {
                     // here so each column of the columns in keyColumns set is added
@@ -1207,7 +1214,7 @@ var ERMrest = (function(module) {
                     return column.name;
                 });
 
-                for(var i = 0; i < tuples.length; i++) {
+                for(i = 0; i < tuples.length; i++) {
                     newData = tuples[i].data;
                     oldData = tuples[i]._oldData;
 
@@ -1315,7 +1322,7 @@ var ERMrest = (function(module) {
                 }
 
                 // always alias the keyset for the key data
-                for (var j = 0; j < shortestKeyNames.length; j++) {
+                for (j = 0; j < shortestKeyNames.length; j++) {
                     if (j !== 0) uri += ',';
                     // alias all the columns for the key set
                     uri += module._fixedEncodeURIComponent(shortestKeyNames[j]) + oldAlias + ":=" + module._fixedEncodeURIComponent(shortestKeyNames[j]);
@@ -1325,7 +1332,7 @@ var ERMrest = (function(module) {
                 uri += ';';
 
                 // the keyset is always aliased with the old alias, so make sure to include the new alias in the column projections
-                for (var k = 0; k < columnProjections.length; k++) {
+                for (k = 0; k < columnProjections.length; k++) {
                     if (k !== 0) uri += ',';
                     // alias all the columns for the key set
                     uri += module._fixedEncodeURIComponent(columnProjections[k]) + newAlias + ":=" + module._fixedEncodeURIComponent(columnProjections[k]);
@@ -1342,12 +1349,11 @@ var ERMrest = (function(module) {
                     }
 
                     var etag = response.headers().etag;
-                    var pageData = [],
-                        page;
+                    var pageData = [];
 
                     var uri = self._location.service + "/catalog/" + self._location.catalog + "/entity/" + self._location.schemaName + ':' + self._location.tableName + '/';
                     // loop through each returned Row and get the key value
-                    for (var j = 0; j < response.data.length; j++) {
+                    for (j = 0; j < response.data.length; j++) {
                         // build the uri
                         if (j !== 0)
                         uri += ';';
@@ -1357,7 +1363,7 @@ var ERMrest = (function(module) {
                             uri += module._fixedEncodeURIComponent(keyName) + '=' + module._fixedEncodeURIComponent(response.data[j][keyName + newAlias]);
                         } else {
                             uri += '(';
-                            for (var k = 0; k < self._shortestKey.length; k++) {
+                            for (k = 0; k < self._shortestKey.length; k++) {
                                 if (k !== 0)
                                 uri += '&';
                                 keyName = self._shortestKey[k].name;
@@ -1379,10 +1385,61 @@ var ERMrest = (function(module) {
                             }
                         }
                     }
-                    var ref = new Reference(module._parse(uri), self._table.schema.catalog);
-                    page = new Page(ref.contextualize.compact, etag, pageData, false, false);
 
-                    defer.resolve(page);
+                    // NOTE: ermrest returns only some of the column data.
+                    // make sure that pageData has all the submitted and updated data
+                    for (i = 0; i < tuples.length; i++) {
+                      for (j in tuples[i].data) {
+                        if (!tuples[i].data.hasOwnProperty(j)) continue;
+                        if (j in pageData[i]) continue; // pageData already has this data
+                        pageData[i][j] =tuples[i].data[j]; // add the missing data
+                      }
+                    }
+
+                    var ref = new Reference(module._parse(uri), self._table.schema.catalog).contextualize.compact;
+                    var successfulPage = new Page(ref, etag, pageData, false, false);
+                    var failedPage = null;
+
+
+                    // if the returned page is smaller than the initial page,
+                    // then some of the columns failed to update.
+                    if (tuples.length > successfulPage.tuples.length) {
+                      var unchangedPageData = [], keyMatch, rowMatch;
+
+                      for (i = 0; i < tuples.length; i++) {
+                        rowMatch = false;
+
+                        for (j = 0; j < successfulPage.tuples.length; j++) {
+                          keyMatch = true;
+
+                          for (k = 0; k < shortestKeyNames.length; k++) {
+                            keyName = shortestKeyNames[k];
+                            if (tuples[i].data[keyName] === successfulPage.tuples[j].data[keyName]) {
+                              // these keys don't match, go for the next tuple
+                              keyMatch = false;
+                              break;
+                            }
+                          }
+
+                          if (keyMatch) {
+                            // all the key columns match, then rows match.
+                            rowMatch = true;
+                            break;
+                          }
+                        }
+
+                        if (!rowMatch) {
+                          // didn't find a match, so add as failed
+                          unchangedPageData.push(tuples[i].data);
+                        }
+                      }
+                      failedPage = new Page(ref, etag, unchangedPageData, false, false);
+                    }
+
+                    defer.resolve({
+                      "successful": successfulPage,
+                      "failed": failedPage
+                    });
                 }, function error(response) {
                     var error = module._responseToError(response);
                     return defer.reject(error);

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -90,7 +90,7 @@ exports.execute = function (options) {
                 var rows = [{ id: 9999, name: "Paula", value: 5 }];
 
                 createReference.create(rows).then(function (response) {
-                    var page = response;
+                    var page = response.successful;
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.reference._context).toEqual("compact", "page reference is not in the correct context.")
@@ -112,7 +112,7 @@ exports.execute = function (options) {
                             { id: 9802, name: "Garnet", value: 36 }];
 
                 createReference.create(rows).then(function (response) {
-                    var page = response;
+                    var page = response.successful;
 
                     expect(page).toEqual(jasmine.any(Object));
                     expect(page.reference._context).toEqual("compact", "page reference is not in the correct context.")

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -93,6 +93,7 @@ exports.execute = function (options) {
                     var page = response;
 
                     expect(page).toEqual(jasmine.any(Object));
+                    expect(page.reference._context).toEqual("compact", "page reference is not in the correct context.")
                     expect(page._data.length).toBe(rows.length);
                     expect(page._data[0].id).toBe((rows[0].id).toString());
                     expect(page._data[0].name).toBe(rows[0].name);
@@ -114,6 +115,7 @@ exports.execute = function (options) {
                     var page = response;
 
                     expect(page).toEqual(jasmine.any(Object));
+                    expect(page.reference._context).toEqual("compact", "page reference is not in the correct context.")
                     expect(page._data.length).toBe(rows.length);
                     for(var i = 0; i < page._data.length; i++) {
                         expect(page._data[i].id).toBe((rows[i].id).toString());

--- a/test/specs/reference/tests/10.update.js
+++ b/test/specs/reference/tests/10.update.js
@@ -91,6 +91,7 @@ exports.execute = function (options) {
 
                     return reference.update(response.tuples);
                 }).then(function (response) {
+                    response = response.successful;
                     expect(response._data.length).toBe(1);
 
                     checkPageValues(response._data, tuples, sortBy);
@@ -206,6 +207,7 @@ exports.execute = function (options) {
 
                     return reference.update(tuples);
                 }).then(function (response) {
+                    response = response.successful;
                     expect(response._data.length).toBe(1, "Update data set that was returned is not the right length");
 
                     checkPageValues(response._data, tuples, sortBy);
@@ -270,6 +272,7 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
+                        response = response.successful;
                         expect(response._data.length).toBe(1, "response data is not the same size as given.");
                         expect(response.reference._context).toEqual("compact", "page reference is not in the correct context.");
 
@@ -318,6 +321,7 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
+                        response = response.successful;
                         expect(response._data.length).toBe(1);
 
                         checkPageValues(response._data, tuples, sortBy);
@@ -366,6 +370,7 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
+                        response = response.successful;
                         expect(response._data.length).toBe(1);
 
                         checkPageValues(response._data, tuples, sortBy);
@@ -414,6 +419,7 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
+                        response = response.successful;
                         expect(response._data.length).toBe(1);
 
                         checkPageValues(response._data, tuples, sortBy);
@@ -464,6 +470,7 @@ exports.execute = function (options) {
 
                             return reference.update(response.tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(1);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -516,6 +523,7 @@ exports.execute = function (options) {
 
                             return reference.update(response.tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(1);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -580,6 +588,7 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
+                        response = response.successful;
                         expect(response._data.length).toBe(1);
 
                         checkPageValues(response._data, tuples, sortBy);
@@ -616,6 +625,7 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
+                        response = response.successful;
                         expect(response._data.length).toBe(1);
 
                         checkPageValues(response._data, tuples, sortBy);
@@ -652,6 +662,7 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
+                        response = response.successful;
                         expect(response._data.length).toBe(1);
 
                         checkPageValues(response._data, tuples, sortBy);
@@ -688,6 +699,7 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
+                        response = response.successful;
                         expect(response._data.length).toBe(1);
 
                         checkPageValues(response._data, tuples, sortBy);
@@ -727,6 +739,7 @@ exports.execute = function (options) {
 
                             return reference.update(response.tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(1);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -767,6 +780,7 @@ exports.execute = function (options) {
 
                             return reference.update(response.tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(1);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -807,6 +821,7 @@ exports.execute = function (options) {
 
                             return reference.update(response.tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(1);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -849,6 +864,7 @@ exports.execute = function (options) {
 
                                     return reference.update(response.tuples);
                                 }).then(function (response) {
+                                    response = response.successful;
                                     expect(response._data.length).toBe(1);
 
                                     checkPageValues(response._data, tuples, sortBy);
@@ -889,6 +905,7 @@ exports.execute = function (options) {
 
                                     return reference.update(response.tuples);
                                 }).then(function (response) {
+                                    response = response.successful;
                                     expect(response._data.length).toBe(1);
 
                                     checkPageValues(response._data, tuples, sortBy);
@@ -930,6 +947,7 @@ exports.execute = function (options) {
 
                                 return reference.update(response.tuples);
                             }).then(function (response) {
+                                response = response.successful;
                                 expect(response._data.length).toBe(1);
 
                                 checkPageValues(response._data, tuples, sortBy);
@@ -970,6 +988,7 @@ exports.execute = function (options) {
 
                                 return reference.update(response.tuples);
                             }).then(function (response) {
+                                response = response.successful;
                                 expect(response._data.length).toBe(1);
 
                                 checkPageValues(response._data, tuples, sortBy);
@@ -1013,6 +1032,7 @@ exports.execute = function (options) {
 
                                 return reference.update(response.tuples);
                             }).then(function (response) {
+                                response = response.successful;
                                 expect(response._data.length).toBe(1);
 
                                 checkPageValues(response._data, tuples, sortBy);
@@ -1057,6 +1077,7 @@ exports.execute = function (options) {
 
                                 return reference.update(response.tuples);
                             }).then(function (response) {
+                                response = response.successful;
                                 expect(response._data.length).toBe(1);
 
                                 checkPageValues(response._data, tuples, sortBy);
@@ -1103,6 +1124,7 @@ exports.execute = function (options) {
 
                                 return reference.update(response.tuples);
                             }).then(function (response) {
+                                response = response.successful;
                                 expect(response._data.length).toBe(1);
 
                                 checkPageValues(response._data, tuples, sortBy);
@@ -1147,6 +1169,7 @@ exports.execute = function (options) {
 
                                 return reference.update(response.tuples);
                             }).then(function (response) {
+                                response = response.successful;
                                 expect(response._data.length).toBe(1);
 
                                 checkPageValues(response._data, tuples, sortBy);
@@ -1202,6 +1225,7 @@ exports.execute = function (options) {
 
                             return reference.update(tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(updateData.length);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -1291,6 +1315,7 @@ exports.execute = function (options) {
 
                             return reference.update(tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(updateData.length);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -1358,6 +1383,7 @@ exports.execute = function (options) {
 
                             return reference.update(tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(updateData.length);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -1429,6 +1455,7 @@ exports.execute = function (options) {
 
                             return reference.update(tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(updateData.length);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -1526,6 +1553,7 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
+                        response = response.successful;
                         expect(response._data.length).toBe(1);
 
                         checkPageValues(response._data, tuples, sortBy);
@@ -1562,6 +1590,7 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
+                        response = response.successful;
                         expect(response._data.length).toBe(1);
 
                         checkPageValues(response._data, tuples, sortBy);
@@ -1600,6 +1629,7 @@ exports.execute = function (options) {
 
                             return reference.update(response.tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(1);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -1640,6 +1670,7 @@ exports.execute = function (options) {
 
                             return reference.update(response.tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(1);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -1700,6 +1731,7 @@ exports.execute = function (options) {
 
                             return reference.update(tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(updateData.length);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -1765,6 +1797,7 @@ exports.execute = function (options) {
 
                             return reference.update(tuples);
                         }).then(function (response) {
+                            response = response.successful;
                             expect(response._data.length).toBe(updateData.length);
 
                             checkPageValues(response._data, tuples, sortBy);
@@ -1833,6 +1866,7 @@ exports.execute = function (options) {
 
                                 return reference.update(tuples);
                             }).then(function (response) {
+                                response = response.successful;
                                 expect(response._data.length).toBe(updateData.length);
 
                                 checkPageValues(response._data, tuples, sortBy);

--- a/test/specs/reference/tests/10.update.js
+++ b/test/specs/reference/tests/10.update.js
@@ -270,7 +270,8 @@ exports.execute = function (options) {
 
                         return reference.update(response.tuples);
                     }).then(function (response) {
-                        expect(response._data.length).toBe(1);
+                        expect(response._data.length).toBe(1, "response data is not the same size as given.");
+                        expect(response.reference._context).toEqual("compact", "page reference is not in the correct context.");
 
                         checkPageValues(response._data, tuples, sortBy);
 
@@ -281,8 +282,8 @@ exports.execute = function (options) {
                     }).then(function (response) {
                         var pageData = response._data[0];
 
-                        expect(pageData.ind_key1).toBe(updateData.ind_key1);
-                        expect(pageData.ind_key1).not.toBe(tuple._oldData.ind_key1);
+                        expect(pageData.ind_key1).toBe(updateData.ind_key1, "updated data is not correct.");
+                        expect(pageData.ind_key1).not.toBe(tuple._oldData.ind_key1, "data has not been updated.");
 
                         done();
                     }).catch(function (error) {


### PR DESCRIPTION
This PR,
- Changes `create`and `update` functions to return two pages. One containing the tuples that have been updated and the other tuples that failed.
- Changes the context of returned page in `create` and `update` to `compact`.