### PR TITLE
install can do remote installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,8 @@ SOURCE=$(JS)/core.js \
 	   $(JS)/node.js \
 	   $(JS)/ng.js \
 
-# Vendor libs; it installs everything in that dir
+# Vendor libs
 VENDOR=vendor
-LIBS=$(patsubst %, $(ERMRESTJSDIR)/%, $(wildcard $(VENDOR)/*))
 
 # Build target
 BUILD=build
@@ -129,44 +128,20 @@ clean:
 distclean: clean
 	rm -rf $(MODULES)
 
-.PHONY: test
-test:  $(TEST)
-
 # Rule to run the unit tests
-$(TEST): $(BUILD)
+.PHONY: test
+test: $(BUILD)
 	node test/jasmine-runner.js
-	@touch $(TEST)
 
 # Rule to install the package
-.PHONY: install installm
-install: $(ERMRESTJSDIR)/$(PKG) $(ERMRESTJSDIR)/$(VER) $(LIBS)
+.PHONY: install
+install: $(BUILD)/$(PKG) $(BUILD)/$(VER) $(VENDOR)/*
+	rsync -avz $(BUILD)/ $(ERMRESTJSDIR)
+	rsync -avz $(VENDOR) $(ERMRESTJSDIR)
 
-installm: install $(ERMRESTJSDIR)/$(MIN)
-
-# Rule to make deployment dir
-# NOTE: we do not make the base dir, it must be present.
-#       For example `/var/www/html/ermrestjs` will require
-#       that `/var/www/html` exists. If it does not, then
-#       the user must create it _before_ attempting to
-#       install this package.
-$(ERMRESTJSDIR): $(dir $(ERMRESTJSDIR))
-	mkdir -p $(ERMRESTJSDIR)
-
-$(ERMRESTJSDIR)/$(VENDOR): $(ERMRESTJSDIR)
-	mkdir -p $(ERMRESTJSDIR)/$(VENDOR)
-
-$(ERMRESTJSDIR)/$(VER): $(BUILD)/$(VER) $(ERMRESTJSDIR)
-	cp $(BUILD)/$(VER) $(ERMRESTJSDIR)/$(VER)
-
-$(ERMRESTJSDIR)/$(PKG): $(BUILD)/$(PKG) $(ERMRESTJSDIR)
-	cp $(BUILD)/$(PKG) $(ERMRESTJSDIR)/$(PKG)
-
-$(ERMRESTJSDIR)/$(MIN): $(BUILD)/$(MIN) $(ERMRESTJSDIR)
-	cp $(BUILD)/$(MIN) $(ERMRESTJSDIR)/$(MIN)
-
-# Rule to install vendor libs
-$(ERMRESTJSDIR)/$(VENDOR)/%: $(VENDOR)/% $(ERMRESTJSDIR)/$(VENDOR)
-	cp -f $< $@
+.PHONY: installm
+installm: install $(BUILD)/$(MIN)
+	rsync -avz $(BUILD)/$(MIN) $(ERMRESTJSDIR)/$(MIN)
 
 # Rules for help/usage
 .PHONY: help usage

--- a/Makefile
+++ b/Makefile
@@ -134,14 +134,16 @@ test: $(BUILD)
 	node test/jasmine-runner.js
 
 # Rule to install the package
-.PHONY: install
-install: $(BUILD)/$(PKG) $(BUILD)/$(VER) $(VENDOR)/*
+.PHONY: install installm dont_install_in_root
+install: $(BUILD)/$(PKG) $(BUILD)/$(VER) $(VENDOR)/* dont_install_in_root
 	rsync -avz $(BUILD)/ $(ERMRESTJSDIR)
 	rsync -avz $(VENDOR) $(ERMRESTJSDIR)
 
-.PHONY: installm
-installm: install $(BUILD)/$(MIN)
+installm: install $(BUILD)/$(MIN) dont_install_in_root
 	rsync -avz $(BUILD)/$(MIN) $(ERMRESTJSDIR)/$(MIN)
+
+dont_install_in_root:
+	@echo "$(ERMRESTJSDIR)" | egrep -vq "^/$$|.*:/$$"
 
 # Rules for help/usage
 .PHONY: help usage

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ distclean: clean
 
 # Rule to run the unit tests
 .PHONY: test
-test: $(BUILD)
+test: $(BUILD) ../ErmrestDataUtils
 	node test/jasmine-runner.js
 
 # Rule to install the package

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # ermrestjs [![Build Status](https://travis-ci.org/informatics-isi-edu/ermrestjs.svg?branch=master)](https://travis-ci.org/informatics-isi-edu/ermrestjs) -- ERMrest client library in JavaScript
 
 The ermrestjs library is a client API for the
-[ERMrest](http://github.com/informatics-isi-edu/ermrest) service. _This
-project is a work in progress. The API is undergoing frequent changes._
+[ERMrest](http://github.com/informatics-isi-edu/ermrest) service. It provides a higher-level, simplified interface for working with the entity-relationship concepts that are native to ERMrest.
 
 ## Runtime environments
 
 We intend for ermrestjs to be usable in browser and node environments.
 - Browsers: ermrestjs should work in current versions of Firefox, Chrome,
     Safari, Edge, and Internet Explorer (10+).
-- Node: while not the main target of ermrestjs, it includes bindings for 
+- Node: while not the main target of ermrestjs, it includes bindings for
     node.
 - Angular: while ermrestjs is intended to be framework-neutral, it includes
     bindings for angular 1.x.
@@ -22,22 +21,26 @@ The library consists of the following scripts:
 
 ## Documention
 
-See the [API reference](doc/api.md).
-
-See the [Angular Bindings](doc/angular.md).
+- [API reference](doc/api.md)
+- [Angular Bindings](doc/angular.md)
 
 ## Development dependencies
 
-We use a combination of [nodejs](https://www.nodejs.org), npm, and good old
-fashioned [make](https://en.wikipedia.org/wiki/Makefile). However, you only
-need `make` to build the non-minified package and run the install command.
+1. [make](https://en.wikipedia.org/wiki/Makefile): Make is required for any build or development. With `make` only the non-minified package can be built and installed.
+2.
+2. [nodejs](https://www.nodejs.org) (v 6.x): Node is required for most development operations including linting, minifying, and testing.
+3. [ErmrestDataUtils](#ErmrestDataUtils): see discussion below.
 
-Developers using Mac OS X should see this limitation [issue 207](https://github.com/informatics-isi-edu/ermrestjs/issues/207).
+### Limitations
+
+- Developers using Mac OS X should see this limitation [issue 207](https://github.com/informatics-isi-edu/ermrestjs/issues/207).
+- Also on Mac, we have found problems with the nodejs installed by Homebrew, so we recommend downloading directly from the nodejs site.
+
+### ErmrestDataUtils
 
 In addition ermrestjs is also dependent on another gituhub repo [ErmrestDataUtils](https://github.com/informatics-isi-edu/ErmrestDataUtils). You will need to pull that repo first in the same directory where you plan to pull ermrestjs
 
 ```sh
-
 # Clone the ErmrestDatautils repo
 $ git clone https://github.com/informatics-isi-edu/ErmrestDataUtils.git
 
@@ -76,25 +79,30 @@ $ make all
 
 ## How to deploy ermrestjs
 
-To deploy the packages run the following command and _optionally_ you may set
-the `ERMRESTJSDIR` variable to an alternative deployment directory:
-
-```
-$ make [ERMRESTJSDIR=dir] install
-```
+### Set the deployment directory (optional)
 
 Set `ERMRESTJSDIR` to specify a target deployment location. By default, it the
 install target is `/var/www/html/ermrestjs`. If this directory does not exist,
 it will first create it. You may need to run `make install` with _super user_
 privileges depending on the installation directory you chose.
 
-Note that the `Makefile` **will not** create the base directory of the
-deployment directory. For example, if the default `/var/www/html` directory
-does not exist, you must create it first before running the install command. If
-it does not exist, you will get an error like this:
+**Important Note**: A very silly thing to do would be to set your deployment directory to root `/` and run `make install` with `sudo`. This would be very silly indeed, and would probably result in some corruption of your operating system. Surely, no one would ever do this. But, in the off chance that one might attempt such silliness, the `make install` rule specifies a `dont_install_in_root` prerequisite that attempts to put a stop to any such silliness before it goes to far.
+
+### Production deployment installs
+
+This example is for **production** deployments or other deployments to the document root of a Web server. As noted above, this will install to `/var/www/html/ermrestjs`.
 
 ```
-make: *** No rule to make target `/var/www/html', needed by `/var/www/html/ermrestjs'.  Stop.
+# make install
+```
+
+### Test and other personal deployment installs
+
+This example is how you would install the software on a remote server, for example a test server. Replacing `username` and `hostname` with real values.
+
+```
+$ export ERMRESTJSDIR=username@hostname:public_html/ermrestjs
+$ make install
 ```
 
 ## How to update the documentation
@@ -112,11 +120,11 @@ $ make doc
 Before running the test cases you need to set the environment variables.
 
 ```
-export ERMREST_URL=https://YOUR_ERMREST_URL/ermrest
+export ERMREST_URL=https://hostname/ermrest
 export AUTH_COOKIE=YOUR_ERMREST_COOKIE
 ```
 
-To execute test case run the following command
+To execute the tests, run the following command:
 
 ```
 $ make test

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ The library consists of the following scripts:
 ## Development dependencies
 
 1. [make](https://en.wikipedia.org/wiki/Makefile): Make is required for any build or development. With `make` only the non-minified package can be built and installed.
-2.
 2. [nodejs](https://www.nodejs.org) (v 6.x): Node is required for most development operations including linting, minifying, and testing.
 3. [ErmrestDataUtils](#ErmrestDataUtils): see discussion below.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The library consists of the following scripts:
 
 1. [make](https://en.wikipedia.org/wiki/Makefile): Make is required for any build or development. With `make` only the non-minified package can be built and installed.
 2. [nodejs](https://www.nodejs.org) (v 6.x): Node is required for most development operations including linting, minifying, and testing.
-3. [ErmrestDataUtils](#ErmrestDataUtils): see discussion below.
+3. [ErmrestDataUtils](#ermrestdatautils): see discussion below.
 
 ### Limitations
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ $ make all
 
 ### Set the deployment directory (optional)
 
-Set `ERMRESTJSDIR` to specify a target deployment location. By default, it the
+Set `ERMRESTJSDIR` to specify a target deployment location. By default, the
 install target is `/var/www/html/ermrestjs`. If this directory does not exist,
 it will first create it. You may need to run `make install` with _super user_
-privileges depending on the installation directory you chose.
+privileges depending on the installation directory you choose.
 
 **Important Note**: A very silly thing to do would be to set your deployment directory to root `/` and run `make install` with `sudo`. This would be very silly indeed, and would probably result in some corruption of your operating system. Surely, no one would ever do this. But, in the off chance that one might attempt such silliness, the `make install` rule specifies a `dont_install_in_root` prerequisite that attempts to put a stop to any such silliness before it goes to far.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ $ make doc
 ## How to test the package
 
 Before running the test cases you need to set the environment variables.
+- `ERMREST_URL`: the URL to the ermrest service on a (possibly, remote) host.
+- `AUTH_COOKIE`: a cookie valid to the (possibly, remote) host running the ermrest service. See [How To Get Your AUTH_COOKIE](https://github.com/informatics-isi-edu/chaise/wiki/E2E-tests-guide#how-to-get-your-auth_cookie).
 
 ```
 export ERMREST_URL=https://hostname/ermrest


### PR DESCRIPTION
Trying to make the dev/test workflow easier. You can install to your ~userdir like this.

First set this:
```
export ERMRESTJSDIR=USER@HOSTNAME:public_html/ermrestjs
```

Then run this:
```
make install
```

Your code gets pushed to your userdir on the test server for instance.