### PR TITLE
Video support added in ermrestJS

### DIFF
--- a/js/utilities.js
+++ b/js/utilities.js
@@ -1322,7 +1322,7 @@
                             }
                             
                             if(captionHTML.trim().length && flag){
-                                html +=  "<p>"+captionHTML+ "</p>" + videoHTML + videoClass +">"+ srcHTML +"</video>" ;
+                                html +=  "<figure><figcaption>"+captionHTML+ "</figcaption>" + videoHTML + videoClass +">"+ srcHTML +"</video></figure>" ;
                             } else if(flag)
                                 html += videoHTML + videoClass +">"+ srcHTML +"</video>";
                             else

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -1286,7 +1286,7 @@
                         // Check If the markdown is a link
                         if (attrs[0].children[0].type == "link_open") {
                             var videoHTML="<video controls ", openingLink = attrs[0].children[0];
-                            var srcHTML="", videoClass="", flag = true;
+                            var srcHTML="", videoClass="", flag = true, posTop = true;
                             
                             // Add all attributes to the video
                             openingLink.attrs.forEach(function(attr) {
@@ -1302,6 +1302,9 @@
                                 }
                                 else if ( (attr[0] == "loop" || attr[0] == "preload" || attr[0] == "muted" || attr[0] == "autoload") && attr[1]=="") {
                                     videoClass +=  attr[0]+ " ";
+                                }
+                                else if ( (attr[0] == "pos") && attr[1]!=="") {
+                                    posTop =  attr[1].toLowerCase() == 'bottom' ? false : true;
                                 }
                             });
                             
@@ -1321,8 +1324,10 @@
                                 }
                             }
                             
-                            if(captionHTML.trim().length && flag){
+                            if(captionHTML.trim().length && flag && posTop){
                                 html +=  "<figure><figcaption>"+captionHTML+ "</figcaption>" + videoHTML + videoClass +">"+ srcHTML +"</video></figure>" ;
+                            }else if(captionHTML.trim().length && flag){
+                                html +=  "<figure>"+ videoHTML + videoClass +">"+ srcHTML +"</video><figcaption>"+captionHTML+ "</figcaption></figure>" ;
                             } else if(flag)
                                 html += videoHTML + videoClass +">"+ srcHTML +"</video>";
                             else

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -141,6 +141,27 @@ exports.execute = function (options) {
             expect(printMarkdown(dropdownMarkdown)).toBe(dropdownHTML);
 
             expect(printMarkdown(iframeMarkdown + "\n" + dropdownMarkdown)).toBe(iframeHTML + dropdownHTML);
+            
+            //Check for proper rendering of video tag with no attributes
+            var videoMarkDown = '::: video [caption](http://techslides.com/demos/sample-videos/small.mp4){} \n:::';
+            var videoHTML = '<p>caption</p><video controls ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>';
+            expect(printMarkdown(videoMarkDown)).toBe(videoHTML, "The video tag is not rendered properly with no attributes ");
+            
+            //Check for proper rendering of video tag with height and width attributes
+            var videoMarkDown = '::: video [caption](http://techslides.com/demos/sample-videos/small.mp4){width=800 height=200} \n:::';
+            var videoHTML = '<p>caption</p><video controls width=800 height=200 ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>';
+            expect(printMarkdown(videoMarkDown)).toBe(videoHTML, "The video tag is not rendered properly with height and width attributes ");
+            
+            //Check for proper rendering of video tag with height and width attributes and some boolean attributes like loop and muted
+            var videoMarkDown = '::: video [caption](http://techslides.com/demos/sample-videos/small.mp4){width=800 height=200 loop muted} \n:::';
+            var videoHTML = '<p>caption</p><video controls width=800 height=200 loop muted ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>';
+            expect(printMarkdown(videoMarkDown)).toBe(videoHTML, "The video tag is not rendered properly with boolean attributes ");
+            
+            //Check for proper rendering of video tag with some invalid attributes
+            var videoMarkDown = '::: video [caption](http://techslides.com/demos/sample-videos/small.mp4){loop=5 width=800} \n:::';
+            var videoHTML = '<p>caption</p><video controls width=800 ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>';
+            console.log(printMarkdown(videoMarkDown));
+            expect(printMarkdown(videoMarkDown)).toBe(videoHTML, "The video tag is not rendered properly with invalid attributes ");
 
         });
 

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -144,23 +144,22 @@ exports.execute = function (options) {
             
             //Check for proper rendering of video tag with no attributes
             var videoMarkDown = '::: video [caption](http://techslides.com/demos/sample-videos/small.mp4){} \n:::';
-            var videoHTML = '<p>caption</p><video controls ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>';
+            var videoHTML = '<figure><figcaption>caption</figcaption><video controls ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video></figure>';
             expect(printMarkdown(videoMarkDown)).toBe(videoHTML, "The video tag is not rendered properly with no attributes ");
             
             //Check for proper rendering of video tag with height and width attributes
             var videoMarkDown = '::: video [caption](http://techslides.com/demos/sample-videos/small.mp4){width=800 height=200} \n:::';
-            var videoHTML = '<p>caption</p><video controls width=800 height=200 ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>';
+            var videoHTML = '<figure><figcaption>caption</figcaption><video controls width=800 height=200 ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video></figure>';
             expect(printMarkdown(videoMarkDown)).toBe(videoHTML, "The video tag is not rendered properly with height and width attributes ");
             
             //Check for proper rendering of video tag with height and width attributes and some boolean attributes like loop and muted
             var videoMarkDown = '::: video [caption](http://techslides.com/demos/sample-videos/small.mp4){width=800 height=200 loop muted} \n:::';
-            var videoHTML = '<p>caption</p><video controls width=800 height=200 loop muted ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>';
+            var videoHTML = '<figure><figcaption>caption</figcaption><video controls width=800 height=200 loop muted ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video></figure>';
             expect(printMarkdown(videoMarkDown)).toBe(videoHTML, "The video tag is not rendered properly with boolean attributes ");
             
             //Check for proper rendering of video tag with some invalid attributes
             var videoMarkDown = '::: video [caption](http://techslides.com/demos/sample-videos/small.mp4){loop=5 width=800} \n:::';
-            var videoHTML = '<p>caption</p><video controls width=800 ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>';
-            console.log(printMarkdown(videoMarkDown));
+            var videoHTML = '<figure><figcaption>caption</figcaption><video controls width=800 ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video></figure>';
             expect(printMarkdown(videoMarkDown)).toBe(videoHTML, "The video tag is not rendered properly with invalid attributes ");
 
         });

