### PR TITLE
Added client context header for logging in HTTP

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -48,7 +48,7 @@
      * @memberof ERMrest
      * @function
      * @param {string} uri URI of the ERMrest service.
-     * @param {Object} [params={cid:'null'}] An optional server query parameter
+     * @param {Object} [contextHeaderParams={cid:'null'}] An optional server header parameters for context logging
      * appended to the end of any request to the server.
      * @return {ERMrest.Server} Returns a server instance.
      * @throws {ERMrest.InvalidInputError} URI is missing
@@ -57,21 +57,21 @@
      * URI should be to the ERMrest _service_. For example,
      * `https://www.example.org/ermrest`.
      */
-    function getServer(uri, params) {
+    function getServer(uri, contextHeaderParams) {
 
         if (uri === undefined || uri === null)
             throw new module.InvalidInputError("URI undefined or null");
 
-        if (typeof params === 'undefined' || params === null) {
+        if (typeof contextHeaderParams === 'undefined' || contextHeaderParams === null) {
             // Set default cid to a truthy string because a true null will not
             // appear as a query parameter but we want to track cid even when cid
             // isn't provided
-            params = {'cid': 'null'};
+            contextHeaderParams = {'cid': 'null'};
         }
 
-        var server = _servers[uri]; // TODO this lookup should factor in params
+        var server = _servers[uri];
         if (!server) {
-            server = new Server(uri, params);
+            server = new Server(uri, contextHeaderParams);
 
             server.catalogs = new Catalogs(server);
             _servers[uri] = server;
@@ -86,7 +86,7 @@
      * @param {string} uri URI of the ERMrest service.
      * @constructor
      */
-    function Server(uri, params) {
+    function Server(uri, contextHeaderParams) {
 
         /**
          * The URI of the ERMrest service
@@ -100,8 +100,8 @@
          * @type {Object}
          */
         this._http = module._wrap_http(module._http);
-        this._http.params = params || {};
-        this._http.params.cid = this._http.params.cid || null;
+        this._http.contextHeaderParams = contextHeaderParams || {};
+        this._http.contextHeaderParams.cid = this._http.contextHeaderParams.cid || null;
 
         /**
          *

--- a/js/http.js
+++ b/js/http.js
@@ -119,30 +119,45 @@
             scope = scope || window;
             var cfg_idx = _method_to_config_idx[method];
             return function() {
-                // if no default params, then just call the fn
                 var args;
-                if (this.params) {
-                    // not allowed to alter 'arguments' so you must make a shallow
-                    // copy. it is also an 'array-like' object but not an actual
-                    // array, therefore arguments.slice() does not work.
-                    args = [];
-                    for (var i=0, len=arguments.length; i<len; i++) {
-                        args[i] = arguments[i];
-                    }
 
-                    // make sure arguments has a config, and config has a params
-                    var config = args[cfg_idx] = args[cfg_idx] || {};
-                    config.params = config.params || {};
+                // not allowed to alter 'arguments' so you must make a shallow
+                // copy. it is also an 'array-like' object but not an actual
+                // array, therefore arguments.slice() does not work.
+                args = [];
+                for (var i=0, len=arguments.length; i<len; i++) {
+                    args[i] = arguments[i];
+                }
 
-                    // now add default params iff they do not collide
-                    for (var key in this.params) {
-                        if (!(key in config.params)) {
-                            config.params[key] = this.params[key];
+                // make sure arguments has a config, and config has a headers
+                var config = args[cfg_idx] = args[cfg_idx] || {};
+            
+                // now add default headers i
+                config.headers = config.headers || {};
+
+                // if no default contextHeaderParams, then just call the fn
+                if (this.contextHeaderParams) {
+                    // Iterate over headers iff they do not collide
+                    var contextHeader = config.headers[module._contextHeaderName] = config.headers[module._contextHeaderName] ||  {};
+                    for (var key in this.contextHeaderParams) {
+                        if (!(key in contextHeader)) {
+                            contextHeader[key] = this.contextHeaderParams[key];
                         }
                     }
-                }
-                else {
+                } else {
                     args = arguments;
+                }
+
+                /** 
+                  * If context header is found in header then encode the stringified value of the header and unescape to keep some of them same
+                  *     JSON and HTTP safe reserved chars: {, }, ", ,, :
+                  *     non-reserved punctuation: -, _, ., ~
+                  *     digit: 0 - 9
+                  *     alpha: A - Z and a - z
+                  * 
+                  **/
+                if (typeof config.headers[module._contextHeaderName] === 'object') {
+                    config.headers[module._contextHeaderName] = unescape(module._fixedEncodeURIComponent(config.headers[module._contextHeaderName]));
                 }
 
                 // now call the fn, with retry logic
@@ -167,24 +182,24 @@
                             }, delay);
                             delay *= 2;
                         } else if (method == 'delete' && response.status == _http_status_codes.not_found) {
-                            /* SPECIAL CASE: "retried delete"
-                             * This indicates that a 'delete' was attempted, but
-                             * failed due to a transient error. It was retried
-                             * at least one more time and at some point
-                             * succeeded.
-                             *
-                             * Both of the currently supported delete operations
-                             * (entity/ and attribute/) return 204 No Content.
-                             */
+                            /** SPECIAL CASE: "retried delete"
+                              * This indicates that a 'delete' was attempted, but
+                              * failed due to a transient error. It was retried
+                              * at least one more time and at some point
+                              * succeeded.
+                              *
+                              * Both of the currently supported delete operations
+                              * (entity/ and attribute/) return 204 No Content.
+                              */
 
-                             // If we get an HTTP error with HTML in it, this means something the server returned as an error.
-                             // Ermrest never produces HTML errors, so this was produced by the server itself
-                             if (response.headers()['content-type'] && response.headers()['content-type'].indexOf("html") > -1) {
-                                 response.status = response.statusCode = _http_status_codes.internal_server_error;
-                                 response.data = "An unexpected error has occurred. Please report this problem to your system administrators.";
-                             } else {
-                                 response.status = response.statusCode = _http_status_codes.no_content;
-                             }
+                            // If we get an HTTP error with HTML in it, this means something the server returned as an error.
+                            // Ermrest never produces HTML errors, so this was produced by the server itself
+                            if (response.headers()['content-type'] && response.headers()['content-type'].indexOf("html") > -1) {
+                                response.status = response.statusCode = _http_status_codes.internal_server_error;
+                                response.data = "An unexpected error has occurred. Please report this problem to your system administrators.";
+                            } else {
+                                response.status = response.statusCode = _http_status_codes.no_content;
+                            }
 
                             module._onload().then(function() {
                                 deferred.resolve(response);

--- a/js/reference.js
+++ b/js/reference.js
@@ -35,7 +35,7 @@
      * @function resolve
      * @param {string} uri -  An ERMrest resource URI, such as
      * `https://example.org/ermrest/catalog/1/entity/s:t/k=123`.
-     * @param {Object} [params] - An optional parameters object. The (key, value)
+     * @param {Object} [contextHeaderParams] - An optional context header parameters object. The (key, value)
      * pairs from the object are converted to URL `key=value` query parameters
      * and appended to every request to the ERMrest service.
      * @return {Promise} Promise when resolved passes the
@@ -48,7 +48,7 @@
      * {@link ERMrest.UnauthorizedError},
      * {@link ERMrest.NotFoundError},
      */
-    module.resolve = function (uri, params) {
+    module.resolve = function (uri, contextHeaderParams) {
         try {
             verify(uri, "'uri' must be specified");
             var defer = module._q.defer();
@@ -57,7 +57,7 @@
             // make sure all the dependencies are loaded
             module._onload().then(function () {
                 location = module.parse(uri);
-                var server = module.ermrestFactory.getServer(location.service, params);
+                var server = module.ermrestFactory.getServer(location.service, contextHeaderParams);
 
                 // find the catalog
                 return server.catalogs.get(location.catalog);

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -2095,3 +2095,5 @@
     ];
 
     module._systemColumns = ['RID', 'RCB', 'RMB', 'RCT', 'RMT'];
+
+    module._contextHeaderName = 'Deriva-Client-Context';

--- a/test/specs/errors/tests/05.http_retry_error.js
+++ b/test/specs/errors/tests/05.http_retry_error.js
@@ -33,7 +33,7 @@ exports.execute = function (options) {
         	delay += server._http.initial_delay;
 
 	        nock(url, ops)
-	          .get("/ermrest/catalog/" + id + "/schema?cid=null")
+	          .get("/ermrest/catalog/" + id + "/schema")
 	          .reply(503, 'Service Unavailable')
 	          .persist();
 
@@ -62,7 +62,7 @@ exports.execute = function (options) {
         	delay += server._http.initial_delay;
 
 	        nock(url, ops)
-	          .get("/ermrest/catalog/" + id + "/schema?cid=null")
+	          .get("/ermrest/catalog/" + id + "/schema")
 	          .reply(500, 'Internal Server Error')
 	          .persist();
 
@@ -91,7 +91,7 @@ exports.execute = function (options) {
         	}
         	delay += server._http.initial_delay;
 
-        	var uri = "/ermrest/catalog/" + catalog.id + "/entity/a:=error_schema:valid_table_name/id=8001?cid=null"
+        	var uri = "/ermrest/catalog/" + catalog.id + "/entity/a:=error_schema:valid_table_name/id=8001"
 
 	        nock(url, ops)
               .filteringPath(function(path){ return uri; })

--- a/test/specs/errors/tests/06.http_401_error.js
+++ b/test/specs/errors/tests/06.http_401_error.js
@@ -23,7 +23,7 @@ exports.execute = function (options) {
         it("should have no httpUnauthorizedFn handler and make a Get Catalog call and receive an exception with error code 401", function (done) {
             
             nock(url, ops)
-              .get("/ermrest/catalog/" + id + "/schema?cid=null")
+              .get("/ermrest/catalog/" + id + "/schema")
               .reply(401, 'Service Unavailable');
 
             server.catalogs.get(id).then(null, function(err) {
@@ -39,7 +39,7 @@ exports.execute = function (options) {
         it("should have httpUnauthorizedFn handler and make a Get Catalog call, for which the handler should be called and catalog call should fail with 404", function(done) {
             
             nock(url, ops)
-              .get("/ermrest/catalog/" + id + "/schema?cid=null")
+              .get("/ermrest/catalog/" + id + "/schema")
               .reply(401, 'Unauthorized Error');
 
             ermRest.setHttpUnauthorizedFn(function() {

--- a/test/specs/errors/tests/07.http_content_error.js
+++ b/test/specs/errors/tests/07.http_content_error.js
@@ -30,7 +30,7 @@ exports.execute = function (options) {
 
         it("should be returned as a 503 error.", function (done) {
             nock(url, ops)
-                .get("/ermrest/catalog/" + id + "/schema?cid=null")
+                .get("/ermrest/catalog/" + id + "/schema")
                 .reply(404, htmlResponseMessage, {"Content-Type": "text/html"});
 
             server.catalogs.get(id).then(null, function(err) {


### PR DESCRIPTION
This PR adds client context parameters like 'cid' etc to explicit HTTP header `Deriva-Client-Context` as mentioned in https://github.com/informatics-isi-edu/ermrestjs/issues/536. 

You can check the HTTP headers in the network tab of this URL

https://dev.isrd.isi.edu/~chirag/chaise/recordset/#1/isa:dataset@sort(release_date::desc::,id)

In addition you can check the messages log on the machine to be sure.

1. SSH to `dev.isrd` machine.
2. Switch user to root `su -`. 
3. Run `grep "dcctx" /var/log/messages`. You should see your last call entry in the log with name `dcctx`.