### PR TITLE
change uniqueId to use current page refernece

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -1759,7 +1759,7 @@
                  * github issue: #425
                  */
                 var self = this, delFlag = module._operationsFlag.DELETE;
-                
+
                 this._server._http.delete(this.location.ermrestUri).then(function deleteReference(deleteResponse) {
                     defer.resolve();
                 }, function error(deleteError) {
@@ -3880,8 +3880,8 @@
             if (this._uniqueId === undefined) {
                 var key, hasNull = false;
                 this._uniqueId = "";
-                for (var i = 0; i < this.reference.table.shortestKey.length; i++) {
-                    keyName = this.reference.table.shortestKey[i].name;
+                for (var i = 0; i < this._pageRef.table.shortestKey.length; i++) {
+                    keyName = this._pageRef.table.shortestKey[i].name;
                     if (this.data[keyName] == null) {
                         hasNull = true;
                         break;

--- a/test/specs/reference/tests/08.alternative_tables.js
+++ b/test/specs/reference/tests/08.alternative_tables.js
@@ -130,7 +130,7 @@ exports.execute = function (options) {
         var uri14 = options.url + "/catalog/" + catalog_id + "/entity/" + schemaNameEncoded + ":" +
             relatedTable + "/id=1/(id)=(" + schemaNameEncoded + ":" + associatonTable + ":id_related)/(id_base)=(" +
             schemaNameEncoded + ":" + baseTable1Encoded + ":id)";
-        
+
         var facetObject15 = {
             "and": [
                 {"source": [{"inbound": ["reference schema altTables", "alt_detailed_fk"]}, "details"], "search": ["H"]},
@@ -142,10 +142,10 @@ exports.execute = function (options) {
                 ], "choices": ["two"]}
             ]
         };
-        
-        var uri15 = options.url + "/catalog/" + catalog_id + "/entity/" + 
+
+        var uri15 = options.url + "/catalog/" + catalog_id + "/entity/" +
             schemaNameEncoded + ":" + baseTable1Encoded + "/*::facets::" + options.ermRest.encodeFacet(facetObject15);
-            
+
         var facetObject16 = {
             "and": [
                 {"source": [{"outbound": ["reference schema altTables", "alt_detailed_fk"]}, "name"], "search": ["H"]},
@@ -158,8 +158,8 @@ exports.execute = function (options) {
                 ], "choices": ["two"]}
             ]
         };
-        
-        var uri16 = options.url + "/catalog/" + catalog_id + "/entity/" + 
+
+        var uri16 = options.url + "/catalog/" + catalog_id + "/entity/" +
             schemaNameEncoded + ":" + altDetailedTable1Encoded + "/*::facets::" + options.ermRest.encodeFacet(facetObject16);
 
         describe('1. base table with no entity filters,', function() {
@@ -250,6 +250,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("1.A.5 tuple uniqueId should return correct data from base table.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('1.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable1);
@@ -303,6 +307,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("1.B.5 tuple uniqueId should return correct data from base table.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('1.C contextualize compact should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.compactBrief;
                 expect(reference2._table.name).toBe(altCompactTable1);
@@ -354,6 +362,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("1.C.5 tuple uniqueId should return correct data from base table.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
         });
 
@@ -446,6 +458,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("2.A.5 tuple uniqueId should return correct data from base table.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('2.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable1);
@@ -484,7 +500,7 @@ exports.execute = function (options) {
                 expect(tuple.reference._location.path).toBe(schemaNameEncoded + ":" + baseTable1Encoded + "/id=00001");
             });
 
-            it('2.B.3 tuple read should return correct data from base table', function(done) {
+            it('2.B.4 tuple read should return correct data from base table', function(done) {
                 tuple.reference.read(limit).then(function (response) {
                     page = response;
 
@@ -498,6 +514,11 @@ exports.execute = function (options) {
                     done.fail();
                 });
             });
+
+            it("2.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
 
             it('2.C contextualize compact should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.compactBrief;
@@ -550,6 +571,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("2.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
         });
 
@@ -642,6 +667,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("3.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001_12");
+            });
+
             it('3.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable2);
@@ -698,6 +727,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("3.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001_12");
+            });
+
             it('3.C contextualize compact should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.compactBrief;
                 expect(reference2._table.name).toBe(altCompactTable2);
@@ -751,6 +784,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("3.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001_12");
             });
         });
 
@@ -842,6 +879,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("4.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('4.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable1);
@@ -895,6 +936,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("4.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('4.C contextualize compact should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.compactBrief;
                 expect(reference2._table.name).toBe(altCompactTable1);
@@ -946,6 +991,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("4.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
         });
 
@@ -1140,6 +1189,10 @@ exports.execute = function (options) {
                     done.fail();
                 });
             });
+
+            it("5.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
         });
 
         describe('6. alternative detail table with single entity filter (single col key),', function() {
@@ -1227,6 +1280,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("6.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
 
             it('6.B contextualize detailed should return a new reference with alternative table', function() {
@@ -1334,6 +1391,10 @@ exports.execute = function (options) {
                     done.fail();
                 });
             });
+
+            it("6.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
         });
 
         describe('7. alternative detail table with single entity filter (multi col key),', function() {
@@ -1423,6 +1484,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("7.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001_12");
+            });
+
             it('7.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable2);
@@ -1479,6 +1544,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("7.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001_12");
+            });
+
             it('7.C contextualize compact should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.compactBrief;
                 expect(reference2._table.name).toBe(altCompactTable2);
@@ -1533,8 +1602,12 @@ exports.execute = function (options) {
                     done.fail();
                 });
             });
+
+            it("7.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001_12");
+            });
         });