--- a/test/specs/reference/conf/reference_schema/data/reference_values.json
+++ b/test/specs/reference/conf/reference_schema/data/reference_values.json
@@ -1,4 +1,4 @@
-[{"id":4000, "some_markdown": "**date is :**", "name":"Hank", "url": "https://www.google.com", "some_gene_sequence": "GATCGATCGCGTATT" },
+[{"id":4000, "some_markdown": "**date is :**", "name":"Hank", "url": "https://www.google.com", "some_gene_sequence": "GATCGATCGCGTATT", "video_col": "http://techslides.com/demos/sample-videos/small.mp4" },
  {"id":4001, "name":"Harold","some_invisible_column": "Junior"},
  {"id":4002, "url": "https://www.google.com"},
  {"id":4003 ,"some_invisible_column": "Freshmen"},

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -761,11 +761,25 @@
                     "type" : {
                         "typename": "text"
                     }
+                },
+                {
+                  "comment": null,
+                  "name": "video_col",
+                  "type": {
+                    "typename": "text"
+                  },
+                  "annotations": {
+                      "tag:isrd.isi.edu,2016:column-display": {
+                          "*": {
+                            "markdown_pattern": "::: video []({{{video_col}}}){height=500 width=600 loop} \n:::"
+                          }  
+                      }
+                  }
                 }
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns": {
-                  "*": ["id", "name", "url", "image", "image_with_size", "download_link", "iframe", "some_markdown", "some_markdown_with_pattern", "some_gene_sequence", "column_using_invisble_column"]
+                  "*": ["id", "name", "url", "image", "image_with_size", "download_link", "iframe","some_markdown", "some_markdown_with_pattern", "some_gene_sequence", "column_using_invisble_column", "video_col"]
                 }
             }
         },

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -86,9 +86,9 @@ exports.execute = function (options) {
          */
         var testTupleValidity = function(tupleIndex, expectedValues, expectedIsHTMLValues) {
 
-            it("should return 11 values for a tuple", function() {
+            it("should return 12 values for a tuple", function() {
                 var values = tuples[tupleIndex].values;
-                expect(values.length).toBe(11);
+                expect(values.length).toBe(12);
             });
             
             checkValueAndIsHTML("id", tupleIndex, 0, expectedValues, expectedIsHTMLValues);
@@ -100,151 +100,141 @@ exports.execute = function (options) {
             checkValueAndIsHTML("iframe", tupleIndex, 6, expectedValues, expectedIsHTMLValues);
             checkValueAndIsHTML("some_markdown", tupleIndex, 7, expectedValues, expectedIsHTMLValues);  
             checkValueAndIsHTML("some_markdown_with_pattern", tupleIndex, 8, expectedValues, expectedIsHTMLValues);  
-            checkValueAndIsHTML("some_gene_sequence", tupleIndex, 9, expectedValues, expectedIsHTMLValues);        
+            checkValueAndIsHTML("some_gene_sequence", tupleIndex, 9, expectedValues, expectedIsHTMLValues);    
+            checkValueAndIsHTML("video_col", tupleIndex, 11, expectedValues, expectedIsHTMLValues);       
         };
-
-
-
-        describe('for tuple 0 with row values {"id":4000, "some_markdown": "** date is :**", "name":"Hank", "url": "https://www.google.com", "some_gene_sequence": "GATCGATCGCGTATT"},', function() {
-            var values = ['4000',
-                          '<h2>Hank</h2>\n',
-                          '<p><a href="https://www.google.com/Hank">link</a></p>\n',
-                          '<p><img src="http://example.com/4000.png" alt="image"></p>\n',
-                          '<p><img src="https://www.google.com/4000.png" alt="image with size" width="400" height="400"></p>\n',
-                          '<p><a href="https://www.google.com" download="">download link</a></p>\n',
-                          '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Hank caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
-                          '<p><strong>date is :</strong></p>\n',
-                          '<p><strong>Name is :</strong> Hank<br>\n<strong>date is :</strong></p>\n',
-                          '<code>GATCGATCGC GTATT</code>',
-                          'NA'];
-
-            // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, true, true, true, true, true, true, true, true, false];
-
-            testTupleValidity(0, values, isHTML);
-        });
-
-        describe('for tuple 1 with row values {"id":4001, "name":"Harold","some_invisible_column": "Junior"},', function() {
-
-            var values = ['4001',
-                          '<h2>Harold</h2>\n',
-                          '<p><a href="/Harold">link</a></p>\n',
-                          '<p><img src="http://example.com/4001.png" alt="image"></p>\n',
-                          '<p><img src="/4001.png" alt="image with size" width="400" height="400"></p>\n',
-                          '<p><a href="" download="">download link</a></p>\n',
-                          '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Harold caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
-                          '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '<p><strong>Name is :</strong> Harold<br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '',
-                          '<p><a href="http://example.com/Junior">Junior</a></p>\n'];
-
-            // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, true, true, true, true, true, true, true, true, true];
-
-            testTupleValidity(1, values, isHTML);            
-        });
-
-        describe('for tuple 2 with row values {"id":4002, "url": "https://www.google.com"},', function() {
-
-            var values = ['4002',
-                          null,
-                          '',
-                          '<p><img src="http://example.com/4002.png" alt="image"></p>\n',
-                          '<p><img src="https://www.google.com/4002.png" alt="image with size" width="400" height="400"></p>\n',
-                          '<p><a href="https://www.google.com" download="">download link</a></p>\n',
-                          '',
-                          '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '',
-                          '',
-                          'NA'];
-
-            // Change last false to true once gene_sequence type is added
-            var isHTML = [false, false, false, true, true, true, false, true, false, true, false];
-
-            testTupleValidity(2, values, isHTML);
-        });
-
-        describe('for tuple 3 with row values {"id":4003 ,"some_invisible_column": "Freshmen"},', function() {
-
-            var values = ['4003',
-                          null,
-                          '',
-                          '<p><img src="http://example.com/4003.png" alt="image"></p>\n',
-                          '<p><img src="/4003.png" alt="image with size" width="400" height="400"></p>\n',
-                          '<p><a href="" download="">download link</a></p>\n',
-                          '',
-                          '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '',
-                          '',
-                          '<p><a href="http://example.com/Freshmen">Freshmen</a></p>\n'];
-            // Change last false to true once gene_sequence type is added
-            var isHTML = [false, false, false, true, true, true, false, true, false, true, true];
-
-            testTupleValidity(3, values, isHTML);
-        });
-
-        describe('for tuple 4 with row values {"id":4004, "name": "weird & HTML < " },', function() {
-
-            var values = ['4004',
-                          '<h2>weird &amp; HTML &lt;</h2>\n',
-                          '<p>[link](/weird &amp; HTML &lt; )</p>\n',
-                          '<p><img src="http://example.com/4004.png" alt="image"></p>\n',
-                          '<p><img src="/4004.png" alt="image with size" width="400" height="400"></p>\n',
-                          '<p><a href="" download="">download link</a></p>\n',
-                          '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">weird &amp; HTML &lt;  caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
-                          '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '<p><strong>Name is :</strong> weird &amp; HTML &lt;<br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '',
-                          'NA'];
-
-            // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, true, true, true, true, true, true, true, true, false];
-
-            testTupleValidity(4, values, isHTML);
-        });
-
-        describe('for tuple 5 with row values {"id":4005, "name": "<a href=\'javascript:alert();\'></a>" , "some_invisible_column": "Senior"},', function() {
-
-            var values = ['4005',
-                          '<h2>&lt;a href=\'javascript:alert();\'&gt;&lt;/a&gt;</h2>\n',
-                          '<p>[link](/&lt;a href=\'javascript:alert();\'&gt;&lt;/a&gt;)</p>\n',
-                          '<p><img src="http://example.com/4005.png" alt="image"></p>\n',
-                          '<p><img src="/4005.png" alt="image with size" width="400" height="400"></p>\n',
-                          '<p><a href="" download="">download link</a></p>\n',
-                          '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">&lt;a href=‘javascript:alert();’&gt;&lt;/a&gt; caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
-                          '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '<p><strong>Name is :</strong> &lt;a href=\'javascript:alert();\'&gt;&lt;/a&gt;<br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '',
-                          '<p><a href="http://example.com/Senior">Senior</a></p>\n'];
-
-            // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, true, true, true, true, true, true, true, true, true];
-
-            testTupleValidity(5, values, isHTML);
-        });
-
-        describe('for tuple 6 with row values {"id":4006, "name": "<script>alert();</script>", "some_gene_sequence": "GATCGATCGCGTATT" , "some_invisible_column": "Sophomore"},', function() {
-
-            var values = ['4006',
-                          '<h2>&lt;script&gt;alert();&lt;/script&gt;</h2>\n',
-                          '<p><a href="/%3Cscript%3Ealert();%3C/script%3E">link</a></p>\n',
-                          '<p><img src="http://example.com/4006.png" alt="image"></p>\n',
-                          '<p><img src="/4006.png" alt="image with size" width="400" height="400"></p>\n',
-                          '<p><a href="" download="">download link</a></p>\n',
-                          '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">&lt;script&gt;alert();&lt;/script&gt; caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
-                          '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '<p><strong>Name is :</strong> &lt;script&gt;alert();&lt;/script&gt;<br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
-                          '<code>GATCGATCGC GTATT</code>',
-                          '<p><a href="http://example.com/Sophomore">Sophomore</a></p>\n'];
-
-            // Change last false to true once gene_sequence type is added
-            var isHTML = [false, true, true, true, true, true, true, true, true, true, true];
-
-            testTupleValidity(6, values, isHTML);
-        });
         
+        describe("Testing tuples values", function() {
+            var rowValues= [["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4" ],
+             ["id=4001, name=Harold,some_invisible_column= Junior, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+             ["id=4002, url= https://www.google.com, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+             ["id=4003 ,some_invisible_column= Freshmen, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+             ["id=4004, name= weird & HTML < , video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+             ["id=4005, name= <a href='javascript:alert();'></a>, some_invisible_column= Senior, video_col= http://techslides.com//small.mp4"],
+             ["id=4006, name= <script>alert();</script>, some_gene_sequence= GATCGATCGCGTATT, some_invisible_column= Sophomore, video_col= http://techs.com/sample/small.mp4"]]
+
+            var expectedValues =[
+                                [ '4000',
+                                  '<h2>Hank</h2>\n',
+                                  '<p><a href="https://www.google.com/Hank">link</a></p>\n',
+                                  '<p><img src="http://example.com/4000.png" alt="image"></p>\n',
+                                  '<p><img src="https://www.google.com/4000.png" alt="image with size" width="400" height="400"></p>\n',
+                                  '<p><a href="https://www.google.com" download="">download link</a></p>\n',
+                                  '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Hank caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
+                                  '<p><strong>date is :</strong></p>\n',
+                                  '<p><strong>Name is :</strong> Hank<br>\n<strong>date is :</strong></p>\n',
+                                  '<code>GATCGATCGC GTATT</code>',
+                                  'NA',
+                                  '<video controls height=500 width=600 loop ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>'
+                                ],
+                                [
+                                    '4001',
+                                    '<h2>Harold</h2>\n',
+                                    '<p><a href="/Harold">link</a></p>\n',
+                                    '<p><img src="http://example.com/4001.png" alt="image"></p>\n',
+                                    '<p><img src="/4001.png" alt="image with size" width="400" height="400"></p>\n',
+                                    '<p><a href="" download="">download link</a></p>\n',
+                                    '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Harold caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
+                                    '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                                    '<p><strong>Name is :</strong> Harold<br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                                    '',
+                                    '<p><a href="http://example.com/Junior">Junior</a></p>\n',
+                                    ''
+                                ],
+                                [
+                                    '4002',
+                                    null,
+                                    '',
+                                    '<p><img src="http://example.com/4002.png" alt="image"></p>\n',
+                                    '<p><img src="https://www.google.com/4002.png" alt="image with size" width="400" height="400"></p>\n',
+                                    '<p><a href="https://www.google.com" download="">download link</a></p>\n',
+                                    '',
+                                    '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                                    '',
+                                    '',
+                                    'NA',
+                                    ''             
+                                ],
+                                [
+                                    '4003',
+                                    null,
+                                    '',
+                                    '<p><img src="http://example.com/4003.png" alt="image"></p>\n',
+                                    '<p><img src="/4003.png" alt="image with size" width="400" height="400"></p>\n',
+                                    '<p><a href="" download="">download link</a></p>\n',
+                                    '',
+                                    '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                                    '',
+                                    '',
+                                    '<p><a href="http://example.com/Freshmen">Freshmen</a></p>\n',
+                                    ''             
+                                ],
+                                [
+                                    '4004',
+                                    '<h2>weird &amp; HTML &lt;</h2>\n',
+                                    '<p>[link](/weird &amp; HTML &lt; )</p>\n',
+                                    '<p><img src="http://example.com/4004.png" alt="image"></p>\n',
+                                    '<p><img src="/4004.png" alt="image with size" width="400" height="400"></p>\n',
+                                    '<p><a href="" download="">download link</a></p>\n',
+                                    '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">weird &amp; HTML &lt;  caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
+                                    '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                                    '<p><strong>Name is :</strong> weird &amp; HTML &lt;<br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                                    '',
+                                    'NA',
+                                    ''             
+                                ],
+                                [
+                                    '4005',
+                                    '<h2>&lt;a href=\'javascript:alert();\'&gt;&lt;/a&gt;</h2>\n',
+                                    '<p>[link](/&lt;a href=\'javascript:alert();\'&gt;&lt;/a&gt;)</p>\n',
+                                    '<p><img src="http://example.com/4005.png" alt="image"></p>\n',
+                                    '<p><img src="/4005.png" alt="image with size" width="400" height="400"></p>\n',
+                                    '<p><a href="" download="">download link</a></p>\n',
+                                    '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">&lt;a href=‘javascript:alert();’&gt;&lt;/a&gt; caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
+                                    '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                                    '<p><strong>Name is :</strong> &lt;a href=\'javascript:alert();\'&gt;&lt;/a&gt;<br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                                    '',
+                                    '<p><a href="http://example.com/Senior">Senior</a></p>\n',
+                                    ''             
+                                ],
+                                [
+                                    '4006',
+                                    '<h2>&lt;script&gt;alert();&lt;/script&gt;</h2>\n',
+                                    '<p><a href="/%3Cscript%3Ealert();%3C/script%3E">link</a></p>\n',
+                                    '<p><img src="http://example.com/4006.png" alt="image"></p>\n',
+                                    '<p><img src="/4006.png" alt="image with size" width="400" height="400"></p>\n',
+                                    '<p><a href="" download="">download link</a></p>\n',
+                                    '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">&lt;script&gt;alert();&lt;/script&gt; caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
+                                    '<p><strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                                    '<p><strong>Name is :</strong> &lt;script&gt;alert();&lt;/script&gt;<br>\n<strong>This is some markdown</strong> with some <code>code</code> and a <a href="http://www.example.com">link</a></p>\n',
+                                    '<code>GATCGATCGC GTATT</code>',
+                                    '<p><a href="http://example.com/Sophomore">Sophomore</a></p>\n',
+                                    ''             
+                                ]
+                              ];
+            var isHTMLList = [  [false, true, true, true, true, true, true, true, true, true, false, true],
+                                [false, true, true, true, true, true, true, true, true, true, true, true],
+                                [false, false, false, true, true, true, false, true, false, true, false, true],
+                                [false, false, false, true, true, true, false, true, false, true, true, true],
+                                [false, true, true, true, true, true, true, true, true, true, false, true],
+                                [false, true, true, true, true, true, true, true, true, true, true, true],
+                                [false, true, true, true, true, true, true, true, true, true, true, true]
+                             ]
+
+            for(var i=0; i< expectedValues.length; i++){
+                var rowValue = rowValues[i];
+                var expectedValue = expectedValues[i];
+                var isHTML = isHTMLList[i];
+                describe('Testing for tuple '+ i +" with row values {"+ rowValue + "}", function(){
+                    testTupleValidity(i, expectedValue, isHTML);
+                })
+                    
+            }
+        });
 
     });
+    
+    
     
     describe("Test JSON values with and without markdown,", function() {
         //Tested these values as formatted values inside it, to get the exact string after JSON.stringify()

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -105,29 +105,27 @@ exports.execute = function (options) {
         };
         
         describe("Testing tuples values", function() {
-            var rowValues= [["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4" ],
-             ["id=4001, name=Harold,some_invisible_column= Junior, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-             ["id=4002, url= https://www.google.com, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-             ["id=4003 ,some_invisible_column= Freshmen, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-             ["id=4004, name= weird & HTML < , video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-             ["id=4005, name= <a href='javascript:alert();'></a>, some_invisible_column= Senior, video_col= http://techslides.com//small.mp4"],
-             ["id=4006, name= <script>alert();</script>, some_gene_sequence= GATCGATCGCGTATT, some_invisible_column= Sophomore, video_col= http://techs.com/sample/small.mp4"]]
-
-            var expectedValues =[
-                                [ '4000',
-                                  '<h2>Hank</h2>\n',
-                                  '<p><a href="https://www.google.com/Hank">link</a></p>\n',
-                                  '<p><img src="http://example.com/4000.png" alt="image"></p>\n',
-                                  '<p><img src="https://www.google.com/4000.png" alt="image with size" width="400" height="400"></p>\n',
-                                  '<p><a href="https://www.google.com" download="">download link</a></p>\n',
-                                  '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Hank caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
-                                  '<p><strong>date is :</strong></p>\n',
-                                  '<p><strong>Name is :</strong> Hank<br>\n<strong>date is :</strong></p>\n',
-                                  '<code>GATCGATCGC GTATT</code>',
-                                  'NA',
-                                  '<video controls height=500 width=600 loop ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>'
-                                ],
-                                [
+            var testObjects ={ 
+                "test1": {
+                        "rowValue" : ["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4" ],
+                        "expectedValue" : [ '4000',
+                                            '<h2>Hank</h2>\n',
+                                            '<p><a href="https://www.google.com/Hank">link</a></p>\n',
+                                            '<p><img src="http://example.com/4000.png" alt="image"></p>\n',
+                                            '<p><img src="https://www.google.com/4000.png" alt="image with size" width="400" height="400"></p>\n',
+                                            '<p><a href="https://www.google.com" download="">download link</a></p>\n',
+                                            '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Hank caption</figcaption><iframe src="http://example.com/iframe" width="300" ></iframe></figure>',
+                                            '<p><strong>date is :</strong></p>\n',
+                                            '<p><strong>Name is :</strong> Hank<br>\n<strong>date is :</strong></p>\n',
+                                            '<code>GATCGATCGC GTATT</code>',
+                                            'NA',
+                                            '<video controls height=500 width=600 loop ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>'
+                                             ],
+                        "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true]              
+                        },
+                "test2": {
+                    "rowValue" :["id=4001, name=Harold,some_invisible_column= Junior"],
+                    "expectedValue" : [
                                     '4001',
                                     '<h2>Harold</h2>\n',
                                     '<p><a href="/Harold">link</a></p>\n',
@@ -141,7 +139,11 @@ exports.execute = function (options) {
                                     '<p><a href="http://example.com/Junior">Junior</a></p>\n',
                                     ''
                                 ],
-                                [
+                    "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true]
+                    },
+            "test3": {
+                    "rowValue" : ["id=4002, url= https://www.google.com, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+                    "expectedValue" :[
                                     '4002',
                                     null,
                                     '',
@@ -154,8 +156,12 @@ exports.execute = function (options) {
                                     '',
                                     'NA',
                                     ''             
-                                ],
-                                [
+                                    ],
+                    "isHTML" : [false, false, false, true, true, true, false, true, false, true, false, true]
+                    },
+            "test4": {
+                    "rowValue" : ["id=4003 ,some_invisible_column= Freshmen"],
+                    "expectedValue" : [
                                     '4003',
                                     null,
                                     '',
@@ -168,8 +174,12 @@ exports.execute = function (options) {
                                     '',
                                     '<p><a href="http://example.com/Freshmen">Freshmen</a></p>\n',
                                     ''             
-                                ],
-                                [
+                                    ],
+                    "isHTML" : [false, false, false, true, true, true, false, true, false, true, true, true]
+                    },
+            "test5": {
+                    "rowValue" :  ["id=4004, name= weird & HTML < "],
+                    "expectedValue" : [
                                     '4004',
                                     '<h2>weird &amp; HTML &lt;</h2>\n',
                                     '<p>[link](/weird &amp; HTML &lt; )</p>\n',
@@ -182,8 +192,12 @@ exports.execute = function (options) {
                                     '',
                                     'NA',
                                     ''             
-                                ],
-                                [
+                                    ],
+                    "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true]
+                    },
+            "test6": {
+                    "rowValue" : ["id=4005, name= <a href='javascript:alert();'></a>, some_invisible_column= Senior"],
+                    "expectedValue" : [
                                     '4005',
                                     '<h2>&lt;a href=\'javascript:alert();\'&gt;&lt;/a&gt;</h2>\n',
                                     '<p>[link](/&lt;a href=\'javascript:alert();\'&gt;&lt;/a&gt;)</p>\n',
@@ -196,8 +210,12 @@ exports.execute = function (options) {
                                     '',
                                     '<p><a href="http://example.com/Senior">Senior</a></p>\n',
                                     ''             
-                                ],
-                                [
+                                    ],
+                    "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true]
+                    },
+            "test7": {
+                    "rowValue" : ["id=4006, name= <script>alert();</script>, some_gene_sequence= GATCGATCGCGTATT, some_invisible_column= Sophomore"],
+                    "expectedValue" : [
                                     '4006',
                                     '<h2>&lt;script&gt;alert();&lt;/script&gt;</h2>\n',
                                     '<p><a href="/%3Cscript%3Ealert();%3C/script%3E">link</a></p>\n',
@@ -210,25 +228,21 @@ exports.execute = function (options) {
                                     '<code>GATCGATCGC GTATT</code>',
                                     '<p><a href="http://example.com/Sophomore">Sophomore</a></p>\n',
                                     ''             
-                                ]
-                              ];
-            var isHTMLList = [  [false, true, true, true, true, true, true, true, true, true, false, true],
-                                [false, true, true, true, true, true, true, true, true, true, true, true],
-                                [false, false, false, true, true, true, false, true, false, true, false, true],
-                                [false, false, false, true, true, true, false, true, false, true, true, true],
-                                [false, true, true, true, true, true, true, true, true, true, false, true],
-                                [false, true, true, true, true, true, true, true, true, true, true, true],
-                                [false, true, true, true, true, true, true, true, true, true, true, true]
-                             ]
-
-            for(var i=0; i< expectedValues.length; i++){
-                var rowValue = rowValues[i];
-                var expectedValue = expectedValues[i];
-                var isHTML = isHTMLList[i];
+                                    ],
+                    "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true]
+                }
+                
+            }
+            
+            var i = 0;
+            for(var key in testObjects){
+                var rowValue = testObjects[key].rowValue;
+                var expectedValue = testObjects[key].expectedValue;
+                var isHTML = testObjects[key].isHTML;
                 describe('Testing for tuple '+ i +" with row values {"+ rowValue + "}", function(){
                     testTupleValidity(i, expectedValue, isHTML);
                 })
-                    
+                i++;    
             }
         });
 

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -108,30 +108,44 @@ exports.execute = function (options) {
         
         
         describe("Testing tuples values", function() {
-            var rowValues= [["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4" ],
-             ["id=4001, name=Harold,some_invisible_column= Junior, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-             ["id=4002, url= https://www.google.com, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-             ["id=4003 ,some_invisible_column= Freshmen, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-             ["id=4004, name= weird & HTML < , video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-             ["id=4005, name= <a href='javascript:alert();'></a>, some_invisible_column= Senior, video_col= http://techslides.com//small.mp4"],
-             ["id=4006, name= <script>alert();</script>, some_gene_sequence= GATCGATCGCGTATT, some_invisible_column= Sophomore, video_col= http://techs.com/sample/small.mp4"]]
-
-            var expectedValues =[ ["4000", "Hank", "https://www.google.com", null, null, null, null, '**date is :**', '**Name is :**', "GATCGATCGCGTATT",null, "http://techslides.com/demos/sample-videos/small.mp4"],
-                                  ["4001", "Harold", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null],
-                                  ["4002", null, "https://www.google.com", null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null],
-                                  ["4003", null, null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**',null, null, null],
-                                  ["4004", "weird & HTML < ", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null ],
-                                  ["4005", "<a href='javascript:alert();'></a>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null],
-                                  ["4006", "<script>alert();</script>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', "GATCGATCGCGTATT", null, null]
-                              ];
-
-            for(var i=0; i< expectedValues.length; i++){
-                var rowValue = rowValues[i];
-                var expectedValue = expectedValues[i];
+            var testObjects ={
+                "test1": {
+                        "rowValue" : ["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4" ],
+                        "expectedValue": ["4000", "Hank", "https://www.google.com", null, null, null, null, '**date is :**', '**Name is :**', "GATCGATCGCGTATT",null, "http://techslides.com/demos/sample-videos/small.mp4"] 
+                        },
+                "test2": {
+                        "rowValue" : ["id=4001, name=Harold,some_invisible_column= Junior, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+                        "expectedValue" : ["4001", "Harold", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null]
+                        },
+                "test3": {
+                        "rowValue" : ["id=4002, url= https://www.google.com, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+                        "expectedValue" : ["4002", null, "https://www.google.com", null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null]
+                        },
+                "test4": {
+                        "rowValue" : ["id=4003 ,some_invisible_column= Freshmen, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+                        "expectedValue" :["4003", null, null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**',null, null, null]
+                        },
+                "test5": {
+                        "rowValue" :["id=4004, name= weird & HTML < , video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+                        "expectedValue" :["4004", "weird & HTML < ", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null ]
+                        },
+                "test6": {
+                        "rowValue": ["id=4005, name= <a href='javascript:alert();'></a>, some_invisible_column= Senior, video_col= http://techslides.com//small.mp4"],
+                        "expectedValue": ["4005", "<a href='javascript:alert();'></a>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null]
+                        },
+                "test7": {
+                        "rowValue" :["id=4006, name= <script>alert();</script>, some_gene_sequence= GATCGATCGCGTATT, some_invisible_column= Sophomore, video_col= http://techs.com/sample/small.mp4"],
+                        "expectedValue": ["4006", "<script>alert();</script>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', "GATCGATCGCGTATT", null, null]
+                        }
+                }
+            var i =0;
+            for(var key in testObjects){
+                var rowValue = testObjects[key].rowValue;
+                var expectedValue = testObjects[key].expectedValue;
                 describe('Testing for tuple '+ i +" with row values {"+ rowValue + "}", function(){
                     testTupleValidity(i, expectedValue);
                 })
-                    
+                i++;    
             }
         });
         

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -60,7 +60,7 @@ exports.execute = function (options) {
                 var expectedValue = expectedValues[valueIndex];
 
                 // Check value is same as expected
-                expect(value).toBe(expectedValue);
+                expect(value).toBe(expectedValue, columnName+" column value is "+ value+ " expected it to be "+expectedValue);
             });
 
 
@@ -69,7 +69,7 @@ exports.execute = function (options) {
                 var isHTML = tuple.isHTML[valueIndex];
 
                 // Check isHTML is same as expected; either true or false
-                expect(isHTML).toBe(false);
+                expect(isHTML).toBe(false, columnName + " column isHTML should be set to false but was found to be true" );
             });
 
         };
@@ -86,7 +86,7 @@ exports.execute = function (options) {
             it("should return 1 values for a tuple", function() {
                 var values = tuples[tupleIndex].values;
 
-                expect(values.length).toBe(11);
+                expect(values.length).toBe(12);
             });
 
             checkValueAndIsHTML("id", tupleIndex, 0, expectedValues);
@@ -99,140 +99,40 @@ exports.execute = function (options) {
             checkValueAndIsHTML("some_markdown", tupleIndex, 7, expectedValues);
             checkValueAndIsHTML("some_markdown_with_pattern", tupleIndex, 8, expectedValues);
             checkValueAndIsHTML("some_gene_sequence", tupleIndex, 9, expectedValues);
+            checkValueAndIsHTML("video_col", tupleIndex, 11, expectedValues);
+
         };
 
 
 
-        describe('for tuple 0 with row values {"id":4000, "some_markdown": "** date is :**", "name":"Hank", "url": "https://www.google.com", "some_gene_sequence": "GATCGATCGCGTATT"},', function() {
-            var values = [
-                            "4000",
-                            "Hank",
-                            "https://www.google.com",
-                            null,
-                            null,
-                            null,
-                            null,
-                            '**date is :**',
-                            '**Name is :**',
-                            "GATCGATCGCGTATT",
-                            null
-                          ];
+        
+        
+        describe("Testing tuples values", function() {
+            var rowValues= [["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4" ],
+             ["id=4001, name=Harold,some_invisible_column= Junior, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+             ["id=4002, url= https://www.google.com, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+             ["id=4003 ,some_invisible_column= Freshmen, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+             ["id=4004, name= weird & HTML < , video_col= http://techslides.com/demos/sample-videos/small.mp4"],
+             ["id=4005, name= <a href='javascript:alert();'></a>, some_invisible_column= Senior, video_col= http://techslides.com//small.mp4"],
+             ["id=4006, name= <script>alert();</script>, some_gene_sequence= GATCGATCGCGTATT, some_invisible_column= Sophomore, video_col= http://techs.com/sample/small.mp4"]]
 
-            testTupleValidity(0, values);
-        });
+            var expectedValues =[ ["4000", "Hank", "https://www.google.com", null, null, null, null, '**date is :**', '**Name is :**', "GATCGATCGCGTATT",null, "http://techslides.com/demos/sample-videos/small.mp4"],
+                                  ["4001", "Harold", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null],
+                                  ["4002", null, "https://www.google.com", null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null],
+                                  ["4003", null, null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**',null, null, null],
+                                  ["4004", "weird & HTML < ", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null ],
+                                  ["4005", "<a href='javascript:alert();'></a>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null],
+                                  ["4006", "<script>alert();</script>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', "GATCGATCGCGTATT", null, null]
+                              ];
 
-        describe('for tuple 1 with row values {"id":4001, "name":"Harold","some_invisible_column": "Junior"},', function() {
-
-            var values = [
-                            "4001",
-                            "Harold",
-                            null,
-                            null,
-                            null,
-                            null,
-                            null,
-                            '**This is some markdown** with some `code` and a [link](http://www.example.com)',
-                            '**Name is :**',
-                            null,
-                            null
-                          ];
-
-            testTupleValidity(1, values);
-        });
-
-        describe('for tuple 2 with row values {"id":4002, "url": "https://www.google.com"},', function() {
-
-            var values =  [
-                            "4002",
-                            null,
-                            "https://www.google.com",
-                            null,
-                            null,
-                            null,
-                            null,
-                            '**This is some markdown** with some `code` and a [link](http://www.example.com)',
-                            '**Name is :**',
-                            null,
-                            null
-                          ];
-
-            testTupleValidity(2, values);
-        });
-
-        describe('for tuple 3 with row values {"id":4003 ,"some_invisible_column": "Freshmen"},', function() {
-
-            var values = [
-                            "4003",
-                            null,
-                            null,
-                            null,
-                            null,
-                            null,
-                            null,
-                            '**This is some markdown** with some `code` and a [link](http://www.example.com)',
-                            '**Name is :**',
-                            null,
-                            null
-                          ];
-
-            testTupleValidity(3, values);
-        });
-
-        describe('for tuple 4 with row values {"id":4004, "name": "weird & HTML < " },', function() {
-
-            var values = [
-                            "4004",
-                            "weird & HTML < ",
-                            null,
-                            null,
-                            null,
-                            null,
-                            null,
-                            '**This is some markdown** with some `code` and a [link](http://www.example.com)',
-                            '**Name is :**',
-                            null,
-                            null
-                          ];
-
-            testTupleValidity(4, values);
-        });
-
-        describe('for tuple 5 with row values {"id":4005, "name": "<a href=\'javascript:alert();\'></a>" , "some_invisible_column": "Senior"},', function() {
-
-            var values = [
-                            "4005",
-                            "<a href='javascript:alert();'></a>",
-                            null,
-                            null,
-                            null,
-                            null,
-                            null,
-                            '**This is some markdown** with some `code` and a [link](http://www.example.com)',
-                            '**Name is :**',
-                            null,
-                            null
-                          ];
-
-            testTupleValidity(5, values);
-        });
-
-        describe('for tuple 6 with row values {"id":4006, "name": "<script>alert();</script>", "some_gene_sequence": "GATCGATCGCGTATT" , "some_invisible_column": "Sophomore"},', function() {
-
-            var values = [
-                            "4006",
-                            "<script>alert();</script>",
-                            null,
-                            null,
-                            null,
-                            null,
-                            null,
-                            '**This is some markdown** with some `code` and a [link](http://www.example.com)',
-                            '**Name is :**',
-                            "GATCGATCGCGTATT",
-                            null
-                          ];
-
-            testTupleValidity(6, values);
+            for(var i=0; i< expectedValues.length; i++){
+                var rowValue = rowValues[i];
+                var expectedValue = expectedValues[i];
+                describe('Testing for tuple '+ i +" with row values {"+ rowValue + "}", function(){
+                    testTupleValidity(i, expectedValue);
+                })
+                    
+            }
         });
         
         


### PR DESCRIPTION
This PR is to support video playback in chaise, for which we needed functionality in ermrestJS supporting custom markdown tag for video

The attributes supported (autoplay, height, loop, muted, preload, src, width)

Only mp4 format as it seems to be supported in all major browsers.

