### PR TITLE
Uinit asset

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -4910,8 +4910,8 @@
         var col = this.filenameColumn ? this.filenameColumn : this._baseCol;
         var url = data[this._baseCol.name];
 
-        // add the uint=1 query params
-        url += ( url.indexOf("?") !== -1 ? "&": "?") + "uint=1";
+        // add the uinit=1 query params
+        url += ( url.indexOf("?") !== -1 ? "&": "?") + "uinit=1";
         var keyValues = {
             "caption": col.formatvalue(data[col.name], context, options),
             "url": url

--- a/js/reference.js
+++ b/js/reference.js
@@ -1759,7 +1759,7 @@
                  * github issue: #425
                  */
                 var self = this, delFlag = module._operationsFlag.DELETE;
-                
+
                 this._server._http.delete(this.location.ermrestUri).then(function deleteReference(deleteResponse) {
                     defer.resolve();
                 }, function error(deleteError) {
@@ -4908,9 +4908,13 @@
         // otherwise return a download link
         var template = "[{{{caption}}}]({{{url}}}){download .download}";
         var col = this.filenameColumn ? this.filenameColumn : this._baseCol;
+        var url = data[this._baseCol.name];
+
+        // add the uint=1 query params
+        url += ( url.indexOf("?") !== -1 ? "&": "?") + "uint=1";
         var keyValues = {
             "caption": col.formatvalue(data[col.name], context, options),
-            "url": data[this._baseCol.name]
+            "url": url
         };
         var unformatted = module._renderTemplate(template, keyValues, this.table, this._context, {formatted: true});
         return {isHTML: true, value: module._formatUtils.printMarkdown(unformatted, {inline:true}), unformatted: unformatted};

--- a/test/specs/reference/tests/14.pseudo_columns.js
+++ b/test/specs/reference/tests/14.pseudo_columns.js
@@ -203,7 +203,7 @@ exports.execute = function (options) {
             '1000', '10001', 'filename', '1,242', 'md5', 'sha256',
             '',
             '<h2>filename</h2>\n',
-            '<a href="https://dev.isrd.isi.edu" download="" class="download">filename</a>',
+            '<a href="https://dev.isrd.isi.edu?uint=1" download="" class="download">filename</a>',
             '4'
         ];
 

--- a/test/specs/reference/tests/14.pseudo_columns.js
+++ b/test/specs/reference/tests/14.pseudo_columns.js
@@ -203,7 +203,7 @@ exports.execute = function (options) {
             '1000', '10001', 'filename', '1,242', 'md5', 'sha256',
             '',
             '<h2>filename</h2>\n',
-            '<a href="https://dev.isrd.isi.edu?uint=1" download="" class="download">filename</a>',
+            '<a href="https://dev.isrd.isi.edu?uinit=1" download="" class="download">filename</a>',
             '4'
         ];
 

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -663,9 +663,13 @@ exports.execute = function (options) {
                         expect(val).toEqual("<h2>filename</h2>\n");
                     });
 
-                    it("otherwise return a download link", function() {
+                    it("otherwise return a download link with query parameter", function() {
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com", "col_filename": "filename"}).value;
-                        expect(val).toEqual('<a href="https://example.com" download="" class="download">filename</a>');
+                        expect(val).toEqual('<a href="https://example.com?uint=1" download="" class="download">filename</a>', "value missmatch.");
+
+                        val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com?query=1&v=1", "col_filename": "filename"}).value;
+                        //NOTE this is the output but it will be displayed correctly.
+                        expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1&amp;uint=1" download="" class="download">filename</a>', "couldn't handle having query params in the url.");
                     });
                  });
 

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -665,11 +665,11 @@ exports.execute = function (options) {
 
                     it("otherwise return a download link with query parameter", function() {
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com", "col_filename": "filename"}).value;
-                        expect(val).toEqual('<a href="https://example.com?uint=1" download="" class="download">filename</a>', "value missmatch.");
+                        expect(val).toEqual('<a href="https://example.com?uinit=1" download="" class="download">filename</a>', "value missmatch.");
 
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com?query=1&v=1", "col_filename": "filename"}).value;
                         //NOTE this is the output but it will be displayed correctly.
-                        expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1&amp;uint=1" download="" class="download">filename</a>', "couldn't handle having query params in the url.");
+                        expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1&amp;uinit=1" download="" class="download">filename</a>', "couldn't handle having query params in the url.");
                     });
                  });
 


### PR DESCRIPTION
Add query parameter `uinit=1` to asset download links. It turns out the markdown will escape the `&` character, but the browser will compile to the correct link.