### PR TITLE
Add Extra Functionality to Pass Object to Context Header

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -276,6 +276,7 @@ to use for ERMrest JavaScript agents.
         * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
         * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
         * [.csvDownloadLink](#ERMrest.Reference+csvDownloadLink) ⇒ <code>String</code>
+        * [.defaultLogInfo](#ERMrest.Reference+defaultLogInfo) : <code>Object</code>
         * [.removeAllFacetFilters()](#ERMrest.Reference+removeAllFacetFilters) ⇒ <code>ERMrest.reference</code>
         * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
             * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
@@ -2230,6 +2231,7 @@ Constructor for a ParsedFilter.
     * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
     * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
     * [.csvDownloadLink](#ERMrest.Reference+csvDownloadLink) ⇒ <code>String</code>
+    * [.defaultLogInfo](#ERMrest.Reference+defaultLogInfo) : <code>Object</code>
     * [.removeAllFacetFilters()](#ERMrest.Reference+removeAllFacetFilters) ⇒ <code>ERMrest.reference</code>
     * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
         * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
@@ -2491,6 +2493,12 @@ Returns a uri that will properly generate the download link for a csv document
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 **Returns**: <code>String</code> - A string representing the url for direct csv download  
+<a name="ERMrest.Reference+defaultLogInfo"></a>
+
+#### reference.defaultLogInfo : <code>Object</code>
+The default information that we want to be logged including catalog, schema_table, and facet (filter).
+
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+removeAllFacetFilters"></a>
 
 #### reference.removeAllFacetFilters() ⇒ <code>ERMrest.reference</code>

--- a/doc/api.md
+++ b/doc/api.md
@@ -277,7 +277,7 @@ to use for ERMrest JavaScript agents.
         * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
         * [.csvDownloadLink](#ERMrest.Reference+csvDownloadLink) ⇒ <code>String</code>
         * [.removeAllFacetFilters()](#ERMrest.Reference+removeAllFacetFilters) ⇒ <code>ERMrest.reference</code>
-        * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
+        * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
             * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
         * [.read(limit, contextHeaderParams)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
         * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
@@ -2231,7 +2231,7 @@ Constructor for a ParsedFilter.
     * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
     * [.csvDownloadLink](#ERMrest.Reference+csvDownloadLink) ⇒ <code>String</code>
     * [.removeAllFacetFilters()](#ERMrest.Reference+removeAllFacetFilters) ⇒ <code>ERMrest.reference</code>
-    * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
+    * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
         * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
     * [.read(limit, contextHeaderParams)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
     * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
@@ -2500,7 +2500,7 @@ Remove all the fitlers from facets
 **Returns**: <code>ERMrest.reference</code> - A reference without facet filters  
 <a name="ERMrest.Reference+create"></a>
 
-#### reference.create(data) ⇒ <code>Promise</code>
+#### reference.create(data, contextHeaderParams) ⇒ <code>Promise</code>
 Creates a set of tuples in the references relation. Note, this
 operation sets the `defaults` list according to the table
 specification, and not according to the contents of in the input
@@ -2517,6 +2517,7 @@ or rejected with any of the following errors:
 | Param | Type | Description |
 | --- | --- | --- |
 | data | <code>Array</code> | The array of data to be created as new tuples. |
+| contextHeaderParams | <code>Object</code> | the object that we want to log. |
 
 <a name="ERMrest.Reference+create..columnDiff"></a>
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -279,10 +279,10 @@ to use for ERMrest JavaScript agents.
         * [.removeAllFacetFilters()](#ERMrest.Reference+removeAllFacetFilters) ⇒ <code>ERMrest.reference</code>
         * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
             * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
-        * [.read(limit)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
+        * [.read(limit, contextHeaderParams)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
         * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
-        * [.update(tuples)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
-        * [.delete()](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
+        * [.update(tuples, contextHeaderParams)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
+        * [.delete(contextHeaderParams)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
             * [~self](#ERMrest.Reference+delete..self)
         * [.related([tuple])](#ERMrest.Reference+related) ⇒ [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
         * [.search(term)](#ERMrest.Reference+search) ⇒ <code>Reference</code>
@@ -2190,9 +2190,9 @@ Constructor for a ParsedFilter.
 #### parsedFilter.setFilters(filters)
 **Kind**: instance method of [<code>ParsedFilter</code>](#ERMrest.ParsedFilter)  
 
-| Param | Description |
-| --- | --- |
-| filters | array of binary predicate |
+| Param | Type | Description |
+| --- | --- | --- |
+| filters | <code>Array.&lt;ParsedFilter&gt;</code> | array of binary predicate |
 
 <a name="ERMrest.ParsedFilter+setBinaryPredicate"></a>
 
@@ -2233,10 +2233,10 @@ Constructor for a ParsedFilter.
     * [.removeAllFacetFilters()](#ERMrest.Reference+removeAllFacetFilters) ⇒ <code>ERMrest.reference</code>
     * [.create(data)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
         * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
-    * [.read(limit)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
+    * [.read(limit, contextHeaderParams)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
     * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
-    * [.update(tuples)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
-    * [.delete()](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
+    * [.update(tuples, contextHeaderParams)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
+    * [.delete(contextHeaderParams)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
         * [~self](#ERMrest.Reference+delete..self)
     * [.related([tuple])](#ERMrest.Reference+related) ⇒ [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
     * [.search(term)](#ERMrest.Reference+search) ⇒ <code>Reference</code>
@@ -2530,7 +2530,7 @@ The 6 is ignored because we only want to know what's in the minuend that is not 
 **Kind**: inner method of [<code>create</code>](#ERMrest.Reference+create)  
 <a name="ERMrest.Reference+read"></a>
 
-#### reference.read(limit) ⇒ <code>Promise</code>
+#### reference.read(limit, contextHeaderParams) ⇒ <code>Promise</code>
 Reads the referenced resources and returns a promise for a page of
 tuples. The `limit` parameter is required and must be a positive
 integer. The page of tuples returned will be described by the
@@ -2561,6 +2561,7 @@ or rejected with any of these errors:
 | Param | Type | Description |
 | --- | --- | --- |
 | limit | <code>number</code> | The limit of results to be returned by the read request. __required__ |
+| contextHeaderParams | <code>Object</code> | the object that we want to log. |
 
 <a name="ERMrest.Reference+sort"></a>
 
@@ -2580,7 +2581,7 @@ Return a new Reference with the new sorting
 
 <a name="ERMrest.Reference+update"></a>
 
-#### reference.update(tuples) ⇒ <code>Promise</code>
+#### reference.update(tuples, contextHeaderParams) ⇒ <code>Promise</code>
 Updates a set of resources.
 
 **Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
@@ -2593,15 +2594,21 @@ or rejected with any of these errors:
 | Param | Type | Description |
 | --- | --- | --- |
 | tuples | <code>Array</code> | array of tuple objects so that the new data nd old data can be used to determine key changes. tuple.data has the new data tuple._oldData has the data before changes were made |
+| contextHeaderParams | <code>Object</code> | the object that we want to log. |
 
 <a name="ERMrest.Reference+delete"></a>
 
-#### reference.delete() ⇒ <code>Promise</code>
+#### reference.delete(contextHeaderParams) ⇒ <code>Promise</code>
 Deletes the referenced resources.
 
 **Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
 **Returns**: <code>Promise</code> - A promise resolved with empty object or rejected with any of these errors:
 - ERMrestjs corresponding http errors, if ERMrest returns http error.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| contextHeaderParams | <code>Object</code> | the object that we want to log. |
+
 <a name="ERMrest.Reference+delete..self"></a>
 
 ##### delete~self

--- a/js/ag_reference.js
+++ b/js/ag_reference.js
@@ -202,8 +202,13 @@ AttributeGroupReference.prototype = {
             if (!contextHeaderParams || !isObject(contextHeaderParams)) {
                 contextHeaderParams = {"action": "read"};
             }
+
+            contextHeaderParams.page_size = limit;
+
+            var headers = {};
+            headers[module._contextHeaderName] = contextHeaderParams;
             var config = {
-                headers: this._generateContextHeader(contextHeaderParams, limit)
+                headers: headers
             };
             this._server._http.get(uri, config).then(function (response) {
 

--- a/js/ag_reference.js
+++ b/js/ag_reference.js
@@ -185,9 +185,10 @@ AttributeGroupReference.prototype = {
     /**
      *
      * @param  {int=} limit
+     * @param {Object} contextHeaderParams the object that we want to log.
      * @return {ERMRest.AttributeGroupPage}
      */
-    read: function (limit) {
+    read: function (limit, contextHeaderParams) {
         try {
             var defer = module._q.defer();
             var hasPaging = (typeof limit === "number" && limit > 0);
@@ -198,7 +199,13 @@ AttributeGroupReference.prototype = {
             }
 
             var currRef = this;
-            this._server._http.get(uri).then(function (response) {
+            if (!contextHeaderParams || !isObject(contextHeaderParams)) {
+                contextHeaderParams = {"action": "read"};
+            }
+            var config = {
+                headers: this._generateContextHeader(contextHeaderParams, limit)
+            };
+            this._server._http.get(uri, config).then(function (response) {
 
                 //determine hasNext and hasPrevious
                 var hasPrevious, hasNext = false;

--- a/js/errors.js
+++ b/js/errors.js
@@ -282,3 +282,32 @@
 
     NoConnectionError.prototype = Object.create(Error.prototype);
     NoConnectionError.prototype.constructor = NoConnectionError;
+
+
+    /**
+     * Log the error object to the given ermrest location.
+     * It will generate a put request to the /terminal_error with the correct headers.
+     * ermrset will return a 400 page, but will log the message.
+     * @param  {object} err             the error object
+     * @param  {string} ermrestLocation the ermrest location
+     */
+    module.logError = function (err, ermrestLocation) {
+        var defer = module._q.defer();
+        var http = module._wrap_http(module._http);
+
+        var headers = {};
+        headers[module._contextHeaderName] = {
+            e: 1,
+            name: err.constructor.name,
+            message: err.message
+        };
+
+        // this http request will fail but will still log the message.
+        http.put(ermrestLocation + "/terminal_error", {}, {headers: headers}).then(function () {
+            defer.resolve();
+        }).catch(function (err) {
+            defer.resolve();
+        });
+
+        return defer.promise;
+    };

--- a/js/http.js
+++ b/js/http.js
@@ -131,7 +131,7 @@
 
                 // make sure arguments has a config, and config has a headers
                 var config = args[cfg_idx] = args[cfg_idx] || {};
-            
+
                 // now add default headers i
                 config.headers = config.headers || {};
 
@@ -148,16 +148,17 @@
                     args = arguments;
                 }
 
-                /** 
+                /**
                   * If context header is found in header then encode the stringified value of the header and unescape to keep some of them same
                   *     JSON and HTTP safe reserved chars: {, }, ", ,, :
                   *     non-reserved punctuation: -, _, ., ~
                   *     digit: 0 - 9
                   *     alpha: A - Z and a - z
-                  * 
+                  *
                   **/
                 if (typeof config.headers[module._contextHeaderName] === 'object') {
-                    config.headers[module._contextHeaderName] = unescape(module._fixedEncodeURIComponent(JSON.stringify(config.headers[module._contextHeaderName])));
+                    // encode and make sure it's not very lengthy
+                    config.headers[module._contextHeaderName] = module._certifyContextHeader(config.headers[module._contextHeaderName]);
                 }
 
                 // now call the fn, with retry logic

--- a/js/parser.js
+++ b/js/parser.js
@@ -1127,7 +1127,7 @@
           */
          setFilters: function(filters) {
              this.filters = filters;
-             this.facet = this._filterToFacet(this);
+             this.facet = _filterToFacet(this);
          },
 
          /**
@@ -1140,61 +1140,8 @@
              this.column = colname;
              this.operator = operator;
              this.value = value;
-             this.facet = this._filterToFacet(this);
-         },
 
-         // turn filter into facet, will return null if it's not possible to do so.
-         _filterToFacet: function () {
-             var facet = {}, self = this, parsed, op;
-
-             // base for binary predicate filters
-             if (self instanceof ParsedFilter && self.type === module.filterTypes.BINARYPREDICATE){
-                  facet.source = self.column;
-                  switch (self.operator) {
-                      case "::gt::":
-                          facet.ranges = [{min: self.value}];
-                          break;
-                      case "::lt::":
-                          facet.ranges = [{max: self.value}];
-                          break;
-                      case "::null::":
-                          facet.choices = [null];
-                          break;
-                      case "::ciregexp::":
-                          facet.search = [self.value];
-                          break;
-                      case "=":
-                          facet.choices = [self.value];
-                          break;
-                      default:
-                         return null;
-                  }
-                  return facet;
-              }
-
-              // if it's an array of filters
-             if (Array.isArray(self.filters)) {
-                 if (this.type === module.filterTypes.DISJUNCTION) {
-                    op = "or";
-                } else if (this.type === module.filterTypes.CONJUNCTION) {
-                    op = "and";
-                } else {
-                    return null;
-                }
-
-                self.filters.forEach(function (f) {
-                    parsed = f._filterToFacet();
-                    if (parsed) {
-                        if (!Array.isArray(facet[op])) facet[op] = [];
-                        facet[op].push(parsed);
-                    }
-                });
-
-                return facet;
-            }
-
-            // invalid filter
-            return null;
+             this.facet = {and: [_filterToFacet(this)]};
          }
      };
 
@@ -1261,6 +1208,84 @@
         var filter = new ParsedFilter(type);
         filter.setFilters(filters);
         return filter;
+    }
+
+    /**
+     * Turn filter into facet, will return null if it's not possible to do so.
+     * @param       {ParsedFilter} parsedFilte
+     * @return      {Object}
+     */
+    function _filterToFacet(parsedFilter) {
+        var facet = {}, orSources = {}, parsed, op, i, f;
+
+        // base for binary predicate filters
+        if (parsedFilter instanceof ParsedFilter && parsedFilter.type === module.filterTypes.BINARYPREDICATE){
+            facet.source = parsedFilter.column;
+            switch (parsedFilter.operator) {
+                case "::gt::":
+                    facet.ranges = [{min: parsedFilter.value}];
+                    break;
+                case "::lt::":
+                    facet.ranges = [{max: parsedFilter.value}];
+                    break;
+                case "::null::":
+                    facet.choices = [null];
+                    break;
+                case "::ciregexp::":
+                    facet.search = [parsedFilter.value];
+                    break;
+                case "=":
+                    facet.choices = [parsedFilter.value];
+                    break;
+                default:
+                    return null;
+            }
+            return facet;
+        }
+
+        // if it's an array of filters
+        if (Array.isArray(parsedFilter.filters)) {
+            if (parsedFilter.type === module.filterTypes.DISJUNCTION) {
+                op = "or";
+            } else if (parsedFilter.type === module.filterTypes.CONJUNCTION) {
+                op = "and";
+            } else {
+                return null;
+            }
+
+            // will add the facets in the parsed to facet object
+            var mergeFacets = function (c) {
+                if (!parsed[c]) return;
+                if (!facet[op][index][c]) facet[op][index][c] = [];
+                facet[op][index][c].push(parsed[c][0]);
+            };
+
+            facet[op] = [];
+            for (i = 0; i < parsedFilter.filters.length; i++) {
+                f = parsedFilter.filters[i];
+                parsed = _filterToFacet(f);
+
+                // couldn't parse it.
+                if (!parsed) return null;
+
+                if (op === "or" && f.type === module.filterTypes.BINARYPREDICATE) {
+                    if (orSources[parsed.source] > -1) {
+                        var index = orSources[parsed.source];
+                        ["ranges", "choices", "search"].forEach(mergeFacets);
+                        continue;
+                    } else {
+                        orSources[parsed.source] = facet[op].length;
+                    }
+                }
+
+                facet[op].push(parsed);
+            }
+
+            return facet;
+        }
+
+       // invalid filter
+       return null;
     }
 
     module.filterTypes = Object.freeze({

--- a/js/reference.js
+++ b/js/reference.js
@@ -926,6 +926,7 @@
          * specification, and not according to the contents of in the input
          * tuple.
          * @param {!Array} data The array of data to be created as new tuples.
+         * @param {Object} contextHeaderParams the object that we want to log.
          * @returns {Promise} A promise resolved with a object containing `successful` and `failure` attributes.
          * Both are {@link ERMrest.Page} of results.
          * or rejected with any of the following errors:
@@ -933,7 +934,7 @@
          * - {@link ERMrest.InvalidInputError}: If `limit` is invalid.
          * - ERMrestjs corresponding http errors, if ERMrest returns http error.
          */
-        create: function(data) {
+        create: function(data, contextHeaderParams) {
             var self = this;
             try {
                 //  verify: data is not null, data has non empty tuple set
@@ -952,8 +953,16 @@
                     uri += (i === 0 ? "?defaults=" : ',') + module._fixedEncodeURIComponent(defaults[i]);
                 }
 
+                // create the context header params for log
+                if (!contextHeaderParams || !isObject(contextHeaderParams)) {
+                    contextHeaderParams = {"action": "create"};
+                }
+                var config = {
+                    headers: this._generateContextHeader(contextHeaderParams, data.length)
+                };
+
                 //  do the 'post' call
-                this._server._http.post(uri, data).then(function(response) {
+                this._server._http.post(uri, data, config).then(function(response) {
                     var etag = response.headers().etag;
                     //  new page will have a new reference (uri that filters on a disjunction of ids of these tuples)
                     var uri = self._location.compactUri + '/',
@@ -1071,6 +1080,7 @@
          *
          * @param {!number} limit The limit of results to be returned by the
          * read request. __required__
+         * @param {Object} contextHeaderParams the object that we want to log.
          *
          * @returns {Promise} A promise resolved with {@link ERMrest.Page} of results,
          * or rejected with any of these errors:
@@ -1079,7 +1089,7 @@
          * - {@link ERMrest.NotFoundError}: If asks for sorting based on columns that are not valid.
          * - ERMrestjs corresponding http errors, if ERMrest returns http error.
          */
-        read: function(limit) {
+        read: function(limit, contextHeaderParams) {
             try {
 
                 var defer = module._q.defer();
@@ -1271,7 +1281,13 @@
                 // attach `this` (Reference) to a variable
                 // `this` inside the Promise request is a Window object
                 var ownReference = this;
-                this._server._http.get(uri).then(function readReference(response) {
+                if (!contextHeaderParams || !isObject(contextHeaderParams)) {
+                    contextHeaderParams = {"action": "read"};
+                }
+                var config = {
+                    headers: this._generateContextHeader(contextHeaderParams, limit)
+                };
+                this._server._http.get(uri, config).then(function (response) {
                     var etag = response.headers().etag;
 
                     var hasPrevious, hasNext = false;
@@ -1364,13 +1380,14 @@
          * @param {Array} tuples array of tuple objects so that the new data nd old data can be used to determine key changes.
          * tuple.data has the new data
          * tuple._oldData has the data before changes were made
+         * @param {Object} contextHeaderParams the object that we want to log.
          * @returns {Promise} A promise resolved with a object containing `successful` and `failure` attributes.
          * Both are {@link ERMrest.Page} of results.
          * or rejected with any of these errors:
          * - {@link ERMrest.InvalidInputError}: If `limit` is invalid or reference is not in `entry/edit` context.
          * - ERMrestjs corresponding http errors, if ERMrest returns http error.
          */
-        update: function(tuples) {
+        update: function(tuples, contextHeaderParams) {
             try {
                 verify(tuples, "'tuples' must be specified");
                 verify(tuples.length > 0, "'tuples' must have at least one row to update");
@@ -1591,7 +1608,13 @@
                     uri += module._fixedEncodeURIComponent(columnProjections[k]) + newAlias + ":=" + module._fixedEncodeURIComponent(columnProjections[k]);
                 }
 
-                this._server._http.put(uri, submissionData).then(function updateReference(response) {
+                if (!contextHeaderParams || !isObject(contextHeaderParams)) {
+                    contextHeaderParams = {"action": "update"};
+                }
+                var config = {
+                    headers: this._generateContextHeader(contextHeaderParams, submissionData.length)
+                };
+                this._server._http.put(uri, submissionData, config).then(function updateReference(response) {
                     // Some data was not updated
                     if (response.status === 200 && response.data.length < submissionData.length) {
                         var updatedRows = response.data;
@@ -1737,11 +1760,11 @@
 
         /**
          * Deletes the referenced resources.
-         *
+         * @param {Object} contextHeaderParams the object that we want to log.
          * @returns {Promise} A promise resolved with empty object or rejected with any of these errors:
          * - ERMrestjs corresponding http errors, if ERMrest returns http error.
          */
-        delete: function() {
+        delete: function(contextHeaderParams) {
             try {
 
                 var defer = module._q.defer();
@@ -1759,8 +1782,13 @@
                  * github issue: #425
                  */
                 var self = this, delFlag = module._operationsFlag.DELETE;
-
-                this._server._http.delete(this.location.ermrestUri).then(function deleteReference(deleteResponse) {
+                if (!contextHeaderParams || !isObject(contextHeaderParams)) {
+                    contextHeaderParams = {"action": "delete"};
+                }
+                var config = {
+                    headers: this._generateContextHeader(contextHeaderParams)
+                };
+                this._server._http.delete(this.location.ermrestUri, config).then(function (deleteResponse) {
                     defer.resolve();
                 }, function error(deleteError) {
                     return defer.reject(module._responseToError(deleteError, self, delFlag));
@@ -2012,6 +2040,26 @@
          **/
         get csvDownloadLink() {
             return this.location.ermrestUri + "?limit=none&accept=csv&download=" + module._fixedEncodeURIComponent(this.displayname.unformatted);
+        },
+
+        get defaultLogInfo() {
+            if (this._defaultLogInfo === undefined) {
+                var obj = {};
+                obj.table = this.table.name;
+
+                if (this.location.facets) {
+                    obj.facets = this.location.facets;
+                } else if (this.location.filter) {
+                    if (this.location.filter.facet) {
+                        obj.facets = this.location.filter.facet;
+                    } else {
+                        obj.filters = this.location.filtersString;
+                    }
+                }
+
+                this._defaultLogInfo = obj;
+            }
+            return this._defaultLogInfo;
         },
 
         /**
@@ -2736,6 +2784,24 @@
             }
 
             return newRef;
+        },
+
+        _generateContextHeader: function (contextHeaderParams, page_size) {
+            if (!contextHeaderParams || !isObject(contextHeaderParams)) {
+                contextHeaderParams = {};
+            }
+
+            for (var key in this.defaultLogInfo) {
+                contextHeaderParams[key] = this.defaultLogInfo[key];
+            }
+
+            if (isInteger(page_size)) {
+                contextHeaderParams.page_size = page_size;
+            }
+
+            var headers = {};
+            headers[module._contextHeaderName] = contextHeaderParams;
+            return headers;
         }
     };
 

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -211,6 +211,15 @@
     };
 
     /**
+     * Returns true if given parameter isan integer
+     * @param  {*} x
+     * @return {boolean}
+     */
+    var isInteger = function (x) {
+        return (typeof x === 'number') && (x % 1 === 0);
+    };
+
+    /**
      * @private
      * @param {Object} child child class
      * @param {Object} parent parent class

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -2171,6 +2171,166 @@
         return m && r;
     };
 
+    /**
+     * Given an object will make sure it's safe for header.
+     * @param  {object} obj JavaScript object or JSON object
+     * @return {string} A safe string for http header
+     */
+    module._encodeHeaderContent = function (obj) {
+        return unescape(module._fixedEncodeURIComponent(JSON.stringify(obj)));
+    };
+
+    /**
+     * Given a header value, will encode and truncate if its length is more than the allowed length.
+     * These are the allowed and expected values in a header:
+     * - cid
+     * - pid
+     * - wid
+     * - schema_table: schema:table
+     * - filter
+     * - facet
+     * - referrer: for related entities the main entity, for recordset facets: the main entity
+     *    - filter
+     *    - facet
+     *    - schema_table
+     * - source: the source object of facet
+     * @param  {object} header The header content
+     * @return {object}
+     */
+    module._certifyContextHeader = function (header) {
+        var MAX_LENGTH = 6500;
+        var encode = module._encodeHeaderContent;
+        var res = encode(header), prevRes, facetRes;
+
+        if (res.length < MAX_LENGTH) {
+            return res;
+        }
+
+        // the minimal required attributes for log
+        var obj = {
+            cid: header.cid,
+            wid: header.wid,
+            pid: header.pid,
+            action: header.action,
+            schema_table: header.schema_table,
+            t: 1 // indicates that this request has been truncated
+        };
+
+        prevRes = res = encode(obj);
+        if (res.length >= MAX_LENGTH) {
+            return {};
+        }
+
+        // truncate facet or filter
+        // if it's a facet that has `and` in the first level,
+        // it will remove only the array element that is needed. otherwise
+        // the whole facet/filter will be removed.
+        var truncateFacet = function (obj, header, key) {
+            var prevRes = encode(obj);
+            var h = key ? header[key] : header;
+
+            if (h.filter) {
+                // add the filter
+                if (key) {
+                    obj[key].filter = h.filter;
+                } else {
+                    obj.filter = h.filter;
+                }
+
+                // encode and test the length
+                res = encode(obj);
+                if (res.length >= MAX_LENGTH) {
+                    // it was lengthy so just return the obj without filter
+                    return {truncated: true, res: prevRes};
+                }
+
+                // return result with filter
+                return {truncated: false, res: res};
+            }
+
+            // this function only expects facet and filter. it will ignore other variables
+            if (!h.facet) {
+                return {truncated: false, res: prevRes};
+            }
+
+            // only optimized for just one type of facet that we currently support: {and: []}
+            // otherwise just treat it as a object
+            if (!Array.isArray(h.facet.and)) {
+
+                // add the facet
+                if (key) {
+                    obj[key].facet = h.facet;
+                } else {
+                    obj.facet = h.facet;
+                }
+
+                // encode and test the length
+                res = encode(obj);
+                if (res.length >= MAX_LENGTH) {
+                    return {truncated: true, res: prevRes};
+                }
+
+                // return result with facet
+                return {truncated: true, res: res};
+            }
+
+            if (key) {
+                obj[key].facet = {and: []};
+            } else {
+                obj.facet = {and: []};
+            }
+
+            // add fitlers in the and array one by one until getting to the limit.
+            for (var i = 0; i < h.facet.and.length; i++) {
+                if (key) {
+                    obj[key].facet.and.push(h.facet.and[i]);
+                } else {
+                    obj.facet.and.push(h.facet.and[i]);
+                }
+
+                res = encode(obj);
+                if (res.length >= MAX_LENGTH) {
+                    return {truncated: true, res: prevRes};
+                }
+                prevRes = res;
+            }
+
+            // this means that the object had other attributes (apart from filter and facet)
+            // which is getting truncated
+            return {truncated: true, res: res};
+        };
+
+        // referrer: schema_table, facet (filter)
+        if (header.referrer) {
+            obj.referrer = {
+                schema_table: header.referrer.schema_table
+            };
+            res = encode(obj);
+            if (res.length >= MAX_LENGTH) {
+                return prevRes;
+            }
+
+            // take care of facet and fitler in referrer
+            facetRes = truncateFacet(obj, header, "referrer");
+            if (facetRes.truncated) {
+                return facetRes.res;
+            }
+            prevRes = facetRes.res;
+        }
+
+        // .source
+        if (header.source) {
+            obj.source = header.source;
+            res = encode(obj);
+            if (res.length >= MAX_LENGTH) {
+                return prevRes;
+            }
+        }
+
+        // take care of facet and fitler
+        return truncateFacet(obj, header).res;
+    };
+
     module._constraintTypes = Object.freeze({
         KEY: "k",
         FOREIGN_KEY: "fk"

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -172,7 +172,7 @@ exports.execute = function (options) {
                 expect(reference.canUpdate).toBeDefined();
                 expect(reference.create()).toBeDefined();
                 expect(reference.read()).toBeDefined();
-                expect(reference.csvDownloadLink).toBe(reference.location.ermrestUri + "?limit=none&accept=csv&download=" + reference.displayname.unformatted);
+                expect(reference.csvDownloadLink).toBe(reference.location.ermrestUri + "?limit=none&accept=csv&uinit=1&download=" + reference.displayname.unformatted);
             });
 
             it('reference should be properly defined after the callback is resolved.', function() {


### PR DESCRIPTION
This PR includes 
- (#558) Changing filter to facet for log purposes. It's only now for the log purposes because it  produces facets that the current faceting implementation might not understand.
- ([chaise#1389](https://github.com/informatics-isi-edu/chaise/issues/1389), #536) Adding functionality so chaise can pass extra objects to be logged by each request to ermrest.
- (#578) A method to log the errors in ermrest by creating a fake request which will result in 400 but will be logged anyways.