-        
+
         describe('8. alternative detail table with multiple entity filters,', function() {
             var reference, reference2, page, tuple;
             var limit = 25;
@@ -1621,6 +1694,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("8.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('8.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable1);
@@ -1674,6 +1751,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("8.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('8.C contextualize compact should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.compactBrief;
                 expect(reference2._table.name).toBe(altCompactTable1);
@@ -1725,6 +1806,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("8.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
         });
 
@@ -1814,6 +1899,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("9.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('9.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable1);
@@ -1867,6 +1956,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("9.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('9.C contextualize compact should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.compactBrief;
                 expect(reference2._table.name).toBe(altCompactTable1);
@@ -1918,6 +2011,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("9.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
         });
 
@@ -2006,6 +2103,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("10.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
 
             it('10.B contextualize detailed should return a new reference with alternative table', function() {
@@ -2113,6 +2214,10 @@ exports.execute = function (options) {
                     done.fail();
                 });
             });
+
+            it("10.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
         });
 
         describe('11. alternative compact table with single entity filter (multi col key),', function() {
@@ -2202,6 +2307,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("11.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001_12");
+            });
+
             it('11.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable2);
@@ -2258,6 +2367,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("11.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001_12");
+            });
+
             it('11.C contextualize compact should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.compactBrief;
                 expect(reference2._table.name).toBe(altCompactTable2);
@@ -2311,6 +2424,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("11.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001_12");
             });
         });
 
@@ -2400,6 +2517,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("12.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('12.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable1);
@@ -2453,6 +2574,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("12.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('12.C contextualize compact should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.compactBrief;
                 expect(reference2._table.name).toBe(altCompactTable1);
@@ -2504,6 +2629,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("12.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
         });
 
@@ -2595,6 +2724,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("13.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('13.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable1);
@@ -2646,6 +2779,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("13.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
 
             it('13.C contextualize compact should return a new reference with alternative table', function() {
@@ -2701,6 +2838,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("13.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it("13.D contextualizing a contextualized reference should not remove the join., ", function () {
                 reference3 = reference2.contextualize.entry;
                 expect(reference3._table.name).toBe(baseTable1);
@@ -2752,6 +2893,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("13.D.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
         });
 
@@ -2843,6 +2988,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("14.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
+
             it('14.B contextualize detailed should return a new reference with alternative table', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable1);
@@ -2894,6 +3043,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("14.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
             });
 
             it('14.C contextualize compact should return a new reference with alternative table', function() {
@@ -2948,6 +3101,10 @@ exports.execute = function (options) {
                     done.fail();
                 });
             });
+
+            it("14.C.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00001");
+            });
         });
 
         describe("15. base table with facets, ", function () {
@@ -2969,7 +3126,7 @@ exports.execute = function (options) {
                     done.fail();
                 });
             });
