### PR TITLE
Update projections

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -3643,8 +3643,7 @@ URI should be to the ERMrest _service_. For example,
 <a name="ERMrest.parse"></a>
 
 ### ERMrest.parse(uri) ⇒ <code>ERMrest.Location</code>
-This is an internal function that parses a URI and constructs an
-internal representation of the URI.
+This function parses a URI and constructs a representation of the URI.
 
 **Kind**: static method of [<code>ERMrest</code>](#ERMrest)  
 **Returns**: <code>ERMrest.Location</code> - Location object created from the URI.  

--- a/js/reference.js
+++ b/js/reference.js
@@ -1160,28 +1160,22 @@ var ERMrest = (function(module) {
                         // response.data is sometimes in a different order
                         // so collecting the data could be incorrect if we don't make sure the response data and tuple data are in the same order
                         // the entity is updated properly just the data returned from this request is in a different order sometimes
-                        var shortKey,
-                            rowIndexInSubData = j,
-                            match = false,
-                            duplicate = false;
-                            
-                        for (n = 0; n < shortestKeyNames.length; n++) {
-                            shortKey = shortestKeyNames[n];
-                            for (t = 0; t < tuples.length; t++) {
+                        var shortKey, rowIndexInSubData,
+                            matchCt = 0;            // used to verify the number of matches for each shortest key value
+
+                        for (t = 0; t < tuples.length; t++) {
+                            for (n = 0; n < shortestKeyNames.length; n++) {
+                                shortKey = shortestKeyNames[n];
                                 var responseVal = getAliasedKeyVal(response.data[j], shortKey);
 
                                 // if the value is the same, use this t index for the pageData object
                                 if (tuples[t].data[shortKey] == responseVal) {
-                                    // we haven't matched the row yet
                                     // this comes into play when the shortest key is a set of column names
-                                    if (!match) {
-                                        match = true;
-                                    } else {
-                                        // this means the current shortest key is a composite key and both tuples have the same value for this key name
-                                        duplicate = true;
-                                    }
+                                    // if the values match increase te counter
+                                    matchCt++;
 
-                                    if (match && !duplicate) {
+                                    // if our counter is the asme length as the list of shortest key names, it's an exact match to the t tuple
+                                    if (matchCt == shortestKeyNames.length) {
                                         rowIndexInSubData = t;
                                     }
                                 }

--- a/js/reference.js
+++ b/js/reference.js
@@ -946,6 +946,13 @@ var ERMrest = (function(module) {
                     }
                 };
 
+                // gets the key value based on which way the key was aliased.
+                // use the new alias value for the shortest key first meaning the key was changed
+                // if the new alias value is null, key wasn't changed so we can use the old alias
+                var getAliasedKeyVal = function(responseRowData, keyName) {
+                    return (responseRowData[keyName + newAlias] == null ? responseRowData[keyName + oldAlias] : responseRowData[keyName + newAlias] );
+                };
+
                 shortestKeyNames = this._shortestKey.map(function (column) {
                     return column.name;
                 });
@@ -1133,17 +1140,18 @@ var ERMrest = (function(module) {
                         // build the uri
                         if (j !== 0)
                         uri += ';';
+
                         // shortest key is made up from one column
                         if (self._shortestKey.length == 1) {
                             keyName = self._shortestKey[0].name;
-                            uri += module._fixedEncodeURIComponent(keyName) + '=' + module._fixedEncodeURIComponent(response.data[j][keyName + newAlias]);
+                            uri += module._fixedEncodeURIComponent(keyName) + '=' + module._fixedEncodeURIComponent( getAliasedKeyVal(response.data[j], keyName) );
                         } else {
                             uri += '(';
                             for (k = 0; k < self._shortestKey.length; k++) {
                                 if (k !== 0)
                                 uri += '&';
                                 keyName = self._shortestKey[k].name;
-                                uri += module._fixedEncodeURIComponent(keyName) + '=' + module._fixedEncodeURIComponent(response.data[j][keyName + newAlias]);
+                                uri += module._fixedEncodeURIComponent(keyName) + '=' + module._fixedEncodeURIComponent( getAliasedKeyVal(response.data[j], keyName) );
                             }
                             uri += ')';
                         }
@@ -1158,9 +1166,8 @@ var ERMrest = (function(module) {
                         for (var n = 0; n < shortestKeyNames.length; n++) {
                             shortKey = shortestKeyNames[n];
                             for (var t = 0; t < tuples.length; t++) {
-                                // use the new alias value for the shortest key first meaning the key was changed
-                                // if the new alias value is null, key wasn't changed so we can use the old alias
-                                var responseVal = (response.data[j][shortKey + newAlias] == null ? response.data[j][shortKey + oldAlias] : response.data[j][shortKey + newAlias] );
+                                var responseVal = getAliasedKeyVal(response.data[j], shortKey);
+
                                 // if the value is the same, use this t index for the pageData object
                                 if (tuples[t].data[shortKey] == responseVal) {
                                     // we haven't matched the row yet

--- a/js/reference.js
+++ b/js/reference.js
@@ -924,7 +924,8 @@ var ERMrest = (function(module) {
                     keyWasModified = false,
                     tuple, oldData, allOldData = [], newData, allNewData = [], keyName;
 
-                var i, j, k, m, n;
+                // for loop variables, NOTE: maybe we should name these better
+                var i, j, k, m, n, t;
 
                 var column, keyColumns, referenceColumn;
 
@@ -1159,13 +1160,14 @@ var ERMrest = (function(module) {
                         // response.data is sometimes in a different order
                         // so collecting the data could be incorrect if we don't make sure the response data and tuple data are in the same order
                         // the entity is updated properly just the data returned from this request is in a different order sometimes
-                        // NOTE: this doesn't take into account whether there's a composite key or not, if composite key is used and one part of the key is the same for both rows, it may flip the value incorrectly
-                        var rowIndexInSubData, shortKey;
-                        var match = false,
+                        var shortKey,
+                            rowIndexInSubData = j,
+                            match = false,
                             duplicate = false;
-                        for (var n = 0; n < shortestKeyNames.length; n++) {
+                            
+                        for (n = 0; n < shortestKeyNames.length; n++) {
                             shortKey = shortestKeyNames[n];
-                            for (var t = 0; t < tuples.length; t++) {
+                            for (t = 0; t < tuples.length; t++) {
                                 var responseVal = getAliasedKeyVal(response.data[j], shortKey);
 
                                 // if the value is the same, use this t index for the pageData object

--- a/js/reference.js
+++ b/js/reference.js
@@ -918,25 +918,30 @@ var ERMrest = (function(module) {
                     newAlias = "_n",
                     uri = this._location.service + "/catalog/" + this._location.catalog + "/attributegroup/" + this._location.schemaName + ':' + this._location.tableName + '/';
 
-                var submissionData = [],
-                    columnProjections = [],
-                    shortestKeyNames = [],
+                var submissionData = [],        // the list of submission data for updating
+                    columnProjections = [],     // the list of column names to use in the uri projection list
+                    shortestKeyNames = [],      // list of shortest key names to use in the uri key list
                     keyWasModified = false,
                     tuple, oldData, allOldData = [], newData, allNewData = [], keyName;
 
-                var i, j, k;
+                var i, j, k, m, n;
 
-                // add column name into list of column projections and data into the submission data
-                var addProjectionAndKeyData = function(index, colName) {
-                    // here so each column of the columns in keyColumns set is added
-                    if (columnProjections.indexOf(colName) === -1) {
-                        // the list of column names to use in the uri
+                var column, keyColumns, referenceColumn;
+
+                // add column name into list of column projections if not in column projections set and data has changed
+                var addProjection = function(colName) {
+                    // don't add a column name in if it's already there
+                    // this can be the case for multi-edit
+                    // and if the data is unchanged, no need to add the column name to the projections list
+                    if ( (columnProjections.indexOf(colName) === -1) && (oldData[colName] != newData[colName]) ) {
                         columnProjections.push(colName);
                     }
+                };
 
-                    // if the current keyColumnName is in shortestKeyNames, we already added the data to submissionData
-                    if (shortestKeyNames.indexOf(colName) === -1) {
-                        // alias all data to prevent aliasing data to the same name as another column that exists in the table
+                // add data into submission data if in column projection set
+                var addSubmissionData = function(index, colName) {
+                    // if the column is in the column projections list, add the data to submission data
+                    if (columnProjections.indexOf(colName) > -1) {
                         submissionData[index][colName + newAlias] = newData[colName];
                     }
                 };
@@ -945,7 +950,9 @@ var ERMrest = (function(module) {
                     return column.name;
                 });
 
-                for(i = 0; i < tuples.length; i++) {
+                // loop through each tuple and the visible columns list for each to determine what columns to add to the projection set
+                // If a column is changed in one tuple but not another, that column's value for every tuple needs to be present in the submission data
+                for (i = 0; i < tuples.length; i++) {
                     newData = tuples[i].data;
                     oldData = tuples[i]._oldData;
 
@@ -953,85 +960,45 @@ var ERMrest = (function(module) {
                     allOldData.push(oldData);
                     allNewData.push(newData);
 
-                    submissionData[i] = {};
+                    // Loop throught the visible columns list and see what data the user changed
+                    // if we saw changes to data, add the constituent columns to the projections list
+                    for (m = 0; m < this.columns.length; m++) {
+                        column = this.columns[m];
 
-                    for (var keyIndex = 0; keyIndex < shortestKeyNames.length; keyIndex++) {
-                        var shortestKey = shortestKeyNames[keyIndex];
-
-                        // shortest key should always be aliased in case that key value was changed
-                        // use a suffix of '_o' to represent changes to a value that's in the shortest key that was changed, everything else gets '_n'
-                        submissionData[i][shortestKey + oldAlias] = oldData[shortestKey];
-                        submissionData[i][shortestKey + newAlias] = newData[shortestKey];
-
-                        // don't add the current key to the column projections if it's already in there
-                        // this can happen when there are multiple tuples or when a key is part of the visible column set
-                        if (columnProjections.indexOf(shortestKey) === -1) {
-                            // keys are aliased and included in both the keyset and column projections set
-                            columnProjections.push(shortestKey);
-                        }
-                    }
-
-                    // Loop through the visible columns so the submission data is based off of the visible columns list
-                    for (var m = 0; m < this.columns.length; m++) {
-                        var column = this.columns[m];
-
-                        // if the column is disabled (generated or immutable), continue
-                        // no need to submit update data in the submission object
+                        // if the column is disabled (generated or immutable), no need to add the column name to the projections list
                         if (column.inputDisabled) {
                             continue;
                         }
 
                         // If columns is a pusedo column
                         if (column.isPseudo) {
-
                             // If a column is an asset column then set values for
                             // dependent properties like filename, bytes_count_column, md5 and sha
                             if (column.isAsset) {
-
-                                var isNull = newData[column.name] === null ? true : false;
-
-                                // Populate all values in row depending on column from current
-
-                                // If column has a filename column then populate its value
+                                // If column has a filename column then add it to the projections
                                 if (column.filenameColumn) {
-
-                                    // If asset url is null then set filename also null
-                                    if (isNull) newData[column.filenameColumn.name] = null;
-
-                                    addProjectionAndKeyData(i, column.filenameColumn.name);
+                                    addProjection(column.filenameColumn.name);
                                 }
 
-                                // If column has a bytecount column then populate its value
+                                // If column has a bytecount column thenadd it to the projections
                                 if (column.byteCountColumn) {
-
-                                    // If asset url is null then set filename also null
-                                    if (isNull) newData[column.byteCountColumn.name] = null;
-
-                                    addProjectionAndKeyData(i, column.byteCountColumn.name);
+                                    addProjection(column.byteCountColumn.name);
                                 }
 
-                                // If column has a md5 column then populate its value
+                                // If column has a md5 column then add it to the projections
                                 if (column.md5 && typeof column.md5 === 'object') {
-
-                                    // If asset url is null then set filename also null
-                                    if (isNull) newData[column.md5.name] = null;
-
-                                    addProjectionAndKeyData(i, column.md5.name);
+                                    addProjection(column.md5.name);
                                 }
 
-                                // If column has a sha256 column then populate its value
+                                // If column has a sha256 column then add it to the projections
                                 if (column.sha256 && typeof column.sha256 === 'object') {
-
-                                    // If asset url is null then set filename also null
-                                    if (isNull) newData[column.sha256.name] = null;
-
-                                    addProjectionAndKeyData(i, column.sha256.name);
+                                    addProjection(column.sha256.name);
                                 }
 
-                                addProjectionAndKeyData(i, column.name);
+                                addProjection(column.name);
 
                             } else {
-                                var keyColumns = [];
+                                keyColumns = [];
 
                                 if (column.isKey) {
                                     keyColumns = column.key.colset.columns;
@@ -1039,15 +1006,95 @@ var ERMrest = (function(module) {
                                     keyColumns =  column.foreignKey.colset.columns;
                                 }
 
-                                for (var n = 0; n < keyColumns.length; n++) {
-                                    var referenceColumn = keyColumns[n];
-                                    keyColumnName = referenceColumn.name;
+                                for (n = 0; n < keyColumns.length; n++) {
+                                    keyColumnName = keyColumns[n].name;
 
-                                    addProjectionAndKeyData(i, keyColumnName);
+                                    addProjection(keyColumnName);
                                 }
                             }
                         } else {
-                            addProjectionAndKeyData(i, column.name);
+                            addProjection(column.name);
+                        }
+                    }
+                }
+
+                /* This loop manages adding the values based on the columnProjections set and setting columns associated with asset columns properly */
+                // loop through each tuple again and set the data value from the tuple in submission data for each column projection
+                for (i = 0; i < tuples.length; i++) {
+                    newData = tuples[i].data;
+                    oldData = tuples[i]._oldData;
+
+                    submissionData[i] = {};
+
+                    for (var keyIndex = 0; keyIndex < shortestKeyNames.length; keyIndex++) {
+                        var shortestKey = shortestKeyNames[keyIndex];
+
+                        // shortest key should always be aliased in case that key value was changed
+                        // use a suffix of '_o' to represent the old value for the shortest key everything else gets '_n'
+                        console.log("tuples index: ", i);
+                        console.log(oldData);
+                        submissionData[i][shortestKey + oldAlias] = oldData[shortestKey];
+                    }
+
+                    // Loop through the columns, check if it;s in columnProjections, and collect the necessary data for submission
+                    for (m = 0; m < this.columns.length; m++) {
+                        column = this.columns[m];
+
+                        // If columns is a pusedo column
+                        if (column.isPseudo) {
+                            // If a column is an asset column then set values for
+                            // dependent properties like filename, bytes_count_column, md5 and sha
+                            if (column.isAsset) {
+                                var isNull = newData[column.name] === null ? true : false;
+                                /* Populate all values in row depending on column from current asset */
+
+                                // If column has a filename column then populate its value
+                                if (column.filenameColumn) {
+                                    // If asset url is null then set filename also null
+                                    if (isNull) newData[column.filenameColumn.name] = null;
+                                    addSubmissionData(i, column.filenameColumn.name);
+                                }
+
+                                // If column has a bytecount column then populate its value
+                                if (column.byteCountColumn) {
+                                    // If asset url is null then set filename also null
+                                    if (isNull) newData[column.byteCountColumn.name] = null;
+                                    addSubmissionData(i, column.byteCountColumn.name);
+                                }
+
+                                // If column has a md5 column then populate its value
+                                if (column.md5 && typeof column.md5 === 'object') {
+                                    // If asset url is null then set filename also null
+                                    if (isNull) newData[column.md5.name] = null;
+                                    addSubmissionData(i, column.md5.name);
+                                }
+
+                                // If column has a sha256 column then populate its value
+                                if (column.sha256 && typeof column.sha256 === 'object') {
+                                    // If asset url is null then set filename also null
+                                    if (isNull) newData[column.sha256.name] = null;
+                                    addSubmissionData(i, column.sha256.name);
+                                }
+
+                                addSubmissionData(i, column.name);
+
+                            } else {
+                                keyColumns = [];
+
+                                if (column.isKey) {
+                                    keyColumns = column.key.colset.columns;
+                                } else if (column.isForeignKey) {
+                                    keyColumns =  column.foreignKey.colset.columns;
+                                }
+
+                                for (n = 0; n < keyColumns.length; n++) {
+                                    keyColumnName = keyColumns[n].name;
+
+                                    addSubmissionData(i, keyColumnName);
+                                }
+                            }
+                        } else {
+                            addSubmissionData(i, column.name);
                         }
                     }
                 }
@@ -1069,6 +1116,8 @@ var ERMrest = (function(module) {
                     uri += module._fixedEncodeURIComponent(columnProjections[k]) + newAlias + ":=" + module._fixedEncodeURIComponent(columnProjections[k]);
                 }
 
+                console.log("+++++++++++submissionData++++++++++++");
+                console.log(submissionData);
                 this._server._http.put(uri, submissionData).then(function updateReference(response) {
                     // Some data was not updated
                     if (response.status === 200 && response.data.length < submissionData.length) {
@@ -1117,14 +1166,17 @@ var ERMrest = (function(module) {
                         }
                     }
 
+                    // TODO: response.data is sometimes in a different order, so collecting the data is sometimes incorrect
+                    // the entity is updated properly just the data returned from this request is wrong somtimes.
+
                     // NOTE: ermrest returns only some of the column data.
                     // make sure that pageData has all the submitted and updated data
                     for (i = 0; i < tuples.length; i++) {
-                      for (j in tuples[i].data) {
-                        if (!tuples[i].data.hasOwnProperty(j)) continue;
-                        if (j in pageData[i]) continue; // pageData already has this data
-                        pageData[i][j] =tuples[i].data[j]; // add the missing data
-                      }
+                        for (j in tuples[i].data) {
+                            if (!tuples[i].data.hasOwnProperty(j)) continue;
+                            if (j in pageData[i]) continue; // pageData already has this data
+                            pageData[i][j] =tuples[i].data[j]; // add the missing data
+                        }
                     }
 
                     var ref = new Reference(module._parse(uri), self._table.schema.catalog).contextualize.compact;
@@ -1135,41 +1187,41 @@ var ERMrest = (function(module) {
                     // if the returned page is smaller than the initial page,
                     // then some of the columns failed to update.
                     if (tuples.length > successfulPage.tuples.length) {
-                      var unchangedPageData = [], keyMatch, rowMatch;
+                        var unchangedPageData = [], keyMatch, rowMatch;
 
-                      for (i = 0; i < tuples.length; i++) {
-                        rowMatch = false;
+                        for (i = 0; i < tuples.length; i++) {
+                            rowMatch = false;
 
-                        for (j = 0; j < successfulPage.tuples.length; j++) {
-                          keyMatch = true;
+                            for (j = 0; j < successfulPage.tuples.length; j++) {
+                                keyMatch = true;
 
-                          for (k = 0; k < shortestKeyNames.length; k++) {
-                            keyName = shortestKeyNames[k];
-                            if (tuples[i].data[keyName] === successfulPage.tuples[j].data[keyName]) {
-                              // these keys don't match, go for the next tuple
-                              keyMatch = false;
-                              break;
+                                for (k = 0; k < shortestKeyNames.length; k++) {
+                                    keyName = shortestKeyNames[k];
+                                    if (tuples[i].data[keyName] === successfulPage.tuples[j].data[keyName]) {
+                                        // these keys don't match, go for the next tuple
+                                        keyMatch = false;
+                                        break;
+                                    }
+                                }
+
+                                if (keyMatch) {
+                                    // all the key columns match, then rows match.
+                                    rowMatch = true;
+                                    break;
+                                }
                             }
-                          }
 
-                          if (keyMatch) {
-                            // all the key columns match, then rows match.
-                            rowMatch = true;
-                            break;
-                          }
+                            if (!rowMatch) {
+                                // didn't find a match, so add as failed
+                                unchangedPageData.push(tuples[i].data);
+                            }
                         }
-
-                        if (!rowMatch) {
-                          // didn't find a match, so add as failed
-                          unchangedPageData.push(tuples[i].data);
-                        }
-                      }
-                      failedPage = new Page(ref, etag, unchangedPageData, false, false);
+                        failedPage = new Page(ref, etag, unchangedPageData, false, false);
                     }
 
                     defer.resolve({
-                      "successful": successfulPage,
-                      "failed": failedPage
+                        "successful": successfulPage,
+                        "failed": failedPage
                     });
                 }, function error(response) {
                     var error = module._responseToError(response);
@@ -2779,13 +2831,13 @@ var ERMrest = (function(module) {
                             this._values[i] = presentation.value;
                             this._isHTML[i] = presentation.isHTML;
                         }
-                        //Added this if conditon explicitly for json/jsonb because we need to pass the 
+                        //Added this if conditon explicitly for json/jsonb because we need to pass the
                         //formatted string representation of JSON and JSONBvalues
                         else if (column.type.name === "json" || column.type.name === "jsonb") {
                             presentation = column.formatPresentation(keyValues[column.name], { formattedValues: keyValues , context: this._pageRef._context });
                             this._values[i] = presentation.value;
                             this._isHTML[i] = presentation.isHTML;
-                        } 
+                        }
                         else {
                             this._values[i] = this._data[column.name];
                             this._isHTML[i] = false;

--- a/js/reference.js
+++ b/js/reference.js
@@ -1139,8 +1139,7 @@ var ERMrest = (function(module) {
                     // loop through each returned Row and get the key value
                     for (j = 0; j < response.data.length; j++) {
                         // build the uri
-                        if (j !== 0)
-                        uri += ';';
+                        if (j !== 0) uri += ';';
 
                         // shortest key is made up from one column
                         if (self._shortestKey.length == 1) {
@@ -1160,10 +1159,12 @@ var ERMrest = (function(module) {
                         // response.data is sometimes in a different order
                         // so collecting the data could be incorrect if we don't make sure the response data and tuple data are in the same order
                         // the entity is updated properly just the data returned from this request is in a different order sometimes
-                        var shortKey, rowIndexInSubData,
-                            matchCt = 0;            // used to verify the number of matches for each shortest key value
+                        var shortKey,
+                            rowIndexInSubData = -1;
 
-                        for (t = 0; t < tuples.length; t++) {
+                        for (t = 0; t < tuples.length && rowIndexInSubData === -1; t++) {
+                            // used to verify the number of matches for each shortest key value
+                            var matchCt = 0;
                             for (n = 0; n < shortestKeyNames.length; n++) {
                                 shortKey = shortestKeyNames[n];
                                 var responseVal = getAliasedKeyVal(response.data[j], shortKey);
@@ -1173,12 +1174,11 @@ var ERMrest = (function(module) {
                                     // this comes into play when the shortest key is a set of column names
                                     // if the values match increase te counter
                                     matchCt++;
-
-                                    // if our counter is the asme length as the list of shortest key names, it's an exact match to the t tuple
-                                    if (matchCt == shortestKeyNames.length) {
-                                        rowIndexInSubData = t;
-                                    }
                                 }
+                            }
+                            // if our counter is the same length as the list of shortest key names, it's an exact match to the t tuple
+                            if (matchCt == shortestKeyNames.length) {
+                                rowIndexInSubData = t;
                             }
                         }
 

--- a/test/specs/reference/conf/update_schema/data/table_w_composite_key_as_shortest_key.json
+++ b/test/specs/reference/conf/update_schema/data/table_w_composite_key_as_shortest_key.json
@@ -1,0 +1,3 @@
+[{"id_1": 1, "id_2": 2, "text_1": "first", "text_2": "top"},
+ {"id_1": 2, "id_2": 3, "text_1": "second", "text_2": "middle"},
+ {"id_1": 3, "id_2": 4, "text_1": "third", "text_2": "bottom"}]

--- a/test/specs/reference/conf/update_schema/schema.json
+++ b/test/specs/reference/conf/update_schema/schema.json
@@ -316,14 +316,14 @@
             "column_definitions": [
                 {
                     "name": "id_1",
-                    "nullok": true,
+                    "nullok": false,
                     "type": {
                         "typename": "int8"
                     }
                 },
                 {
                     "name": "id_2",
-                    "nullok": true,
+                    "nullok": false,
                     "type": {
                         "typename": "int8"
                     }

--- a/test/specs/reference/conf/update_schema/schema.json
+++ b/test/specs/reference/conf/update_schema/schema.json
@@ -297,6 +297,60 @@
                 }
             }
         },
+        "table_w_composite_key_as_shortest_key": {
+            "comment": "Table with composite key which is the shortest key too",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id_1", "id_2"
+                    ]
+                }
+            ],
+            "entityCount": 0,
+            "foreign_keys": [],
+            "table_name": "table_w_composite_key_as_shortest_key",
+            "schema_name": "update_schema",
+            "column_definitions": [
+                {
+                    "name": "id_1",
+                    "nullok": true,
+                    "type": {
+                        "typename": "int8"
+                    }
+                },
+                {
+                    "name": "id_2",
+                    "nullok": true,
+                    "type": {
+                        "typename": "int8"
+                    }
+                },
+                {
+                    "name": "text_1",
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "text_2",
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2016:table-display": {
+                    "row_name": {
+                        "row_markdown_pattern": "{{id_1}} , {{id_2}}"
+                    }
+                }
+            }
+        },
         "table_w_independent_key": {
             "comment": "Table with independent key",
             "kind": "table",
@@ -330,6 +384,7 @@
         "update_table",
         "update_table_with_foreign_key",
         "table_w_composite_key",
+        "table_w_composite_key_as_shortest_key",
         "table_w_independent_key"
     ],
     "comment": null,

--- a/test/utils/utilities.js
+++ b/test/utils/utilities.js
@@ -19,7 +19,7 @@ exports.checkPageValues = function(pageData, tuples, sortBy) {
         var responseData = pageData[i];
         for (var j = 0; j < columns.length; j++) {
             var columnName = columns[j];
-            expect(responseData[columnName]).toBe(tupleData[columnName]);
+            expect(responseData[columnName]).toBe(tupleData[columnName], "Value " + responseData[columnName] + " for column " + columnName + " does not match tuple data value");
         }
     }
 }


### PR DESCRIPTION
This PR fixes issue #443 and chaise issue [#1173](https://github.com/informatics-isi-edu/chaise/issues/1173).

The changes were made to only include the changed columns in the column projections and submission data now. In doing so this uncovered that we were copying the data from the tuples to the page data object improperly because of inconsistent ordering.

Another issue with not submitting all the data is that we can no longer rely on key values to be aliased with the new alias. If a key wasn't changed, we only send the old key value (before we sent both regardless).

I made sure the chaise e2e tests still pass based on the changes I made.

One thing to note:
lines 1175-1184 are meant to address the case when the shortest key is a composite key *AND* those columns were changed in _multiple entities_. It seems to work appropriately, but doesn't actually verify a case like this:
```
[row 1: {
  comp_key1: 1,
  comp_key2: 2
}, row 2: {
  comp_key1: 1,
  comp_key2: 3
}, row 3: {
  comp_key1: 2,
  comp_key2: 3
}]
```
In this case it would set the `duplicate` for both keys and never set the `rowIndexInSubData` (row index in submission data) value properly.

@RFSH: Do you think I should add another test case to `10.update.js` where a composite key is changed to be like the above and then verify the row contents? (I think I already know this answer)