### PR TITLE
Changes to avoid regression in JSON value formatting in templates

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1751,7 +1751,7 @@ var ERMrest = (function (module) {
                 //Cases to support json and jsonb columns
                 case 'json':
                 case 'jsonb':
-                    data = utils.printJSON(data,options);
+                    data = utils.printJSON(data);
                     break;
                 default: // includes 'text' and 'longtext' cases
                     data = utils.printText(data, options);

--- a/js/reference.js
+++ b/js/reference.js
@@ -2873,9 +2873,8 @@ var ERMrest = (function(module) {
                         //Added this if conditon explicitly for json/jsonb because we need to pass the
                         //formatted string representation of JSON and JSONBvalues
                         else if (column.type.name === "json" || column.type.name === "jsonb") {
-                            presentation = column.formatPresentation(keyValues[column.name], { formattedValues: keyValues , context: this._pageRef._context });
-                            this._values[i] = presentation.value;
-                            this._isHTML[i] = presentation.isHTML;
+                            this._values[i] = keyValues[column.name];
+                            this._isHTML[i] = false;
                         }
                         else {
                             this._values[i] = this._data[column.name];
@@ -2900,7 +2899,12 @@ var ERMrest = (function(module) {
                         } else {
                             values[i] = column.formatPresentation(keyValues[column.name], { formattedValues: keyValues , context: this._pageRef._context });
                             // If the column type is json or jsonB we will send the templated string with <pre> tag
-                            if (column.type.name === "gene_sequence"|| column.type.name === "json" || column.type.name === "jsonb") {
+                            if(column.type.name === "json" || column.type.name === "jsonb"){
+                                values[i].value = column.appendPreTag(values[i].value);
+                                values[i].isHTML = true;
+                            }
+                            
+                            if (column.type.name === "gene_sequence") {
                                 values[i].isHTML = true;
                             }
                         }
@@ -3258,7 +3262,11 @@ var ERMrest = (function(module) {
             }
             return {isHTML: isHTML, value: value};
         },
-
+        
+        appendPreTag: function appendPreTag(value) {
+            return '<pre>'+value+'</pre>';
+        },
+        
         /**
          * @desc Indicates if the input should be disabled, in different contexts
          * true: input must be disabled

--- a/js/reference.js
+++ b/js/reference.js
@@ -2899,8 +2899,8 @@ var ERMrest = (function(module) {
                         } else {
                             values[i] = column.formatPresentation(keyValues[column.name], { formattedValues: keyValues , context: this._pageRef._context });
                             // If the column type is json or jsonB we will send the templated string with <pre> tag
-                            if(column.type.name === "json" || column.type.name === "jsonb"){
-                                values[i].value = column.appendPreTag(values[i].value);
+                            if((!values[i].isHTML) && (column.type.name === "json" || column.type.name === "jsonb")){
+                                values[i].value = "<pre>"+ values[i].value + "</pre>";
                                 values[i].isHTML = true;
                             }
                             
@@ -3261,14 +3261,6 @@ var ERMrest = (function(module) {
                 value += (i>0 ? ":" : "") + curr.value;
             }
             return {isHTML: isHTML, value: value};
-        },
-        /**
-         * Append a <pre> tag to the value so that the beautified JSON can be shown including the whitespaces.
-         * @param {String} value This is the formatted string that we get after stringifying
-         * @returns {String} A string representation of the stringified value enclosed in a <pre> tag
-         */
-        appendPreTag: function appendPreTag(value) {
-            return '<pre>'+value+'</pre>';
         },
         
         /**

--- a/js/reference.js
+++ b/js/reference.js
@@ -3262,7 +3262,11 @@ var ERMrest = (function(module) {
             }
             return {isHTML: isHTML, value: value};
         },
-        
+        /**
+         * Append a <pre> tag to the value so that the beautified JSON can be shown including the whitespaces.
+         * @param {String} value This is the formatted string that we get after stringifying
+         * @returns {String} A string representation of the stringified value enclosed in a <pre> tag
+         */
         appendPreTag: function appendPreTag(value) {
             return '<pre>'+value+'</pre>';
         },

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -735,28 +735,13 @@ var ERMrest = (function(module) {
         /**
         * @function		    
         * @param {Object} value A json value to transform
-        * @param {Object} [options] Configuration options.
         * @return {string} A string representation of value based on different context
-        *                Entry/Edit: the beautified version of JSON in other cases
-        *                View: a special case to show null if the value is blank string
+        *                  The beautified version of JSON in other cases
+            *              A special case to show null if the value is blank string
         * @desc Formats a given json value into a string for display.
         */
         printJSON: function printJSON(value, options) {
-            options = (typeof options === 'undefined') ? {} : options;
-            if(module._isEntryContext(options.context)){
-                return  JSON.stringify(value,undefined,2);
-             }
-             
-             else{
-                 var formattedValue;
-                 if (value=== "") {
-                     formattedValue= JSON.stringify(null);
-                  }
-                  else {
-                     formattedValue= JSON.stringify(value,undefined,2);
-                  }
-                  return formattedValue;
-             }
+            return value === "" ? JSON.stringify(null) : JSON.stringify(value, undefined, 2);
        },
 
         /**

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -742,25 +742,25 @@ var ERMrest = (function(module) {
         * @desc Formats a given json value into a string for display.
         */
         printJSON: function printJSON(value, options) {
-           options = (typeof options === 'undefined') ? {} : options;
-           if(module._isEntryContext(options.context)){
-               return  JSON.stringify(value,undefined,2);
-            }
-            
-            else{
-                var formattedValue;
-                if (value === null || value=== "") {
-                    formattedValue= JSON.stringify(null);
-                    formattedValue ='<pre>'+formattedValue+'</pre>';
-                 }
-                 
-                 else {
-                    formattedValue= JSON.stringify(value,undefined,2);
-                    formattedValue ='<pre>'+formattedValue+'</pre>';
-                 }
-                 
-                 return formattedValue;
-            }
+            options = (typeof options === 'undefined') ? {} : options;
+            if(module._isEntryContext(options.context)){
+                return  JSON.stringify(value,undefined,2);
+             }
+             
+             else{
+                 var formattedValue;
+                 if (value === null || value=== "") {
+                     formattedValue= JSON.stringify(null);
+                     formattedValue =formattedValue;
+                  }
+                  
+                  else {
+                     formattedValue= JSON.stringify(value,undefined,2);
+                     formattedValue =formattedValue;
+                  }
+                  
+                  return formattedValue;
+             }
        },
 
         /**

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -738,7 +738,7 @@ var ERMrest = (function(module) {
         * @param {Object} [options] Configuration options.
         * @return {string} A string representation of value based on different context
         *                Entry/Edit: the beautified version of JSON in other cases
-        *                View: a string preformatted with <pre> tag to display in the UI
+        *                View: a special case to show null if the value is blank string
         * @desc Formats a given json value into a string for display.
         */
         printJSON: function printJSON(value, options) {
@@ -749,16 +749,12 @@ var ERMrest = (function(module) {
              
              else{
                  var formattedValue;
-                 if (value === null || value=== "") {
+                 if (value=== "") {
                      formattedValue= JSON.stringify(null);
-                     formattedValue =formattedValue;
                   }
-                  
                   else {
                      formattedValue= JSON.stringify(value,undefined,2);
-                     formattedValue =formattedValue;
                   }
-                  
                   return formattedValue;
              }
        },

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -62,17 +62,16 @@ exports.execute = function (options) {
             expect(printText({key:123,subkey:{subsubkey:456}})).toBe('{"key":123,"subkey":{"subsubkey":456}}');
         });
         
-        it('printJSON() should show raw JSON value Edit Context.', function() {
+        it('printJSON() should show stringified version of JSON value.', function() {
             var printJSON = formatUtils.printJSON;
-            var options={context:'entry/edit'};
-            expect(printJSON(null,options)).toBe('null');
-            expect(printJSON('',options)).toBe('""');
-            expect(printJSON(true,options)).toBe('true');
-            expect(printJSON(false,options)).toBe('false');
-            expect(printJSON(2.9,options)).toBe('2.9');
+            expect(printJSON(null)).toBe('null');
+            expect(printJSON('')).toBe('null');
+            expect(printJSON(true)).toBe('true');
+            expect(printJSON(false)).toBe('false');
+            expect(printJSON(2.9)).toBe('2.9');
             let valueToTest={"name":"testing"};
             let expectedJSON= JSON.stringify(valueToTest,undefined,2);
-            expect(printJSON(valueToTest,options)).toBe(expectedJSON);
+            expect(printJSON(valueToTest)).toBe(expectedJSON);
         });
 
         it('printMarkdown() should process Markdown into HTML.', function() {

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -62,7 +62,7 @@ exports.execute = function (options) {
             expect(printText({key:123,subkey:{subsubkey:456}})).toBe('{"key":123,"subkey":{"subsubkey":456}}');
         });
         
-        it('printJSON() should format JSON values correctly for Edit Context.', function() {
+        it('printJSON() should show raw JSON value Edit Context.', function() {
             var printJSON = formatUtils.printJSON;
             var options={context:'entry/edit'};
             expect(printJSON(null,options)).toBe('null');
@@ -72,19 +72,6 @@ exports.execute = function (options) {
             expect(printJSON(2.9,options)).toBe('2.9');
             let valueToTest={"name":"testing"};
             let expectedJSON= JSON.stringify(valueToTest,undefined,2);
-            expect(printJSON(valueToTest,options)).toBe(expectedJSON);
-        });
-        
-        it('printJSON() should format JSON values correctly for Not Edit Context.', function() {
-            var printJSON = formatUtils.printJSON;
-            var options={context:'detailed'};
-            expect(printJSON(null,options)).toBe('<pre>null</pre>');
-            expect(printJSON('',options)).toBe('<pre>null</pre>');
-            expect(printJSON(true,options)).toBe('<pre>true</pre>');
-            expect(printJSON(false,options)).toBe('<pre>false</pre>');
-            expect(printJSON(2.9,options)).toBe('<pre>2.9</pre>');
-            let valueToTest={"name":"testing"};
-            let expectedJSON= "<pre>"+JSON.stringify(valueToTest,undefined,2)+"</pre>";
             expect(printJSON(valueToTest,options)).toBe(expectedJSON);
         });
 

--- a/test/specs/reference/conf/reference_schema/data/jsontest_table.json
+++ b/test/specs/reference/conf/reference_schema/data/jsontest_table.json
@@ -1,7 +1,7 @@
-[{"id":"1001","json_col":true,"jsonb_col":true},
-{"id":"1002","json_col":{},"jsonb_col":{}},
-{"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}},
-{"id":"1004","json_col":false,"jsonb_col":false},
-{"id":"1005","json_col":2.9,"jsonb_col":2.9},
-{"id":"1006","json_col":"","jsonb_col":""}
+[{"id":"1001","json_col":true,"jsonb_col":true,"json_col_with_markdownpattern":"processed"},
+{"id":"1002","json_col":{},"jsonb_col":{},"json_col_with_markdownpattern":"Activated"},
+{"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"},"json_col_with_markdownpattern":"Analysed"},
+{"id":"1004","json_col":false,"jsonb_col":false,"json_col_with_markdownpattern":"Shipped"},
+{"id":"1005","json_col":2.9,"jsonb_col":2.9,"json_col_with_markdownpattern":"OnHold"},
+{"id":"1006","json_col":"","jsonb_col":"","json_col_with_markdownpattern":"Complete"}
 ]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -36,7 +36,24 @@
                     "type": {
                         "typename": "jsonb"
                     }
-                }
+                },
+                {
+                     "comment": null, 
+                     "name": "json_col_with_markdownpattern", 
+                     "default": null, 
+                     "nullok": true, 
+                     "type": {
+                       "typename": "json"
+                     }, 
+                     "annotations": {
+                       "tag:isrd.isi.edu,2016:column-display": {
+                         "*": {
+                           "markdown_pattern": " Status is: {{{json_col_with_markdownpattern}}}"
+                         }
+                       }
+                   }
+               }
+
             ]
         },
         "reference_table": {

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -339,9 +339,9 @@ exports.execute = function (options) {
                 expect(values[0]).toBe(uri);
                 var json='<pre>'+JSON.stringify(expectedValues[i].json_col,"undefined",2)+'</pre>';
                 var jsonb='<pre>'+JSON.stringify(expectedValues[i].jsonb_col,"undefined",2)+'</pre>';
-                expect(values[1]).toBe(json);
-                expect(values[2]).toBe(jsonb);
-                expect(values[3]).toBe(expectedValues[i].json_col_with_markdownpattern);
+                expect(values[1]).toBe(json, "Mismatch in tuple with index = "+ i +", column= json_col");
+                expect(values[2]).toBe(jsonb ,"Mismatch in tuple with index = "+ i +", column= jsonb_col");
+                expect(values[3]).toBe(expectedValues[i].json_col_with_markdownpattern, "Mismatch in tuple with index = "+ i +", column= json_col_with_markdownpattern");
             }
         });
     });

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -246,14 +246,14 @@ exports.execute = function (options) {
 
     });
     
-    describe("Testing for JSON AND JSONB Values", function() {
+    describe("Testing for JSON AND JSONB Values,", function() {
         //Tested these values as formatted values inside it, to get the exact string after JSON.stringify()
-        var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true},
-        {"id":"1002","json_col":{},"jsonb_col":{}},
-        {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}},
-        {"id":"1004","json_col":false,"jsonb_col":false},
-        {"id":"1005","json_col":2.9,"jsonb_col":2.9},
-        {"id":"1006","json_col":null,"jsonb_col":null}];
+        var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true,"json_col_with_markdownpattern": "<pre><p>Status is: “processed”</p>\n</pre>"},
+        {"id":"1002","json_col":{},"jsonb_col":{}, "json_col_with_markdownpattern": "<pre><p>Status is: “Activated”</p>\n</pre>"},
+        {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}, "json_col_with_markdownpattern": "<pre><p>Status is: “Analysed”</p>\n</pre>"},
+        {"id":"1004","json_col":false,"jsonb_col":false, "json_col_with_markdownpattern": "<pre><p>Status is: “Shipped”</p>\n</pre>"},
+        {"id":"1005","json_col":2.9,"jsonb_col":2.9, "json_col_with_markdownpattern": "<pre><p>Status is: “OnHold”</p>\n</pre>"},
+        {"id":"1006","json_col":null,"jsonb_col":null, "json_col_with_markdownpattern": "<pre><p>Status is: “Complete”</p>\n</pre>"}];
 
         var catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "reference_schema",
@@ -341,6 +341,7 @@ exports.execute = function (options) {
                 var jsonb='<pre>'+JSON.stringify(expectedValues[i].jsonb_col,"undefined",2)+'</pre>';
                 expect(values[1]).toBe(json);
                 expect(values[2]).toBe(jsonb);
+                expect(values[3]).toBe(expectedValues[i].json_col_with_markdownpattern);
             }
         });
     });

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -248,12 +248,12 @@ exports.execute = function (options) {
     
     describe("Testing for JSON AND JSONB Values,", function() {
         //Tested these values as formatted values inside it, to get the exact string after JSON.stringify()
-        var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true,"json_col_with_markdownpattern": "<pre><p>Status is: “processed”</p>\n</pre>"},
-        {"id":"1002","json_col":{},"jsonb_col":{}, "json_col_with_markdownpattern": "<pre><p>Status is: “Activated”</p>\n</pre>"},
-        {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}, "json_col_with_markdownpattern": "<pre><p>Status is: “Analysed”</p>\n</pre>"},
-        {"id":"1004","json_col":false,"jsonb_col":false, "json_col_with_markdownpattern": "<pre><p>Status is: “Shipped”</p>\n</pre>"},
-        {"id":"1005","json_col":2.9,"jsonb_col":2.9, "json_col_with_markdownpattern": "<pre><p>Status is: “OnHold”</p>\n</pre>"},
-        {"id":"1006","json_col":null,"jsonb_col":null, "json_col_with_markdownpattern": "<pre><p>Status is: “Complete”</p>\n</pre>"}];
+        var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true,"json_col_with_markdownpattern": "<p>Status is: “processed”</p>\n"},
+        {"id":"1002","json_col":{},"jsonb_col":{}, "json_col_with_markdownpattern": "<p>Status is: “Activated”</p>\n"},
+        {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}, "json_col_with_markdownpattern": "<p>Status is: “Analysed”</p>\n"},
+        {"id":"1004","json_col":false,"jsonb_col":false, "json_col_with_markdownpattern": "<p>Status is: “Shipped”</p>\n"},
+        {"id":"1005","json_col":2.9,"jsonb_col":2.9, "json_col_with_markdownpattern": "<p>Status is: “OnHold”</p>\n"},
+        {"id":"1006","json_col":null,"jsonb_col":null, "json_col_with_markdownpattern": "<p>Status is: “Complete”</p>\n"}];
 
         var catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "reference_schema",

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -243,7 +243,7 @@ exports.execute = function (options) {
             {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}, "json_col_without_markdownpattern": "\"Analysed\""},
             {"id":"1004","json_col":false,"jsonb_col":false, "json_col_without_markdownpattern": "\"Shipped\""},
             {"id":"1005","json_col":2.9,"jsonb_col":2.9, "json_col_without_markdownpattern": "\"OnHold\""},
-            {"id":"1006","json_col":"","jsonb_col":"", "json_col_without_markdownpattern": "\"Complete\""}];
+            {"id":"1006","json_col":null,"jsonb_col":null, "json_col_without_markdownpattern": "\"Complete\""}];
 
             var catalog_id = process.env.DEFAULT_CATALOG,
                 schemaName = "reference_schema",

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -238,12 +238,12 @@ exports.execute = function (options) {
         
         describe("Testing for EDIT JSON and JSONB Values", function() {
             //Tested these values as formatted values inside it, to get the exact string after JSON.stringify()
-            var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true, "json_col_without_markdownpattern": "\"processed\""},
-            {"id":"1002","json_col":{},"jsonb_col":{}, "json_col_without_markdownpattern": "\"Activated\""},
-            {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}, "json_col_without_markdownpattern": "\"Analysed\""},
-            {"id":"1004","json_col":false,"jsonb_col":false, "json_col_without_markdownpattern": "\"Shipped\""},
-            {"id":"1005","json_col":2.9,"jsonb_col":2.9, "json_col_without_markdownpattern": "\"OnHold\""},
-            {"id":"1006","json_col":null,"jsonb_col":null, "json_col_without_markdownpattern": "\"Complete\""}];
+            var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true, "json_col_with_markdownpattern": "\"processed\""},
+            {"id":"1002","json_col":{},"jsonb_col":{}, "json_col_with_markdownpattern": "\"Activated\""},
+            {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}, "json_col_with_markdownpattern": "\"Analysed\""},
+            {"id":"1004","json_col":false,"jsonb_col":false, "json_col_with_markdownpattern": "\"Shipped\""},
+            {"id":"1005","json_col":2.9,"jsonb_col":2.9, "json_col_with_markdownpattern": "\"OnHold\""},
+            {"id":"1006","json_col":null,"jsonb_col":null, "json_col_with_markdownpattern": "\"Complete\""}];
 
             var catalog_id = process.env.DEFAULT_CATALOG,
                 schemaName = "reference_schema",
