### PR TITLE
unify mustache template rendering usage

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -2260,6 +2260,7 @@ The logic for are sorted based on following attributes:
 
 #### reference.unfilteredReference : [<code>Reference</code>](#ERMrest.Reference)
 This will generate a new unfiltered reference each time.
+Returns a reference that points to all entities of current table
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+appLink"></a>

--- a/js/core.js
+++ b/js/core.js
@@ -1783,7 +1783,12 @@ var ERMrest = (function (module) {
                 var template = display.markdownPattern; // pattern
 
                 // Code to do template/string replacement using keyValues
-                value = module._renderTemplate(template, options.formattedValues, options);
+                if (options === undefined || options.formattedValues === undefined) {
+                    options.formattedValues = module._getFormattedKeyValues(this.table.columns, context, data);
+                }
+                
+                options.formatted = true; // to avoid creating formattedValues again
+                value = module._renderTemplate(template, options.formattedValues, this.table, context, options);
             }
 
 

--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -278,13 +278,10 @@ var ERMrest = (function(module) {
             if (this.column.md5 && typeof this.column.md5 === "object") ignoredColumns.push(this.column.md5.name);
             if (this.column.sha256 && typeof this.column.sha256 === "object") ignoredColumns.push(this.column.sha256.name); 
             
-            // since we are going to format the values, ignoredColumns will be available
-            // in formmatted and unformatted forms. Following makes sure that we have
-            // added these two to the ignoredColumns
-            for(var i = 0; i < ignoredColumns.length; i++) {
-                
-            }
-            
+            ignoredColumns.push("md5_hex");
+            ignoredColumns.push("md5_base64");
+            ignoredColumns.push("filename");
+            ignoredColumns.push("size");
             ignoredColumns.push(this.column.name + ".md5_hex");
             ignoredColumns.push(this.column.name + ".md5_base64");
             ignoredColumns.push(this.column.name + ".filename");

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -1405,7 +1405,7 @@ var ERMrest = (function(module) {
         
         // to avoid computing data multiple times, or if we don't want the formatted values
         if (options === undefined || !options.formatted) {
-            // make sure to add formmatted columns too.
+            // make sure to add formatted columns too.
             if (ignoredColumns !== undefined) {
                 ignoredColumns.forEach(function (col) {
                     ignoredColumns.push("_" + col);
@@ -1415,7 +1415,7 @@ var ERMrest = (function(module) {
             data = module._getFormattedKeyValues(table.columns, context, data);
         }
         
-        // render the template using Mustache
+        // call the actual mustache validator
         return module._validateMustacheTemplate(template, data, ignoredColumns);
     };
 

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -159,13 +159,13 @@ exports.execute = function (options) {
             }
         });
 
-        it('module._renderTemplate() should function correctly for Null and Non-null values', function() {
-            expect(module._renderTemplate("My name is {{name}}", {name: 'John'})).toBe("My name is John");
-            expect(module._renderTemplate("My name is {{name}}", { name: null })).toBe(null);
-            expect(module._renderTemplate("My name is {{name}}", {})).toBe(null);
-            expect(module._renderTemplate("My name is {{#name}}{{name}}{{/name}}", {})).toBe("My name is ");
-            expect(module._renderTemplate("My name is {{^name}}{{name}}{{/name}}", {})).toBe("My name is ");
-            expect(module._renderTemplate("My name is {{^name}}John{{/name}}", {})).toBe("My name is John");
+        it('module._renderMustacheTemplate() should function correctly for Null and Non-null values', function() {
+            expect(module._renderMustacheTemplate("My name is {{name}}", {name: 'John'})).toBe("My name is John");
+            expect(module._renderMustacheTemplate("My name is {{name}}", { name: null })).toBe(null);
+            expect(module._renderMustacheTemplate("My name is {{name}}", {})).toBe(null);
+            expect(module._renderMustacheTemplate("My name is {{#name}}{{name}}{{/name}}", {})).toBe("My name is ");
+            expect(module._renderMustacheTemplate("My name is {{^name}}{{name}}{{/name}}", {})).toBe("My name is ");
+            expect(module._renderMustacheTemplate("My name is {{^name}}John{{/name}}", {})).toBe("My name is John");
         });
 
         var obj = {
@@ -238,11 +238,11 @@ exports.execute = function (options) {
                 "note": "With encoding and escaping. Should give correct HTML with valid caption a link"
             }];
 
-        it('module._renderTemplate() and module._renderMarkdown() should function correctly for Markdown Escaping and Encoding', function() {
+        it('module._renderMustacheTemplate() and module._renderMarkdown() should function correctly for Markdown Escaping and Encoding', function() {
             var printMarkdown = formatUtils.printMarkdown;
 
             templateCases.forEach(function(ex) {
-                var template = module._renderTemplate(ex.template, obj);
+                var template = module._renderMustacheTemplate(ex.template, obj);
                 expect(template).toBe(ex.after_mustache);
                 var html = printMarkdown(template);
                 expect(html).toBe(ex.after_render + '\n');

--- a/test/specs/upload/conf/upload/schema.json
+++ b/test/specs/upload/conf/upload/schema.json
@@ -74,7 +74,7 @@
           },
           "annotations": {
             "tag:isrd.isi.edu,2017:asset": {
-              "url_pattern" : "/hatrac/ermrestjstest/{{{fk_id}}}/{{{uri.md5_hex}}}",
+              "url_pattern" : "/hatrac/ermrestjstest/{{{_fk_id}}}/{{{_uri.md5_hex}}}",
               "filename_column" : "filename", 
               "byte_count_column" : "bytes",
               "md5" : "checksum"

--- a/test/specs/upload/tests/01.checksum.js
+++ b/test/specs/upload/tests/01.checksum.js
@@ -11,7 +11,7 @@ exports.execute = function (options) {
             table,
             columnName = "uri",
             column,
-            template = "/hatrac/ermrestjstest/{{{fk_id}}}/{{{uri.md5_hex}}}",
+            template = "/hatrac/ermrestjstest/{{{_fk_id}}}/{{{_uri.md5_hex}}}",
             ermRest,
             reference;
 

--- a/test/specs/upload/tests/02.upload_process.js
+++ b/test/specs/upload/tests/02.upload_process.js
@@ -11,7 +11,7 @@ exports.execute = function (options) {
             table,
             columnName = "uri",
             column,
-            template = "/hatrac/{{{fk_id}}}/{{{uri.md5_hex}}}",
+            template = "/hatrac/{{{_fk_id}}}/{{{_uri.md5_hex}}}",
             ermRest,
             reference;
 


### PR DESCRIPTION
We had a `_renderTemplate` function that was being used directly in different places. This function would render mustache template with given data. But the data was not following the rules that we had in place for raw and formatted values (by using '_').
Now `_renderTemplate` function will generate the formatted and raw values if the given data is not formatted. Also `_validateTemplate` function has been refactored to support both `url_pattern` and other usages of mustache template.


-----------------
P.S.
- This most probably will break chaise test cases, I will fix those testcases in my chaise PR.

- After merging this, I will update the asset annotation document.