### PR TITLE
Added date support in Mustache template exposing it as $moment

### DIFF
--- a/js/utilities.js
+++ b/js/utilities.js
@@ -1510,6 +1510,54 @@
         };
     };
 
+    /**
+     * @function
+     * @desc
+     * Gets currDate object once the page loads for future access in templates
+     * @return {Object} A date object that contains all properties
+     */
+    var getCurrDate = function() {
+        var date = new Date();
+
+        var dateObj = {};
+        
+        // Set date properties
+        dateObj.day = date.getDay();
+        dateObj.date = date.getDate();
+        dateObj.month = date.getMonth() + 1;
+        dateObj.year = date.getFullYear();
+        dateObj.dateString = date.toDateString();
+
+        // Set Time porperties
+        dateObj.hours = date.getHours();
+        dateObj.minutes = date.getMinutes();
+        dateObj.seconds = date.getSeconds();
+        dateObj.milliseconds = date.getMilliseconds();
+        dateObj.timestamp = date.getTime();
+        dateObj.timeString = date.toTimeString();
+
+        dateObj.ISOString = date.toISOString();
+        dateObj.GMTString = date.toGMTString();
+        dateObj.UTCString = date.toUTCString();
+        
+        dateObj.localeDateString = date.toLocaleDateString();
+        dateObj.localeTimeString = date.toLocaleTimeString();
+        dateObj.localeString = date.toLocaleString();
+
+        return dateObj;
+    };
+    module._currDate = getCurrDate();
+
+    /**
+     * @function
+     * @desc
+     * Add utility objects such as date (Computed value) to mustache data obj 
+     * so that they can be accessed in the template
+     */
+    module._addErmrestVarsToTemplate = function(obj) {
+        obj.$moment = module._currDate;
+    };
+
     /*
      * @function
      * @private
@@ -1520,22 +1568,14 @@
      * @desc Returns a string produced as a result of templating using `Mustache`.
      */
     module._renderMustacheTemplate = function(template, keyValues, options) {
+        if (typeof template !== 'string') return null;
+
         options = options || {};
 
         var obj = {};
 
-        if (keyValues) {
-            for (var k in keyValues) {
-                // Replace "." with "_" to avoid problems with templating
-                var newKey = k.replace(/\./g,"_");
-
-                obj[newKey] = keyValues[k];
-            }
-
-        }
-
-
-        if (typeof template !== 'string') return null;
+        // Inject ermrest internal utility objects such as date
+        module._addErmrestVarsToTemplate(obj);
 
         // Inject the encode function in the keyValues object
         obj.encode = module._encodeForTemplate;
@@ -1551,6 +1591,19 @@
                 };
             });
         }
+
+        if (keyValues) {
+            for (var k in keyValues) {
+                // Replace "." with "_" to avoid problems with templating
+                var newKey = k.replace(/\./g,"_");
+
+                obj[newKey] = keyValues[k];
+            }
+
+        }
+
+
+        
 
         // If we should validate, validate the template and if returns false, return null.
         if (!options.avoidValidation && !module._validateMustacheTemplate(template, obj)) {

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -200,6 +200,22 @@ exports.execute = function (options) {
             expect(module._renderMustacheTemplate("My name is {{^name}}John{{/name}}", {})).toBe("My name is John");
         });
 
+        it('module._renderMustacheTemplate() should inject $moment obj', function() {
+            var moment = module._currDate;
+            expect(moment).toBeDefined();
+            expect(module._renderMustacheTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' })).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
+            expect(module._renderMustacheTemplate("Todays date is {{$moment.dateString}}", {})).toBe("Todays date is " + moment.dateString);
+            
+            expect(module._renderMustacheTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {})).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
+            expect(module._renderMustacheTemplate("Current time is {{$moment.timeString}}", {})).toBe("Current time is " + moment.timeString);
+
+            expect(module._renderMustacheTemplate("ISO string is {{$moment.ISOString}}", {})).toBe("ISO string is " + moment.ISOString);
+            expect(module._renderMustacheTemplate("GMT string is {{$moment.GMTString}}", {})).toBe("GMT string is " + moment.GMTString);
+            expect(module._renderMustacheTemplate("UTC string is {{$moment.UTCString}}", {})).toBe("UTC string is " + moment.UTCString);
+
+            expect(module._renderMustacheTemplate("Local time string is {{$moment.localeTimeString}}", {})).toBe("Local time string is " + moment.localeTimeString);
+        });
+
         var obj = {
             "str.witha.": "**somevalue ] which is ! special and [ contains special <bold> characters 12/26/2016 ( and **",
             "m1": "[a markdown link](http://example.com/foo)",


### PR DESCRIPTION
This PR adds date support in Mustache templates as mentioned [here](https://github.com/informatics-isi-edu/ermrestjs/issues/522) by exposing `$moment` object which can be easily accessed in templates for current date and time.