-            
+
             it('15.2 base table should be properly defined', function() {
                 expect(reference._table.name).toBe(baseTable1, "table name missmatch.");
                 expect(reference._table._alternatives.detailed.name).toBe(altDetailedTable1, "detailed alternative table missmatch.");
@@ -2989,12 +3146,12 @@ exports.execute = function (options) {
                 expect(reference2._shortestKey.length).toBe(1, "shortestkey length missmatch.");
                 expect(reference2._shortestKey[0].name).toBe("id", "shortestkey name missmatch.");
             });
-            
+
             it("15.A.0 returned reference should have correct facets.", function () {
                 expect(reference2.location.facets).toBeDefined("facets was not defined.");
                 expect(JSON.stringify(reference2.location.facets.decoded)).toEqual(JSON.stringify(facetObject15), "facets missmatch.");
             });
-            
+
             it('15.A.1 read should return a Page object that is defined.', function(done) {
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -3040,6 +3197,10 @@ exports.execute = function (options) {
                 });
             });
 
+            it("15.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00002");
+            });
+
             it('15.B contextualize detailed should return a new reference with alternative table.', function() {
                 reference2 = reference.contextualize.detailed;
                 expect(reference2._table.name).toBe(altDetailedTable1, "table missmatch.");
@@ -3047,7 +3208,7 @@ exports.execute = function (options) {
                 expect(reference2._shortestKey[0].name).toBe("id x", "shortestkey name missmatch.");
                 expect(reference2.displayname.value).toBe(altDetailedTable1, "displayname missmatch.");
             });
-            
+
             it("15.B.0 returned reference should have correct facets.", function () {
                 newFacetObject = {
                     "and": [
@@ -3064,7 +3225,7 @@ exports.execute = function (options) {
                 expect(reference2.location.facets).toBeDefined("facets was not defined.");
                 expect(JSON.stringify(reference2.location.facets.decoded)).toEqual(JSON.stringify(newFacetObject), "facets missmatch.");
             });
-            
+
             it('15.B.1 read should return a Page object that is defined.', function(done) {
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -3106,6 +3267,10 @@ exports.execute = function (options) {
                     done.fail();
                 });
             });
+
+            it("15.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00002");
+            });
         });
 
         describe("16. alternative detailed table with facets,", function () {
@@ -3127,7 +3292,7 @@ exports.execute = function (options) {
                     done.fail();
                 });
             });
-            
+
             it('16.2 alternative table should be properly defined', function() {
                 expect(reference._location.uri).toBe(uri16, "uri missmatch.");
                 expect(reference._table.name).toBe(altDetailedTable1, "table name missmatch.");
@@ -3145,7 +3310,7 @@ exports.execute = function (options) {
                 expect(reference2._shortestKey.length).toBe(1, "shortestkey length missmatch.");
                 expect(reference2._shortestKey[0].name).toBe("id", "shortestkey name missmatch.");
             });
-            
+
             it("16.A.0 returned reference should have correct facets.", function () {
                 newFacetObject = {
                     "and": [
@@ -3161,7 +3326,7 @@ exports.execute = function (options) {
                 expect(reference2.location.facets).toBeDefined("facets was not defined.");
                 expect(JSON.stringify(reference2.location.facets.decoded)).toEqual(JSON.stringify(newFacetObject), "facets missmatch.");
             });
-            
+
             it('16.A.1 read should return a Page object that is defined.', function(done) {
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -3205,13 +3370,17 @@ exports.execute = function (options) {
                 });
             });
 
+            it("16.A.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00002");
+            });
+
             it('16.B contextualize compact should return a new reference with alternative table.', function() {
                 reference2 = reference.contextualize.compact;
                 expect(reference2._table.name).toBe(altCompactTable1, "table missmatch.");
                 expect(reference2._shortestKey.length).toBe(1, "shortestkey missmatch.");
                 expect(reference2._shortestKey[0].name).toBe("id y", "shortestkey name missmatch.");
             });
-            
+
             it("16.B.0 returned reference should have correct facets.", function () {
                 newFacetObject = {
                     "and": [
@@ -3232,7 +3401,7 @@ exports.execute = function (options) {
                 expect(reference2.location.facets).toBeDefined("facets was not defined.");
                 expect(JSON.stringify(reference2.location.facets.decoded)).toEqual(JSON.stringify(newFacetObject), "facets missmatch.");
             });
-            
+
             it('16.B.1 read should return a Page object that is defined.', function(done) {
                 reference2.read(limit).then(function (response) {
                     page = response;
@@ -3273,6 +3442,10 @@ exports.execute = function (options) {
                     console.dir(err);
                     done.fail();
                 });
+            });
+
+            it("16.B.5 tuple uniqueId should return correct data.", function () {
+                expect(tuple.uniqueId).toEqual("00002");
             });
         });
     });


### PR DESCRIPTION
Tuple.uniqueId was using the tuple.reference API which is applying the alternative logic. This was resulting in tuple.uniqueId to be null.