### PR TITLE
Fixed file-api Mime module issue by adding package lock using shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,11 @@
+{
+  "name": "ermrestjs",
+  "version": "0.0.0",
+  "dependencies": {
+    "mime": {
+      "version": "1.4.0",
+      "from": "mime@1.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.0.tgz"
+    }
+  }
+}


### PR DESCRIPTION
We run `npm shrinkwrap` which generates a file named `npm-shrinkwrap.json`. This file contains the modules that should not be updated and fixed. It is a lock file.