### PR TITLE
Simple column aggregates defined

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -289,12 +289,12 @@ to use for ERMrest JavaScript agents.
         * [new ReferenceColumn(reference, baseCols)](#new_ERMrest.ReferenceColumn_new)
         * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
         * [.table](#ERMrest.ReferenceColumn+table) : [<code>Table</code>](#ERMrest.Table)
-        * [.aggregate](#ERMrest.ReferenceColumn+aggregate) : [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)
         * [.name](#ERMrest.ReferenceColumn+name) : <code>string</code>
         * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>string</code>
         * [.type](#ERMrest.ReferenceColumn+type) : [<code>Type</code>](#ERMrest.Type)
         * [.nullok](#ERMrest.ReferenceColumn+nullok) : <code>Boolean</code>
         * [.default](#ERMrest.ReferenceColumn+default) : <code>string</code>
+        * [.aggregate](#ERMrest.ReferenceColumn+aggregate) : [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)
         * [.comment](#ERMrest.ReferenceColumn+comment) : <code>string</code>
         * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> \| <code>object</code>
         * [.sortable](#ERMrest.ReferenceColumn+sortable) : <code>boolean</code>
@@ -326,13 +326,13 @@ to use for ERMrest JavaScript agents.
         * [.isInboundForeignKey](#ERMrest.InboundForeignKeyPseudoColumn+isInboundForeignKey) : <code>boolean</code>
     * [.ReferenceAggregateFn](#ERMrest.ReferenceAggregateFn)
         * [new ReferenceAggregateFn()](#new_ERMrest.ReferenceAggregateFn_new)
-        * [.countAgg()](#ERMrest.ReferenceAggregateFn+countAgg) : <code>Object</code>
+        * [.countAgg](#ERMrest.ReferenceAggregateFn+countAgg) : <code>Object</code>
     * [.ColumnAggregateFn](#ERMrest.ColumnAggregateFn)
         * [new ColumnAggregateFn(column)](#new_ERMrest.ColumnAggregateFn_new)
-        * [.minAgg()](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
-        * [.maxAgg()](#ERMrest.ColumnAggregateFn+maxAgg) : <code>Object</code>
-        * [.countNotNullAgg()](#ERMrest.ColumnAggregateFn+countNotNullAgg) : <code>Object</code>
-        * [.countDistinctAgg()](#ERMrest.ColumnAggregateFn+countDistinctAgg) : <code>Object</code>
+        * [.minAgg](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
+        * [.maxAgg](#ERMrest.ColumnAggregateFn+maxAgg) : <code>Object</code>
+        * [.countNotNullAgg](#ERMrest.ColumnAggregateFn+countNotNullAgg) : <code>Object</code>
+        * [.countDistinctAgg](#ERMrest.ColumnAggregateFn+countDistinctAgg) : <code>Object</code>
     * [.Checksum](#ERMrest.Checksum)
         * [new Checksum({file}, {options})](#new_ERMrest.Checksum_new)
     * [.upload](#ERMrest.upload)
@@ -2408,10 +2408,8 @@ c) use space for conjunction of terms
 <a name="ERMrest.Reference+getAggregates"></a>
 
 #### reference.getAggregates(aggregateList) ⇒ <code>Promise</code>
-NOTE: If an alias for an aggregate is a duplicate of another provided alias, a new one will be generated
-
 **Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
-**Returns**: <code>Promise</code> - - Promise contains an object in the form of {alias: value, alias: value}  
+**Returns**: <code>Promise</code> - - Promise contains an array of the aggregate values in the same order as the supplied aggregate list  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2789,12 +2787,12 @@ the _data attribute. This way _data can be modified in chaise without changing t
     * [new ReferenceColumn(reference, baseCols)](#new_ERMrest.ReferenceColumn_new)
     * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
     * [.table](#ERMrest.ReferenceColumn+table) : [<code>Table</code>](#ERMrest.Table)
-    * [.aggregate](#ERMrest.ReferenceColumn+aggregate) : [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)
     * [.name](#ERMrest.ReferenceColumn+name) : <code>string</code>
     * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>string</code>
     * [.type](#ERMrest.ReferenceColumn+type) : [<code>Type</code>](#ERMrest.Type)
     * [.nullok](#ERMrest.ReferenceColumn+nullok) : <code>Boolean</code>
     * [.default](#ERMrest.ReferenceColumn+default) : <code>string</code>
+    * [.aggregate](#ERMrest.ReferenceColumn+aggregate) : [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)
     * [.comment](#ERMrest.ReferenceColumn+comment) : <code>string</code>
     * [.inputDisabled](#ERMrest.ReferenceColumn+inputDisabled) : <code>boolean</code> \| <code>object</code>
     * [.sortable](#ERMrest.ReferenceColumn+sortable) : <code>boolean</code>
@@ -2823,10 +2821,6 @@ indicates this represents is a PseudoColumn or a Column.
 
 #### referenceColumn.table : [<code>Table</code>](#ERMrest.Table)
 **Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
-<a name="ERMrest.ReferenceColumn+aggregate"></a>
-
-#### referenceColumn.aggregate : [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)
-**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+name"></a>
 
 #### referenceColumn.name : <code>string</code>
@@ -2851,6 +2845,12 @@ name of the column.
 
 #### referenceColumn.default : <code>string</code>
 Returns the default value
+
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+<a name="ERMrest.ReferenceColumn+aggregate"></a>
+
+#### referenceColumn.aggregate : [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)
+Returns the aggregate function object
 
 **Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+comment"></a>
@@ -3132,7 +3132,7 @@ Indicates that this ReferenceColumn is an inbound foreign key.
 
 * [.ReferenceAggregateFn](#ERMrest.ReferenceAggregateFn)
     * [new ReferenceAggregateFn()](#new_ERMrest.ReferenceAggregateFn_new)
-    * [.countAgg()](#ERMrest.ReferenceAggregateFn+countAgg) : <code>Object</code>
+    * [.countAgg](#ERMrest.ReferenceAggregateFn+countAgg) : <code>Object</code>
 
 <a name="new_ERMrest.ReferenceAggregateFn_new"></a>
 
@@ -3149,10 +3149,10 @@ Usage:
 
 <a name="ERMrest.ReferenceAggregateFn+countAgg"></a>
 
-#### referenceAggregateFn.countAgg() : <code>Object</code>
+#### referenceAggregateFn.countAgg : <code>Object</code>
 count aggregate representation
 
-**Kind**: instance method of [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)  
+**Kind**: instance property of [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)  
 <a name="ERMrest.ColumnAggregateFn"></a>
 
 ### ERMrest.ColumnAggregateFn
@@ -3160,10 +3160,10 @@ count aggregate representation
 
 * [.ColumnAggregateFn](#ERMrest.ColumnAggregateFn)
     * [new ColumnAggregateFn(column)](#new_ERMrest.ColumnAggregateFn_new)
-    * [.minAgg()](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
-    * [.maxAgg()](#ERMrest.ColumnAggregateFn+maxAgg) : <code>Object</code>
-    * [.countNotNullAgg()](#ERMrest.ColumnAggregateFn+countNotNullAgg) : <code>Object</code>
-    * [.countDistinctAgg()](#ERMrest.ColumnAggregateFn+countDistinctAgg) : <code>Object</code>
+    * [.minAgg](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
+    * [.maxAgg](#ERMrest.ColumnAggregateFn+maxAgg) : <code>Object</code>
+    * [.countNotNullAgg](#ERMrest.ColumnAggregateFn+countNotNullAgg) : <code>Object</code>
+    * [.countDistinctAgg](#ERMrest.ColumnAggregateFn+countDistinctAgg) : <code>Object</code>
 
 <a name="new_ERMrest.ColumnAggregateFn_new"></a>
 
@@ -3186,28 +3186,28 @@ Usage:
 
 <a name="ERMrest.ColumnAggregateFn+minAgg"></a>
 
-#### columnAggregateFn.minAgg() : <code>Object</code>
+#### columnAggregateFn.minAgg : <code>Object</code>
 minimum aggregate representation
 
-**Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
+**Kind**: instance property of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
 <a name="ERMrest.ColumnAggregateFn+maxAgg"></a>
 
-#### columnAggregateFn.maxAgg() : <code>Object</code>
+#### columnAggregateFn.maxAgg : <code>Object</code>
 maximum aggregate representation
 
-**Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
+**Kind**: instance property of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
 <a name="ERMrest.ColumnAggregateFn+countNotNullAgg"></a>
 
-#### columnAggregateFn.countNotNullAgg() : <code>Object</code>
+#### columnAggregateFn.countNotNullAgg : <code>Object</code>
 not null count aggregate representation
 
-**Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
+**Kind**: instance property of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
 <a name="ERMrest.ColumnAggregateFn+countDistinctAgg"></a>
 
-#### columnAggregateFn.countDistinctAgg() : <code>Object</code>
+#### columnAggregateFn.countDistinctAgg : <code>Object</code>
 distinct count aggregate representation
 
-**Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
+**Kind**: instance property of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
 <a name="ERMrest.Checksum"></a>
 
 ### ERMrest.Checksum

--- a/doc/api.md
+++ b/doc/api.md
@@ -326,11 +326,13 @@ to use for ERMrest JavaScript agents.
         * [.isInboundForeignKey](#ERMrest.InboundForeignKeyPseudoColumn+isInboundForeignKey) : <code>boolean</code>
     * [.ReferenceAggregateFn](#ERMrest.ReferenceAggregateFn)
         * [new ReferenceAggregateFn()](#new_ERMrest.ReferenceAggregateFn_new)
+        * [.countAgg()](#ERMrest.ReferenceAggregateFn+countAgg) : <code>Object</code>
     * [.ColumnAggregateFn](#ERMrest.ColumnAggregateFn)
         * [new ColumnAggregateFn(column)](#new_ERMrest.ColumnAggregateFn_new)
-        * [.minAgg(alias)](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
-        * [.maxAgg(alias)](#ERMrest.ColumnAggregateFn+maxAgg) : <code>Object</code>
-        * [.countDistinctAgg(alias)](#ERMrest.ColumnAggregateFn+countDistinctAgg) : <code>Object</code>
+        * [.minAgg()](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
+        * [.maxAgg()](#ERMrest.ColumnAggregateFn+maxAgg) : <code>Object</code>
+        * [.countNotNullAgg()](#ERMrest.ColumnAggregateFn+countNotNullAgg) : <code>Object</code>
+        * [.countDistinctAgg()](#ERMrest.ColumnAggregateFn+countDistinctAgg) : <code>Object</code>
     * [.Checksum](#ERMrest.Checksum)
         * [new Checksum({file}, {options})](#new_ERMrest.Checksum_new)
     * [.upload](#ERMrest.upload)
@@ -3127,20 +3129,30 @@ Indicates that this ReferenceColumn is an inbound foreign key.
 
 ### ERMrest.ReferenceAggregateFn
 **Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+
+* [.ReferenceAggregateFn](#ERMrest.ReferenceAggregateFn)
+    * [new ReferenceAggregateFn()](#new_ERMrest.ReferenceAggregateFn_new)
+    * [.countAgg()](#ERMrest.ReferenceAggregateFn+countAgg) : <code>Object</code>
+
 <a name="new_ERMrest.ReferenceAggregateFn_new"></a>
 
 #### new ReferenceAggregateFn()
 Constructs an Aggregate Funciton object
 
 Reference Aggregate Functions is a collection of available aggregates for the
-particular Reference (count for the table). Each aggregate should return an
-object that includes it's `alias` if it was provided and the string
-representation for querying the information.
+particular Reference (count for the table). Each aggregate should return the string
+representation for querying that information.
 
 Usage:
  Clients _do not_ directly access this constructor. ERMrest.Reference will
  access this constructor for purposes of fetching aggregate data about the table.
 
+<a name="ERMrest.ReferenceAggregateFn+countAgg"></a>
+
+#### referenceAggregateFn.countAgg() : <code>Object</code>
+count aggregate representation
+
+**Kind**: instance method of [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)  
 <a name="ERMrest.ColumnAggregateFn"></a>
 
 ### ERMrest.ColumnAggregateFn
@@ -3148,9 +3160,10 @@ Usage:
 
 * [.ColumnAggregateFn](#ERMrest.ColumnAggregateFn)
     * [new ColumnAggregateFn(column)](#new_ERMrest.ColumnAggregateFn_new)
-    * [.minAgg(alias)](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
-    * [.maxAgg(alias)](#ERMrest.ColumnAggregateFn+maxAgg) : <code>Object</code>
-    * [.countDistinctAgg(alias)](#ERMrest.ColumnAggregateFn+countDistinctAgg) : <code>Object</code>
+    * [.minAgg()](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
+    * [.maxAgg()](#ERMrest.ColumnAggregateFn+maxAgg) : <code>Object</code>
+    * [.countNotNullAgg()](#ERMrest.ColumnAggregateFn+countNotNullAgg) : <code>Object</code>
+    * [.countDistinctAgg()](#ERMrest.ColumnAggregateFn+countDistinctAgg) : <code>Object</code>
 
 <a name="new_ERMrest.ColumnAggregateFn_new"></a>
 
@@ -3159,8 +3172,7 @@ Constructs an Aggregate Function object
 
 Column Aggregate Functions is a collection of available aggregates for the
 particular ReferenceColumn (min, max, count not null, and count distinct for it's column).
-Each aggregate should return an object that includes it's `alias` if it was
-provided and the string representation for querying for that information.
+Each aggregate should return the string representation for querying for that information.
 
 Usage:
  Clients _do not_ directly access this constructor. ERMrest.ReferenceColumn
@@ -3174,37 +3186,28 @@ Usage:
 
 <a name="ERMrest.ColumnAggregateFn+minAgg"></a>
 
-#### columnAggregateFn.minAgg(alias) : <code>Object</code>
+#### columnAggregateFn.minAgg() : <code>Object</code>
 minimum aggregate representation
 
 **Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| alias | <code>string</code> | key name that the returned values for this aggregate will be available under |
-
 <a name="ERMrest.ColumnAggregateFn+maxAgg"></a>
 
-#### columnAggregateFn.maxAgg(alias) : <code>Object</code>
+#### columnAggregateFn.maxAgg() : <code>Object</code>
 maximum aggregate representation
 
 **Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
+<a name="ERMrest.ColumnAggregateFn+countNotNullAgg"></a>
 
-| Param | Type | Description |
-| --- | --- | --- |
-| alias | <code>string</code> | key name that the returned values for this aggregate will be available under |
+#### columnAggregateFn.countNotNullAgg() : <code>Object</code>
+not null count aggregate representation
 
+**Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
 <a name="ERMrest.ColumnAggregateFn+countDistinctAgg"></a>
 
-#### columnAggregateFn.countDistinctAgg(alias) : <code>Object</code>
+#### columnAggregateFn.countDistinctAgg() : <code>Object</code>
 distinct count aggregate representation
 
 **Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| alias | <code>string</code> | key name that the returned values for this aggregate will be available under |
-
 <a name="ERMrest.Checksum"></a>
 
 ### ERMrest.Checksum

--- a/doc/api.md
+++ b/doc/api.md
@@ -2406,8 +2406,10 @@ c) use space for conjunction of terms
 <a name="ERMrest.Reference+getAggregates"></a>
 
 #### reference.getAggregates(aggregateList) ⇒ <code>Promise</code>
+NOTE: If an alias for an aggregate is a duplicate of another provided alias, a new one will be generated
+
 **Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
-**Returns**: <code>Promise</code> - TODO: not sure of the structure of this returned promise yet  
+**Returns**: <code>Promise</code> - - Promise contains an object in the form of {alias: value, alias: value}  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/doc/api.md
+++ b/doc/api.md
@@ -235,6 +235,7 @@ to use for ERMrest JavaScript agents.
     * [.Reference](#ERMrest.Reference)
         * [new Reference(location, catalog)](#new_ERMrest.Reference_new)
         * [.contextualize](#ERMrest.Reference+contextualize)
+        * [.aggregate](#ERMrest.Reference+aggregate) : [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)
         * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
         * [.uri](#ERMrest.Reference+uri) : <code>string</code>
         * [.session](#ERMrest.Reference+session)
@@ -258,6 +259,7 @@ to use for ERMrest JavaScript agents.
         * [.delete(tuples)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
         * [.related([tuple])](#ERMrest.Reference+related) ⇒ [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
         * [.search(term)](#ERMrest.Reference+search) ⇒ <code>Reference</code>
+        * [.getAggregates(aggregateList)](#ERMrest.Reference+getAggregates) ⇒ <code>Promise</code>
         * [.generateColumnsList(tuple)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
     * [.Page](#ERMrest.Page)
         * [new Page(reference, etag, data, hasNext, hasPrevious)](#new_ERMrest.Page_new)
@@ -322,6 +324,8 @@ to use for ERMrest JavaScript agents.
         * [.foreignKey](#ERMrest.InboundForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
         * [.isPseudo](#ERMrest.InboundForeignKeyPseudoColumn+isPseudo) : <code>boolean</code>
         * [.isInboundForeignKey](#ERMrest.InboundForeignKeyPseudoColumn+isInboundForeignKey) : <code>boolean</code>
+    * [.ReferenceAggregateFn](#ERMrest.ReferenceAggregateFn)
+        * [new ReferenceAggregateFn()](#new_ERMrest.ReferenceAggregateFn_new)
     * [.ColumnAggregateFn](#ERMrest.ColumnAggregateFn)
         * [new ColumnAggregateFn(column)](#new_ERMrest.ColumnAggregateFn_new)
         * [.minAgg(alias)](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
@@ -1986,6 +1990,7 @@ Constructor for a ParsedFilter.
 * [.Reference](#ERMrest.Reference)
     * [new Reference(location, catalog)](#new_ERMrest.Reference_new)
     * [.contextualize](#ERMrest.Reference+contextualize)
+    * [.aggregate](#ERMrest.Reference+aggregate) : [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)
     * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
     * [.uri](#ERMrest.Reference+uri) : <code>string</code>
     * [.session](#ERMrest.Reference+session)
@@ -2009,6 +2014,7 @@ Constructor for a ParsedFilter.
     * [.delete(tuples)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
     * [.related([tuple])](#ERMrest.Reference+related) ⇒ [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
     * [.search(term)](#ERMrest.Reference+search) ⇒ <code>Reference</code>
+    * [.getAggregates(aggregateList)](#ERMrest.Reference+getAggregates) ⇒ <code>Promise</code>
     * [.generateColumnsList(tuple)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
 
 <a name="new_ERMrest.Reference_new"></a>
@@ -2050,6 +2056,10 @@ The `reference` is unchanged, while `recordref` now represents a
 reconfigured reference. For instance, `recordref.columns` may be
 different compared to `reference.columns`.
 
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+<a name="ERMrest.Reference+aggregate"></a>
+
+#### reference.aggregate : [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+displayname"></a>
 
@@ -2392,6 +2402,16 @@ c) use space for conjunction of terms
 | Param | Type | Description |
 | --- | --- | --- |
 | term | <code>string</code> | search term, undefined to clear search |
+
+<a name="ERMrest.Reference+getAggregates"></a>
+
+#### reference.getAggregates(aggregateList) ⇒ <code>Promise</code>
+**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
+**Returns**: <code>Promise</code> - TODO: not sure of the structure of this returned promise yet  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| aggregateList | [<code>Array.&lt;ColumnAggregateFn&gt;</code>](#ERMrest.ColumnAggregateFn) | list of aggregate functions to apply to GET uri |
 
 <a name="ERMrest.Reference+generateColumnsList"></a>
 
@@ -3101,6 +3121,24 @@ indicates this represents is a PseudoColumn or a Column.
 Indicates that this ReferenceColumn is an inbound foreign key.
 
 **Kind**: instance property of [<code>InboundForeignKeyPseudoColumn</code>](#ERMrest.InboundForeignKeyPseudoColumn)  
+<a name="ERMrest.ReferenceAggregateFn"></a>
+
+### ERMrest.ReferenceAggregateFn
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+<a name="new_ERMrest.ReferenceAggregateFn_new"></a>
+
+#### new ReferenceAggregateFn()
+Constructs an Aggregate Funciton object
+
+Reference Aggregate Functions is a collection of available aggregates for the
+particular Reference (count for the table). Each aggregate should return an
+object that includes it's `alias` if it was provided and the string
+representation for querying the information.
+
+Usage:
+ Clients _do not_ directly access this constructor. ERMrest.Reference will
+ access this constructor for purposes of fetching aggregate data about the table.
+
 <a name="ERMrest.ColumnAggregateFn"></a>
 
 ### ERMrest.ColumnAggregateFn
@@ -3118,7 +3156,7 @@ Indicates that this ReferenceColumn is an inbound foreign key.
 Constructs an Aggregate Function object
 
 Column Aggregate Functions is a collection of available aggregates for the
-particular ReferenceColumn (min, max, and distinct for it's column).
+particular ReferenceColumn (min, max, count not null, and count distinct for it's column).
 Each aggregate should return an object that includes it's `alias` if it was
 provided and the string representation for querying for that information.
 
@@ -3130,7 +3168,7 @@ Usage:
 
 | Param | Type | Description |
 | --- | --- | --- |
-| column | [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn) | if provided, the column that is used for creating column aggregates |
+| column | [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn) | the column that is used for creating column aggregates |
 
 <a name="ERMrest.ColumnAggregateFn+minAgg"></a>
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -287,6 +287,7 @@ to use for ERMrest JavaScript agents.
         * [new ReferenceColumn(reference, baseCols)](#new_ERMrest.ReferenceColumn_new)
         * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
         * [.table](#ERMrest.ReferenceColumn+table) : [<code>Table</code>](#ERMrest.Table)
+        * [.aggregate](#ERMrest.ReferenceColumn+aggregate) : [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)
         * [.name](#ERMrest.ReferenceColumn+name) : <code>string</code>
         * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>string</code>
         * [.type](#ERMrest.ReferenceColumn+type) : [<code>Type</code>](#ERMrest.Type)
@@ -321,6 +322,11 @@ to use for ERMrest JavaScript agents.
         * [.foreignKey](#ERMrest.InboundForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
         * [.isPseudo](#ERMrest.InboundForeignKeyPseudoColumn+isPseudo) : <code>boolean</code>
         * [.isInboundForeignKey](#ERMrest.InboundForeignKeyPseudoColumn+isInboundForeignKey) : <code>boolean</code>
+    * [.ColumnAggregateFn](#ERMrest.ColumnAggregateFn)
+        * [new ColumnAggregateFn(column)](#new_ERMrest.ColumnAggregateFn_new)
+        * [.minAgg(alias)](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
+        * [.maxAgg(alias)](#ERMrest.ColumnAggregateFn+maxAgg) : <code>Object</code>
+        * [.countDistinctAgg(alias)](#ERMrest.ColumnAggregateFn+countDistinctAgg) : <code>Object</code>
     * [.Checksum](#ERMrest.Checksum)
         * [new Checksum({file}, {options})](#new_ERMrest.Checksum_new)
     * [.upload](#ERMrest.upload)
@@ -2759,6 +2765,7 @@ the _data attribute. This way _data can be modified in chaise without changing t
     * [new ReferenceColumn(reference, baseCols)](#new_ERMrest.ReferenceColumn_new)
     * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
     * [.table](#ERMrest.ReferenceColumn+table) : [<code>Table</code>](#ERMrest.Table)
+    * [.aggregate](#ERMrest.ReferenceColumn+aggregate) : [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)
     * [.name](#ERMrest.ReferenceColumn+name) : <code>string</code>
     * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>string</code>
     * [.type](#ERMrest.ReferenceColumn+type) : [<code>Type</code>](#ERMrest.Type)
@@ -2791,6 +2798,10 @@ indicates this represents is a PseudoColumn or a Column.
 <a name="ERMrest.ReferenceColumn+table"></a>
 
 #### referenceColumn.table : [<code>Table</code>](#ERMrest.Table)
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+<a name="ERMrest.ReferenceColumn+aggregate"></a>
+
+#### referenceColumn.aggregate : [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)
 **Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
 <a name="ERMrest.ReferenceColumn+name"></a>
 
@@ -3090,6 +3101,70 @@ indicates this represents is a PseudoColumn or a Column.
 Indicates that this ReferenceColumn is an inbound foreign key.
 
 **Kind**: instance property of [<code>InboundForeignKeyPseudoColumn</code>](#ERMrest.InboundForeignKeyPseudoColumn)  
+<a name="ERMrest.ColumnAggregateFn"></a>
+
+### ERMrest.ColumnAggregateFn
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+
+* [.ColumnAggregateFn](#ERMrest.ColumnAggregateFn)
+    * [new ColumnAggregateFn(column)](#new_ERMrest.ColumnAggregateFn_new)
+    * [.minAgg(alias)](#ERMrest.ColumnAggregateFn+minAgg) : <code>Object</code>
+    * [.maxAgg(alias)](#ERMrest.ColumnAggregateFn+maxAgg) : <code>Object</code>
+    * [.countDistinctAgg(alias)](#ERMrest.ColumnAggregateFn+countDistinctAgg) : <code>Object</code>
+
+<a name="new_ERMrest.ColumnAggregateFn_new"></a>
+
+#### new ColumnAggregateFn(column)
+Constructs an Aggregate Function object
+
+Column Aggregate Functions is a collection of available aggregates for the
+particular ReferenceColumn (min, max, and distinct for it's column).
+Each aggregate should return an object that includes it's `alias` if it was
+provided and the string representation for querying for that information.
+
+Usage:
+ Clients _do not_ directly access this constructor. ERMrest.ReferenceColumn
+ will access this constructor for purposes of fetching aggregate data
+ for a specific column
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| column | [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn) | if provided, the column that is used for creating column aggregates |
+
+<a name="ERMrest.ColumnAggregateFn+minAgg"></a>
+
+#### columnAggregateFn.minAgg(alias) : <code>Object</code>
+minimum aggregate representation
+
+**Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| alias | <code>string</code> | key name that the returned values for this aggregate will be available under |
+
+<a name="ERMrest.ColumnAggregateFn+maxAgg"></a>
+
+#### columnAggregateFn.maxAgg(alias) : <code>Object</code>
+maximum aggregate representation
+
+**Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| alias | <code>string</code> | key name that the returned values for this aggregate will be available under |
+
+<a name="ERMrest.ColumnAggregateFn+countDistinctAgg"></a>
+
+#### columnAggregateFn.countDistinctAgg(alias) : <code>Object</code>
+distinct count aggregate representation
+
+**Kind**: instance method of [<code>ColumnAggregateFn</code>](#ERMrest.ColumnAggregateFn)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| alias | <code>string</code> | key name that the returned values for this aggregate will be available under |
+
 <a name="ERMrest.Checksum"></a>
 
 ### ERMrest.Checksum

--- a/js/reference.js
+++ b/js/reference.js
@@ -1578,7 +1578,7 @@ var ERMrest = (function(module) {
             var aggAliases = [];
             for (var i = 0; i < aggregateList.length; i++) {
                 var agg = aggregateList[i];
-                var alias = (agg.alias != null ? agg.alias : i);
+                var alias = (agg.alias !== null ? agg.alias : i);
 
                 // this alias is already used, should only be the case when the user defined an alias to be used twice
                 if (aggAliases.indexOf(alias) > -1) {
@@ -1587,7 +1587,7 @@ var ERMrest = (function(module) {
                 aggAliases.push(alias);
 
                 // if this is the first aggregate, begin with the baseUri
-                if (i == 0) {
+                if (i === 0) {
                     url = baseUri;
                 } else {
                     url += ",";
@@ -1596,7 +1596,7 @@ var ERMrest = (function(module) {
                 // if adding the next aggregate to the url will push it past url length limit, push url onto the urlSet and reset the working url
                 if ((url + alias + ":=" + agg.value).length > URL_LENGTH_LIMIT) {
                     // strip off an extra ','
-                    if (url.charAt(url.length-1) == ',') {
+                    if (url.charAt(url.length-1) === ',') {
                         url = url.substring(0, url.length-1);
                     }
 
@@ -1607,7 +1607,7 @@ var ERMrest = (function(module) {
                 url += alias + ":=" + agg.value;
 
                 // We are at the end of the aggregate list
-                if (i+1 == aggregateList.length) {
+                if (i+1 === aggregateList.length) {
                     urlSet.push(url);
                 }
             }

--- a/js/reference.js
+++ b/js/reference.js
@@ -1473,7 +1473,12 @@ var ERMrest = (function(module) {
             return newReference;
         },
 
-        getAggregates: function() {
+        /**
+         *
+         * @param {ERMrest.ColumnAggregateFn[]} aggregateList - list of aggregate functions to apply to GET uri
+         * @return {Promise} TODO: not sure of the structure of this returned promise yet
+         */
+        getAggregates: function(aggregateList) {
 
         },
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -1571,12 +1571,12 @@ var ERMrest = (function(module) {
             // use this index to get the next ascii value in the alphabet starting at `a`
             var aliasCounter = 0;
             function generateAlias() {
-                var alias = String.fromCharCode(97 + aliasCounter);
+                var alias = aliasCounter;
                 aliasCounter++;
                 return alias;
             }
 
-            var url = this.location.service + "/catalog/" + this.location.catalog + "/aggregate/" + this.location.compactPath + "/";
+            var url = this.location.service + "/catalog/" + this.location.catalog + "/aggregate/" + this.location.ermrestCompactPath + "/";
             // for matching the aliases after the data returns
             var aggAliases = [];
             for (var i = 0; i < aggregateList.length; i++) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -3148,11 +3148,6 @@ var ERMrest = (function(module) {
          */
         this.table = this._baseCols[0].table;
 
-        /**
-         * @type {ERMrest.ColumnAggregateFn}
-         */
-        this.aggregate = new ColumnAggregateFn(this);
-
     }
 
     ReferenceColumn.prototype = {
@@ -3223,6 +3218,17 @@ var ERMrest = (function(module) {
                 this._default = this._simple ? this._baseCols[0].default : null;
             }
             return this._default;
+        },
+
+        /**
+         * @desc Returns the aggregate function object
+         * @type {ERMrest.ColumnAggregateFn}
+         */
+        get aggregate() {
+            if (this._aggregate === undefined) {
+                this._aggregate = !this.isPseudo ? new ColumnAggregateFn(this) : null;
+            }
+            return this._aggregate;
         },
 
         /**
@@ -4237,7 +4243,7 @@ var ERMrest = (function(module) {
          * @type {Object}
          * @desc count aggregate representation
          */
-        countAgg: function() {
+        get countAgg() {
             return "cnt(*)";
         }
     };
@@ -4258,11 +4264,7 @@ var ERMrest = (function(module) {
      * @param {ERMrest.ReferenceColumn} column - the column that is used for creating column aggregates
      */
     function ColumnAggregateFn (column) {
-        if (column.isPseudo && !column.isAsset) {
-            // NOTE: not sure how to handle this
-        } else {
-            this.column = column;
-        }
+        this.column = column;
     }
 
     ColumnAggregateFn.prototype = {
@@ -4270,7 +4272,7 @@ var ERMrest = (function(module) {
          * @type {Object}
          * @desc minimum aggregate representation
          */
-        minAgg: function() {
+        get minAgg() {
             return "min(" + module._fixedEncodeURIComponent(this.column.name) + ")";
         },
 
@@ -4278,7 +4280,7 @@ var ERMrest = (function(module) {
          * @type {Object}
          * @desc maximum aggregate representation
          */
-        maxAgg: function() {
+        get maxAgg() {
             return "max(" + module._fixedEncodeURIComponent(this.column.name) + ")";
         },
 
@@ -4286,7 +4288,7 @@ var ERMrest = (function(module) {
          * @type {Object}
          * @desc not null count aggregate representation
          */
-        countNotNullAgg: function() {
+        get countNotNullAgg() {
             return "cnt(" + module._fixedEncodeURIComponent(this.column.name) + ")";
         },
 
@@ -4294,7 +4296,7 @@ var ERMrest = (function(module) {
          * @type {Object}
          * @desc distinct count aggregate representation
          */
-        countDistinctAgg: function() {
+        get countDistinctAgg() {
             return "cnt_d(" + module._fixedEncodeURIComponent(this.column.name) + ")";
         }
     };

--- a/js/reference.js
+++ b/js/reference.js
@@ -1561,9 +1561,10 @@ var ERMrest = (function(module) {
         },
 
         /**
+         * NOTE: If an alias for an aggregate is a duplicate of another provided alias, a new one will be generated
          *
          * @param {ERMrest.ColumnAggregateFn[]} aggregateList - list of aggregate functions to apply to GET uri
-         * @return {Promise} TODO: not sure of the structure of this returned promise yet
+         * @return {Promise} - Promise contains an object in the form of {alias: value, alias: value}
          */
         getAggregates: function(aggregateList) {
             var defer = module._q.defer();

--- a/js/reference.js
+++ b/js/reference.js
@@ -1473,6 +1473,10 @@ var ERMrest = (function(module) {
             return newReference;
         },
 
+        getAggregates: function() {
+
+        },
+
         setNewTable: function(table) {
             this._table = table;
             this._shortestKey = table.shortestKey;
@@ -2986,6 +2990,11 @@ var ERMrest = (function(module) {
          */
         this.table = this._baseCols[0].table;
 
+        /**
+         * @type {ERMrest.ColumnAggregateFn}
+         */
+        this.aggregate = new ColumnAggregateFn(this);
+
     }
 
     ReferenceColumn.prototype = {
@@ -4050,8 +4059,63 @@ var ERMrest = (function(module) {
         }
     });
 
+    /**
+     * Constructs an Aggregate Function object
+     *
+     * Column Aggregate Functions is a collection of available aggregates for the
+     * particular ReferenceColumn (min, max, and distinct for it's column).
+     * Each aggregate should return an object that includes it's `alias` if it was
+     * provided and the string representation for querying for that information.
+     *
+     * Usage:
+     *  Clients _do not_ directly access this constructor. ERMrest.ReferenceColumn
+     *  will access this constructor for purposes of fetching aggregate data
+     *  for a specific column
+     * @memberof ERMrest
+     * @class
+     * @param {ERMrest.ReferenceColumn} column - if provided, the column that is used for creating column aggregates
+     */
+    function ColumnAggregateFn (column) {
+        this.column = column;
+    }
 
+    ColumnAggregateFn.prototype = {
+        /**
+         * @type {Object}
+         * @param {string} alias - key name that the returned values for this aggregate will be available under
+         * @desc minimum aggregate representation
+         */
+        get minAgg (alias) {
+            return {
+                "alias": typeof alias !== "string" ? null: alias,
+                "value": "min(" + module._fixedEncodeURIComponent(this.column.name) + ")"
+            }
+        },
 
+        /**
+         * @type {Object}
+         * @param {string} alias - key name that the returned values for this aggregate will be available under
+         * @desc maximum aggregate representation
+         */
+        get maxAgg (alias) {
+            return {
+                "alias": typeof alias !== "string" ? null : alias,
+                "value": "max(" + module._fixedEncodeURIComponent(this.column.name) + ")"
+            }
+        },
+
+        /**
+         * @type {Object}
+         * @param {string} alias - key name that the returned values for this aggregate will be available under
+         * @desc distinct count aggregate representation
+         */
+        get countDistinctAgg (alias) {
+            return {
+                "alias": typeof alias !== "string" ? null : alias,
+                "value": "cnt_d(" + module._fixedEncodeURIComponent(this.column.name) + ")"
+            }
+        }
+    };
 
     return module;
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -1561,10 +1561,9 @@ var ERMrest = (function(module) {
         },
 
         /**
-         * NOTE: If an alias for an aggregate is a duplicate of another provided alias, a new one will be generated
          *
          * @param {ERMrest.ColumnAggregateFn[]} aggregateList - list of aggregate functions to apply to GET uri
-         * @return {Promise} - Promise contains an object in the form of {alias: value, alias: value}
+         * @return {Promise} - Promise contains an array of the aggregate values in the same order as the supplied aggregate list
          */
         getAggregates: function(aggregateList) {
             var defer = module._q.defer();
@@ -4259,7 +4258,11 @@ var ERMrest = (function(module) {
      * @param {ERMrest.ReferenceColumn} column - the column that is used for creating column aggregates
      */
     function ColumnAggregateFn (column) {
-        this.column = column;
+        if (column.isPseudo && !column.isAsset) {
+            // NOTE: not sure how to handle this
+        } else {
+            this.column = column;
+        }
     }
 
     ColumnAggregateFn.prototype = {

--- a/js/reference.js
+++ b/js/reference.js
@@ -4085,11 +4085,11 @@ var ERMrest = (function(module) {
          * @param {string} alias - key name that the returned values for this aggregate will be available under
          * @desc minimum aggregate representation
          */
-        get minAgg (alias) {
+        minAgg: function(alias) {
             return {
                 "alias": typeof alias !== "string" ? null: alias,
                 "value": "min(" + module._fixedEncodeURIComponent(this.column.name) + ")"
-            }
+            };
         },
 
         /**
@@ -4097,11 +4097,11 @@ var ERMrest = (function(module) {
          * @param {string} alias - key name that the returned values for this aggregate will be available under
          * @desc maximum aggregate representation
          */
-        get maxAgg (alias) {
+        maxAgg: function(alias) {
             return {
                 "alias": typeof alias !== "string" ? null : alias,
                 "value": "max(" + module._fixedEncodeURIComponent(this.column.name) + ")"
-            }
+            };
         },
 
         /**
@@ -4109,11 +4109,11 @@ var ERMrest = (function(module) {
          * @param {string} alias - key name that the returned values for this aggregate will be available under
          * @desc distinct count aggregate representation
          */
-        get countDistinctAgg (alias) {
+        countDistinctAgg: function(alias) {
             return {
                 "alias": typeof alias !== "string" ? null : alias,
                 "value": "cnt_d(" + module._fixedEncodeURIComponent(this.column.name) + ")"
-            }
+            };
         }
     };
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -1572,32 +1572,26 @@ var ERMrest = (function(module) {
 
             var URL_LENGTH_LIMIT = 2048;
 
-            // use this index to get the next ascii value in the alphabet starting at `a`
-            var aliasCounter = 0;
-            function generateAlias() {
-                var alias = aliasCounter;
-                aliasCounter++;
-                return alias;
-            }
-
             var urlSet = [];
             var baseUri = this.location.service + "/catalog/" + this.location.catalog + "/aggregate/" + this.location.ermrestCompactPath + "/";
             // for matching the aliases after the data returns
             var aggAliases = [];
             for (var i = 0; i < aggregateList.length; i++) {
                 var agg = aggregateList[i];
+                var alias = (agg.alias != null ? agg.alias : i);
+
+                // this alias is already used, should only be the case when the user defined an alias to be used twice
+                if (aggAliases.indexOf(alias) > -1) {
+                    alias = i;
+                }
+                aggAliases.push(alias);
+
                 // if this is the first aggregate, begin with the baseUri
                 if (i == 0) {
                     url = baseUri;
                 } else {
                     url += ",";
                 }
-                var alias = (agg.alias != null ? agg.alias : generateAlias());
-                // this alias is already used, should only be the case when the user defined an alias to be used twice
-                if (aggAliases.indexOf(alias) > -1) {
-                    alias = generateAlias();
-                }
-                aggAliases.push(alias);
 
                 // if adding the next aggregate to the url will push it past url length limit, push url onto the urlSet and reset the working url
                 if ((url + alias + ":=" + agg.value).length > URL_LENGTH_LIMIT) {

--- a/test/specs/reference/conf/aggregate.conf.json
+++ b/test/specs/reference/conf/aggregate.conf.json
@@ -1,0 +1,15 @@
+{
+    "catalog": {},
+    "schema": {
+        "name": "aggregate_schema",
+        "createNew": true,
+        "path": "test/specs/reference/conf/aggregate_schema/schema.json"
+    },
+    "tables": {
+        "createNew": true
+    },
+    "entities": {
+        "createNew": true,
+        "path": "test/specs/reference/conf/aggregate_schema/data"
+    }
+}

--- a/test/specs/reference/conf/aggregate_schema/data/aggregate_table.json
+++ b/test/specs/reference/conf/aggregate_schema/data/aggregate_table.json
@@ -1,0 +1,5 @@
+[{"id":1,"int_agg":7,"float_agg":12.4,"text_agg":"house","date_agg":null,"timestamp_agg":"2016-03-16T02:12:00"},
+ {"id":2,"int_agg":2,"float_agg":36.721,"text_agg":"house","date_agg":"2017-07-17","timestamp_agg":"2017-04-13T14:10:00"},
+ {"id":3,"int_agg":7,"float_agg":null,"text_agg":"sandwich","date_agg":"2016-12-06","timestamp_agg":"2012-01-22T12:54:00"},
+ {"id":4,"int_agg":33,"float_agg":0.4222,"text_agg":"bread","date_agg":"2015-01-11","timestamp_agg":"2016-03-16T14:30:00"},
+ {"id":5,"int_agg":215,"float_agg":36.9201,"text_agg":null,"date_agg":null,"timestamp_agg":"2010-05-22T17:44:00"}]

--- a/test/specs/reference/conf/aggregate_schema/schema.json
+++ b/test/specs/reference/conf/aggregate_schema/schema.json
@@ -1,0 +1,71 @@
+{
+    "comment": "schema for testing aggregate APIs",
+    "schema_name": "aggregate_schema",
+    "tables": {
+        "aggregate_table": {
+            "comment": "Table to represent a testing aggregate functions.",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id"
+                    ]
+                }
+            ],
+            "foreign_keys": [],
+            "table_name": "aggregate_table",
+            "schema_name": "aggregate_schema",
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "serial4"
+                    }
+                },
+                {
+                    "name": "int_agg",
+                    "nullok": true,
+                    "type": {
+                        "typename": "integer"
+                    }
+                },
+                {
+                    "name": "float_agg",
+                    "nullok": true,
+                    "type": {
+                        "typename": "float4"
+                    }
+                },
+                {
+                    "name": "text_agg",
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "date_agg",
+                    "nullok": true,
+                    "type": {
+                        "typename": "date"
+                    }
+                },
+                {
+                    "name": "timestamp_agg",
+                    "nullok": true,
+                    "type": {
+                        "typename": "timestamp"
+                    }
+                }
+            ],
+            "annotations": {}
+        }
+    },
+    "annotations": {},
+    "table_names": [
+        "aggregate_table"
+    ]
+}

--- a/test/specs/reference/spec.js
+++ b/test/specs/reference/spec.js
@@ -16,7 +16,8 @@ require('./../../utils/starter.spec.js').runTests({
         "/reference/tests/13.search.js",
         "/reference/tests/14.pseudo_columns.js",
         "/reference/tests/15.reference_column.js",
-        "/reference/tests/16.default_value.js"
+        "/reference/tests/16.default_value.js",
+        "/reference/tests/17.aggregates.js"
 
     ],
     schemaConfigurations: [
@@ -30,6 +31,7 @@ require('./../../utils/starter.spec.js').runTests({
         "/reference/conf/update.conf.json",
         "/reference/conf/delete.conf.json",
         "/reference/conf/default_value.conf.json",
-        "/reference/conf/columns.conf.json"
+        "/reference/conf/columns.conf.json",
+        "/reference/conf/aggregate.conf.json"
     ]
 });

--- a/test/specs/reference/tests/17.aggregates.js
+++ b/test/specs/reference/tests/17.aggregates.js
@@ -25,7 +25,7 @@ exports.execute = function (options) {
 
         it("should get the aggregate count for the aggregate_table table.", function(done) {
             var aggregateList = [
-                reference.aggregate.countAgg()
+                reference.aggregate.countAgg
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
@@ -42,10 +42,10 @@ exports.execute = function (options) {
         it("should get aggregates for int_agg column.", function(done) {
             var intColumnAggs = reference.columns[1].aggregate;
             var aggregateList = [
-                intColumnAggs.countNotNullAgg(),
-                intColumnAggs.countDistinctAgg(),
-                intColumnAggs.minAgg(),
-                intColumnAggs.maxAgg()
+                intColumnAggs.countNotNullAgg,
+                intColumnAggs.countDistinctAgg,
+                intColumnAggs.minAgg,
+                intColumnAggs.maxAgg
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
@@ -65,10 +65,10 @@ exports.execute = function (options) {
         it("should get aggregates for float_agg column.", function(done) {
             var floatColumnAggs = reference.columns[2].aggregate;
             var aggregateList = [
-                floatColumnAggs.countNotNullAgg(),
-                floatColumnAggs.countDistinctAgg(),
-                floatColumnAggs.minAgg(),
-                floatColumnAggs.maxAgg()
+                floatColumnAggs.countNotNullAgg,
+                floatColumnAggs.countDistinctAgg,
+                floatColumnAggs.minAgg,
+                floatColumnAggs.maxAgg
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
@@ -88,10 +88,10 @@ exports.execute = function (options) {
         it("should get aggregates for text_agg column.", function(done) {
             var textColumnAggs = reference.columns[3].aggregate;
             var aggregateList = [
-                textColumnAggs.countNotNullAgg(),
-                textColumnAggs.countDistinctAgg(),
-                textColumnAggs.minAgg(),
-                textColumnAggs.maxAgg()
+                textColumnAggs.countNotNullAgg,
+                textColumnAggs.countDistinctAgg,
+                textColumnAggs.minAgg,
+                textColumnAggs.maxAgg
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
@@ -111,10 +111,10 @@ exports.execute = function (options) {
         it("should get aggregates for date_agg column.", function(done) {
             var dateColumnAggs = reference.columns[4].aggregate;
             var aggregateList = [
-                dateColumnAggs.countNotNullAgg(),
-                dateColumnAggs.countDistinctAgg(),
-                dateColumnAggs.minAgg(),
-                dateColumnAggs.maxAgg()
+                dateColumnAggs.countNotNullAgg,
+                dateColumnAggs.countDistinctAgg,
+                dateColumnAggs.minAgg,
+                dateColumnAggs.maxAgg
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
@@ -134,10 +134,10 @@ exports.execute = function (options) {
         it("should get aggregates for timestamp_agg column.", function(done) {
             var timestampColumnAggs = reference.columns[5].aggregate;
             var aggregateList = [
-                timestampColumnAggs.countNotNullAgg(),
-                timestampColumnAggs.countDistinctAgg(),
-                timestampColumnAggs.minAgg(),
-                timestampColumnAggs.maxAgg()
+                timestampColumnAggs.countNotNullAgg,
+                timestampColumnAggs.countDistinctAgg,
+                timestampColumnAggs.minAgg,
+                timestampColumnAggs.maxAgg
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {

--- a/test/specs/reference/tests/17.aggregates.js
+++ b/test/specs/reference/tests/17.aggregates.js
@@ -159,5 +159,35 @@ exports.execute = function (options) {
                 done.fail();
             });
         });
+
+        it("should get aggregates for different columns without aliases being set.", function(done) {
+            var aggregateList = [
+                reference.columns[1].aggregate.countNotNullAgg(),
+                reference.columns[1].aggregate.minAgg(),
+                reference.columns[1].aggregate.maxAgg(),
+                reference.columns[2].aggregate.countNotNullAgg(),
+                reference.columns[2].aggregate.minAgg(),
+                reference.columns[2].aggregate.maxAgg()
+            ];
+
+            reference.getAggregates(aggregateList).then(function (response) {
+                response = response[0];
+
+                // returned values have keys based on their index in the aggregateList
+                // int aggs
+                expect(response['0']).toBe(5);
+                expect(response['1']).toBe(2);
+                expect(response['2']).toBe(215);
+                // float aggs
+                expect(response['3']).toBe(4);
+                expect(response['4']).toBe(0.4222);
+                expect(response['5']).toBe(36.9201);
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
     });
 }

--- a/test/specs/reference/tests/17.aggregates.js
+++ b/test/specs/reference/tests/17.aggregates.js
@@ -29,7 +29,6 @@ exports.execute = function (options) {
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
-                response = response[0];
 
                 expect(response.cnt).toBe(5, "Table count is incorrect");
 
@@ -50,7 +49,6 @@ exports.execute = function (options) {
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
-                response = response[0];
 
                 expect(response.cnt).toBe(5, "Int count not null is incorrect");
                 expect(response.unique).toBe(4, "Int unique count is incorrect");
@@ -74,7 +72,6 @@ exports.execute = function (options) {
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
-                response = response[0];
 
                 expect(response.cnt).toBe(4, "Float count not null is incorrect");
                 expect(response.unique).toBe(4, "Float unique count is incorrect");
@@ -98,7 +95,6 @@ exports.execute = function (options) {
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
-                response = response[0];
 
                 expect(response.cnt).toBe(4, "Text count not null is incorrect");
                 expect(response.unique).toBe(3, "Text unique count is incorrect");
@@ -122,7 +118,6 @@ exports.execute = function (options) {
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
-                response = response[0];
 
                 expect(response.cnt).toBe(3, "Date count not null is incorrect");
                 expect(response.unique).toBe(3, "Date unique count is incorrect");
@@ -146,7 +141,6 @@ exports.execute = function (options) {
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
-                response = response[0];
 
                 expect(response.cnt).toBe(5, "Timestamp count not null is incorrect");
                 expect(response.unique).toBe(5, "Timestamp unique count is incorrect");
@@ -171,7 +165,6 @@ exports.execute = function (options) {
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
-                response = response[0];
 
                 // returned values have keys based on their index in the aggregateList
                 // int aggs

--- a/test/specs/reference/tests/17.aggregates.js
+++ b/test/specs/reference/tests/17.aggregates.js
@@ -156,25 +156,161 @@ exports.execute = function (options) {
 
         it("should get aggregates for different columns without aliases being set.", function(done) {
             var aggregateList = [
+                // int aggs
                 reference.columns[1].aggregate.countNotNullAgg(),
                 reference.columns[1].aggregate.minAgg(),
                 reference.columns[1].aggregate.maxAgg(),
+                // float aggs
                 reference.columns[2].aggregate.countNotNullAgg(),
                 reference.columns[2].aggregate.minAgg(),
                 reference.columns[2].aggregate.maxAgg()
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
-
                 // returned values have keys based on their index in the aggregateList
                 // int aggs
-                expect(response['0']).toBe(5);
-                expect(response['1']).toBe(2);
-                expect(response['2']).toBe(215);
+                expect(response['0']).toBe(5, "Int count not null is incorrect");
+                expect(response['1']).toBe(2, "Int min value is incorrect");
+                expect(response['2']).toBe(215, "Int max value is incorrect");
                 // float aggs
-                expect(response['3']).toBe(4);
-                expect(response['4']).toBe(0.4222);
-                expect(response['5']).toBe(36.9201);
+                expect(response['3']).toBe(4, "Float count not null is incorrect");
+                expect(response['4']).toBe(0.4222, "Float min value is incorrect");
+                expect(response['5']).toBe(36.9201, "Float max value is incorrect");
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+
+        // verifies that aliasing when not set is based on aggregate list index
+        it("should get aggregates for different columns with some aliases being set.", function(done) {
+            var aggregateList = [
+                // int aggs
+                reference.columns[1].aggregate.countNotNullAgg(),
+                reference.columns[1].aggregate.minAgg("int_min"),
+                reference.columns[1].aggregate.maxAgg(),
+                // float aggs
+                reference.columns[2].aggregate.countNotNullAgg("float_cnt"),
+                reference.columns[2].aggregate.minAgg(),
+                reference.columns[2].aggregate.maxAgg(),
+                // text agg
+                reference.columns[3].aggregate.minAgg("text_min")
+            ];
+
+            reference.getAggregates(aggregateList).then(function (response) {
+                // returned values have keys based on their index in the aggregateList
+                // int aggs
+                expect(response['0']).toBe(5, "Int count not null is incorrect");
+                expect(response.int_min).toBe(2, "Int min value is incorrect");
+                expect(response['2']).toBe(215, "Int max value is incorrect");
+                // float aggs
+                expect(response.float_cnt).toBe(4, "Float count not null is incorrect");
+                expect(response['4']).toBe(0.4222, "Float min value is incorrect");
+                expect(response['5']).toBe(36.9201, "Float max value is incorrect");
+                // text agg
+                expect(response.text_min).toBe("bread", "Text min value is incorrect");
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+
+        // Produces 2 request URLs. One of length 2036 and the other is 410. All data should be lumped into one response though
+        it("should get aggregates for different columns when there are too many aggregates for one request.", function(done) {
+            var aggregateList = [
+                // int aggs
+                reference.columns[1].aggregate.countNotNullAgg("int_count_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[1].aggregate.countDistinctAgg("int_distinct_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[1].aggregate.minAgg("int_min_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[1].aggregate.maxAgg("int_max_agg_long_name_but_the_name_was_not_long_enough"),
+                // float aggs
+                reference.columns[2].aggregate.countNotNullAgg("float_count_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[2].aggregate.countDistinctAgg("float_distinct_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[2].aggregate.minAgg("float_min_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[2].aggregate.maxAgg("float_max_agg_long_name_but_the_name_was_not_long_enough"),
+                // text aggs
+                reference.columns[3].aggregate.countNotNullAgg("text_count_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[3].aggregate.countDistinctAgg("text_distinct_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[3].aggregate.minAgg("text_min_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[3].aggregate.maxAgg("text_max_agg_long_name_but_the_name_was_not_long_enough"),
+                // date aggs
+                reference.columns[4].aggregate.countNotNullAgg("date_count_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[4].aggregate.countDistinctAgg("date_distinct_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[4].aggregate.minAgg("date_min_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[4].aggregate.maxAgg("date_max_agg_long_name_but_the_name_was_not_long_enough"),
+                // timestamp aggs
+                reference.columns[5].aggregate.countNotNullAgg("t_stamp_count_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[5].aggregate.countDistinctAgg("t_stamp_distinct_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[5].aggregate.minAgg("t_stamp_min_agg_long_name_but_the_name_was_not_long_enough"),
+                reference.columns[5].aggregate.maxAgg("t_stamp_max_agg_long_name_but_the_name_was_not_long_enough"),
+
+                // repeated aggregates with a different alias because length is still not passed the limit
+                // int aggs 2
+                reference.columns[1].aggregate.countNotNullAgg("int_count_agg_long_name_again_to_increase_limit"),
+                reference.columns[1].aggregate.countDistinctAgg("int_distinct_agg_long_name_again_to_increase_limit"),
+                reference.columns[1].aggregate.minAgg("int_min_agg_long_name_again_to_increase_limit"),
+                reference.columns[1].aggregate.maxAgg("int_max_agg_long_name_again_to_increase_limit"),
+                // float aggs 2
+                reference.columns[2].aggregate.countNotNullAgg("float_count_agg_long_name_again_to_increase_limit"),
+                reference.columns[2].aggregate.countDistinctAgg("float_distinct_agg_long_name_again_to_increase_limit"),
+                reference.columns[2].aggregate.minAgg("float_min_agg_long_name_again_to_increase_limit"),
+                reference.columns[2].aggregate.maxAgg("float_max_agg_long_name_again_to_increase_limit"),
+                // text aggs 2
+                reference.columns[3].aggregate.countNotNullAgg("text_count_agg_long_name_again_to_increase_limit"),
+                reference.columns[3].aggregate.countDistinctAgg("text_distinct_agg_long_name_again_to_increase_limit"),
+                reference.columns[3].aggregate.minAgg("text_min_agg_long_name_again_to_increase_limit"),
+                reference.columns[3].aggregate.maxAgg("text_max_agg_long_name_again_to_increase_limit")
+            ];
+
+            reference.getAggregates(aggregateList).then(function (response) {
+
+                expect(response).toEqual(jasmine.any(Object));
+
+                // int aggs
+                expect(response.int_count_agg_long_name_but_the_name_was_not_long_enough).toBe(5, "Int count not null is incorrect");
+                expect(response.int_distinct_agg_long_name_but_the_name_was_not_long_enough).toBe(4, "Int unique count is incorrect");
+                expect(response.int_min_agg_long_name_but_the_name_was_not_long_enough).toBe(2, "Int min value is incorrect");
+                expect(response.int_max_agg_long_name_but_the_name_was_not_long_enough).toBe(215, "Int max value is incorrect");
+                // float aggs
+                expect(response.float_count_agg_long_name_but_the_name_was_not_long_enough).toBe(4, "Float count not null is incorrect");
+                expect(response.float_distinct_agg_long_name_but_the_name_was_not_long_enough).toBe(4, "Float unique count is incorrect");
+                expect(response.float_min_agg_long_name_but_the_name_was_not_long_enough).toBe(0.4222, "Float min value is incorrect");
+                expect(response.float_max_agg_long_name_but_the_name_was_not_long_enough).toBe(36.9201, "Float max value is incorrect");
+                // text aggs
+                expect(response.text_count_agg_long_name_but_the_name_was_not_long_enough).toBe(4, "Text count not null is incorrect");
+                expect(response.text_distinct_agg_long_name_but_the_name_was_not_long_enough).toBe(3, "Text unique count is incorrect");
+                expect(response.text_min_agg_long_name_but_the_name_was_not_long_enough).toBe("bread", "Text min value is incorrect");
+                expect(response.text_max_agg_long_name_but_the_name_was_not_long_enough).toBe("sandwich", "Text max value is incorrect");
+                // date aggs
+                expect(response.date_count_agg_long_name_but_the_name_was_not_long_enough).toBe(3, "Date count not null is incorrect");
+                expect(response.date_distinct_agg_long_name_but_the_name_was_not_long_enough).toBe(3, "Date unique count is incorrect");
+                expect(response.date_min_agg_long_name_but_the_name_was_not_long_enough).toBe("2015-01-11", "Date min value is incorrect");
+                expect(response.date_max_agg_long_name_but_the_name_was_not_long_enough).toBe("2017-07-17", "Date max value is incorrect");
+                // timestamp aggs
+                expect(response.t_stamp_count_agg_long_name_but_the_name_was_not_long_enough).toBe(5, "Timestamp count not null is incorrect");
+                expect(response.t_stamp_distinct_agg_long_name_but_the_name_was_not_long_enough).toBe(5, "Timestamp unique count is incorrect");
+                expect(response.t_stamp_min_agg_long_name_but_the_name_was_not_long_enough).toBe("2010-05-22T17:44:00", "Timestamp min value is incorrect");
+                expect(response.t_stamp_max_agg_long_name_but_the_name_was_not_long_enough).toBe("2017-04-13T14:10:00", "Timestamp max value is incorrect");
+
+                // repeated aggregates with a different alias
+                expect(response.int_count_agg_long_name_again_to_increase_limit).toBe(5, "Int count not null 2 is incorrect");
+                expect(response.int_distinct_agg_long_name_again_to_increase_limit).toBe(4, "Int unique count 2 is incorrect");
+                expect(response.int_min_agg_long_name_again_to_increase_limit).toBe(2, "Int min value 2 is incorrect");
+                expect(response.int_max_agg_long_name_again_to_increase_limit).toBe(215, "Int max value 2 is incorrect");
+                // float aggs
+                expect(response.float_count_agg_long_name_again_to_increase_limit).toBe(4, "Float count not null 2 is incorrect");
+                expect(response.float_distinct_agg_long_name_again_to_increase_limit).toBe(4, "Float unique count 2 is incorrect");
+                expect(response.float_min_agg_long_name_again_to_increase_limit).toBe(0.4222, "Float min value 2 is incorrect");
+                expect(response.float_max_agg_long_name_again_to_increase_limit).toBe(36.9201, "Float max value 2 is incorrect");
+                // text aggs
+                expect(response.text_count_agg_long_name_again_to_increase_limit).toBe(4, "Text count not null 2 is incorrect");
+                expect(response.text_distinct_agg_long_name_again_to_increase_limit).toBe(3, "Text unique count 2 is incorrect");
+                expect(response.text_min_agg_long_name_again_to_increase_limit).toBe("bread", "Text min value 2 is incorrect");
+                expect(response.text_max_agg_long_name_again_to_increase_limit).toBe("sandwich", "Text max value 2 is incorrect");
 
                 done();
             }).catch(function (error) {

--- a/test/specs/reference/tests/17.aggregates.js
+++ b/test/specs/reference/tests/17.aggregates.js
@@ -1,0 +1,163 @@
+exports.execute = function (options) {
+    // Test Cases:
+    describe("for testing default values while creating an entity/entities,", function () {
+        var reference;
+        var catalog_id = process.env.DEFAULT_CATALOG,
+            schemaName = "aggregate_schema",
+            tableName = "aggregate_table";
+
+        // Columns in aggregate table are as follows:
+        // [id, int_agg, float_agg, text_agg, date_agg, timestamp_agg]
+
+        var baseUri = options.url + "/catalog/" + catalog_id + "/entity/"
+            + schemaName + ":" + tableName;
+
+        beforeAll(function (done) {
+            options.ermRest.resolve(baseUri, {cid: "test"}).then(function (response) {
+                reference = response;
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+
+        it("should get the aggregate count for the aggregate_table table.", function(done) {
+            var aggregateList = [
+                reference.aggregate.countAgg("cnt")
+            ];
+
+            reference.getAggregates(aggregateList).then(function (response) {
+                response = response[0];
+
+                expect(response.cnt).toBe(5, "Table count is incorrect");
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+
+        it("should get aggregates for int_agg column.", function(done) {
+            var intColumnAggs = reference.columns[1].aggregate;
+            var aggregateList = [
+                intColumnAggs.countNotNullAgg("cnt"),
+                intColumnAggs.countDistinctAgg("unique"),
+                intColumnAggs.minAgg("min"),
+                intColumnAggs.maxAgg("max")
+            ];
+
+            reference.getAggregates(aggregateList).then(function (response) {
+                response = response[0];
+
+                expect(response.cnt).toBe(5, "Int count not null is incorrect");
+                expect(response.unique).toBe(4, "Int unique count is incorrect");
+                expect(response.min).toBe(2, "Int min value is incorrect");
+                expect(response.max).toBe(215, "Int max value is incorrect");
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+
+        it("should get aggregates for float_agg column.", function(done) {
+            var floatColumnAggs = reference.columns[2].aggregate;
+            var aggregateList = [
+                floatColumnAggs.countNotNullAgg("cnt"),
+                floatColumnAggs.countDistinctAgg("unique"),
+                floatColumnAggs.minAgg("min"),
+                floatColumnAggs.maxAgg("max")
+            ];
+
+            reference.getAggregates(aggregateList).then(function (response) {
+                response = response[0];
+
+                expect(response.cnt).toBe(4, "Float count not null is incorrect");
+                expect(response.unique).toBe(4, "Float unique count is incorrect");
+                expect(response.min).toBe(0.4222, "Float min value is incorrect");
+                expect(response.max).toBe(36.9201, "Float max value is incorrect");
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+
+        it("should get aggregates for text_agg column.", function(done) {
+            var textColumnAggs = reference.columns[3].aggregate;
+            var aggregateList = [
+                textColumnAggs.countNotNullAgg("cnt"),
+                textColumnAggs.countDistinctAgg("unique"),
+                textColumnAggs.minAgg("min"),
+                textColumnAggs.maxAgg("max")
+            ];
+
+            reference.getAggregates(aggregateList).then(function (response) {
+                response = response[0];
+
+                expect(response.cnt).toBe(4, "Text count not null is incorrect");
+                expect(response.unique).toBe(3, "Text unique count is incorrect");
+                expect(response.min).toBe("bread", "Text min value is incorrect");
+                expect(response.max).toBe("sandwich", "Text max value is incorrect");
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+
+        it("should get aggregates for date_agg column.", function(done) {
+            var dateColumnAggs = reference.columns[4].aggregate;
+            var aggregateList = [
+                dateColumnAggs.countNotNullAgg("cnt"),
+                dateColumnAggs.countDistinctAgg("unique"),
+                dateColumnAggs.minAgg("min"),
+                dateColumnAggs.maxAgg("max")
+            ];
+
+            reference.getAggregates(aggregateList).then(function (response) {
+                response = response[0];
+
+                expect(response.cnt).toBe(3, "Date count not null is incorrect");
+                expect(response.unique).toBe(3, "Date unique count is incorrect");
+                expect(response.min).toBe("2015-01-11", "Date min value is incorrect");
+                expect(response.max).toBe("2017-07-17", "Date max value is incorrect");
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+
+        it("should get aggregates for timestamp_agg column.", function(done) {
+            var timestampColumnAggs = reference.columns[5].aggregate;
+            var aggregateList = [
+                timestampColumnAggs.countNotNullAgg("cnt"),
+                timestampColumnAggs.countDistinctAgg("unique"),
+                timestampColumnAggs.minAgg("min"),
+                timestampColumnAggs.maxAgg("max")
+            ];
+
+            reference.getAggregates(aggregateList).then(function (response) {
+                response = response[0];
+
+                expect(response.cnt).toBe(5, "Timestamp count not null is incorrect");
+                expect(response.unique).toBe(5, "Timestamp unique count is incorrect");
+                expect(response.min).toBe("2010-05-22T17:44:00", "Timestamp min value is incorrect");
+                expect(response.max).toBe("2017-04-13T14:10:00", "Timestamp max value is incorrect");
+
+                done();
+            }).catch(function (error) {
+                console.dir(error);
+                done.fail();
+            });
+        });
+    });
+}

--- a/test/specs/reference/tests/17.aggregates.js
+++ b/test/specs/reference/tests/17.aggregates.js
@@ -1,6 +1,6 @@
 exports.execute = function (options) {
     // Test Cases:
-    describe("for testing default values while creating an entity/entities,", function () {
+    describe("for testing aggregate functions on tables and columns,", function () {
         var reference;
         var catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "aggregate_schema",
@@ -25,12 +25,12 @@ exports.execute = function (options) {
 
         it("should get the aggregate count for the aggregate_table table.", function(done) {
             var aggregateList = [
-                reference.aggregate.countAgg("cnt")
+                reference.aggregate.countAgg()
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
 
-                expect(response.cnt).toBe(5, "Table count is incorrect");
+                expect(response[0]).toBe(5, "Table count is incorrect");
 
                 done();
             }).catch(function (error) {
@@ -42,18 +42,18 @@ exports.execute = function (options) {
         it("should get aggregates for int_agg column.", function(done) {
             var intColumnAggs = reference.columns[1].aggregate;
             var aggregateList = [
-                intColumnAggs.countNotNullAgg("cnt"),
-                intColumnAggs.countDistinctAgg("unique"),
-                intColumnAggs.minAgg("min"),
-                intColumnAggs.maxAgg("max")
+                intColumnAggs.countNotNullAgg(),
+                intColumnAggs.countDistinctAgg(),
+                intColumnAggs.minAgg(),
+                intColumnAggs.maxAgg()
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
 
-                expect(response.cnt).toBe(5, "Int count not null is incorrect");
-                expect(response.unique).toBe(4, "Int unique count is incorrect");
-                expect(response.min).toBe(2, "Int min value is incorrect");
-                expect(response.max).toBe(215, "Int max value is incorrect");
+                expect(response[0]).toBe(5, "Int count not null is incorrect");
+                expect(response[1]).toBe(4, "Int unique count is incorrect");
+                expect(response[2]).toBe(2, "Int min value is incorrect");
+                expect(response[3]).toBe(215, "Int max value is incorrect");
 
                 done();
             }).catch(function (error) {
@@ -65,18 +65,18 @@ exports.execute = function (options) {
         it("should get aggregates for float_agg column.", function(done) {
             var floatColumnAggs = reference.columns[2].aggregate;
             var aggregateList = [
-                floatColumnAggs.countNotNullAgg("cnt"),
-                floatColumnAggs.countDistinctAgg("unique"),
-                floatColumnAggs.minAgg("min"),
-                floatColumnAggs.maxAgg("max")
+                floatColumnAggs.countNotNullAgg(),
+                floatColumnAggs.countDistinctAgg(),
+                floatColumnAggs.minAgg(),
+                floatColumnAggs.maxAgg()
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
 
-                expect(response.cnt).toBe(4, "Float count not null is incorrect");
-                expect(response.unique).toBe(4, "Float unique count is incorrect");
-                expect(response.min).toBe(0.4222, "Float min value is incorrect");
-                expect(response.max).toBe(36.9201, "Float max value is incorrect");
+                expect(response[0]).toBe(4, "Float count not null is incorrect");
+                expect(response[1]).toBe(4, "Float unique count is incorrect");
+                expect(response[2]).toBe(0.4222, "Float min value is incorrect");
+                expect(response[3]).toBe(36.9201, "Float max value is incorrect");
 
                 done();
             }).catch(function (error) {
@@ -88,18 +88,18 @@ exports.execute = function (options) {
         it("should get aggregates for text_agg column.", function(done) {
             var textColumnAggs = reference.columns[3].aggregate;
             var aggregateList = [
-                textColumnAggs.countNotNullAgg("cnt"),
-                textColumnAggs.countDistinctAgg("unique"),
-                textColumnAggs.minAgg("min"),
-                textColumnAggs.maxAgg("max")
+                textColumnAggs.countNotNullAgg(),
+                textColumnAggs.countDistinctAgg(),
+                textColumnAggs.minAgg(),
+                textColumnAggs.maxAgg()
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
 
-                expect(response.cnt).toBe(4, "Text count not null is incorrect");
-                expect(response.unique).toBe(3, "Text unique count is incorrect");
-                expect(response.min).toBe("bread", "Text min value is incorrect");
-                expect(response.max).toBe("sandwich", "Text max value is incorrect");
+                expect(response[0]).toBe(4, "Text count not null is incorrect");
+                expect(response[1]).toBe(3, "Text unique count is incorrect");
+                expect(response[2]).toBe("bread", "Text min value is incorrect");
+                expect(response[3]).toBe("sandwich", "Text max value is incorrect");
 
                 done();
             }).catch(function (error) {
@@ -111,18 +111,18 @@ exports.execute = function (options) {
         it("should get aggregates for date_agg column.", function(done) {
             var dateColumnAggs = reference.columns[4].aggregate;
             var aggregateList = [
-                dateColumnAggs.countNotNullAgg("cnt"),
-                dateColumnAggs.countDistinctAgg("unique"),
-                dateColumnAggs.minAgg("min"),
-                dateColumnAggs.maxAgg("max")
+                dateColumnAggs.countNotNullAgg(),
+                dateColumnAggs.countDistinctAgg(),
+                dateColumnAggs.minAgg(),
+                dateColumnAggs.maxAgg()
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
 
-                expect(response.cnt).toBe(3, "Date count not null is incorrect");
-                expect(response.unique).toBe(3, "Date unique count is incorrect");
-                expect(response.min).toBe("2015-01-11", "Date min value is incorrect");
-                expect(response.max).toBe("2017-07-17", "Date max value is incorrect");
+                expect(response[0]).toBe(3, "Date count not null is incorrect");
+                expect(response[1]).toBe(3, "Date unique count is incorrect");
+                expect(response[2]).toBe("2015-01-11", "Date min value is incorrect");
+                expect(response[3]).toBe("2017-07-17", "Date max value is incorrect");
 
                 done();
             }).catch(function (error) {
@@ -134,183 +134,18 @@ exports.execute = function (options) {
         it("should get aggregates for timestamp_agg column.", function(done) {
             var timestampColumnAggs = reference.columns[5].aggregate;
             var aggregateList = [
-                timestampColumnAggs.countNotNullAgg("cnt"),
-                timestampColumnAggs.countDistinctAgg("unique"),
-                timestampColumnAggs.minAgg("min"),
-                timestampColumnAggs.maxAgg("max")
+                timestampColumnAggs.countNotNullAgg(),
+                timestampColumnAggs.countDistinctAgg(),
+                timestampColumnAggs.minAgg(),
+                timestampColumnAggs.maxAgg()
             ];
 
             reference.getAggregates(aggregateList).then(function (response) {
 
-                expect(response.cnt).toBe(5, "Timestamp count not null is incorrect");
-                expect(response.unique).toBe(5, "Timestamp unique count is incorrect");
-                expect(response.min).toBe("2010-05-22T17:44:00", "Timestamp min value is incorrect");
-                expect(response.max).toBe("2017-04-13T14:10:00", "Timestamp max value is incorrect");
-
-                done();
-            }).catch(function (error) {
-                console.dir(error);
-                done.fail();
-            });
-        });
-
-        it("should get aggregates for different columns without aliases being set.", function(done) {
-            var aggregateList = [
-                // int aggs
-                reference.columns[1].aggregate.countNotNullAgg(),
-                reference.columns[1].aggregate.minAgg(),
-                reference.columns[1].aggregate.maxAgg(),
-                // float aggs
-                reference.columns[2].aggregate.countNotNullAgg(),
-                reference.columns[2].aggregate.minAgg(),
-                reference.columns[2].aggregate.maxAgg()
-            ];
-
-            reference.getAggregates(aggregateList).then(function (response) {
-                // returned values have keys based on their index in the aggregateList
-                // int aggs
-                expect(response['0']).toBe(5, "Int count not null is incorrect");
-                expect(response['1']).toBe(2, "Int min value is incorrect");
-                expect(response['2']).toBe(215, "Int max value is incorrect");
-                // float aggs
-                expect(response['3']).toBe(4, "Float count not null is incorrect");
-                expect(response['4']).toBe(0.4222, "Float min value is incorrect");
-                expect(response['5']).toBe(36.9201, "Float max value is incorrect");
-
-                done();
-            }).catch(function (error) {
-                console.dir(error);
-                done.fail();
-            });
-        });
-
-        // verifies that aliasing when not set is based on aggregate list index
-        it("should get aggregates for different columns with some aliases being set.", function(done) {
-            var aggregateList = [
-                // int aggs
-                reference.columns[1].aggregate.countNotNullAgg(),
-                reference.columns[1].aggregate.minAgg("int_min"),
-                reference.columns[1].aggregate.maxAgg(),
-                // float aggs
-                reference.columns[2].aggregate.countNotNullAgg("float_cnt"),
-                reference.columns[2].aggregate.minAgg(),
-                reference.columns[2].aggregate.maxAgg(),
-                // text agg
-                reference.columns[3].aggregate.minAgg("text_min")
-            ];
-
-            reference.getAggregates(aggregateList).then(function (response) {
-                // returned values have keys based on their index in the aggregateList
-                // int aggs
-                expect(response['0']).toBe(5, "Int count not null is incorrect");
-                expect(response.int_min).toBe(2, "Int min value is incorrect");
-                expect(response['2']).toBe(215, "Int max value is incorrect");
-                // float aggs
-                expect(response.float_cnt).toBe(4, "Float count not null is incorrect");
-                expect(response['4']).toBe(0.4222, "Float min value is incorrect");
-                expect(response['5']).toBe(36.9201, "Float max value is incorrect");
-                // text agg
-                expect(response.text_min).toBe("bread", "Text min value is incorrect");
-
-                done();
-            }).catch(function (error) {
-                console.dir(error);
-                done.fail();
-            });
-        });
-
-        // Produces 2 request URLs. One of length 2036 and the other is 410. All data should be lumped into one response though
-        it("should get aggregates for different columns when there are too many aggregates for one request.", function(done) {
-            var aggregateList = [
-                // int aggs
-                reference.columns[1].aggregate.countNotNullAgg("int_count_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[1].aggregate.countDistinctAgg("int_distinct_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[1].aggregate.minAgg("int_min_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[1].aggregate.maxAgg("int_max_agg_long_name_but_the_name_was_not_long_enough"),
-                // float aggs
-                reference.columns[2].aggregate.countNotNullAgg("float_count_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[2].aggregate.countDistinctAgg("float_distinct_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[2].aggregate.minAgg("float_min_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[2].aggregate.maxAgg("float_max_agg_long_name_but_the_name_was_not_long_enough"),
-                // text aggs
-                reference.columns[3].aggregate.countNotNullAgg("text_count_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[3].aggregate.countDistinctAgg("text_distinct_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[3].aggregate.minAgg("text_min_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[3].aggregate.maxAgg("text_max_agg_long_name_but_the_name_was_not_long_enough"),
-                // date aggs
-                reference.columns[4].aggregate.countNotNullAgg("date_count_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[4].aggregate.countDistinctAgg("date_distinct_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[4].aggregate.minAgg("date_min_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[4].aggregate.maxAgg("date_max_agg_long_name_but_the_name_was_not_long_enough"),
-                // timestamp aggs
-                reference.columns[5].aggregate.countNotNullAgg("t_stamp_count_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[5].aggregate.countDistinctAgg("t_stamp_distinct_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[5].aggregate.minAgg("t_stamp_min_agg_long_name_but_the_name_was_not_long_enough"),
-                reference.columns[5].aggregate.maxAgg("t_stamp_max_agg_long_name_but_the_name_was_not_long_enough"),
-
-                // repeated aggregates with a different alias because length is still not passed the limit
-                // int aggs 2
-                reference.columns[1].aggregate.countNotNullAgg("int_count_agg_long_name_again_to_increase_limit"),
-                reference.columns[1].aggregate.countDistinctAgg("int_distinct_agg_long_name_again_to_increase_limit"),
-                reference.columns[1].aggregate.minAgg("int_min_agg_long_name_again_to_increase_limit"),
-                reference.columns[1].aggregate.maxAgg("int_max_agg_long_name_again_to_increase_limit"),
-                // float aggs 2
-                reference.columns[2].aggregate.countNotNullAgg("float_count_agg_long_name_again_to_increase_limit"),
-                reference.columns[2].aggregate.countDistinctAgg("float_distinct_agg_long_name_again_to_increase_limit"),
-                reference.columns[2].aggregate.minAgg("float_min_agg_long_name_again_to_increase_limit"),
-                reference.columns[2].aggregate.maxAgg("float_max_agg_long_name_again_to_increase_limit"),
-                // text aggs 2
-                reference.columns[3].aggregate.countNotNullAgg("text_count_agg_long_name_again_to_increase_limit"),
-                reference.columns[3].aggregate.countDistinctAgg("text_distinct_agg_long_name_again_to_increase_limit"),
-                reference.columns[3].aggregate.minAgg("text_min_agg_long_name_again_to_increase_limit"),
-                reference.columns[3].aggregate.maxAgg("text_max_agg_long_name_again_to_increase_limit")
-            ];
-
-            reference.getAggregates(aggregateList).then(function (response) {
-
-                expect(response).toEqual(jasmine.any(Object));
-
-                // int aggs
-                expect(response.int_count_agg_long_name_but_the_name_was_not_long_enough).toBe(5, "Int count not null is incorrect");
-                expect(response.int_distinct_agg_long_name_but_the_name_was_not_long_enough).toBe(4, "Int unique count is incorrect");
-                expect(response.int_min_agg_long_name_but_the_name_was_not_long_enough).toBe(2, "Int min value is incorrect");
-                expect(response.int_max_agg_long_name_but_the_name_was_not_long_enough).toBe(215, "Int max value is incorrect");
-                // float aggs
-                expect(response.float_count_agg_long_name_but_the_name_was_not_long_enough).toBe(4, "Float count not null is incorrect");
-                expect(response.float_distinct_agg_long_name_but_the_name_was_not_long_enough).toBe(4, "Float unique count is incorrect");
-                expect(response.float_min_agg_long_name_but_the_name_was_not_long_enough).toBe(0.4222, "Float min value is incorrect");
-                expect(response.float_max_agg_long_name_but_the_name_was_not_long_enough).toBe(36.9201, "Float max value is incorrect");
-                // text aggs
-                expect(response.text_count_agg_long_name_but_the_name_was_not_long_enough).toBe(4, "Text count not null is incorrect");
-                expect(response.text_distinct_agg_long_name_but_the_name_was_not_long_enough).toBe(3, "Text unique count is incorrect");
-                expect(response.text_min_agg_long_name_but_the_name_was_not_long_enough).toBe("bread", "Text min value is incorrect");
-                expect(response.text_max_agg_long_name_but_the_name_was_not_long_enough).toBe("sandwich", "Text max value is incorrect");
-                // date aggs
-                expect(response.date_count_agg_long_name_but_the_name_was_not_long_enough).toBe(3, "Date count not null is incorrect");
-                expect(response.date_distinct_agg_long_name_but_the_name_was_not_long_enough).toBe(3, "Date unique count is incorrect");
-                expect(response.date_min_agg_long_name_but_the_name_was_not_long_enough).toBe("2015-01-11", "Date min value is incorrect");
-                expect(response.date_max_agg_long_name_but_the_name_was_not_long_enough).toBe("2017-07-17", "Date max value is incorrect");
-                // timestamp aggs
-                expect(response.t_stamp_count_agg_long_name_but_the_name_was_not_long_enough).toBe(5, "Timestamp count not null is incorrect");
-                expect(response.t_stamp_distinct_agg_long_name_but_the_name_was_not_long_enough).toBe(5, "Timestamp unique count is incorrect");
-                expect(response.t_stamp_min_agg_long_name_but_the_name_was_not_long_enough).toBe("2010-05-22T17:44:00", "Timestamp min value is incorrect");
-                expect(response.t_stamp_max_agg_long_name_but_the_name_was_not_long_enough).toBe("2017-04-13T14:10:00", "Timestamp max value is incorrect");
-
-                // repeated aggregates with a different alias
-                expect(response.int_count_agg_long_name_again_to_increase_limit).toBe(5, "Int count not null 2 is incorrect");
-                expect(response.int_distinct_agg_long_name_again_to_increase_limit).toBe(4, "Int unique count 2 is incorrect");
-                expect(response.int_min_agg_long_name_again_to_increase_limit).toBe(2, "Int min value 2 is incorrect");
-                expect(response.int_max_agg_long_name_again_to_increase_limit).toBe(215, "Int max value 2 is incorrect");
-                // float aggs
-                expect(response.float_count_agg_long_name_again_to_increase_limit).toBe(4, "Float count not null 2 is incorrect");
-                expect(response.float_distinct_agg_long_name_again_to_increase_limit).toBe(4, "Float unique count 2 is incorrect");
-                expect(response.float_min_agg_long_name_again_to_increase_limit).toBe(0.4222, "Float min value 2 is incorrect");
-                expect(response.float_max_agg_long_name_again_to_increase_limit).toBe(36.9201, "Float max value 2 is incorrect");
-                // text aggs
-                expect(response.text_count_agg_long_name_again_to_increase_limit).toBe(4, "Text count not null 2 is incorrect");
-                expect(response.text_distinct_agg_long_name_again_to_increase_limit).toBe(3, "Text unique count 2 is incorrect");
-                expect(response.text_min_agg_long_name_again_to_increase_limit).toBe("bread", "Text min value 2 is incorrect");
-                expect(response.text_max_agg_long_name_again_to_increase_limit).toBe("sandwich", "Text max value 2 is incorrect");
+                expect(response[0]).toBe(5, "Timestamp count not null is incorrect");
+                expect(response[1]).toBe(5, "Timestamp unique count is incorrect");
+                expect(response[2]).toBe("2010-05-22T17:44:00", "Timestamp min value is incorrect");
+                expect(response[3]).toBe("2017-04-13T14:10:00", "Timestamp max value is incorrect");
 
                 done();
             }).catch(function (error) {


### PR DESCRIPTION
This PR adds basic functionality for column aggregates (count not null, count distinct, min, and max) and table aggregates (count not null). This is for issue #304.