### PR TITLE
Multi-select functionality for chaise

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -286,6 +286,7 @@ to use for ERMrest JavaScript agents.
         * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
         * [.isHTML](#ERMrest.Tuple+isHTML) : <code>Array.&lt;string&gt;</code>
         * [.displayname](#ERMrest.Tuple+displayname) : <code>string</code>
+        * [.uniqueId](#ERMrest.Tuple+uniqueId) : <code>string</code>
         * [.update()](#ERMrest.Tuple+update) ⇒ <code>Promise</code>
         * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
         * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : [<code>Reference</code>](#ERMrest.Reference)
@@ -2660,6 +2661,7 @@ if (content) {
     * [.values](#ERMrest.Tuple+values) : <code>Array.&lt;string&gt;</code>
     * [.isHTML](#ERMrest.Tuple+isHTML) : <code>Array.&lt;string&gt;</code>
     * [.displayname](#ERMrest.Tuple+displayname) : <code>string</code>
+    * [.uniqueId](#ERMrest.Tuple+uniqueId) : <code>string</code>
     * [.update()](#ERMrest.Tuple+update) ⇒ <code>Promise</code>
     * [.delete()](#ERMrest.Tuple+delete) ⇒ <code>Promise</code>
     * [.getAssociationRef()](#ERMrest.Tuple+getAssociationRef) : [<code>Reference</code>](#ERMrest.Reference)
@@ -2800,6 +2802,13 @@ Usage:
 ```
 console.log("This tuple has a displayable name of ", tuple.displayname.value);
 ```
+
+**Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
+<a name="ERMrest.Tuple+uniqueId"></a>
+
+#### tuple.uniqueId : <code>string</code>
+The unique identifier for this tuple composed of the values for each
+of the shortest key columns concatenated together by an '_'
 
 **Kind**: instance property of [<code>Tuple</code>](#ERMrest.Tuple)  
 <a name="ERMrest.Tuple+update"></a>

--- a/js/reference.js
+++ b/js/reference.js
@@ -3161,6 +3161,12 @@ var ERMrest = (function(module) {
             return this._displayname;
         },
 
+        /**
+         * The unique identifier for this tuple composed of the values for each
+         * of the shortest key columns concatenated together by an '_'
+         *
+         * @type {string}
+         */
         get uniqueId() {
             if (!this._uniqueId) {
                 var key;

--- a/js/reference.js
+++ b/js/reference.js
@@ -3135,7 +3135,7 @@ var ERMrest = (function(module) {
          */
         get isHTML() {
             // this._isHTML has not been populated then call this.values getter to populate values and isHTML array
-            if (this._isHTML == undefined) {
+            if (this._isHTML === undefined) {
                 var value = this.values;
             }
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -70,23 +70,23 @@ var ERMrest = (function(module) {
             verify(uri, "'uri' must be specified");
             var defer = module._q.defer();
             var location;
-            
+
             // make sure all the dependencies are loaded
             module._onload().then(function () {
                 location = module.parse(uri);
                 var server = module.ermrestFactory.getServer(location.service, params);
-                
+
                 // find the catalog
                 return server.catalogs.get(location.catalog);
             }).then(function (catalog) {
-                
+
                 //create Reference
                 defer.resolve(new Reference(location, catalog));
             }, function (error) {
-                
+
                 throw error;
             }).catch(function(exception) {
-                
+
                 defer.reject(exception);
             });
 
@@ -143,7 +143,7 @@ var ERMrest = (function(module) {
             throw new module.InvalidInputError(message);
         }
     }
-    
+
     /**
      * Returns true if given value is defined and not null.
      * @param  {object}  v the object that we want to test
@@ -304,7 +304,7 @@ var ERMrest = (function(module) {
             }
             return this._referenceColumns;
         },
-        
+
         /**
          * Facets that should be represented to the user.
          * Heuristics:
@@ -323,45 +323,45 @@ var ERMrest = (function(module) {
          *    console.log("Column name:", fc.column.name, "has following facets:", fc.filters);
          *  }
          * ```
-         * 
-         * @return {ERMrest.FacetColumn[]} 
+         *
+         * @return {ERMrest.FacetColumn[]}
          */
         get facetColumns() {
             if (this._facetColumns === undefined) {
                 this._facetColumns = [];
-                
+
                 // this reference should be only used for getting the list,
                 var detailedRef = (this._context === module._contexts.DETAILED) ? this : this.contextualize.detailed;
                 var compactRef = (this._context === module._contexts.COMPACT) ? this : this.contextualize.compact;
                 var self = this;
-                
+
                 var jsonFilters = this.location.facets ? this.location.facets.decoded : null;
                 var andOperator = module._FacetsLogicalOperators.AND;
                 var andFilters = [];
-                
+
                 // check if both sources are the same.
                 var sameSource = function (source, filterSource) {
                     if (!Array.isArray(source)) {
                         return source === filterSource;
                     }
-                    
+
                     if (source.length !== filterSource.length) {
                         return false;
                     }
-                    
+
                     for (var i = 0; i < source.length; i++) {
                         if (typeof source[i] === "string" && source[i] !== filterSource[i]) {
                             return false;
                         }
-                        
+
                         if (source[i].schema !== filterSource[i].schema || source[i].constraint != filterSource[i].constraint) {
                             return false;
                         }
-                        
+
                     }
                     return true;
                 };
-                
+
                 // find already applied filter to the face column.
                 var findFilter = function (source) {
                     for (var i = 0; i < andFilters.length; i++) {
@@ -371,14 +371,14 @@ var ERMrest = (function(module) {
                     }
                     return null;
                 };
-                
+
                 // extract the filters
                 if (jsonFilters && jsonFilters.hasOwnProperty(andOperator) && Array.isArray(jsonFilters[andOperator])) {
                     andFilters = jsonFilters[andOperator];
                 }
-                
+
                 var index = 0;
-                
+
                 // all the visible columns in compact context
                 var columns = compactRef.columns;
                 columns.forEach(function (col) {
@@ -388,7 +388,7 @@ var ERMrest = (function(module) {
                         self._facetColumns.push(fc);
                     }
                 });
-                
+
                 // all the realted in detailed context
                 var related = detailedRef.related();
                 related.forEach(function (relRef) {
@@ -400,7 +400,7 @@ var ERMrest = (function(module) {
             }
             return this._facetColumns;
         },
-        
+
         /**
          * Remove all the fitlers from facets
          * @return {ERMrest.reference} A reference without facet filters
@@ -408,13 +408,13 @@ var ERMrest = (function(module) {
         removeAllFacetFilters: function () {
             var newReference = _referenceCopy(this);
             delete newReference._facetColumns;
-            
+
             newReference._location = this._location._clone();
             newReference._location.facets = null;
-            
+
             return newReference;
         },
-        
+
         /**
          * Location object that has uri of current reference
          * @return {ERMrest.Location}
@@ -857,7 +857,7 @@ var ERMrest = (function(module) {
                  *
                  * NOTE:
                  * This piece of code is dependent on the same assumptions as the current parser, which are:
-                 *   0. 
+                 *   0.
                  *   1. There is no alias in url (more precisely `F1`, `F2`, `F3`, ...)
                  *   2. Filter comes before the link syntax.
                  *   3. There is no trailing `/` in uri (as it will break the ermrest too).
@@ -3161,6 +3161,19 @@ var ERMrest = (function(module) {
             return this._displayname;
         },
 
+        get uniqueId() {
+            if (!this._uniqueId) {
+                var key;
+                this._uniqueId = "";
+                for (var i = 0; i < this.reference.table.shortestKey.length; i++) {
+                    keyName = this.reference.table.shortestKey[i].name;
+                    if (i != 0) this._uniqueId += "_";
+                    this._uniqueId += this.data[keyName];
+                }
+            }
+            return this._uniqueId;
+        },
+
         /**
          * If the Tuple is derived from an association related table,
          * this function will return a reference to the corresponding
@@ -4344,7 +4357,7 @@ var ERMrest = (function(module) {
             throw new Error("can not use this type of column in entry mode.");
         }
     });
-        
+
     /**
      * Represent facet columns that are available.
      * NOTE:
@@ -4359,18 +4372,18 @@ var ERMrest = (function(module) {
     function FacetColumn (reference, refColumn, index) {
         verify(!refColumn.isAsset && !refColumn.isKey, "Facet Column cannot be asset or key pseudo-column.");
         verify(!refColumn.isForeignKey || refColumn.foreignKey.simple, "Facet Column does not support composite foreign keys.");
-        
+
         /**
          * The {@link ERMrest.ReferenceColumn} that this facet belongs to. If it is
          * undefined, that means this facet belongs to the table and not column.
          * @type {ERMrest.ReferenceColumn}
          */
         this.column = refColumn;
-        
+
         this.reference = reference;
-        
+
         this.index = index;
-        
+
         /**
          * Filters that are applied to this facet.
          */
@@ -4378,7 +4391,7 @@ var ERMrest = (function(module) {
     }
     FacetColumn.prototype = {
         constructor: FacetColumn,
-        
+
         /**
          * data source of this facet. Can be used to find filters for this facet
          * @return {String} [description]
@@ -4388,7 +4401,7 @@ var ERMrest = (function(module) {
                 if (!isDefinedAndNotNull(this.column)) {
                     return "*";
                 }
-                
+
                 if (this.column.isForeignKey) {
                     var constraint = this.column.foreignKey.constraint_names[0];
                     return [
@@ -4396,20 +4409,20 @@ var ERMrest = (function(module) {
                         this.column.foreignKey.key.colset.columns[0].name
                     ];
                 }
-                
+
                 if (this.column.isInboundForeignKey) {
                     var res = [];
                     var origFkR = this.column.foreignKey;
                     var association = this.column.reference.derivedAssociationReference;
-                    
+
                     res.push({
-                        "schema": origFkR.constraint_names[0][0], 
+                        "schema": origFkR.constraint_names[0][0],
                         "constraint": origFkR.constraint_names[0][1]
                     });
-                    
+
                     if (association) {
                         res.push({
-                            "schema": association._secondFKR.constraint_names[0][0], 
+                            "schema": association._secondFKR.constraint_names[0][0],
                             "constraint": association._secondFKR.constraint_names[0][1]
                         });
                         res.push(association._secondFKR.key.colset.columns[0].name);
@@ -4418,12 +4431,12 @@ var ERMrest = (function(module) {
                     }
                     return res;
                 }
-                
+
                 return this.column.name;
             }
             return this._source;
         },
-        
+
         /**
          * Return JSON presentation of the filters.
          * It will be in the following format:
@@ -4436,10 +4449,10 @@ var ERMrest = (function(module) {
          *    "search": [v, ...]
          * }
          * ```
-         * 
+         *
          * @return {Object}
          */
-        toJSON: function () {            
+        toJSON: function () {
             var res = { "source": this.dataSource};
             for (var i = 0, f; i < this.filters.length; i++) {
                 f = this.filters[i];
@@ -4448,10 +4461,10 @@ var ERMrest = (function(module) {
                 }
                 res[f.facetFilterKey].push(f.toJSON());
             }
-            
+
             return res;
         },
-        
+
         /**
          * Given an object will create list of filters.
          *
@@ -4464,13 +4477,13 @@ var ERMrest = (function(module) {
          *    "search": [v, ...]
          * }
          * ```
-         * 
+         *
          * @param  {Object} json JSON representation of filters
          */
         setFilters: function (json) {
             var self = this;
             self.filters = [];
-                        
+
             if (!isDefinedAndNotNull(json)) {
                 return;
             }
@@ -4481,14 +4494,14 @@ var ERMrest = (function(module) {
                     self.filters.push(new ChoiceFacetFilter(ch));
                 });
             }
-            
+
             // create range filters
             if (Array.isArray(json.ranges)) {
                 json.ranges.forEach(function (ch) {
                     self.filters.push(new RangeFacetFilter(ch.min, ch.max));
                 });
             }
-            
+
             // create search filters
             if (Array.isArray(json.search)) {
                 json.search.forEach(function (ch) {
@@ -4496,7 +4509,7 @@ var ERMrest = (function(module) {
                 });
             }
         },
-        
+
         /**
          * Create a new Reference with appending a new Search filter to current FacetColumn
          * @param  {String} term the term for search
@@ -4504,13 +4517,13 @@ var ERMrest = (function(module) {
          */
         addSearchFilter: function (term) {
             verify (isDefinedAndNotNull(term), "`term` is required.");
-            
+
             var filters = this.filters.slice();
             filters.push(new SearchFacetFilter(term));
-            
+
             return this._applyFilters(filters);
         },
-        
+
         /**
          * Create a new Reference with appending a new choice filter to current FacetColumn
          * @param  {String|int} term the term for choice
@@ -4519,10 +4532,10 @@ var ERMrest = (function(module) {
         addChoiceFilter: function (term) {
             var filters = this.filters.slice();
             filters.push(new ChoiceFacetFilter(term));
-            
+
             return this._applyFilters(filters);
         },
-        
+
         /**
          * Create a new Reference with appending a new range filter to current FacetColumn
          * @param  {String|int=} min minimum value. Can be null or undefined.
@@ -4531,60 +4544,60 @@ var ERMrest = (function(module) {
          */
         addRangeFilter: function (min, max) {
             verify (isDefinedAndNotNull(min) || isDefinedAndNotNull(max), "One of min and max must be defined.");
-            
+
             var filters = this.filters.slice();
             filters.push(new RangeFacetFilter(min, max));
-            
+
             return this._applyFilters(filters);
         },
-        
+
         /**
          * Create a new Reference by removing all the filters from current facet.
          * @return {ERMrest.Reference} the reference with the new filter
          */
         removeAllFilters: function() {
-            
+
             return this._applyFilters([]);
         },
-        
+
         /**
          * Create a new Reference by removing a filter from current facet.
-         * @param  {int} index index of element that we want to remove from list 
+         * @param  {int} index index of element that we want to remove from list
          * @return {ERMrest.Reference} the reference with the new filter
          */
         removeFilter: function (index) {
             var filters = this.filters.slice();
             filters.splice(index, 1);
-            
+
             return this._applyFilters(filters);
         },
-        
-        
+
+
         /**
-         * Given an array of {@link ERMrest.FacetFilter}, will return a new 
+         * Given an array of {@link ERMrest.FacetFilter}, will return a new
          * {@link ERMrest.Reference} with the applied filters to the current FacetColumn
          * @private
          * @param  {ERMrest.FacetFilter[]} filters array of filters
          * @return {ERMrest.Reference} the reference with the new filter
          */
         _applyFilters: function (filters) {
-            
+
             // create a new FacetColumn so it doesn't reference to the current FacetColumn
             var fc = new FacetColumn(this.reference, this.column, this.index);
             fc.filters = filters;
-            
+
             var newReference = _referenceCopy(this.reference);
-            
+
             // clone the location object
             newReference._location = this.reference._location._clone();
-            
+
             // make sure reference.facetColumns and newRef.facetColumns are not referencing the same thing
             delete newReference._facetColumns;
             newReference._facetColumns = this.reference.facetColumns.slice();
             newReference._facetColumns[this.index] = fc;
-            
+
             var jsonFilters = [];
-            
+
             // gather all the filters from the facetColumns
             // NOTE: this part can be improved so we just change one JSON element.
             newReference._facetColumns.forEach(function (fc) {
@@ -4592,18 +4605,18 @@ var ERMrest = (function(module) {
                     jsonFilters.push(fc.toJSON());
                 }
             });
-            
+
             // change the facets in location object
             if (jsonFilters.length > 0) {
                 newReference._location.facets = {"and": jsonFilters};
             } else {
                 newReference._location.facets = null;
             }
-            
+
             return newReference;
         }
     };
-    
+
     /**
      * Represent filters that can be applied to facet
      * @param       {String|int} term the valeu of filter
@@ -4614,7 +4627,7 @@ var ERMrest = (function(module) {
     }
     FacetFilter.prototype = {
         constructor: FacetFilter,
-        
+
         /**
          * String representation of filter
          * @return {string}
@@ -4622,7 +4635,7 @@ var ERMrest = (function(module) {
         toString: function () {
             return this.term;
         },
-        
+
         /**
          * JSON representation of filter
          * @return {string}
@@ -4631,12 +4644,12 @@ var ERMrest = (function(module) {
             return this.toString();
         }
     };
-    
+
     /**
      * Represent choice filters that can be applied to facet.
      * JSON representation of this filter:
      * "choices": [v1, ...]
-     * 
+     *
      * Extends {@link ERMrest.FacetFilter}.
      * @param       {String|int} term the valeu of filter
      * @constructor
@@ -4646,12 +4659,12 @@ var ERMrest = (function(module) {
         this.facetFilterKey = "choices";
     }
     module._extends(ChoiceFacetFilter, FacetFilter);
-    
+
     /**
      * Represent search filters that can be applied to facet.
      * JSON representation of this filter:
      * "search": [v1, ...]
-     * 
+     *
      * Extends {@link ERMrest.FacetFilter}.
      * @param       {String|int} term the valeu of filter
      * @constructor
@@ -4661,12 +4674,12 @@ var ERMrest = (function(module) {
         this.facetFilterKey = "search";
     }
     module._extends(SearchFacetFilter, FacetFilter);
-    
+
     /**
      * Represent range filters that can be applied to facet.
      * JSON representation of this filter:
      * "ranges": [{min: v1, max: v2}]
-     * 
+     *
      * Extends {@link ERMrest.FacetFilter}.
      * @param       {String|int=} min
      * @param       {String|int=} max
@@ -4678,14 +4691,14 @@ var ERMrest = (function(module) {
         this.facetFilterKey = "ranges";
     }
     module._extends(RangeFacetFilter, FacetFilter);
-    
+
     /**
      * String representation of range filter. With the format of:
      *
      * - both min and max defined: `{{min}}-{{max}}`
      * - only min defined: `> {{min}}`
      * - only max defined: `{{max}} <`
-     * 
+     *
      * @return {string}
      */
     RangeFacetFilter.prototype.toString = function () {
@@ -4698,7 +4711,7 @@ var ERMrest = (function(module) {
         }
         return this.min + " - " + this.max;
     };
-    
+
     /**
      * JSON representation of range filter.
      * @return {Object}
@@ -4792,7 +4805,7 @@ var ERMrest = (function(module) {
         }
     };
 
-    
+
     return module;
 
 }(ERMrest || {}));

--- a/js/reference.js
+++ b/js/reference.js
@@ -3135,7 +3135,7 @@ var ERMrest = (function(module) {
          */
         get isHTML() {
             // this._isHTML has not been populated then call this.values getter to populate values and isHTML array
-            if (!this._isHTML) {
+            if (this._isHTML == undefined) {
                 var value = this.values;
             }
 
@@ -3155,7 +3155,7 @@ var ERMrest = (function(module) {
          * @type {string}
          */
         get displayname() {
-            if (!this._displayname) {
+            if (this._displayname === undefined) {
                 this._displayname = module._generateRowName(this._pageRef._table, this._pageRef._context, this._data);
             }
             return this._displayname;
@@ -3168,7 +3168,7 @@ var ERMrest = (function(module) {
          * @type {string}
          */
         get uniqueId() {
-            if (!this._uniqueId) {
+            if (this._uniqueId === undefined) {
                 var key;
                 this._uniqueId = "";
                 for (var i = 0; i < this.reference.table.shortestKey.length; i++) {

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -35,6 +35,51 @@ var ERMrest = (function(module) {
         };
     }
 
+    // polyfill for Array.findIndex
+    if (!Array.prototype.findIndex) {
+        Object.defineProperty(Array.prototype, 'findIndex', {
+            value: function(predicate) {
+                // 1. Let O be ? ToObject(this value).
+                if (this == null) {
+                    throw new TypeError('"this" is null or not defined');
+                }
+
+                var o = Object(this);
+
+                // 2. Let len be ? ToLength(? Get(O, "length")).
+                var len = o.length >>> 0;
+
+                // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+                if (typeof predicate !== 'function') {
+                    throw new TypeError('predicate must be a function');
+                }
+
+                // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+                var thisArg = arguments[1];
+
+                // 5. Let k be 0.
+                var k = 0;
+
+                // 6. Repeat, while k < len
+                while (k < len) {
+                    // a. Let Pk be ! ToString(k).
+                    // b. Let kValue be ? Get(O, Pk).
+                    // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+                    // d. If testResult is true, return k.
+                    var kValue = o[k];
+                    if (predicate.call(thisArg, kValue, k, o)) {
+                        return k;
+                    }
+                    // e. Increase k by 1.
+                    k++;
+                }
+
+                // 7. Return -1.
+                return -1;
+            }
+        });
+    }
+
     // Polyfill for string.endswith
     if (!String.prototype.endsWith) {
         String.prototype.endsWith = function(searchString, position) {

--- a/test/specs/reference/conf/reference_schema/data/table_w_only_composite_key.json
+++ b/test/specs/reference/conf/reference_schema/data/table_w_only_composite_key.json
@@ -1,0 +1,1 @@
+[{"id_1": "comp-part-1", "id_2": "comp-part-2"}]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -38,13 +38,13 @@
                     }
                 },
                 {
-                     "comment": null, 
-                     "name": "json_col_with_markdownpattern", 
-                     "default": null, 
-                     "nullok": true, 
+                     "comment": null,
+                     "name": "json_col_with_markdownpattern",
+                     "default": null,
+                     "nullok": true,
                      "type": {
                        "typename": "json"
-                     }, 
+                     },
                      "annotations": {
                        "tag:isrd.isi.edu,2016:column-display": {
                          "*": {
@@ -775,7 +775,7 @@
             "entityCount": 0,
             "foreign_keys": [],
             "table_name": "table_w_composite_key",
-            "schema_name": "columns_schema",
+            "schema_name": "reference_schema",
             "column_definitions": [
                 {
                     "name": "id",
@@ -784,6 +784,50 @@
                         "typename": "text"
                     }
                 },
+                {
+                    "name": "id_1",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "id_2",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2016:table-display": {
+                    "row_name": {
+                        "row_markdown_pattern": "{{id_1}} , {{id_2}}"
+                    }
+                },
+                "tag:isrd.isi.edu,2016:visible-columns": {
+                    "entry/edit": [],
+                    "entry/create": []
+                }
+            }
+        },
+        "table_w_only_composite_key": {
+            "comment": "Table with composite key as the only key",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id_1", "id_2"
+                    ]
+                }
+            ],
+            "entityCount": 0,
+            "foreign_keys": [],
+            "table_name": "table_w_only_composite_key",
+            "schema_name": "reference_schema",
+            "column_definitions": [
                 {
                     "name": "id_1",
                     "nullok": false,

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -5,13 +5,17 @@ exports.execute = function (options) {
             schemaName = "reference_schema",
             tableName = "reference_table",
             tableNameWithSlash = "table_w_slash",
+            tableNameWithCompKey = "table_w_only_composite_key",
             entityId = 9000,
             lowerLimit = 8999,
             upperLimit = 9010,
             originalTimeout;
 
-        var entityWithSlash = baseUri = options.url + "/catalog/" + catalog_id + "/entity/"
+        var entityWithSlash = options.url + "/catalog/" + catalog_id + "/entity/"
             + schemaName + ":" + tableNameWithSlash;
+
+        var entityWithCompositeKey = options.url + "/catalog/" + catalog_id + "/entity/"
+            + schemaName + ":" + tableNameWithCompKey;
 
         var baseUri = options.url + "/catalog/" + catalog_id + "/entity/"
             + schemaName + ":" + tableName;
@@ -264,6 +268,10 @@ exports.execute = function (options) {
 
             it('tuples should have methods properly defined.', function() {
                 expect(tuple.values).toBeDefined();
+                expect(tuple.isHTML).toBeDefined();
+                expect(tuple.displayname).toEqual(jasmine.any(Object), "tuple.displayname is not an object");
+                expect(tuple.displayname.value).toBe("Hank", "tuple.displayname.value is incorrect");
+                expect(tuple.uniqueId).toBe("9000", "tuple.uniqueId is incorrect");
             });
 
             it('tuple.copy should create a shallow copy of the tuple except for the data.', function() {
@@ -289,6 +297,27 @@ exports.execute = function (options) {
                 // based on order in reference_table.json
                 expect(values[1]).toBe(tuple._data.name);
                 expect(values[2]).toBe(tuple._data.value.toString());
+            });
+
+            it('uniqueId for an entity with a composite key should be set properly.', function(done) {
+                var reference, page, tuple;
+
+                options.ermRest.resolve(entityWithCompositeKey, {cid: "test"}).then(function (response) {
+                    reference = response;
+                    reference.session = { attributes: [] };
+
+                    return reference.read(limit);
+                }).then(function (response) {
+                    page = response;
+                    tuple = page.tuples[0];
+
+                    expect(tuple.uniqueId).toBe("comp-part-1_comp-part-2", "tuple.uniqueId with composite key is incorrect");
+
+                    done();
+                }).catch(function (error) {
+                    console.dir(error);
+                    done.fail();
+                });
             });
         });
 


### PR DESCRIPTION
This PR provides some additions to the `ermrestJS` API to support multi-select functionality in the recordset directive in `chaise`.  Changes in this PR include:
 - Added a `uniqueId` function to `Tuple` so each `Tuple` can be identified by a unique identifier when keeping track of currently selected rows
 - Added a polyfill for `Array.findIndex` because it is not supported in IE.
 - in a previous commit directly to master I added `Array.clear` as well for emptying out an array.

This PR is required to be merged before the corresponding [chaise PR](https://github.com/informatics-isi-edu/chaise/pull/1228). This PR helps to fix issue [#1211](https://github.com/informatics-isi-edu/chaise/issues/1211) in chaise.