### PR TITLE
Change Search Operator

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -3634,8 +3634,7 @@ URI should be to the ERMrest _service_. For example,
 <a name="ERMrest.parse"></a>
 
 ### ERMrest.parse(uri) ⇒ <code>ERMrest.Location</code>
-This is an internal function that parses a URI and constructs an
-internal representation of the URI.
+This function parses a URI and constructs a representation of the URI.
 
 **Kind**: static method of [<code>ERMrest</code>](#ERMrest)  
 **Returns**: <code>ERMrest.Location</code> - Location object created from the URI.  

--- a/js/parser.js
+++ b/js/parser.js
@@ -146,7 +146,7 @@ var ERMrest = (function(module) {
         }
 
         // Split compact path on '/'
-        // Expected format: "<schema:table>/<filter(s)>/<joins(s)/<search>"
+        // Expected format: "<schema:table>/<filter(s)>/<joins(s)>/<search>"
         parts = this._compactPath.split('/');
 
         var index = parts.length - 1;
@@ -283,6 +283,8 @@ var ERMrest = (function(module) {
 
         /**
          * <service>/catalog/<catalogId>/<api>/<projectionSchema:projectionTable>/<filters>/<joins>/<search>/<sort>/<page>/<queryParams>
+         * NOTE: some of the components might not be understanable by ermrest, because of pseudo operator (e.g., ::search::).
+         * 
          * @returns {String} The full URI of the location
          */
         get uri() {
@@ -294,6 +296,8 @@ var ERMrest = (function(module) {
 
         /**
          * <service>/catalog/<catalogId>/<api>/<projectionSchema:projectionTable>/<filters>/<joins>/<search>
+         *
+         * NOTE: some of the components might not be understanable by ermrest, because of pseudo operator (e.g., ::search::).
          * @returns {String} The URI without modifiers or queries
          */
         get compactUri() {
@@ -306,6 +310,8 @@ var ERMrest = (function(module) {
         
         /**
          * <projectionSchema:projectionTable>/<filters>/<joins>/<search>/<sort>/<page>/<queryParams>
+         *  NOTE: some of the components might not be understanable by ermrest, because of pseudo operator (e.g., ::search::).
+         *  
          * @returns {String} Path portion of the URI
          * This is everything after the catalog id
          */
@@ -318,6 +324,8 @@ var ERMrest = (function(module) {
 
         /**
          * <projectionSchema:projectionTable>/<filters>/<joins>/<search>
+         * NOTE: some of the components might not be understanable by ermrest, because of pseudo operator (e.g., ::search::).
+         * 
          * @returns {String} Path without modifiers or queries
          */
         get compactPath() {
@@ -350,6 +358,8 @@ var ERMrest = (function(module) {
         
         /**
          * should only be used for internal usage and sending request to ermrest
+         * NOTE: returns a uri that ermrest understands
+         * 
          * <service>/catalog/<catalogId>/<api>/<projectionSchema:projectionTable>/<filters>/<joins>/<search>/<sort>/<page>/<queryParams>
          * @returns {String} The full URI of the location for ermrest
          */
@@ -363,6 +373,8 @@ var ERMrest = (function(module) {
         /**
          * should only be used for internal usage and sending request to ermrest
          * <projectionSchema:projectionTable>/<filters>/<joins>/<search>
+         *
+         * NOTE: returns a uri that ermrest understands
          * @returns {String} The URI without modifiers or queries for ermrest
          */
         get ermrestCompactUri() {
@@ -375,6 +387,8 @@ var ERMrest = (function(module) {
         
         /**
          * should only be used for internal usage and sending request to ermrest
+         * 
+         * NOTE: returns a path that ermrest understands
          * @returns {String} Path portion of the URI
          * This is everything after the catalog id for ermrest
          */
@@ -387,6 +401,8 @@ var ERMrest = (function(module) {
 
         /**
          * should only be used for internal usage and sending request to ermrest
+         *
+         * NOTE: returns a path that ermrest understands
          * @returns {String} Path without modifiers or queries for ermrest
          */
         get ermrestCompactPath() {

--- a/js/reference.js
+++ b/js/reference.js
@@ -470,7 +470,7 @@ var ERMrest = (function(module) {
                 var defaults = getDefaults();
 
                 // construct the uri
-                var uri = this._location.compactUri;
+                var uri = this._location.ermrestCompactUri;
                 for (var i = 0; i < defaults.length; i++) {
                     uri += (i === 0 ? "?defaults=" : ',') + module._fixedEncodeURIComponent(defaults[i]);
                 }
@@ -725,7 +725,7 @@ var ERMrest = (function(module) {
                  *   4. There is no trailing `/` in uri (as it will break the ermrest too).
                  * */
                 if (this._table.foreignKeys.length() > 0) {
-                    var compactPath = this._location.compactPath,
+                    var compactPath = this._location.ermrestCompactPath,
                         tableIndex = 0,
                         fkList = "",
                         sortColumn,
@@ -734,8 +734,8 @@ var ERMrest = (function(module) {
                         parts;
 
                     // add M alias to current table
-                    if (this._location.searchFilter) { // remove search filter
-                        compactPath = compactPath.replace("/" + this._location.searchFilter, "");
+                    if (this._location.ermrestSearchFilter) { // remove search filter
+                        compactPath = compactPath.replace("/" + this._location.ermrestSearchFilter, "");
                     }
                     parts = compactPath.split('/');
                     linking = parts[parts.length-1].match(/(\(.*\)=\(.*:.*:.*\))/);
@@ -744,9 +744,9 @@ var ERMrest = (function(module) {
                     }
                     compactPath = compactPath.substring(0, tableIndex) + "M:=" + compactPath.substring(tableIndex);
 
-                    // add search filter back
-                    if (this._location.searchFilter) {
-                        compactPath = compactPath + "/" + this._location.searchFilter;
+                    // add ermrest understandable search filter back
+                    if (this._location.ermrestSearchFilter) {
+                        compactPath = compactPath + "/" + this._location.ermrestSearchFilter;
                     }
 
                     // create the uri with attributegroup and alias
@@ -1213,7 +1213,7 @@ var ERMrest = (function(module) {
                  * github issue: #425
                  */
 
-                this._server._http.delete(this.uri).then(function deleteReference(deleteResponse) {
+                this._server._http.delete(this.location.ermrestUri).then(function deleteReference(deleteResponse) {
                     defer.resolve();
                 }, function error(deleteError) {
                     return defer.reject(module._responseToError(deleteError));
@@ -2034,7 +2034,7 @@ var ERMrest = (function(module) {
                 if (source._location.hasJoin) {
                     // returns true if join is on alternative shared key
                     var joinOnAlternativeKey = function () {
-                        var joinCols = source._location.lastJoin.rightCols,
+                        var joinCols = source._location.lastJoin.toCols,
                             keyCols = source._table._baseTable._altSharedKey.colset.columns;
 
                         if (joinCols.length != keyCols.length) {
@@ -2062,9 +2062,9 @@ var ERMrest = (function(module) {
                             newRightCols = [],
                             col;
 
-                        for (var i = 0; i < currJoin.rightCols.length; i++) {
+                        for (var i = 0; i < currJoin.toCols.length; i++) {
                             // find the column object
-                            col = source._table.columns.get(currJoin.rightCols[i]);
+                            col = source._table.columns.get(currJoin.toCols[i]);
 
                             // map the column from source table to alternative table
                             col = newTable._altForeignKey.mapping.getFromColumn(col);
@@ -2073,7 +2073,7 @@ var ERMrest = (function(module) {
                             newRightCols.push((i === 0) ? col.toString() : module._fixedEncodeURIComponent(col.name));
                         }
 
-                        return "(" + currJoin.leftColsStr + ")=(" + newRightCols.join(",") + ")";
+                        return "(" + currJoin.fromColsStr + ")=(" + newRightCols.join(",") + ")";
                     };
 
                     // 2.1. if _altSharedKey is the same as the join

--- a/js/reference.js
+++ b/js/reference.js
@@ -712,7 +712,7 @@ var ERMrest = (function(module) {
                 // this will update location.sort and all the uri and path
                 this._location.sortObject = sortObject;
 
-                var uri = this._location.compactUri; // used for the http request
+                var uri = this._location.ermrestCompactUri; // used for the http request
 
                 /** Change api to attributegroup for retrieving the foreign key data
                  * This will just affect the http request and not this._location

--- a/test/specs/parser/tests/01.parser.js
+++ b/test/specs/parser/tests/01.parser.js
@@ -236,26 +236,18 @@ exports.execute = function (options) {
 
                 var filter1 = parsedFilter.filters[0];
                 expect(filter1.type).toBe("BinaryPredicate");
-                expect(filter1.column).toBe("id2");
+                expect(filter1.column).toBe("id");
                 expect(filter1.operator).toBe("::gt::");
                 expect(filter1.value).toBe(lowerLimit.toString());
 
                 var filter2 = parsedFilter.filters[1];
                 expect(filter2.type).toBe("BinaryPredicate");
-                expect(filter2.column).toBe("id2");
+                expect(filter2.column).toBe("id");
                 expect(filter2.operator).toBe("::lt::");
                 expect(filter2.value).toBe(upperLimit.toString());
             });
         });
     });
 
-    describe("Location.search", function() {
-        var catalogId = 1,
-            schemaName = "parse_schema",
-            tableName = "parse_table";
-
-        it("should set the search filter and update the uri parameters.", function() {
-
-        });
-    });
+    // NOTE: search test cases are in refererence/13.search.js
 }

--- a/test/specs/reference/tests/13.search.js
+++ b/test/specs/reference/tests/13.search.js
@@ -6,9 +6,9 @@ exports.execute = function (options) {
             tableName = "search parser",
             intRegexPrefix = floatRegexPrefix = "^(.*[^0-9.])?0*",
             intRegexSuffix = "([^0-9].*|$)",
-            filter1 = "*::ciregexp::hank",
+            filter1 = "*::search::hank",
             // filter2 is a regular expression that will be url encoded.
-            filter2 = "*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(intRegexPrefix + "11" + intRegexSuffix);
+            filter2 = "*::search::" + 11;
 
         var multipleEntityUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"
             + tableName;
@@ -91,8 +91,9 @@ exports.execute = function (options) {
 
             it('search() using conjunction of words. ', function(done) {
                 reference2 = reference1.search("\"hank\" 11");
-                expect(reference2.location.searchTerm).toBe("\"hank\" 11");
-                expect(reference2.location.searchFilter).toBe(filter1 + "&" + filter2);
+                expect(reference2.location.searchTerm).toBe("\"hank\" 11", "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::%22hank%22%2011", "searchFilter missmatch.");
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::hank&*::ciregexp::" +  options.ermRest._fixedEncodeURIComponent(intRegexPrefix + "11" + intRegexSuffix), "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -119,8 +120,9 @@ exports.execute = function (options) {
                 // rows with `name x` == "int" are notating that the int value is what is being tested for
                 searchTerm = "1";
                 reference2 = reference1.search(searchTerm);
-                expect(reference2.location.searchTerm).toBe(searchTerm);
-                expect(reference2.location.searchFilter).toBe("*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(intRegexPrefix + searchTerm + intRegexSuffix));
+                expect(reference2.location.searchTerm).toBe(searchTerm, "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::" + searchTerm, "searchFilter missmatch.");
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(intRegexPrefix + searchTerm + intRegexSuffix), "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -145,9 +147,10 @@ exports.execute = function (options) {
                 // `id x` == 35-38, should all match;  39 and 40 are negative cases
                 searchTerm = "11.1";
                 reference2 = reference1.search(searchTerm);
-                expect(reference2.location.searchTerm).toBe(searchTerm);
+                expect(reference2.location.searchTerm).toBe(searchTerm, "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::" + searchTerm, "searchFilter missmatch.");
                 // Can't use searchTerm in the encode function because the term has to be regular expression encoded first, '\' is the regex escape character
-                expect(reference2.location.searchFilter).toBe("*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(floatRegexPrefix + "11\\.1"));
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(floatRegexPrefix + "11\\.1"), "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -173,9 +176,10 @@ exports.execute = function (options) {
                 // this is similar to the previous case that tests `11.1` and should match those positive cases as well
                 searchTerm = "11.";
                 reference2 = reference1.search(searchTerm);
-                expect(reference2.location.searchTerm).toBe(searchTerm);
+                expect(reference2.location.searchTerm).toBe(searchTerm, "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::" + searchTerm, "searchFilter missmatch.");
                 // Can't use searchTerm in the encode function because the term has to be regular expression encoded first, '\' is the regex escape character
-                expect(reference2.location.searchFilter).toBe("*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(floatRegexPrefix + "11\\."));
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(floatRegexPrefix + "11\\."), "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -200,9 +204,10 @@ exports.execute = function (options) {
                 // `id x` == 47-50 should all match; 51 and 52 are negative cases
                 searchTerm = ".1";
                 reference2 = reference1.search(searchTerm);
-                expect(reference2.location.searchTerm).toBe(searchTerm);
+                expect(reference2.location.searchTerm).toBe(searchTerm, "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::" + searchTerm, "searchFilter missmatch.");
                 // Can't use searchTerm in the encode function because the term has to be regular expression encoded first, '\' is the regex escape character
-                expect(reference2.location.searchFilter).toBe("*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(floatRegexPrefix + "\\.1"));
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(floatRegexPrefix + "\\.1"), "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -228,11 +233,10 @@ exports.execute = function (options) {
                 limit = 20;
 
             it("with a full set of quotation marks.", function(done) {
-                var quotedFilter = "*::ciregexp::harold";
-
                 reference2 = reference1.search("\"harold\"");
-                expect(reference2.location.searchTerm).toBe("\"harold\"");
-                expect(reference2.location.searchFilter).toBe(quotedFilter);
+                expect(reference2.location.searchTerm).toBe("\"harold\"", "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::%22harold%22", "searchFilter missmatch.");
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::harold", "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -253,11 +257,10 @@ exports.execute = function (options) {
             });
 
             it("with quoted whitespace around the search term.", function(done) {
-                var quotedFilter = "*::ciregexp::%20william%20";
-
                 reference2 = reference1.search("\" william \"");
-                expect(reference2.location.searchTerm).toBe("\" william \"");
-                expect(reference2.location.searchFilter).toBe(quotedFilter);
+                expect(reference2.location.searchTerm).toBe("\" william \"", "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::%22%20william%20%22", "searchFilter missmatch.");
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::%20william%20", "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -278,11 +281,10 @@ exports.execute = function (options) {
             });
 
             it("with two words in 1 quoted term.", function(done) {
-                var quotedFilter = "*::ciregexp::wallace%20II";
-
                 reference2 = reference1.search("\"wallace II\"");
-                expect(reference2.location.searchTerm).toBe("\"wallace II\"");
-                expect(reference2.location.searchFilter).toBe(quotedFilter);
+                expect(reference2.location.searchTerm).toBe("\"wallace II\"", "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::%22wallace%20II%22", "searchFilter missmatch.");
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::wallace%20II", "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -303,11 +305,10 @@ exports.execute = function (options) {
             });
 
             it("with multiple quoted terms split by a space.", function(done) {
-                var quotedFilter = "*::ciregexp::wallace&*::ciregexp::II";
-
                 reference2 = reference1.search("\"wallace\" \"II\"");
-                expect(reference2.location.searchTerm).toBe("\"wallace\" \"II\"");
-                expect(reference2.location.searchFilter).toBe(quotedFilter);
+                expect(reference2.location.searchTerm).toBe("\"wallace\" \"II\"", "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::%22wallace%22%20%22II%22", "searchFilter missmatch.");
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::wallace&*::ciregexp::II", "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -332,8 +333,9 @@ exports.execute = function (options) {
                 var quotedFilter = "*::ciregexp::william&*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(intRegexPrefix + "17" + intRegexSuffix);
 
                 reference2 = reference1.search("\"william\" \"17\"");
-                expect(reference2.location.searchTerm).toBe("\"william\" \"17\"");
-                expect(reference2.location.searchFilter).toBe(quotedFilter);
+                expect(reference2.location.searchTerm).toBe("\"william\" \"17\"", "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::%22william%22%20%2217%22", "searchFilter missmatch.");
+                expect(reference2.location.ermrestSearchFilter).toBe(quotedFilter, "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -354,11 +356,10 @@ exports.execute = function (options) {
             });
 
             it("with multiple quoted terms split by a '|'.", function(done) {
-                var quotedFilter = "*::ciregexp::wallace%7CII";
-
                 reference2 = reference1.search("\"wallace|II\"");
                 expect(reference2.location.searchTerm).toBe("\"wallace|II\"");
-                expect(reference2.location.searchFilter).toBe(quotedFilter);
+                expect(reference2.location.searchFilter).toBe("*::search::%22wallace%7CII%22", "searchFilter missmatch.");
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::wallace%7CII", "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -379,11 +380,10 @@ exports.execute = function (options) {
             });
 
             it("without an ending quote.", function(done) {
-                var quotedFilter = "*::ciregexp::harold";
-
                 reference2 = reference1.search("\"harold");
-                expect(reference2.location.searchTerm).toBe("\"harold");
-                expect(reference2.location.searchFilter).toBe(quotedFilter);
+                expect(reference2.location.searchTerm).toBe("\"harold", "searchTerm missmatch.");
+                expect(reference2.location.searchFilter).toBe("*::search::%22harold", "searchFilter missmatch.");
+                expect(reference2.location.ermrestSearchFilter).toBe("*::ciregexp::harold", "ermrestSearchFilter missmatch.");
 
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -409,8 +409,9 @@ exports.execute = function (options) {
             var limit = 20;
 
             it('location should have correct search parameters ', function() {
-                expect(reference3.location.searchTerm).toBe("hank " + intRegexPrefix + "11" + intRegexSuffix);
-                expect(reference3.location.searchFilter).toBe(filter1 + "&" + filter2);
+                expect(reference3.location.searchTerm).toBe("hank 11", "searchTerm missmatch.");
+                expect(reference3.location.searchFilter).toBe(filter1 + "&" + filter2, "searchFilter missmatch.");
+                expect(reference3.location.ermrestSearchFilter).toBe("*::ciregexp::hank" + "&" + "*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(intRegexPrefix + "11" + intRegexSuffix), "ermrestSearchFilter missmatch.");
             });
 
             it('read should return a Page object that is defined.', function(done) {


### PR DESCRIPTION
Previously we were using actual `::ciregex::` operator for search, the problem with that usage was that we were manipulating the searchTerm internally so ermrest understands it. For instance when we search for `11`, what we need to send to ermrest is `^(.*[^0-9.])?0*11([^0-9].*|$)` regular expression. So we needed to keep two versions of filter, one that users see and one that ermrest understand.

The uri that parser returns (`Location.uri`) is what the client (chaise) understand and other apis for ermrest uri (`Location.ermrsetUri`, `Location.ermrestPath`, etc.) are introduced.

Issue: #455