@@ -330,7 +330,7 @@ exports.execute = function (options) {
                     var jsonb=JSON.stringify(expectedValues[i].jsonb_col,undefined,2);
                     expect(values[1]).toBe(json);
                     expect(values[2]).toBe(jsonb);
-                    expect(values[3]).toBe(expectedValues[i].json_col_without_markdownpattern);
+                    expect(values[3]).toBe(expectedValues[i].json_col_with_markdownpattern);
                 }
             });
         });

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -325,12 +325,12 @@ exports.execute = function (options) {
                 
                 for( var i=0; i<limit; i++){
                     var values=tuples[i].values;
-                    expect(values[0]).toBe(expectedValues[i].id);
+                    expect(values[0]).toBe(expectedValues[i].id, "Mismatch in tuple with index = "+ i +", column=id");
                     var json=JSON.stringify(expectedValues[i].json_col,undefined,2);
                     var jsonb=JSON.stringify(expectedValues[i].jsonb_col,undefined,2);
-                    expect(values[1]).toBe(json);
-                    expect(values[2]).toBe(jsonb);
-                    expect(values[3]).toBe(expectedValues[i].json_col_with_markdownpattern);
+                    expect(values[1]).toBe(json, "Mismatch in tuple with index = "+ i +", column= json_col");
+                    expect(values[2]).toBe(jsonb, "Mismatch in tuple with index = "+ i +", column= jsonb_col");
+                    expect(values[3]).toBe(expectedValues[i].json_col_with_markdownpattern, "Mismatch in tuple with index = "+ i +", column= json_col_with_markdownpattern");
                 }
             });
         });

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -238,12 +238,12 @@ exports.execute = function (options) {
         
         describe("Testing for EDIT JSON and JSONB Values", function() {
             //Tested these values as formatted values inside it, to get the exact string after JSON.stringify()
-            var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true},
-            {"id":"1002","json_col":{},"jsonb_col":{}},
-            {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}},
-            {"id":"1004","json_col":false,"jsonb_col":false},
-            {"id":"1005","json_col":2.9,"jsonb_col":2.9},
-            {"id":"1006","json_col":"","jsonb_col":""}];
+            var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true, "json_col_without_markdownpattern": "\"processed\""},
+            {"id":"1002","json_col":{},"jsonb_col":{}, "json_col_without_markdownpattern": "\"Activated\""},
+            {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}, "json_col_without_markdownpattern": "\"Analysed\""},
+            {"id":"1004","json_col":false,"jsonb_col":false, "json_col_without_markdownpattern": "\"Shipped\""},
+            {"id":"1005","json_col":2.9,"jsonb_col":2.9, "json_col_without_markdownpattern": "\"OnHold\""},
+            {"id":"1006","json_col":"","jsonb_col":"", "json_col_without_markdownpattern": "\"Complete\""}];
 
             var catalog_id = process.env.DEFAULT_CATALOG,
                 schemaName = "reference_schema",
@@ -330,6 +330,7 @@ exports.execute = function (options) {
                     var jsonb=JSON.stringify(expectedValues[i].jsonb_col,undefined,2);
                     expect(values[1]).toBe(json);
                     expect(values[2]).toBe(jsonb);
+                    expect(values[3]).toBe(expectedValues[i].json_col_without_markdownpattern);
                 }
             });
         });


### PR DESCRIPTION
The `<pre>` tags were visible in the UI because the function doing the markdown templating was getting the formatted JSON value to display in the UI. These changes now allow ermrestJS to template a value first and then append a`<pre>` tag to display in the UI.