### PR TITLE
Changes made for JSON and JSONB column support

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1711,7 +1711,7 @@ var ERMrest = (function (module) {
         this.formatvalue = function (data, options) {
             //This check has been added to show "null" in all the rows if the user inputs blank string
             //We are opting json out here because we want null in the UI instead of "", so we do not call _getNullValue for json
-            if (data === undefined || (data === null && this.type.name.indexOf('json') !== 0)) {
+            if (data === undefined || (data === null && this.type.name.indexOf('json') !== 0) || (data === null && this.type.name.indexOf('jsonb') !== 0)) {
                     return this._getNullValue(options ? options.context : undefined);
                 }
             if (data === undefined) {

--- a/js/core.js
+++ b/js/core.js
@@ -1709,7 +1709,13 @@ var ERMrest = (function (module) {
          * @returns {string} The formatted value.
          */
         this.formatvalue = function (data, options) {
-            if (data === undefined || data === null) {
+            //This check has been added to show "null" in all the rows if the user inputs blank string
+            if(this.type.name!=='json'){
+                if (data === undefined || data === null) {
+                    return this._getNullValue(options ? options.context : undefined);
+                }
+            }
+            if (data === undefined) {
                 return this._getNullValue(options ? options.context : undefined);
             }
             /* TODO format the raw value based on the column definition
@@ -1742,6 +1748,11 @@ var ERMrest = (function (module) {
                     break;
                 case 'gene_sequence':
                     data = utils.printGeneSeq(data, options);
+                    break;
+                //Cases to support json and jsonb columns
+                case 'json':
+                case 'jsonb':
+                    data = utils.printJSON(data,options);
                     break;
                 default: // includes 'text' and 'longtext' cases
                     data = utils.printText(data, options);

--- a/js/core.js
+++ b/js/core.js
@@ -1710,11 +1710,10 @@ var ERMrest = (function (module) {
          */
         this.formatvalue = function (data, options) {
             //This check has been added to show "null" in all the rows if the user inputs blank string
-            if(this.type.name!=='json'){
-                if (data === undefined || data === null) {
+            //We are opting json out here because we want null in the UI instead of "", so we do not call _getNullValue for json
+            if (data === undefined || (data === null && this.type.name.indexOf('json') !== 0)) {
                     return this._getNullValue(options ? options.context : undefined);
                 }
-            }
             if (data === undefined) {
                 return this._getNullValue(options ? options.context : undefined);
             }

--- a/js/reference.js
+++ b/js/reference.js
@@ -2730,8 +2730,8 @@ var ERMrest = (function(module) {
                             this._isHTML[i] = presentation.isHTML;
                         }
                         //Added this if conditon explicitly for json/jsonb because we need to pass the 
-                        //formatted string representation of JSON values
-                        else if(column.type.name === ("json" || "jsonb")){
+                        //formatted string representation of JSON and JSONBvalues
+                        else if (column.type.name === "json" || column.type.name === "jsonb") {
                             presentation = column.formatPresentation(keyValues[column.name], { formattedValues: keyValues , context: this._pageRef._context });
                             this._values[i] = presentation.value;
                             this._isHTML[i] = presentation.isHTML;
@@ -2758,7 +2758,7 @@ var ERMrest = (function(module) {
                             }
                         } else {
                             values[i] = column.formatPresentation(keyValues[column.name], { formattedValues: keyValues , context: this._pageRef._context });
-
+                            // If the column type is json or jsonB we will send the templated string with <pre> tag
                             if (column.type.name === "gene_sequence"|| column.type.name === "json" || column.type.name === "jsonb") {
                                 values[i].isHTML = true;
                             }

--- a/js/reference.js
+++ b/js/reference.js
@@ -2728,7 +2728,15 @@ var ERMrest = (function(module) {
                             }
                             this._values[i] = presentation.value;
                             this._isHTML[i] = presentation.isHTML;
-                        } else {
+                        }
+                        //Added this if conditon explicitly for json/jsonb because we need to pass the 
+                        //formatted string representation of JSON values
+                        else if(column.type.name === ("json" || "jsonb")){
+                            presentation = column.formatPresentation(keyValues[column.name], { formattedValues: keyValues , context: this._pageRef._context });
+                            this._values[i] = presentation.value;
+                            this._isHTML[i] = presentation.isHTML;
+                        } 
+                        else {
                             this._values[i] = this._data[column.name];
                             this._isHTML[i] = false;
                         }
@@ -2751,7 +2759,7 @@ var ERMrest = (function(module) {
                         } else {
                             values[i] = column.formatPresentation(keyValues[column.name], { formattedValues: keyValues , context: this._pageRef._context });
 
-                            if (column.type.name === "gene_sequence") {
+                            if (column.type.name === "gene_sequence"|| column.type.name === "json" || column.type.name === "jsonb") {
                                 values[i].isHTML = true;
                             }
                         }

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -731,6 +731,43 @@ var ERMrest = (function(module) {
 
             return module._markdownIt.render(value);
         },
+        
+        /**
+        * @function		    
+        * @param {Object} value A json value to transform
+        * @param {Object} [options] Configuration options.
+        * @return {string} A string representation of value
+        * @desc Formats a given json value into a string for display.
+        */
+        printJSON: function printJSON(value, options) {
+           options = (typeof options === 'undefined') ? {} : options;
+           if(options.context==="entry/edit"){
+               if (value === null) {
+                   return 'null';
+                }
+                else if (typeof value === 'object') {
+                       return JSON.stringify(value,undefined,2);
+                }
+            }
+            
+            else{
+                var formattedValue;
+                if (value === null) {
+                    formattedValue= JSON.stringify(null);
+                    formattedValue ='<pre>'+formattedValue+'</pre>';
+                 }
+                 else if (typeof value === 'object' || typeof value === 'boolean') {
+                    formattedValue= JSON.stringify(value,undefined,2);
+                    formattedValue ='<pre>'+formattedValue+'</pre>';
+                 }
+                 else if (typeof value === 'string') {
+                    formattedValue= JSON.stringify(value,undefined,2);
+                    formattedValue ='"'+formattedValue+'"';
+                 }
+                 return formattedValue;
+            }
+           return value.toString();
+       },
 
         /**
          * @function

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -736,21 +736,15 @@ var ERMrest = (function(module) {
         * @function		    
         * @param {Object} value A json value to transform
         * @param {Object} [options] Configuration options.
-        * @return {string} A string representation of value
+        * @return {string} A string representation of value based on different context
+        *                Entry/Edit: the beautified version of JSON in other cases
+        *                View: a string preformatted with <pre> tag to display in the UI
         * @desc Formats a given json value into a string for display.
         */
         printJSON: function printJSON(value, options) {
            options = (typeof options === 'undefined') ? {} : options;
-           if(options.context==="entry/edit"){
-               if (value === null) {
-                   return 'null';
-                }
-                else if (typeof value === 'object') {
-                       return JSON.stringify(value,undefined,2);
-                }
-                else if (typeof value === 'string') {
-                   return  JSON.stringify(value,undefined,2);
-                }
+           if(module._isEntryContext(options.context)){
+               return  JSON.stringify(value,undefined,2);
             }
             
             else{
@@ -767,7 +761,6 @@ var ERMrest = (function(module) {
                  
                  return formattedValue;
             }
-           return value.toString();
        },
 
         /**

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -752,18 +752,19 @@ var ERMrest = (function(module) {
             
             else{
                 var formattedValue;
-                if (value === null) {
+                if (value === null || value=== "") {
                     formattedValue= JSON.stringify(null);
-                    formattedValue ='<pre>'+formattedValue+'</pre>';
-                 }
-                 else if (typeof value === 'object' || typeof value === 'boolean') {
-                    formattedValue= JSON.stringify(value,undefined,2);
                     formattedValue ='<pre>'+formattedValue+'</pre>';
                  }
                  else if (typeof value === 'string') {
                     formattedValue= JSON.stringify(value,undefined,2);
                     formattedValue ='"'+formattedValue+'"';
                  }
+                 else {
+                    formattedValue= JSON.stringify(value,undefined,2);
+                    formattedValue ='<pre>'+formattedValue+'</pre>';
+                 }
+                 
                  return formattedValue;
             }
            return value.toString();

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -748,6 +748,9 @@ var ERMrest = (function(module) {
                 else if (typeof value === 'object') {
                        return JSON.stringify(value,undefined,2);
                 }
+                else if (typeof value === 'string') {
+                   return  JSON.stringify(value,undefined,2);
+                }
             }
             
             else{
@@ -756,10 +759,7 @@ var ERMrest = (function(module) {
                     formattedValue= JSON.stringify(null);
                     formattedValue ='<pre>'+formattedValue+'</pre>';
                  }
-                 else if (typeof value === 'string') {
-                    formattedValue= JSON.stringify(value,undefined,2);
-                    formattedValue ='"'+formattedValue+'"';
-                 }
+                 
                  else {
                     formattedValue= JSON.stringify(value,undefined,2);
                     formattedValue ='<pre>'+formattedValue+'</pre>';

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -70,6 +70,9 @@ exports.execute = function (options) {
             expect(printJSON(true,options)).toBe('true');
             expect(printJSON(false,options)).toBe('false');
             expect(printJSON(2.9,options)).toBe('2.9');
+            let valueToTest={"name":"testing"};
+            let expectedJSON= JSON.stringify(valueToTest,undefined,2);
+            expect(printJSON(valueToTest,options)).toBe(expectedJSON);
         });
         
         it('printJSON() should format JSON values correctly for Not Edit Context.', function() {
@@ -80,6 +83,9 @@ exports.execute = function (options) {
             expect(printJSON(true,options)).toBe('<pre>true</pre>');
             expect(printJSON(false,options)).toBe('<pre>false</pre>');
             expect(printJSON(2.9,options)).toBe('<pre>2.9</pre>');
+            let valueToTest={"name":"testing"};
+            let expectedJSON= "<pre>"+JSON.stringify(valueToTest,undefined,2)+"</pre>";
+            expect(printJSON(valueToTest,options)).toBe(expectedJSON);
         });
 
         it('printMarkdown() should process Markdown into HTML.', function() {

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -66,7 +66,7 @@ exports.execute = function (options) {
             var printJSON = formatUtils.printJSON;
             var options={context:'entry/edit'};
             expect(printJSON(null,options)).toBe('null');
-            expect(printJSON('',options)).toBe('');
+            expect(printJSON('',options)).toBe('""');
             expect(printJSON(true,options)).toBe('true');
             expect(printJSON(false,options)).toBe('false');
             expect(printJSON(2.9,options)).toBe('2.9');

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -61,6 +61,26 @@ exports.execute = function (options) {
             expect(printText({key:123})).toBe('{"key":123}');
             expect(printText({key:123,subkey:{subsubkey:456}})).toBe('{"key":123,"subkey":{"subsubkey":456}}');
         });
+        
+        it('printJSON() should format JSON values correctly for Edit Context.', function() {
+            var printJSON = formatUtils.printJSON;
+            var options={context:'entry/edit'};
+            expect(printJSON(null,options)).toBe('null');
+            expect(printJSON('',options)).toBe('');
+            expect(printJSON(true,options)).toBe('true');
+            expect(printJSON(false,options)).toBe('false');
+            expect(printJSON(2.9,options)).toBe('2.9');
+        });
+        
+        it('printJSON() should format JSON values correctly for Not Edit Context.', function() {
+            var printJSON = formatUtils.printJSON;
+            var options={context:'detailed'};
+            expect(printJSON(null,options)).toBe('<pre>null</pre>');
+            expect(printJSON('',options)).toBe('<pre>null</pre>');
+            expect(printJSON(true,options)).toBe('<pre>true</pre>');
+            expect(printJSON(false,options)).toBe('<pre>false</pre>');
+            expect(printJSON(2.9,options)).toBe('<pre>2.9</pre>');
+        });
 
         it('printMarkdown() should process Markdown into HTML.', function() {
             var printMarkdown = formatUtils.printMarkdown;

--- a/test/specs/reference/conf/default_value_schema/schema.json
+++ b/test/specs/reference/conf/default_value_schema/schema.json
@@ -46,13 +46,7 @@
               }
 
           ],
-            "annotations": {
-                "tag:isrd.isi.edu,2016:visible-columns" : {
-                    "*": [
-                    "id", "int_col","text_col","json_col","jsonb_col"
-                  ]
-              }
-            }
+            "annotations": {}
         }
     },
     "table_names": [

--- a/test/specs/reference/conf/default_value_schema/schema.json
+++ b/test/specs/reference/conf/default_value_schema/schema.json
@@ -46,12 +46,24 @@
               }
 
           ],
-            "annotations": {}
+            "annotations": {
+                "tag:isrd.isi.edu,2016:visible-columns" : {
+                    "*": [
+                    "id", "int_col","text_col","json_col","jsonb_col"
+                  ]
+              }
+            }
         }
     },
     "table_names": [
         "default_value_table"
     ],
     "comment": null,
-    "annotations": {}
+    "annotations": {
+        "tag:isrd.isi.edu,2016:visible-columns" : {
+            "*": [
+            "id", "int_col","text_col","json_col","jsonb_col"
+          ]
+      }
+    }
 }

--- a/test/specs/reference/conf/reference_schema/data/jsontest_table.json
+++ b/test/specs/reference/conf/reference_schema/data/jsontest_table.json
@@ -1,0 +1,7 @@
+[{"id":"1001","json_col":true,"jsonb_col":true},
+{"id":"1002","json_col":{},"jsonb_col":{}},
+{"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}},
+{"id":"1004","json_col":false,"jsonb_col":false},
+{"id":"1005","json_col":2.9,"jsonb_col":2.9},
+{"id":"1006","json_col":"","jsonb_col":""}
+]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -1,6 +1,44 @@
 {
     "schema_name": "reference_schema",
     "tables": {
+        "jsontest_table":{
+            "comment": "Table to represent a testable json object",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id"
+                    ]
+                }
+            ],
+            "entityCount": 0,
+            "foreign_keys": [],
+            "table_name": "jsontest_table",
+            "schema_name": "reference_schema",
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "json_col",
+                    "type": {
+                        "typename": "json"
+                    }
+                },
+                {
+                    "name": "jsonb_col",
+                    "type": {
+                        "typename": "jsonb"
+                    }
+                }
+            ]
+        },
         "reference_table": {
             "comment": "Table to represent a testable reference object",
             "kind": "table",

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -247,6 +247,7 @@ exports.execute = function (options) {
     });
     
     describe("Testing for JSON AND JSONB Values", function() {
+        //Tested these values as formatted values inside it, to get the exact string after JSON.stringify()
         var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true},
         {"id":"1002","json_col":{},"jsonb_col":{}},
         {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}},
@@ -265,7 +266,7 @@ exports.execute = function (options) {
 
         var reference, page, tuples, url;
         
-       var chaiseURL = "https://dev.isrd.isi.edu/chaise";
+        var chaiseURL = "https://dev.isrd.isi.edu/chaise";
        var recordURL = chaiseURL + "/record";
        var record2URL = chaiseURL + "/record-two";
        var viewerURL = chaiseURL + "/viewer";

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -331,7 +331,7 @@ exports.execute = function (options) {
             options.ermRest.appLinkFn(appLinkFn);
         });
         
-        it("Testing for JSON and JSONB tuples values", function() {
+        it("JSON and JSONB column should return the expected values in Display Context", function() {
             
             for( var i=0; i<limit; i++){
                 var values=tuples[i].values;

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -242,6 +242,70 @@ exports.execute = function (options) {
 
             testTupleValidity(6, values, isHTML);
         });
+        
 
+    });
+    
+    describe("Testing for JSON AND JSONB Values", function() {
+        var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true},
+        {"id":"1002","json_col":{},"jsonb_col":{}},
+        {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}},
+        {"id":"1004","json_col":false,"jsonb_col":false},
+        {"id":"1005","json_col":2.9,"jsonb_col":2.9},
+        {"id":"1006","json_col":"","jsonb_col":""}];
+
+        var catalog_id = process.env.DEFAULT_CATALOG,
+            schemaName = "reference_schema",
+            tableName = "jsontest_table",
+            lowerLimit = 1001,
+            upperLimit = 2001,
+            limit = 6;
+
+        var multipleEntityUri=options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"+ tableName ;
+
+        var reference, page, tuples;
+
+        beforeAll(function(done) {
+            
+            // Fetch the entities beforehand
+            options.ermRest.resolve(multipleEntityUri).then(function (response) {
+                reference = response;
+                expect(reference).toEqual(jasmine.any(Object));
+                return reference.read(limit);
+            }).then(function (response) {
+                page = response;
+                
+                expect(page).toEqual(jasmine.any(Object));
+                expect(page._data.length).toBe(limit);
+                
+                expect(page.tuples).toBeDefined();
+                jsontuples = page.tuples;
+                expect(jsontuples.length).toBe(limit);
+                
+                done();
+            }, function (err) {
+                console.dir(err);
+                done.fail();
+            }).catch(function(err) {
+                console.dir(err);
+                done.fail();
+            });
+        
+        });
+        
+        it("Testing for JSON and JSONB tuples values", function() {
+            
+            for( var i=0; i<limit; i++){
+                let id=jsontuples[i]._data.id;
+                let josn_col=jsontuples[i]._data.json_col;
+                let josnb_col=jsontuples[i]._data.jsonb_col;
+                expect(id).toBe(expectedValues[i].id);
+                let expectedValueJson=expectedValues[i].json_col;
+                expect(josn_col).toEqual(expectedValueJson);
+            
+                let expectedValueJsonB=expectedValues[i].jsonb_col;
+                expect(josnb_col).toEqual(expectedValueJsonB);
+            }
+        });
     });
 };

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -237,7 +237,7 @@ exports.execute = function (options) {
         
         
         describe("Testing for EDIT JSON and JSONB Values", function() {
-            //Tested this values as formatted values inside it, to get the exact string after JSON.stringify()
+            //Tested these values as formatted values inside it, to get the exact string after JSON.stringify()
             var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true},
             {"id":"1002","json_col":{},"jsonb_col":{}},
             {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}},

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -321,7 +321,7 @@ exports.execute = function (options) {
                 options.ermRest.appLinkFn(appLinkFn);
             });
             
-            it("Testing for EDIT JSON and JSONB tuples values", function() {
+            it("JSON and JSONB column should return the expected values in Edit Context", function() {
                 
                 for( var i=0; i<limit; i++){
                     var values=tuples[i].values;

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -234,6 +234,70 @@ exports.execute = function (options) {
 
             testTupleValidity(6, values);
         });
+        
+        
+        describe("Testing for EDIT JSON and JSONB Values", function() {
+            var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true},
+            {"id":"1002","json_col":{},"jsonb_col":{}},
+            {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}},
+            {"id":"1004","json_col":false,"jsonb_col":false},
+            {"id":"1005","json_col":2.9,"jsonb_col":2.9},
+            {"id":"1006","json_col":"","jsonb_col":""}];
+
+            var catalog_id = process.env.DEFAULT_CATALOG,
+                schemaName = "reference_schema",
+                tableName = "jsontest_table",
+                lowerLimit = 1001,
+                upperLimit = 2001,
+                limit = 6;
+
+            var multipleEntityUri=options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"+ tableName ;
+
+            var reference, page, tuples;
+
+            beforeAll(function(done) {
+                
+                // Fetch the entities beforehand
+                options.ermRest.resolve(multipleEntityUri).then(function (response) {
+                    reference = response;
+                    expect(reference).toEqual(jasmine.any(Object));
+                    return reference.read(limit);
+                }).then(function (response) {
+                    page = response;
+                    
+                    expect(page).toEqual(jasmine.any(Object));
+                    expect(page._data.length).toBe(limit);
+                    
+                    expect(page.tuples).toBeDefined();
+                    jsontuples = page.tuples;
+                    expect(jsontuples.length).toBe(limit);
+                    
+                    done();
+                }, function (err) {
+                    console.dir(err);
+                    done.fail();
+                }).catch(function(err) {
+                    console.dir(err);
+                    done.fail();
+                });
+            
+            });
+            
+            it("Testing for EDIT JSON and JSONB tuples values", function() {
+                
+                for( var i=0; i<limit; i++){
+                    let id=jsontuples[i]._data.id;
+                    let josn_col=jsontuples[i]._data.json_col;
+                    let josnb_col=jsontuples[i]._data.jsonb_col;
+                    expect(id).toBe(expectedValues[i].id);
+                    let expectedValueJson=expectedValues[i].json_col;
+                    expect(josn_col).toEqual(expectedValueJson);
+                
+                    let expectedValueJsonB=expectedValues[i].jsonb_col;
+                    expect(josnb_col).toEqual(expectedValueJsonB);
+                }
+            });
+        });
 
     });
 };

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -253,7 +253,43 @@ exports.execute = function (options) {
 
             var multipleEntityUri=options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"+ tableName ;
 
-            var reference, page, tuples;
+            var reference, page, tuples,url;
+            
+            var chaiseURL = "https://dev.isrd.isi.edu/chaise";
+            var recordURL = chaiseURL + "/record";
+            var record2URL = chaiseURL + "/record-two";
+            var viewerURL = chaiseURL + "/viewer";
+            var searchURL = chaiseURL + "/search";
+            var recordsetURL = chaiseURL + "/recordset";
+
+            var appLinkFn = function (tag, location) {
+                
+                switch (tag) {
+                    case "tag:isrd.isi.edu,2016:chaise:record":
+                        url = recordURL;
+                        break;
+                    case "tag:isrd.isi.edu,2016:chaise:record-two":
+                        url = record2URL;
+                        break;
+                    case "tag:isrd.isi.edu,2016:chaise:viewer":
+                        url = viewerURL;
+                        break;
+                    case "tag:isrd.isi.edu,2016:chaise:search":
+                        url = searchURL;
+                        break;
+                    case "tag:isrd.isi.edu,2016:chaise:recordset":
+                        url = recordsetURL;
+                        break;
+                    default:
+                        url = recordURL;
+                        break;
+                }
+
+                url = url + "/" + location.path;
+
+                return url;
+            };
+
 
             beforeAll(function(done) {
                 
@@ -261,6 +297,7 @@ exports.execute = function (options) {
                 options.ermRest.resolve(multipleEntityUri).then(function (response) {
                     reference = response;
                     expect(reference).toEqual(jasmine.any(Object));
+                    reference = reference.contextualize.entryEdit;
                     return reference.read(limit);
                 }).then(function (response) {
                     page = response;
@@ -269,8 +306,8 @@ exports.execute = function (options) {
                     expect(page._data.length).toBe(limit);
                     
                     expect(page.tuples).toBeDefined();
-                    jsontuples = page.tuples;
-                    expect(jsontuples.length).toBe(limit);
+                    tuples = page.tuples;
+                    expect(tuples.length).toBe(limit);
                     
                     done();
                 }, function (err) {
@@ -280,21 +317,18 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
-            
+                options.ermRest.appLinkFn(appLinkFn);
             });
             
             it("Testing for EDIT JSON and JSONB tuples values", function() {
                 
                 for( var i=0; i<limit; i++){
-                    let id=jsontuples[i]._data.id;
-                    let josn_col=jsontuples[i]._data.json_col;
-                    let josnb_col=jsontuples[i]._data.jsonb_col;
-                    expect(id).toBe(expectedValues[i].id);
-                    let expectedValueJson=expectedValues[i].json_col;
-                    expect(josn_col).toEqual(expectedValueJson);
-                
-                    let expectedValueJsonB=expectedValues[i].jsonb_col;
-                    expect(josnb_col).toEqual(expectedValueJsonB);
+                    var values=tuples[i].values;
+                    expect(values[0]).toBe(expectedValues[i].id);
+                    var json=JSON.stringify(expectedValues[i].json_col,undefined,2);
+                    var jsonb=JSON.stringify(expectedValues[i].jsonb_col,undefined,2);
+                    expect(values[1]).toBe(json);
+                    expect(values[2]).toBe(jsonb);
                 }
             });
         });

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -237,6 +237,7 @@ exports.execute = function (options) {
         
         
         describe("Testing for EDIT JSON and JSONB Values", function() {
+            //Tested this values as formatted values inside it, to get the exact string after JSON.stringify()
             var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true},
             {"id":"1002","json_col":{},"jsonb_col":{}},
             {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}},


### PR DESCRIPTION
The PR has the following changes done:

formatValue() function has been changed for JSON and jsonb column types.

A case is added for JSON and jsonb column types.

If condition in reference.js for JSON and jsonB column types.

PrintJSON() function to stringify the JSON and pass a prettiness factor as well as return the pre-formatted string for display.

Test cases added for the JSON support functionality added.
