### PR TITLE
Added support to consider pure binary association tables with system columns to be considered the same

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1122,8 +1122,8 @@
                 return false; // not binary
             }
 
-            var nonKeyCols = this.columns.all().filter(function(col){
-                return col.memberOfKeys.length === 0;
+            var nonKeyCols = this.columns.all().filter(function(col) {
+            	return col.memberOfKeys.length === 0 && module._systemColumns.indexOf(col.name) === -1;
             }); // columns that are not part of any keys.
 
             return nonKeyCols.length === 0; // check for purity

--- a/js/reference.js
+++ b/js/reference.js
@@ -3229,7 +3229,7 @@
                 this._uniqueId = "";
                 for (var i = 0; i < this.reference.table.shortestKey.length; i++) {
                     keyName = this.reference.table.shortestKey[i].name;
-                    if (i != 0) this._uniqueId += "_";
+                    if (i !== 0) this._uniqueId += "_";
                     this._uniqueId += this.data[keyName];
                 }
             }
@@ -4687,7 +4687,7 @@
          * @type {string}
          */
         get comment () {
-            if (this._comment == undefined) {
+            if (this._comment === undefined) {
                 var fk = this._lastForeignKey ? this._lastForeignKey.obj : null;
                 if (fk === null || !this.isEntityMode) {
                     this._comment = this._column.comment;

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -39,7 +39,7 @@
         Object.defineProperty(Array.prototype, 'findIndex', {
             value: function(predicate) {
                 // 1. Let O be ? ToObject(this value).
-                if (this == null) {
+                if (this === null) {
                     throw new TypeError('"this" is null or not defined');
                 }
 
@@ -1664,3 +1664,5 @@
         MARKDOWN: 'markdown',
         MODULE: 'module'
     });
+
+    module._systemColumns = ['rid', 'rcb', 'rmb', 'rct', 'rmt'];

--- a/test/specs/reference/conf/reference_schema/data/association table with id.json
+++ b/test/specs/reference/conf/reference_schema/data/association table with id.json
@@ -1,3 +1,3 @@
-[{"ID":1,"id from ref table":9001,"id_from_inbound_related_table":1},
-{"ID":2,"id from ref table":9003,"id_from_inbound_related_table":2},
-{"ID":3,"id from ref table":9003,"id_from_inbound_related_table":3}]
+[{"ID":1,"id from ref table":9001,"id_from_inbound_related_table":1,"rid":123,"rcb":"user","rmb":"user","rct":"2017-09-05T15:02:11.501028-07:00","rmt":"2017-09-06T15:02:11.501028-07:00"},
+{"ID":2,"id from ref table":9003,"id_from_inbound_related_table":2,"rid":123,"rcb":"user","rmb":"user","rct":"2017-09-05T15:02:11.501028-07:00","rmt":"2017-09-06T15:02:11.501028-07:00"},
+{"ID":3,"id from ref table":9003,"id_from_inbound_related_table":3,"rid":123,"rcb":"user","rmb":"user","rct":"2017-09-05T15:02:11.501028-07:00","rmt":"2017-09-06T15:02:11.501028-07:00"}]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -343,6 +343,31 @@
                     "name": "id_from_inbound_related_table",
                     "nullok": false,
                     "type": {"typename":"text"}
+                },
+                {
+                    "name": "rid",
+                    "nullok": false,
+                    "type": {"typename":"int8"}
+                },
+                {
+                    "name": "rcb",
+                    "nullok": false,
+                    "type": {"typename":"text"}
+                },
+                {
+                    "name": "rmb",
+                    "nullok": false,
+                    "type": {"typename":"text"}
+                },
+                {
+                    "name": "rct",
+                    "nullok": false,
+                    "type": {"typename":"timestamptz"}
+                },
+                {
+                    "name": "rmt",
+                    "nullok": false,
+                    "type": {"typename":"timestamptz"}
                 }
             ],
             "annotations": {

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -177,7 +177,7 @@ exports.execute = function(options) {
 
         });
 
-        describe('for pure and binray association foreign keys, ', function() {
+        describe('for pure and binary association foreign keys, ', function() {
             var pageWithToName, pageWithID;
 
             it('should have the correct catalog, schema, and table.', function (){
@@ -185,7 +185,7 @@ exports.execute = function(options) {
                 expect(related[2]._table.name).toBe(inboudTableName);
             });
 
-            describe('.displayname, ', function (){
+            describe('.displayname, ', function () {
                 it('should use to_name when annotation is present.', function() {
                   expect(related[2].displayname.value).toBe("to_name_value");
                 });
@@ -194,30 +194,7 @@ exports.execute = function(options) {
                   expect(related[3].displayname.value).toBe(associationTableWithIDDisplayname);
                 });
             });
-
-            describe('.columns, ', function() {
-                it('should ignore all the foreign keys that create the connection for assocation.', function() {
-                    checkReferenceColumns([{
-                        ref: related[2],
-                        expected:[
-                            ["reference_schema", "inbound_related_reference_key"].join("_"), 
-                            ["reference_schema", "fromname_fk_inbound_related_to_reference"].join("_"),
-                            ["reference_schema", "hidden_fk_inbound_related_to_reference"].join("_"),
-                            ["reference_schema", "fk_inbound_related_to_reference"].join("_")
-                    ]}]);
-                });
-                it('should ignore extra serial key columns in the assocation table', function() {
-                    checkReferenceColumns([{
-                        ref: related[3],
-                        expected:[
-                            ["reference_schema", "inbound_related_reference_key"].join("_"), 
-                            ["reference_schema", "fromname_fk_inbound_related_to_reference"].join("_"), 
-                            ["reference_schema", "hidden_fk_inbound_related_to_reference"].join("_"),
-                            ["reference_schema", "fk_inbound_related_to_reference"].join("_")
-                    ]}]);
-                });
-            });
-
+            
             describe('.uri ', function () {
                 it('.uri should be properly defiend based on schema.', function() {
                     expect(related[2].uri).toBe(singleEnitityUri + "/(id)=(reference_schema:association_table_with_toname:id_from_ref_table)/(id_from_inbound_related_table)=(reference_schema:inbound_related_reference_table:id)");


### PR DESCRIPTION

This PR adds a feature requested in this issue https://github.com/informatics-isi-edu/ermrestjs/issues/488.

It extends pure and binary association definition providing support for system columns. 

If `ermrestjs` encounters a table with `system columns...` + `fk1` + `fk2`, it has a  default heuristic to consider that a pure, binary association table.