### PR TITLE
Inline context creation and custom list for empty annotations

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -314,12 +314,7 @@
                 this._facetColumns = [];
                 var self = this;
                 var andOperator = module._FacetsLogicalOperators.AND;
-<<<<<<< HEAD
-                var andFilters = [];
-
-=======
                 
->>>>>>> master
                 /*
                  * Given a ReferenceColumn, InboundForeignKeyPseudoColumn, or ForeignKeyPseudoColumn
                  * will return {"obj": facet object, "column": Column object}
@@ -422,10 +417,6 @@
                     } else {
                         colName = source;
                     }
-<<<<<<< HEAD
-
-                    return { "dataSource": refCol.name, "column": refCol._baseCols[0]};
-=======
                     
                     try {
                         col = table.columns.get(colName);
@@ -447,7 +438,6 @@
                     }
                     
                     return fcObj;
->>>>>>> master
                 };
 
                 /*
@@ -498,23 +488,12 @@
                     }
                     return true;
                 };
-<<<<<<< HEAD
-
-                /*
-                 * given a source, will return the filters that are already applied to it.
-                 */
-                var findFilter = function (source) {
-                    for (var i = 0; i < andFilters.length; i++) {
-                        if (sameSource(source, andFilters[i].source)) {
-                            return andFilters[i];
-=======
                 
                 // only add choices, range, and search
                 var mergeFacetObjects = function (source, extra) {
                     ['choices', 'ranges', 'search'].forEach(function (key) {
                         if (!Array.isArray(extra[key])) {
                             return;
->>>>>>> master
                         }
                         
                         if (!Array.isArray(source[key])) {
@@ -543,22 +522,6 @@
                     
                     });
                 };
-<<<<<<< HEAD
-
-                /*
-                 * Creates a FacetColumn for given ReferenceColumn and adds it to the list.
-                 */
-                var addColumn = function (col, i) {
-                    var source = generateDataSource(col);
-                    var filter = findFilter(source.dataSource);
-                    if (filter === null) {
-                        filter = {"source": source.dataSource};
-                    }
-                    self._facetColumns.push(new FacetColumn(self, i, source.column, filter));
-                };
-
-
-=======
                 
                 var annotationCols = -1, usedAnnotation = false;
                 var facetObjects = [];
@@ -611,7 +574,6 @@
 
                 var jsonFilters = this.location.facets ? this.location.facets.decoded : null;
                 var andFilters = [];
->>>>>>> master
                 // extract the filters
                 if (jsonFilters && jsonFilters.hasOwnProperty(andOperator) && Array.isArray(jsonFilters[andOperator])) {
                     andFilters = jsonFilters[andOperator];
@@ -4760,13 +4722,8 @@
      * @param {?ERMrest.FacetFilter[]} filters Array of filters
      * @constructor
      */
-<<<<<<< HEAD
-    function FacetColumn (reference, index, column, json, filters) {
-
-=======
     function FacetColumn (reference, index, column, facetObject, filters) {
         
->>>>>>> master
         /**
          * The column object that the filters are based on
          * @type {ERMrest.Column}
@@ -4791,13 +4748,8 @@
          * NOTE: we're not validating this data-source, we assume that this is valid.
          * @type {obj|string}
          */
-<<<<<<< HEAD
-        this.dataSource = json.source;
-
-=======
         this.dataSource = facetObject.source;
         
->>>>>>> master
         /**
          * Filters that are applied to this facet.
          * @type{FacetFilter[]}
@@ -4814,9 +4766,6 @@
     }
     FacetColumn.prototype = {
         constructor: FacetColumn,
-<<<<<<< HEAD
-
-=======
         
         /**
          * If has filters it will return true,
@@ -4855,7 +4804,6 @@
             return this._foreignKeys;
         },
         
->>>>>>> master
         // returns the last foreignkey object in the path
         get _lastForeignKey() {
             if (this._lastForeignKey_cached === undefined) {
@@ -4886,22 +4834,11 @@
          * Any of:
          * `choices`, `ranges`, or `search`
          * This should be used if we're not in entity mode.
-<<<<<<< HEAD
-         * TODO: what should be the default? This will eventually change,
-         * currently we are not using multi facet mode, so it won't be used.
-         * NOTE:
-         * If we want to consider a default mode for facets for any column type,
-         * we might want to keep it simple and have the default mode show as choices.
-         * Search mode would imply that the user needs to be aware of the whole set of values they are searching through.
-         * Choices provides some of that information for them.
-         *
-=======
          *
          * 1. use ux_mode if available
          * 2. use choices if in entity mode
          * 3. use range or chocies based on type.
          * 
->>>>>>> master
          * @type {string}
          */
         get preferredMode() {
@@ -4992,31 +4929,6 @@
          */
         get sourceReference () {
             if (this._sourceReference === undefined) {
-<<<<<<< HEAD
-                var jsonFilters = [];
-
-                // convert facets from main table to the current table.
-                if (this.reference.location.facets !== null) {
-                    var pathFromSource = [], // the oppisite direction of path from the main to this FacetColumn
-                        self = this;
-
-                    // create a path from this facetColumn to the base reference
-                    if (Array.isArray(this.dataSource)) {
-                        this.dataSource.forEach(function (ds, index, arr) {
-                            // last elemenet is the column name
-                            if (index !== arr.length -1 ) {
-                                var node;
-                                if ("inbound" in ds) {
-                                    node = {"outbound": ds.inbound};
-                                } else {
-                                    node = {"inbound": ds.outbound};
-                                }
-                                pathFromSource.push(node);
-                            }
-                        });
-                    }
-
-=======
                 var jsonFilters = [],
                     pathFromSource = [], // the path from source reference to this facetColumn
                     self = this,
@@ -5045,7 +4957,6 @@
 
                 // get all the filters from other facetColumns
                 if (this.reference.location.facets !== null) {
->>>>>>> master
                     // create new facet filters
                     // TODO might be able to imporve this. Instead of recreating the whole json file.
                     this.reference.facetColumns.forEach(function (fc, index) {
@@ -5055,30 +4966,20 @@
                     });
                 }
 
-<<<<<<< HEAD
-                var table = this._column.table;
-=======
                 // convert the search into a facet
                 // TODO eventually the search must be changed to facet
                 if (typeof this.reference.location.searchTerm === "string") {
                     jsonFilters.push({"source": "*", "search": [this.reference.location.searchTerm]});
                 }
 
->>>>>>> master
                 var uri = [
                     table.schema.catalog.server.uri ,"catalog" ,
                     module._fixedEncodeURIComponent(table.schema.catalog.id), "entity",
                     pathFromSource.join("/")
                 ].join("/");
-<<<<<<< HEAD
-
-                this._sourceReference = new Reference(module.parse(uri), this.reference.table.schema.catalog);
-
-=======
                 
                 this._sourceReference = new Reference(module.parse(uri), table.schema.catalog);
                 
->>>>>>> master
                 if (jsonFilters.length > 0) {
                     this._sourceReference._location.facets = {"and": jsonFilters};
                 } else {
@@ -5103,12 +5004,6 @@
          */
         get displayname() {
             if (this._displayname === undefined) {
-<<<<<<< HEAD
-                var displayname;
-
-                var fk = this._lastForeignKey;
-
-=======
                 var fk = this._lastForeignKey;
                 
                 if (this._facetObject.markdown_name) {
@@ -5118,21 +5013,16 @@
                         unformatted: "" //TODO is it needed?
                     };
                 }
->>>>>>> master
                 // if is part of the main table, just return the column's displayname
                 else if (fk === null) {
                     this._displayname = this.column.displayname;
                 }
                 // Otherwise
-<<<<<<< HEAD
-                else {
-=======
                 else {      
                     var value, unformatted, isHTML;
                     var displayname, isInbound;
                     
                     isInbound = fk.isInbound;
->>>>>>> master
                     fk = fk.obj;
                     
                     // use from_name of the last fk if it's inbound
@@ -5447,19 +5337,6 @@
                 filter: newFilter
             };
         },
-<<<<<<< HEAD
-
-        /**
-         * Create a new Reference with appending a new entity filter to current FacetColumn
-         * @param  {ERMrest.Tuple} tuple the tuple object that has the row values.
-         * @return {ERMrest.Reference} the reference with the new filter
-         */
-        addEntityFilter: function (tuple) {
-            var filters = this.filters.slice();
-            filters.push(new EntityFacetFilter(tuple, this._column));
-
-            return this._applyFilters(filters);
-=======
         
         removeRangeFilter: function (min, max) {
             //TODO needs refactoring
@@ -5470,7 +5347,6 @@
             return {
                 reference: this._applyFilters(filters)
             };
->>>>>>> master
         },
 
         /**
@@ -5653,34 +5529,6 @@
     };
 
     /**
-<<<<<<< HEAD
-     * Represents entity filters that can be applied to facet.
-     *
-     * @param       {ERMrest.tuple} tuple the tuple object
-     * @constructor
-     */
-    function EntityFacetFilter(tuple, col) {
-
-        ChoiceFacetFilter.superClass.call(this, tuple._data);
-        this.tuple = tuple;
-        this.facetFilterKey = "choices";
-    }
-    module._extends(EntityFacetFilter, FacetFilter);
-
-    /**
-     * String representation of entity filter. It will be the tuple displayname
-     *
-     * @return {string}
-     */
-    EntityFacetFilter.prototype.toString = function () {
-        //TODO: should it be unformatted or not?\
-        //TODO: This will depend on what the toString is going to be used for. If it's for display purposes then yes it should be formatted.
-        return this.tuple.displayname.unformatted;
-    };
-
-    /**
-=======
->>>>>>> master
      * Constructs an Aggregate Funciton object
      *
      * Reference Aggregate Functions is a collection of available aggregates for the

--- a/js/reference.js
+++ b/js/reference.js
@@ -1712,7 +1712,7 @@
                     _separator: "\n",
                     _prefix: "",
                     _suffix: ""
-                }
+                };
 
                 var annotation;
                 // If table has table-display annotation then set it in annotation variable

--- a/js/reference.js
+++ b/js/reference.js
@@ -1540,7 +1540,7 @@
                 if (this._table.annotations.contains(module._annotations.TABLE_DISPLAY)) {
                     annotation = module._getRecursiveAnnotationValue(this._context, this._table.annotations.get(module._annotations.TABLE_DISPLAY).content);
                 }
-
+                
                 // If annotation is defined then parse it
                 if (annotation) {
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -1702,12 +1702,18 @@
          **/
         
         get display() {
-            if (!this._display) {
-                if( this._context == module._contexts.COMPACT_BRIEF_INLINE){
-                    this._display = { type: module._displayTypes.MARKDOWN };
-                }else{
-                    this._display = { type: module._displayTypes.TABLE };
+            if (this._display === undefined) {
+                var displayType =  (this._context === module._contexts.COMPACT_BRIEF_INLINE) ? module._displayTypes.MARKDOWN :  module._displayTypes.TABLE;
+                
+                // if Separator, prefix and suffix are initialized alongwith "type"
+                
+                this._display = {
+                     type: displayType,
+                    _separator: "\n",
+                    _prefix: "",
+                    _suffix: ""
                 }
+
                 var annotation;
                 // If table has table-display annotation then set it in annotation variable
                 if (this._table.annotations.contains(module._annotations.TABLE_DISPLAY)) {
@@ -1751,18 +1757,8 @@
 
                     }
                 }              
-                // if Separator, prefix or suffix is undeifned then it is replaced by fillers to avoid 'undefined'
-                // term appearing on the page.      
-                    if(this._display._separator === undefined){
-                        this._display._separator = "\n";
-                    }
-                    if(this._display._prefix === undefined){
-                        this._display._prefix = "";
-                    }
-                    if(this._display._suffix === undefined){
-                        this._display._suffix = "";
-                    }
-                }
+                    
+            }
 
             return this._display;
         },

--- a/js/reference.js
+++ b/js/reference.js
@@ -1533,7 +1533,7 @@
         get display() {
             if (!this._display) {
                 console.log(this._context);
-                this._display = this._context== module._contexts.COMPACT_BRIEF_INLINE?{ type: module._displayTypes.MARKDOWN }:{ type: module._displayTypes.TABLE };
+                this._display = this._context == module._contexts.COMPACT_BRIEF_INLINE?{ type: module._displayTypes.MARKDOWN }:{ type: module._displayTypes.TABLE };
                 var annotation;
                 // If table has table-display annotation then set it in annotation variable
                 if (this._table.annotations.contains(module._annotations.TABLE_DISPLAY)) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -321,7 +321,7 @@
                 var jsonFilters = this.location.facets ? this.location.facets.decoded : null;
                 var andOperator = module._FacetsLogicalOperators.AND;
                 var andFilters = [];
-                
+
                 /*
                  * Given a ReferenceColumn, InboundForeignKeyPseudoColumn, or ForeignKeyPseudoColumn
                  * will return {"dataSource": source list, "column": Column object}
@@ -337,17 +337,17 @@
                             "column": refCol.foreignKey.key.colset.columns[0]
                         };
                     }
-                    
+
                     if (refCol.isInboundForeignKey) {
                         var res = [];
                         var origFkR = refCol.foreignKey;
                         var association = refCol.reference.derivedAssociationReference;
                         var column;
-                        
+
                         res.push({
                             "inbound": origFkR.constraint_names[0]
                         });
-                        
+
                         if (association) {
                             res.push({
                                 "outbound": association._secondFKR.constraint_names[0]
@@ -359,10 +359,10 @@
                         res.push(column.name);
                         return {"dataSource": res, "column": column};
                     }
-                    
+
                     return { "dataSource": refCol.name, "column": refCol._baseCols[0]};
                 };
-                
+
                 /*
                  * Given two source objects check if they are the same.
                  * Source can be a string or array. If it's an array, the last element
@@ -381,17 +381,17 @@
                     if (source.length !== filterSource.length) {
                         return false;
                     }
-                    
+
                     var key;
                     for (var i = 0; i < source.length; i++) {
                         if (typeof source[i] === "string") {
                             return source[i] === filterSource[i];
                         }
-                        
+
                         if (typeof source[i] !== "object" || typeof filterSource[i] !== "object") {
                             return false;
                         }
-                        
+
                         if (typeof source[i].inbound === "object") {
                             key = "inbound";
                         } else if (typeof source[i].outbound == "object") {
@@ -399,11 +399,11 @@
                         } else {
                             return false;
                         }
-                        
+
                         if (!Array.isArray(filterSource[i][key]) || filterSource[i][key].length !== 2) {
                             return false;
                         }
-                        
+
                         if (source[i][key][0] !== filterSource[i][key][0] || source[i][key][1] != filterSource[i][key][1]) {
                             return false;
                         }
@@ -411,7 +411,7 @@
                     }
                     return true;
                 };
-                
+
                 /*
                  * given a source, will return the filters that are already applied to it.
                  */
@@ -423,7 +423,7 @@
                     }
                     return null;
                 };
-                
+
                 /*
                  * Creates a FacetColumn for given ReferenceColumn and adds it to the list.
                  */
@@ -435,8 +435,8 @@
                     }
                     self._facetColumns.push(new FacetColumn(self, i, source.column, filter));
                 };
-            
-                
+
+
                 // extract the filters
                 if (jsonFilters && jsonFilters.hasOwnProperty(andOperator) && Array.isArray(jsonFilters[andOperator])) {
                     andFilters = jsonFilters[andOperator];
@@ -1532,7 +1532,7 @@
          **/
         get display() {
             if (!this._display) {
-                this._display = { type: module._displayTypes.TABLE };
+                this._display = this_context== module._contexts.COMPACT_BRIEF_INLINE?{ type: module._displayTypes.MARKDOWN }:{ type: module._displayTypes.TABLE };
                 var annotation;
                 // If table has table-display annotation then set it in annotation variable
                 if (this._table.annotations.contains(module._annotations.TABLE_DISPLAY)) {
@@ -2342,6 +2342,14 @@
             return this._contextualize(module._contexts.EDIT);
         },
 
+        /**
+         * get compactBriefInline - The compact brief inline context of the reference
+         * @return {ERMrest.Reference}
+         */
+        get compactBriefInline() {
+            return this._contextualize(module._context.COMPACT_BRIEF_INLINE);
+        },
+
         _contextualize: function(context) {
             var source = this._reference;
 
@@ -2877,6 +2885,7 @@
                     // Get the HTML generated using the markdown pattern generated above
                     this._content =  module._formatUtils.printMarkdown(pattern);
                 } else {
+                    //TODO Create an unordered list of tuples with [tuple.reference](tuple.displayname) format.
                     this._content = null;
                 }
             }
@@ -3157,7 +3166,7 @@
                             }
                         } else {
                             values[i] = column.formatPresentation(keyValues[column.name], { formattedValues: keyValues , context: this._pageRef._context });
-                            
+
                             if (column.type.name === "gene_sequence") {
                                 values[i].isHTML = true;
                             }
@@ -4427,7 +4436,7 @@
      * on columns that are not part of reference column.
      *
      * TODO This is just experimental, the arguments might change eventually.
-     * 
+     *
      * If the ReferenceColumn is not provided, then the FacetColumn is for reference
      *
      * @param {ERMrest.Reference} reference the reference that this FacetColumn blongs to.
@@ -4438,19 +4447,19 @@
      * @constructor
      */
     function FacetColumn (reference, index, column, json, filters) {
-        
+
         /**
          * The column object that the filters are based on
          * @type {ERMrest.Column}
          */
         this._column = column;
-        
+
         /**
          * [reference description]
          * @type {ERMrest.Reference}
          */
         this.reference = reference;
-        
+
         /**
          * The index of facetColumn in the list of facetColumns
          * NOTE: Might not be needed
@@ -4461,10 +4470,10 @@
         /**
          * A valid data-source path
          * NOTE: we're not validating this data-source, we assume that this is valid.
-         * @type {obj|string} 
+         * @type {obj|string}
          */
         this.dataSource = json.source;
-        
+
         /**
          * Filters that are applied to this facet.
          * @type{FacetFilter[]}
@@ -4475,13 +4484,13 @@
         } else {
             this.setFilters(json);
         }
-        
+
         // the whole filter object
         this._json = json;
     }
     FacetColumn.prototype = {
         constructor: FacetColumn,
-        
+
         // returns the last foreignkey object in the path
         get _lastForeignKey() {
             if (this._lastForeignKey_cached === undefined) {
@@ -4490,14 +4499,14 @@
                 } else {
                     var lastJoin = this.dataSource[this.dataSource.length-2];
                     var isInbound = false, constraint;
-                    
+
                     if ("inbound" in lastJoin) {
                         isInbound = true;
                         constraint = lastJoin.inbound;
                     } else {
                         constraint = lastJoin.outbound;
                     }
-                    
+
                     this._lastForeignKey_cached = {
                         "obj": module._getConstraintObject(this._column.table.schema.catalog.id, constraint[0], constraint[1]).object,
                         "isInbound": isInbound
@@ -4506,7 +4515,7 @@
             }
             return this._lastForeignKey_cached;
         },
-        
+
         /**
          * The Preferred ux mode.
          * Any of:
@@ -4515,11 +4524,11 @@
          * TODO: what should be the default? This will eventually change,
          * currently we are not using multi facet mode, so it won't be used.
          * NOTE:
-         * If we want to consider a default mode for facets for any column type, 
-         * we might want to keep it simple and have the default mode show as choices. 
+         * If we want to consider a default mode for facets for any column type,
+         * we might want to keep it simple and have the default mode show as choices.
          * Search mode would imply that the user needs to be aware of the whole set of values they are searching through.
          * Choices provides some of that information for them.
-         * 
+         *
          * @type {string}
          */
         get preferredMode() {
@@ -4534,7 +4543,7 @@
             }
             return this._preferredMode;
         },
-        
+
         /**
          * Returns true if the source is on a key column.
          * TODO right now it's using some heuristic, but eventually it should
@@ -4550,7 +4559,7 @@
             }
             return this._isEntityMode;
         },
-         
+
         /**
          * ReferenceColumn that this facetColumn is based on
          * @type {ERMrest.ReferenceColumn}
@@ -4561,9 +4570,9 @@
             }
             return this._referenceColumn;
         },
-        
+
         /**
-         * uncontextualized {@link ERMrest.Reference} that has all the joins specified 
+         * uncontextualized {@link ERMrest.Reference} that has all the joins specified
          * in the source with all the filters of other FacetColumns in the reference.
          *
          * NOTE: assumptions:
@@ -4574,12 +4583,12 @@
         get sourceReference () {
             if (this._sourceReference === undefined) {
                 var jsonFilters = [];
-                
+
                 // convert facets from main table to the current table.
                 if (this.reference.location.facets !== null) {
                     var pathFromSource = [], // the oppisite direction of path from the main to this FacetColumn
                         self = this;
-                    
+
                     // create a path from this facetColumn to the base reference
                     if (Array.isArray(this.dataSource)) {
                         this.dataSource.forEach(function (ds, index, arr) {
@@ -4595,7 +4604,7 @@
                             }
                         });
                     }
-                    
+
                     // create new facet filters
                     // TODO might be able to imporve this. Instead of recreating the whole json file.
                     this.reference.facetColumns.forEach(function (fc, index) {
@@ -4608,16 +4617,16 @@
                         }
                     });
                 }
-                
+
                 var table = this._column.table;
                 var uri = [
                     table.schema.catalog.server.uri ,"catalog" ,
                     module._fixedEncodeURIComponent(table.schema.catalog.id), "entity",
                     [module._fixedEncodeURIComponent(table.schema.name),module._fixedEncodeURIComponent(table.name)].join(":"),
                 ].join("/");
-                
+
                 this._sourceReference = new Reference(module.parse(uri), this.reference.table.schema.catalog);
-                
+
                 if (jsonFilters.length > 0) {
                     this._sourceReference._location.facets = {"and": jsonFilters};
                 } else {
@@ -4626,31 +4635,31 @@
             }
             return this._sourceReference;
         },
-        
+
         /**
          * Returns the displayname object that should be used for this facetColumn.
-         * 
+         *
          * Heuristics are as follows (first applicable rule):
          *  1. If column is part of the main table (there's no join), use the column's displayname.
          *  2. If last foreignkey is outbound and has to_name, use it.
          *  3. If last foreignkey is inbound and has from_name, use it.
          *  4. Otherwise use the table name.
          *    - If it's in `scalar` mode, append the column name. `table_name (column_name)`.
-         * 
+         *
          * @type {object} Object with `value`, `unformatted`, and `isHTML` as its attributes.
          */
         get displayname() {
             if (this._displayname === undefined) {
                 var displayname;
-                
+
                 var fk = this._lastForeignKey;
-                
+
                 // if is part of the main table, just return the column's displayname
                 if (fk === null) {
                     this._displayname = this.column.displayname;
                 }
                 // Otherwise
-                else {      
+                else {
                     fk = fk.obj;
                     // use from_name of the last fk if it's inbound
                     if (fk.isInbound && fk.from_name !== "") {
@@ -4665,7 +4674,7 @@
                         value = this.column.table.displayname.value;
                         unformatted = this.column.table.displayname.unformatted;
                         isHTML = this.column.table.displayname.isHTML;
-                        
+
                         // add the column name if in scalar mode
                         if (!this.isEntityMode) {
                             value += " (" + this.column.displayname.value + ")";
@@ -4675,13 +4684,13 @@
                             }
                         }
                     }
-                    
+
                     this._displayname = {"value": value, "isHTML": isHTML, "unformatted": unformatted};
-                }         
+                }
             }
             return this._displayname;
         },
-        
+
         /**
          * Could be used as tooltip to provide more information about the facetColumn
          * @type {string}
@@ -4822,10 +4831,10 @@
         addEntityFilter: function (tuple) {
             var filters = this.filters.slice();
             filters.push(new EntityFacetFilter(tuple, this._column));
-            
+
             return this._applyFilters(filters);
         },
-        
+
         /**
          * Create a new Reference by removing all the filters from current facet.
          * @return {ERMrest.Reference} the reference with the new filter
@@ -4859,7 +4868,7 @@
             var self = this;
             var newReference = _referenceCopy(this.reference);
             delete newReference._facetColumns;
-            
+
             // create a new FacetColumn so it doesn't reference to the current FacetColum
             // TODO can be refactored
             var jsonFilters = [];
@@ -4867,7 +4876,7 @@
                 var ThisFC = new FacetColumn(this.reference, this.index, this._column, this._json, filters);
                 jsonFilters.push(ThisFC.toJSON());
             }
-            
+
             // TODO might be able to imporve this. Instead of recreating the whole json file.
             // gather all the filters from the facetColumns
             // NOTE: this part can be improved so we just change one JSON element.
@@ -4997,24 +5006,24 @@
         }
         return res;
     };
-    
+
     /**
      * Represents entity filters that can be applied to facet.
-     * 
+     *
      * @param       {ERMrest.tuple} tuple the tuple object
      * @constructor
      */
     function EntityFacetFilter(tuple, col) {
-        
+
         ChoiceFacetFilter.superClass.call(this, tuple._data);
         this.tuple = tuple;
         this.facetFilterKey = "choices";
     }
     module._extends(EntityFacetFilter, FacetFilter);
-    
+
     /**
      * String representation of entity filter. It will be the tuple displayname
-     * 
+     *
      * @return {string}
      */
     EntityFacetFilter.prototype.toString = function () {

--- a/js/reference.js
+++ b/js/reference.js
@@ -1532,7 +1532,8 @@
          **/
         get display() {
             if (!this._display) {
-                this._display = this_context== module._contexts.COMPACT_BRIEF_INLINE?{ type: module._displayTypes.MARKDOWN }:{ type: module._displayTypes.TABLE };
+                console.log(this._context);
+                this._display = this._context== module._contexts.COMPACT_BRIEF_INLINE?{ type: module._displayTypes.MARKDOWN }:{ type: module._displayTypes.TABLE };
                 var annotation;
                 // If table has table-display annotation then set it in annotation variable
                 if (this._table.annotations.contains(module._annotations.TABLE_DISPLAY)) {
@@ -2347,7 +2348,7 @@
          * @return {ERMrest.Reference}
          */
         get compactBriefInline() {
-            return this._contextualize(module._context.COMPACT_BRIEF_INLINE);
+            return this._contextualize(module._contexts.COMPACT_BRIEF_INLINE);
         },
 
         _contextualize: function(context) {
@@ -2851,6 +2852,7 @@
          * @type {string|null}
          */
         get content() {
+            //console.log(this._context);
             if (this._content !== null) {
                 // If display type is markdown which means row_markdown_pattern is set in table-display
                 if (this._ref.display.type === module._displayTypes.MARKDOWN) {
@@ -2859,14 +2861,23 @@
                     if (!this._data || !this._data.length) {
                         return null;
                     }
-
+                    var inbFKItems = false;
+                    if(this._ref.display._markdownPattern == " " || this._ref.display._markdownPattern == null)
+                        inbFKItems = true;
                     var values = [];
 
                     // Iterate over all data rows to compute the row values depending on the row_markdown_pattern.
                     for (var i = 0; i < this._data.length; i++) {
-
+                        var value = [];
                         // render template
-                        var value = module._renderTemplate(this._ref.display._markdownPattern, this._data[i], this._ref._table, this._ref._context);
+                        if(inbFKItems)
+                        {
+                            value = this.tuples[i].values.join(" ");
+                            value = "<li>" + value + "</li>";
+                        }
+                        else{
+                            value = module._renderTemplate(this._ref.display._markdownPattern, this._data[i], this._ref._table, this._ref._context);
+                        }
 
                         // If value is null or empty, return value on basis of `show_nulls`
                         if (value === null || value.trim() === '') {
@@ -2883,13 +2894,11 @@
                     var pattern = this._ref.display._prefix + values.join(this._ref.display._separator) + this._ref.display._suffix;
 
                     // Get the HTML generated using the markdown pattern generated above
-                    this._content =  module._formatUtils.printMarkdown(pattern);
+                    this._content =  inbFKItems?pattern:module._formatUtils.printMarkdown(pattern);
                 } else {
-                    //TODO Create an unordered list of tuples with [tuple.reference](tuple.displayname) format.
                     this._content = null;
                 }
             }
-
             return this._content;
         }
     };

--- a/js/reference.js
+++ b/js/reference.js
@@ -1750,8 +1750,19 @@
                         this._display._suffix = (typeof annotation.suffix_markdown === 'string') ? annotation.suffix_markdown : "";
 
                     }
+                }              
+                // if Separator, prefix or suffix is undeifned then it is replaced by fillers to avoid 'undefined'
+                // term appearing on the page.      
+                    if(this._display._separator === undefined){
+                        this._display._separator = "\n";
+                    }
+                    if(this._display._prefix === undefined){
+                        this._display._prefix = "";
+                    }
+                    if(this._display._suffix === undefined){
+                        this._display._suffix = "";
+                    }
                 }
-            }
 
             return this._display;
         },
@@ -3098,6 +3109,9 @@
 
         /**
          * HTML representation of the whole page which uses table-display annotation.
+         * If markdownPattern is defined then renderTemplate is called to get the correct display.
+         * In case of no such markdownPattern is defined output is displayed in form of 
+         * unordered list with displayname as text content of the list. 
          * For more info you can refer {ERM.reference.display}
          *
          * Usage:
@@ -3133,17 +3147,9 @@
 
                        // Join the values array using the separator and prepend it with the prefix and append suffix to it.
                        pattern = this._ref.display._prefix + values.join(this._ref.display._separator) + this._ref.display._suffix;
+                       
                    }else{
-                       if(this._ref.display._separator === undefined){
-                           this._ref.display._separator = "";
-                       }
-                       if(this._ref.display._prefix === undefined){
-                           this._ref.display._prefix = "";
-                       }
-                       if(this._ref.display._suffix === undefined){
-                           this._ref.display._suffix = "";
-                       }
-                      // the new logic that you should have added
+                     
                       for ( i = 0; i < this.tuples.length; i++) {
                          var tuple = this.tuples[i];
                          var url = tuple.reference.contextualize.detailed.appLink;

--- a/js/reference.js
+++ b/js/reference.js
@@ -1530,6 +1530,7 @@
          * @type {Object}
          *
          **/
+        
         get display() {
             if (!this._display) {
                 console.log(this._context);

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -116,7 +116,7 @@
     Array.prototype.clear = function() {
         this.length = 0;
     };
-    
+
     /**
      * Returns true if given parameter is object and not null
      * @param  {*} obj
@@ -443,14 +443,14 @@
      */
     module._getFormattedKeyValues = function(columns, context, data) {
         var keyValues = {};
-        
+
         var findCol = function (colName) {
             if (Array.isArray(columns)) {
                 return columns.filter(function (col) {return col.name === colName;})[0];
             }
             return columns.get(k);
         };
-        
+
         for (var k in data) {
 
             try {
@@ -879,7 +879,7 @@
         }
     };
 
-    /** 
+    /**
      * format the raw value based on the column definition type, heuristics, annotations, etc.
      * @param {ERMrest.Type} type - the type object of the column
      * @param {Object} data - the 'raw' data value.
@@ -1643,10 +1643,11 @@
         FILTER: 'filter',
         DEFAULT: '*',
         ROWNAME :'row_name',
-        ROWNAME_UNFORMATTED: "row_name/unformatted"
+        ROWNAME_UNFORMATTED: "row_name/unformatted",
+        COMPACT_BRIEF_INLINE: 'compact/brief/inline'
     });
 
-    module._contextArray = ["compact", "compact/brief", "compact/select", "entry/create", "detailed", "entry/edit", "entry", "filter", "*", "row_name"];
+    module._contextArray = ["compact", "compact/brief", "compact/select", "entry/create", "detailed", "entry/edit", "entry", "filter", "*", "row_name", "compact/brief/inline"];
 
     module._entryContexts = [module._contexts.CREATE, module._contexts.EDIT, module._contexts.ENTRY];
 

--- a/test/specs/annotation/tests/03.table_display.js
+++ b/test/specs/annotation/tests/03.table_display.js
@@ -403,12 +403,18 @@ exports.execute = function (options) {
         describe('markdown display in case of no annotation is defined', function() {
             it('when no annotation is defiend; content should appear in unordered list format.', function(done){
                 var content_without_annotation = '<ul>\n<li><a href="https://dev.isrd.isi.edu/chaise/record/schema_table_display:table_wo_title_wo_annotation/id=20001">20,001</a></li>\n<li><a href="https://dev.isrd.isi.edu/chaise/record/schema_table_display:table_wo_title_wo_annotation/id=20002">20,002</a></li>\n</ul>\n';
+                var content_without_annotation_w_para = '<ul>\n<li>\n<p><a href="https://dev.isrd.isi.edu/chaise/record/schema_table_display:table_wo_title_wo_annotation/id=20001">20,001</a></p>\n</li>\n<li>\n<p><a href="https://dev.isrd.isi.edu/chaise/record/schema_table_display:table_wo_title_wo_annotation/id=20002">20,002</a></p>\n</li>\n</ul>\n';
                 options.ermRest.resolve(table1EntityUri, {cid: "test"}).then(function (response) {
                     return response;
                 }).then(function (reference){ 
                     return reference.read(2);
                 }).then(function (page){
-                    expect(page.content).toBe(content_without_annotation);
+                    if (process.env.TRAVIS){
+                        expect(page.content).toBe(content_without_annotation_w_para);
+                    }else{
+                        expect(page.content).toBe(content_without_annotation);
+                    }
+                        
                     done();
                 }).catch(function(err) {
                     console.log(err);

--- a/test/specs/annotation/tests/03.table_display.js
+++ b/test/specs/annotation/tests/03.table_display.js
@@ -400,5 +400,22 @@ exports.execute = function (options) {
             });
 
         });
+        describe('markdown display in case of no annotation is defined', function() {
+            it('when no annotation is defiend; content should appear in unordered list format.', function(done){
+                var content_without_annotation = '<ul>\n<li><a href="https://dev.isrd.isi.edu/chaise/record/schema_table_display:table_wo_title_wo_annotation/id=20001">20,001</a></li>\n</ul>\n';
+                options.ermRest.resolve(table1EntityUri, {cid: "test"}).then(function (response) {
+                    return response;
+                }).then(function (reference){ 
+                    return reference.read(1);
+                }).then(function (page){
+                    expect(page.content).toBe(content_without_annotation);
+                    done();
+                }).catch(function(err) {
+                    console.log(err);
+                    done.fail();
+                });
+                
+            })
+        });
     });
 };

--- a/test/specs/annotation/tests/03.table_display.js
+++ b/test/specs/annotation/tests/03.table_display.js
@@ -402,11 +402,11 @@ exports.execute = function (options) {
         });
         describe('markdown display in case of no annotation is defined', function() {
             it('when no annotation is defiend; content should appear in unordered list format.', function(done){
-                var content_without_annotation = '<ul>\n<li><a href="https://dev.isrd.isi.edu/chaise/record/schema_table_display:table_wo_title_wo_annotation/id=20001">20,001</a></li>\n</ul>\n';
+                var content_without_annotation = '<ul>\n<li><a href="https://dev.isrd.isi.edu/chaise/record/schema_table_display:table_wo_title_wo_annotation/id=20001">20,001</a></li>\n<li><a href="https://dev.isrd.isi.edu/chaise/record/schema_table_display:table_wo_title_wo_annotation/id=20002">20,002</a></li>\n</ul>\n';
                 options.ermRest.resolve(table1EntityUri, {cid: "test"}).then(function (response) {
                     return response;
                 }).then(function (reference){ 
-                    return reference.read(1);
+                    return reference.read(2);
                 }).then(function (page){
                     expect(page.content).toBe(content_without_annotation);
                     done();


### PR DESCRIPTION
This PR address issue #493 .
`Compact/brief/inline` context has been created and contextualized in `Chaise`. 
The default display is changed to *MARKDOWN* for newly created context.
Chaise repo PR has been raised for review.