### PR TITLE
Update no changes

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -226,6 +226,8 @@ to use for ERMrest JavaScript agents.
         * [new InvalidInputError(message)](#new_ERMrest.InvalidInputError_new)
     * [.MalformedURIError](#ERMrest.MalformedURIError)
         * [new MalformedURIError(message)](#new_ERMrest.MalformedURIError_new)
+    * [.NoDataChangedError](#ERMrest.NoDataChangedError)
+        * [new NoDataChangedError(message)](#new_ERMrest.NoDataChangedError_new)
     * [.NoConnectionError](#ERMrest.NoConnectionError)
         * [new NoConnectionError(message)](#new_ERMrest.NoConnectionError_new)
     * [.ParsedFilter](#ERMrest.ParsedFilter)
@@ -1912,6 +1914,20 @@ An invalid input
 
 #### new MalformedURIError(message)
 A malformed URI was passed to the API.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| message | <code>string</code> | error message |
+
+<a name="ERMrest.NoDataChangedError"></a>
+
+### ERMrest.NoDataChangedError
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+<a name="new_ERMrest.NoDataChangedError_new"></a>
+
+#### new NoDataChangedError(message)
+no data was changed for update
 
 
 | Param | Type | Description |

--- a/js/errors.js
+++ b/js/errors.js
@@ -28,6 +28,7 @@ var ERMrest = (function(module) {
     module.InvalidFilterOperatorError = InvalidFilterOperatorError;
     module.InvalidInputError = InvalidInputError;
     module.MalformedURIError = MalformedURIError;
+    module.NoDataChangedError = NoDataChangedError;
     module.NoConnectionError = NoConnectionError;
 
     /**
@@ -174,6 +175,9 @@ var ERMrest = (function(module) {
     ServiceUnavailableError.prototype = Object.create(Error.prototype);
     ServiceUnavailableError.prototype.constructor = ServiceUnavailableError;
 
+
+    // Errors not associated with http status codes
+    // these are errors that we defined to manage errors in the API
     /**
      * @memberof ERMrest
      * @param {string} message error message
@@ -214,6 +218,19 @@ var ERMrest = (function(module) {
 
     MalformedURIError.prototype = Object.create(Error.prototype);
     MalformedURIError.prototype.constructor = MalformedURIError;
+
+    /**
+     * @memberof ERMrest
+     * @param {string} message error message
+     * @constructor
+     * @desc no data was changed for update
+     */
+    function NoDataChangedError(message) {
+        this.message = message;
+    }
+
+    NoDataChangedError.prototype = Object.create(Error.prototype);
+    NoDataChangedError.prototype.constructor = NoDataChangedError;
 
     /**
      * @memberof ERMrest

--- a/js/reference.js
+++ b/js/reference.js
@@ -1027,6 +1027,10 @@ var ERMrest = (function(module) {
                     }
                 }
 
+                if (columnProjections.length < 1) {
+                    throw new module.NoDataChangedError("No data was changed in the update request. Please check the form content and resubmit the data.");
+                }
+
                 /* This loop manages adding the values based on the columnProjections set and setting columns associated with asset columns properly */
                 // loop through each tuple again and set the data value from the tuple in submission data for each column projection
                 for (i = 0; i < tuples.length; i++) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -1113,12 +1113,10 @@ var ERMrest = (function(module) {
                     uri += module._fixedEncodeURIComponent(shortestKeyNames[j]) + oldAlias + ":=" + module._fixedEncodeURIComponent(shortestKeyNames[j]);
                 }
 
-                // Important NOTE: separator for denoting where the keyset ends and the update column set begins. The shortest key is used as the keyset
-                uri += ';';
-
                 // the keyset is always aliased with the old alias, so make sure to include the new alias in the column projections
                 for (k = 0; k < columnProjections.length; k++) {
-                    if (k !== 0) uri += ',';
+                    // Important NOTE: separator for denoting where the keyset ends and the update column set begins. The shortest key is used as the keyset
+                    uri += (k === 0 ? ';' : ',');
                     // alias all the columns for the key set
                     uri += module._fixedEncodeURIComponent(columnProjections[k]) + newAlias + ":=" + module._fixedEncodeURIComponent(columnProjections[k]);
                 }

--- a/test/specs/reference/tests/10.update.js
+++ b/test/specs/reference/tests/10.update.js
@@ -58,7 +58,7 @@ exports.execute = function (options) {
                     expect(err.message).toEqual("No data was changed in the update request. Please check the form content and resubmit the data.", "Wrong error message was returned");
 
                     done();
-                })
+                });
             });
         });
 


### PR DESCRIPTION
When data is submitted to `ermrestJS` for update without any changes to the entity, an error is thrown and a warning message is shown in chaise.

This must be merged before PR [#1216](https://github.com/informatics-isi-edu/chaise/pull/1216) is merged in `chaise`.