### PR TITLE
Renamed canRead to canSelect and canCreate to canInsert

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -257,8 +257,8 @@ to use for ERMrest JavaScript agents.
         * [.facetColumns](#ERMrest.Reference+facetColumns) ⇒ <code>Array.&lt;ERMrest.FacetColumn&gt;</code>
         * [.location](#ERMrest.Reference+location) ⇒ <code>ERMrest.Location</code>
         * [.isUnique](#ERMrest.Reference+isUnique) : <code>boolean</code>
-        * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> \| <code>undefined</code>
-        * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> \| <code>undefined</code>
+        * [.canInsert](#ERMrest.Reference+canInsert) : <code>boolean</code> \| <code>undefined</code>
+        * [.canSelect](#ERMrest.Reference+canSelect) : <code>boolean</code> \| <code>undefined</code>
         * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> \| <code>undefined</code>
         * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> \| <code>undefined</code>
         * [.display](#ERMrest.Reference+display) : <code>Object</code>
@@ -2109,8 +2109,8 @@ Constructor for a ParsedFilter.
     * [.facetColumns](#ERMrest.Reference+facetColumns) ⇒ <code>Array.&lt;ERMrest.FacetColumn&gt;</code>
     * [.location](#ERMrest.Reference+location) ⇒ <code>ERMrest.Location</code>
     * [.isUnique](#ERMrest.Reference+isUnique) : <code>boolean</code>
-    * [.canCreate](#ERMrest.Reference+canCreate) : <code>boolean</code> \| <code>undefined</code>
-    * [.canRead](#ERMrest.Reference+canRead) : <code>boolean</code> \| <code>undefined</code>
+    * [.canInsert](#ERMrest.Reference+canInsert) : <code>boolean</code> \| <code>undefined</code>
+    * [.canSelect](#ERMrest.Reference+canSelect) : <code>boolean</code> \| <code>undefined</code>
     * [.canUpdate](#ERMrest.Reference+canUpdate) : <code>boolean</code> \| <code>undefined</code>
     * [.canDelete](#ERMrest.Reference+canDelete) : <code>boolean</code> \| <code>undefined</code>
     * [.display](#ERMrest.Reference+display) : <code>Object</code>
@@ -2282,17 +2282,17 @@ console.log("This reference is unique?", (reference.isUnique ? 'yes' : 'no'));
 ```
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
-<a name="ERMrest.Reference+canCreate"></a>
+<a name="ERMrest.Reference+canInsert"></a>
 
-#### reference.canCreate : <code>boolean</code> \| <code>undefined</code>
+#### reference.canInsert : <code>boolean</code> \| <code>undefined</code>
 Indicates whether the client has the permission to _create_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
-<a name="ERMrest.Reference+canRead"></a>
+<a name="ERMrest.Reference+canSelect"></a>
 
-#### reference.canRead : <code>boolean</code> \| <code>undefined</code>
+#### reference.canSelect : <code>boolean</code> \| <code>undefined</code>
 Indicates whether the client has the permission to _read_
 the referenced resource(s). In some cases, this permission cannot
 be determined and the value will be `undefined`.

--- a/js/reference.js
+++ b/js/reference.js
@@ -786,8 +786,8 @@
          * be determined and the value will be `undefined`.
          * @type {(boolean|undefined)}
          */
-        get canCreate() {
-            if (this._canCreate === undefined) {
+        get canInsert() {
+            if (this._canInsert === undefined) {
 
                 // can create if all are true
                 // 1) user has write permission
@@ -795,16 +795,16 @@
                 // 3) not all visible columns in the table are generated
                 var ref = (this._context === module._contexts.CREATE) ? this : this.contextualize.entryCreate;
 
-                this._canCreate = ref._table.kind !== module._tableKinds.VIEW && !ref._table._isGenerated && ref._checkPermissions("insert");
+                this._canInsert = ref._table.kind !== module._tableKinds.VIEW && !ref._table._isGenerated && ref._checkPermissions("insert");
 
-                if (this._canCreate) {
+                if (this._canInsert) {
                     var allColumnsDisabled = ref.columns.every(function (col) {
                         return (col.getInputDisabled(module._contexts.CREATE) !== false);
                     });
-                    this._canCreate = !allColumnsDisabled;
+                    this._canInsert = !allColumnsDisabled;
                 }
             }
-            return this._canCreate;
+            return this._canInsert;
         },
 
         /**
@@ -813,11 +813,11 @@
          * be determined and the value will be `undefined`.
          * @type {(boolean|undefined)}
          */
-        get canRead() {
-            if (this._canRead === undefined) {
-                this._canRead = this._checkPermissions("select");
+        get canSelect() {
+            if (this._canSelect === undefined) {
+                this._canSelect = this._checkPermissions("select");
             }
-            return this._canRead;
+            return this._canSelect;
         },
 
         /**
@@ -867,7 +867,7 @@
 
         /**
          * This is a private funtion that checks the user permissions for modifying the affiliated entity, record or table
-         * Sets a property on the reference object used by canCreate/canUpdate/canDelete
+         * Sets a property on the reference object used by canInsert/canUpdate/canDelete
          * @memberof ERMrest
          * @private
          */
@@ -2077,8 +2077,8 @@
             this._displayname = table.displayname;
             delete this._referenceColumns;
             delete this._related;
-            delete this._canCreate;
-            delete this._canRead;
+            delete this._canInsert;
+            delete this._canSelect;
             delete this._canUpdate;
             delete this._canDelete;
         },
@@ -2446,8 +2446,8 @@
             delete newRef._display;
 
             // delete permissions
-            delete newRef._canCreate;
-            delete newRef._canRead;
+            delete newRef._canInsert;
+            delete newRef._canSelect;
             delete newRef._canUpdate;
             delete newRef._canDelete;
 

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -168,7 +168,7 @@ exports.execute = function (options) {
                 expect(reference.uri).toBe(reference._location.uri);
                 expect(reference.displayname.value).toBe(reference._table.name);
                 expect(reference.table).toBe(reference._table);
-                expect(reference.canCreate).toBeDefined();
+                expect(reference.canInsert).toBeDefined();
                 expect(reference.canUpdate).toBeDefined();
                 expect(reference.create()).toBeDefined();
                 expect(reference.read()).toBeDefined();

--- a/test/specs/reference/tests/06_1.permissions_acls.js
+++ b/test/specs/reference/tests/06_1.permissions_acls.js
@@ -77,12 +77,12 @@ exports.execute = (options) => {
             });
 
             describe("should return true for ,", () => {
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBeTruthy();
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBeTruthy();
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBeTruthy();
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBeTruthy();
                 });
 
                 it("canUpdate.", () => {
@@ -122,8 +122,8 @@ exports.execute = (options) => {
             });
 
             describe("should return false for ", () => {
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBeFalsy();
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBeFalsy();
                 });
 
                 it("canUpdate.", () => {
@@ -135,8 +135,8 @@ exports.execute = (options) => {
                 });
             });
 
-            it("should return true for canRead.", () => {
-                expect(reference.canRead).toBeTruthy();
+            it("should return true for canSelect.", () => {
+                expect(reference.canSelect).toBeTruthy();
             });
 
             afterAll((done) => {
@@ -181,12 +181,12 @@ exports.execute = (options) => {
 
             describe("Table with allowed user context should return true for insert, select, update and delete,", () => {
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(true);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(true);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -213,12 +213,12 @@ exports.execute = (options) => {
                     });
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(true);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(true);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(false);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(false);
                 });
 
                 it("canUpdate.", () => {
@@ -284,12 +284,12 @@ exports.execute = (options) => {
 
             describe("Table with allowed user context should return true for insert, select, update and false for delete,", () => {
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(true);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(true);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -316,12 +316,12 @@ exports.execute = (options) => {
                     });
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(false);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(false);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {

--- a/test/specs/reference/tests/06_2.permissions_annotations.js
+++ b/test/specs/reference/tests/06_2.permissions_annotations.js
@@ -80,12 +80,12 @@ exports.execute = (options) => {
                     expect(reference._table._isGenerated).toBe(true);
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(false);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(false);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -119,12 +119,12 @@ exports.execute = (options) => {
                     expect(reference._table._isGenerated).toBe(true);
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(false);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(false);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -159,12 +159,12 @@ exports.execute = (options) => {
                     expect(reference._table._isGenerated).toBe(false);
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(false);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(false);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -198,12 +198,12 @@ exports.execute = (options) => {
                     expect(reference._table._isGenerated).toBe(false);
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(true);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(true);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -237,12 +237,12 @@ exports.execute = (options) => {
                     expect(reference._table._isImmutable).toBe(true);
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(true);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(true);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -276,12 +276,12 @@ exports.execute = (options) => {
                     expect(reference._table._isImmutable).toBe(true);
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(true);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(true);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -315,12 +315,12 @@ exports.execute = (options) => {
                     expect(reference._table._isImmutable).toBe(false);
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(true);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(true);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -353,12 +353,12 @@ exports.execute = (options) => {
                     expect(reference._table._isImmutable).toBe(false);
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(true);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(true);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -392,12 +392,12 @@ exports.execute = (options) => {
                     expect(reference._table._isNonDeletable).toBe(true);
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(true);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(true);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -431,12 +431,12 @@ exports.execute = (options) => {
                     expect(reference._table._isNonDeletable).toBe(true);
                 });
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(true);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(true);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {
@@ -466,12 +466,12 @@ exports.execute = (options) => {
 
             describe("Table whose visible columns are empty for create and edit context should return false for create and update, and true for read and delete for undefined in other contexts,", () => {
 
-                it("canCreate.", () => {
-                    expect(reference.canCreate).toBe(false);
+                it("canInsert.", () => {
+                    expect(reference.canInsert).toBe(false);
                 });
 
-                it("canRead.", () => {
-                    expect(reference.canRead).toBe(true);
+                it("canSelect.", () => {
+                    expect(reference.canSelect).toBe(true);
                 });
 
                 it("canUpdate.", () => {


### PR DESCRIPTION
This PR renames `canRead` to `canSelect` and `canCreate` to `canInsert` to be more close to actual ACL policies as mentioned [here](https://github.com/informatics-isi-edu/ermrestjs/issues/487).

Merge Chaise [PR](https://github.com/informatics-isi-edu/chaise/pull/1341) immediately after merging this PR to avoid build problems.