### PR TITLE
ColSet Sort Bug

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1503,6 +1503,9 @@ Constructor for ColSet, a set of Column objects.
 <a name="ERMrest.ColSet+columns"></a>
 
 #### colSet.columns : <code>Array</code>
+It won't preserve the order of given columns.
+Returns set of columns sorted by their names.
+
 **Kind**: instance property of [<code>ColSet</code>](#ERMrest.ColSet)  
 <a name="ERMrest.ColSet+toString"></a>
 

--- a/js/core.js
+++ b/js/core.js
@@ -2427,12 +2427,6 @@ var ERMrest = (function (module) {
          * @type {Array}
          */
         this.columns = columns;
-
-        // sorting the column based on their name
-        columns.sort(function(a, b) {
-            return a.name.localeCompare(b.name);
-        });
-
     }
 
     ColSet.prototype = {

--- a/js/core.js
+++ b/js/core.js
@@ -2423,10 +2423,14 @@ var ERMrest = (function (module) {
     function ColSet(columns) {
 
         /**
-         *
+         * It won't preserve the order of given columns.
+         * Returns set of columns sorted by their names.
+         * 
          * @type {Array}
          */
-        this.columns = columns;
+        this.columns = columns.slice().sort(function(a, b) {
+           return a.name.localeCompare(b.name);
+       });
     }
 
     ColSet.prototype = {
@@ -2437,9 +2441,7 @@ var ERMrest = (function (module) {
          * @return {string} string representation of colset object
          */
         toString: function(){
-            return "(" + this.columns.slice().sort(function(a,b){
-                return module._fixedEncodeURIComponent(a.name.localeCompare(b.name));
-            }).map(function(col){
+            return "(" + this.columns.map(function(col){
                 return col.toString();
             }).join(",") + ")";
         },

--- a/test/specs/reference/tests/14.pseudo_columns.js
+++ b/test/specs/reference/tests/14.pseudo_columns.js
@@ -120,8 +120,8 @@ exports.execute = function (options) {
              '<p>12</p>\n',
              '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/id_1=4000&id_2=4001">4000 , 4001</a>',
              '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key_2/id_1=4000&id_2=4003">4000:4003</a>',
-             '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/id_1=4002&id_2=4000">4002 , 4000</a>',
-             '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/id_1=4002&id_2=4001">4002 , 4001</a>',
+             '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/id_1=4000&id_2=4002">4000 , 4002</a>',
+             '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/id_1=4001&id_2=4002">4001 , 4002</a>',
              ''
         ];
 
@@ -139,8 +139,8 @@ exports.execute = function (options) {
             '<p>12</p>\n',
             '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/id=1">4000 , 4001</a>',
             '<a href="https://dev.isrd.isi.edu/chaise/search">1</a>',
-            '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/id=5">4002 , 4000</a>',
-            '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/id=8">4002 , 4001</a>',
+            '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/id=2">4000 , 4002</a>',
+            '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/id=4">4001 , 4002</a>',
             ''
         ];
 
@@ -153,9 +153,9 @@ exports.execute = function (options) {
             '12',
             '4000 , 4001',
             '4000:4003',
-            '4002 , 4000',
-            '4002 , 4001',
-            '' //
+            '4000 , 4002',
+            '4001 , 4002',
+            ''
         ];
 
         var entryRefExpectedLinkedValue = [
@@ -167,17 +167,17 @@ exports.execute = function (options) {
             '12',
             '4000 , 4001',
             '<a href="https://dev.isrd.isi.edu/chaise/search">1</a>',
-            '4002 , 4000',
-            '4002 , 4001',
+            '4000 , 4002',
+            '4001 , 4002',
             ''
         ];
 
         var entryCreateRefExpectedLinkedValue = [
-            'Hank', '', '4002 , 4000', '1'
+            'Hank', '', '4000 , 4002', '1'
         ];
 
         var entryCreateRefExpectedPartialValue = [
-            '9000', '', '4002 , 4000', '1'
+            '9000', '', '4000 , 4002', '1'
         ];
 
         var tableWSlashData = [

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -355,7 +355,7 @@ exports.execute = function (options) {
                 });
 
                 it ('should return a rowname if it is possible to generate one with default values.', function () {
-                    expect(compactColumns[14].default).toEqual('col 5 default , col 4 default');
+                    expect(compactColumns[14].default).toEqual('col 4 default , col 5 default');
                 });
 
                 it ('should return a rowname using only the consitutent column values if rowname heuristics returned an empty string.', function () {


### PR DESCRIPTION
Since the order of columns that ermrest returns in `foreign_key_columns` and `referenced_columns` might change, `ColSet` was sorting these lists to always return a consistent list of columns. But instead of creating a new copy and sorting it, it was sorting the original which caused [this](https://github.com/informatics-isi-edu/chaise/issues/1217) problem.

The test cases in ermrestjs should have caught this bug, but they were expecting wrong results. I fix those test cases as well.