### PR TITLE
Asset logic

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -262,7 +262,6 @@ to use for ERMrest JavaScript agents.
         * [.aggregate](#ERMrest.Reference+aggregate) : [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)
         * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
         * [.uri](#ERMrest.Reference+uri) : <code>string</code>
-        * [.session](#ERMrest.Reference+session)
         * [.table](#ERMrest.Reference+table) : [<code>Table</code>](#ERMrest.Table)
         * [.columns](#ERMrest.Reference+columns) : [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
         * [.facetColumns](#ERMrest.Reference+facetColumns) ⇒ <code>Array.&lt;ERMrest.FacetColumn&gt;</code>
@@ -356,6 +355,7 @@ to use for ERMrest JavaScript agents.
         * [.md5](#ERMrest.AssetPseudoColumn+md5) : [<code>Column</code>](#ERMrest.Column)
         * [.sha256](#ERMrest.AssetPseudoColumn+sha256) : [<code>Column</code>](#ERMrest.Column)
         * [.filenameExtFilter](#ERMrest.AssetPseudoColumn+filenameExtFilter) : [<code>Column</code>](#ERMrest.Column)
+        * [._determineInputDisabled(context)](#ERMrest.AssetPseudoColumn+_determineInputDisabled) ⇒ <code>boolean</code> \| <code>object</code>
     * [.InboundForeignKeyPseudoColumn](#ERMrest.InboundForeignKeyPseudoColumn)
         * [new InboundForeignKeyPseudoColumn(reference, fk)](#new_ERMrest.InboundForeignKeyPseudoColumn_new)
         * [.reference](#ERMrest.InboundForeignKeyPseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
@@ -2216,7 +2216,6 @@ Constructor for a ParsedFilter.
     * [.aggregate](#ERMrest.Reference+aggregate) : [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)
     * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
     * [.uri](#ERMrest.Reference+uri) : <code>string</code>
-    * [.session](#ERMrest.Reference+session)
     * [.table](#ERMrest.Reference+table) : [<code>Table</code>](#ERMrest.Table)
     * [.columns](#ERMrest.Reference+columns) : [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
     * [.facetColumns](#ERMrest.Reference+facetColumns) ⇒ <code>Array.&lt;ERMrest.FacetColumn&gt;</code>
@@ -2304,17 +2303,6 @@ NOTE: It is not understanable by ermrest, and it also doesn't have the modifiers
 Should not be used for sending requests to ermrest, use this.location.ermrestUri instead.
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
-<a name="ERMrest.Reference+session"></a>
-
-#### reference.session
-The session object from the server
-
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| session | <code>Object</code> | the session object |
-
 <a name="ERMrest.Reference+table"></a>
 
 #### reference.table : [<code>Table</code>](#ERMrest.Table)
@@ -3364,6 +3352,7 @@ The Foreign key object that this PseudoColumn is created based on
     * [.md5](#ERMrest.AssetPseudoColumn+md5) : [<code>Column</code>](#ERMrest.Column)
     * [.sha256](#ERMrest.AssetPseudoColumn+sha256) : [<code>Column</code>](#ERMrest.Column)
     * [.filenameExtFilter](#ERMrest.AssetPseudoColumn+filenameExtFilter) : [<code>Column</code>](#ERMrest.Column)
+    * [._determineInputDisabled(context)](#ERMrest.AssetPseudoColumn+_determineInputDisabled) ⇒ <code>boolean</code> \| <code>object</code>
 
 <a name="new_ERMrest.AssetPseudoColumn_new"></a>
 
@@ -3426,6 +3415,17 @@ The column object that sha256 hash is stored in.
 The column object that file extension is stored in.
 
 **Kind**: instance property of [<code>AssetPseudoColumn</code>](#ERMrest.AssetPseudoColumn)  
+<a name="ERMrest.AssetPseudoColumn+_determineInputDisabled"></a>
+
+#### assetPseudoColumn._determineInputDisabled(context) ⇒ <code>boolean</code> \| <code>object</code>
+If url_pattern is invalid or browser_upload=false the input will be disabled.
+
+**Kind**: instance method of [<code>AssetPseudoColumn</code>](#ERMrest.AssetPseudoColumn)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| context | <code>string</code> | the context |
+
 <a name="ERMrest.InboundForeignKeyPseudoColumn"></a>
 
 ### ERMrest.InboundForeignKeyPseudoColumn

--- a/js/core.js
+++ b/js/core.js
@@ -2062,7 +2062,7 @@
                         message: "Automatically generated"
                     };
                 }
-            } else if (context == module._contexts.EDIT) {
+            } else if (context == module._contexts.EDIT || context == module._contexts.ENTRY) {
                 if (this.isSystemColumn || this.isImmutable || isGenerated || isImmutable || isSerial) {
                     return true;
                 }

--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -662,6 +662,11 @@ var ERMrest = (function(module) {
         // Generate url
         var url = module._renderTemplate(template, row, this.reference.table, this.reference._context, { avoidValidation: true });
 
+        // check for having hatrac
+        if ((module._parseUrl(url).pathname.indexOf('/hatrac/') !== 0)) {
+            throw new module.MalformedURIError("The path for uploading a url should begin with /hatrac/ .");
+        }
+
         // If the template is null then throw an error
         if (url === null)  throw new module.MalformedURIError("Some column values are null in the template " + template);
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -2323,34 +2323,13 @@
             // this function will take care of adding column and asset column
             var addColumn = function (col) {
                 if (col.type.name === "text" && col.annotations.contains(module._annotations.ASSET)) {
-
-                    if (("url_pattern" in col.annotations.get(module._annotations.ASSET).content)) {
-
-                        var urlPattern = col.annotations.get(module._annotations.ASSET).content.url_pattern;
-
-                        // If url_pattenr doesn't has hatrac in it then consider the column as a plain text column and proceed
-                        if ((typeof urlPattern !== 'string') || (module._parseUrl(urlPattern).pathname.indexOf('/hatrac/') !== 0)) {
-                            // ignore the column
-                            console.log("url_pattern '" + urlPattern + "' for column '" + col.name + "' doesn't has hatrac");
-                            if (module._isEntryContext(self._context)) {
-                                return;
-                            }
-                        } else {
-                            // add asset annotation
-                            var assetCol = new AssetPseudoColumn(self, col);
-                            assetColumns.push(assetCol);
-                            self._referenceColumns.push(assetCol);
-                            return;
-                        }
-                    } else if (module._isEntryContext(self._context)) {
-                        // ignore the column
-                        console.log("Column " + col.name + " doesn't contains url_pattern");
-                        return;
-                    }
+                    var assetCol = new AssetPseudoColumn(self, col);
+                    assetColumns.push(assetCol);
+                    self._referenceColumns.push(assetCol);
+                    return;
                 }
 
                 // if annotation is not present,
-                // or in any context other than entry, and the url_pattern is not present
                 self._referenceColumns.push(new ReferenceColumn(self, [col]));
             };
 
@@ -4871,7 +4850,7 @@
 
         this._baseCol = column;
 
-        this._annotation = column.annotations.get(module._annotations.ASSET).content;
+        this._annotation = column.annotations.get(module._annotations.ASSET).content || {};
 
         /**
          * @type {boolean}
@@ -4887,6 +4866,20 @@
     }
     // extend the prototype
     module._extends(AssetPseudoColumn, ReferenceColumn);
+
+    /**
+     * If url_pattern is invalid or browser_upload=false the input will be disabled.
+     * @param  {string} context the context
+     * @return {boolean|object}
+     */
+    AssetPseudoColumn.prototype._determineInputDisabled = function (context) {
+        var pat = this._annotation.url_pattern;
+        if (typeof pat !== "string" || pat.length === 0 || this._annotation.browser_upload === false) {
+            return true;
+        }
+        // TODO not sure
+        return AssetPseudoColumn.super._determineInputDisabled.call(this, context);
+    };
 
     // properties to be overriden:
     AssetPseudoColumn.prototype.formatPresentation = function(data, context, options) {
@@ -4928,7 +4921,6 @@
     Object.defineProperty(AssetPseudoColumn.prototype, "urlPattern", {
         get: function () {
             if (this._urlPattern === undefined) {
-                // url_pattern is a required attribute in annotation
                 this._urlPattern = this._annotation.url_pattern;
             }
             return this._urlPattern;

--- a/test/specs/reference/conf/columns_schema/schema.json
+++ b/test/specs/reference/conf/columns_schema/schema.json
@@ -882,6 +882,7 @@
                         "typename": "text"
                     },
                     "annotations": {
+                        "tag:isrd.isi.edu,2016:immutable": null,
                         "tag:isrd.isi.edu,2017:asset": {
                             "url_pattern": "/hatrac/{{col_asset_2}}",
                             "filename_column": "no col",
@@ -1639,7 +1640,7 @@
                     },
                     "annotations": {
                         "tag:isrd.isi.edu,2017:asset": {
-                            "url_pattern" : "/js/ermrestjs/{{{_uri.md5_hex}}}"
+                            "url_pattern" : 1
                         }
                     }
                 },
@@ -1653,7 +1654,7 @@
                     },
                     "annotations": {
                         "tag:isrd.isi.edu,2017:asset": {
-                            "url_pattern" : "/hatrac/js/ermrestjs/{{{_uri.md5_hex}}}"
+                            "url_pattern" : ""
                         }
                     }
                 },
@@ -1667,7 +1668,8 @@
                     },
                     "annotations": {
                         "tag:isrd.isi.edu,2017:asset": {
-                            "url_pattern" : "https://example.com/hatrac/js/ermrestjs/{{{_uri.md5_hex}}}"
+                            "url_pattern" : "https://example.com/hatrac/js/ermrestjs/{{{_uri.md5_hex}}}",
+                            "browser_upload": false
                         }
                     }
                 }

--- a/test/specs/reference/tests/14.pseudo_columns.js
+++ b/test/specs/reference/tests/14.pseudo_columns.js
@@ -194,7 +194,7 @@ exports.execute = function (options) {
         ];
 
         var assetEntryExpectedValue = [
-            '1', '1', '1000', '10001', 'https://dev.isrd.isi.edu', 'https://dev.isrd.isi.edu', 4
+            '1', '1', '1000', '10001', null, 'https://dev.isrd.isi.edu', 'https://dev.isrd.isi.edu', 4
         ];
 
         var assetCompactExpectedValue = [
@@ -297,7 +297,7 @@ exports.execute = function (options) {
          *  5: col_byte
          *  6: col_md5
          *  7: col_sha256
-         *  8: col_asset_1 (asset with default options) is null
+         *  8: col_asset_1 *AssetPseudoColumn* disabeld (no url_pattern)
          *  9: col_asset_2 *AssetPseudoColumn* (asset with invalid options) has column-display
          *  10: col_asset_3 *AssetPseudoColumn* (asset with valid options)
          *  11: col_asset_4 (asset with type not text)
@@ -307,9 +307,10 @@ exports.execute = function (options) {
          *  1: table_w_asset_fk_to_outbound *ForeignKeyPseudoColumn*
          *  2: col_1
          *  3: col_2
-         *  4: col_asset_2 *AssetPseudoColumn*
-         *  5: col_asset_3 *AssetPseudoColumn*
-         *  6: col_asset_4
+         *  4: col_asset_1 *AssetPseudoColumn* (disabled)
+         *  5: col_asset_2 *AssetPseudoColumn*
+         *  6: col_asset_3 *AssetPseudoColumn*
+         *  7: col_asset_4
          *
          *
          *  contexts that are used:
@@ -450,9 +451,17 @@ exports.execute = function (options) {
                     });
 
 
-                    describe("for checking table which has an asset column with invalid url pattern in entry context, ", function() {
+                    describe("for checking table which has asset column without upload feature, ", function() {
 
                         var assetRef1;
+
+                        var checkCol = function (name) {
+                            var colIndex = assetRef1.columns.findIndex(function(c) { return c.name === name; });
+                            expect(colIndex).not.toBe(-1, "column doesn't exist.");
+                            var col = assetRef1.columns[colIndex];
+                            expect(col.isAsset).toBe(true, "column is not asset.");
+                            expect(col.inputDisabled).toBe(true, "column was not disabled.");
+                        }
 
                         beforeAll(function (done) {
                             options.ermRest.resolve(tableWithInvalidUrlPatternURI, { cid: "test" }).then(function (response) {
@@ -465,26 +474,20 @@ exports.execute = function (options) {
                             });
                         });
 
-                        it("'uri1' column should not be returned in visible-columns as it has no url_pattern property", function() {
-                            var column = assetRef1.columns.find(function(c) { return c.name === "uri1" });
-                            expect(column).toBeUndefined();
+                        it("should create asset column if annotation is available, but disable it if url_pattern is missing", function() {
+                            checkCol("uri1");
                         });
 
-                        it("'uri2' column should not be returned in visible-columns as it doesn't has 'hatrac' in url_pattern (/js/ermrestjs/{{{_uri.md5_hex}}}) property", function() {
-                            var column = assetRef1.columns.find(function(c) { return c.name === "uri2" });
-                            expect(column).toBeUndefined();
+                        it("should create asset column if annotation is available, but disable it if url_pattern is not an string", function() {
+                            checkCol("uri2");
                         });
 
-                        it("'uri3' column should be returned in visible-columns and should be of asset type as it has 'hatrac' in url_pattern (/hatrac/js/ermrestjs/{{{_uri.md5_hex}}}) property", function() {
-                            var column = assetRef1.columns.find(function(c) { return c.name === "uri3" });
-                            expect(column).toBeDefined();
-                            expect(column.isAsset).toBe(true);
+                        it("should create asset column if annotation is available, but disable it if url_pattern is an empty string", function() {
+                            checkCol("uri3");
                         });
 
-                        it("'uri3' column should be returned in visible-columns and should be of asset type as it has 'hatrac' in url_pattern (https://example.com/hatrac/js/ermrestjs/{{{_uri.md5_hex}}}) property", function() {
-                            var column = assetRef1.columns.find(function(c) { return c.name === "uri4" });
-                            expect(column).toBeDefined();
-                            expect(column.isAsset).toBe(true);
+                        it("should create asset column if annotation is available, but disable it if browser_upload is false", function() {
+                            checkCol("uri4");
                         });
                     });
                 });
@@ -675,7 +678,7 @@ exports.execute = function (options) {
                                 expected: [
                                     "id",
                                     ["columns_schema", "table_w_asset_fk_to_outbound"].join("_"),
-                                    "col_1", "col_2", "col_asset_2", "col_asset_3", "col_asset_4"
+                                    "col_1", "col_2", "col_asset_1", "col_asset_2", "col_asset_3", "col_asset_4"
                                 ]
                             }]);
                         });
@@ -704,10 +707,10 @@ exports.execute = function (options) {
                     });
 
                     it("if column type is not `text`, should ignore the asset annotation.", function() {
-                      expect(assetRefCompactCols[11].name).toBe("col_asset_4");
-                      expect(assetRefCompactCols[11].isPseudo).toBe(false);
-                      expect(assetRefEntry.columns[6].name).toBe("col_asset_4");
-                      expect(assetRefEntry.columns[6].isPseudo).toBe(false);
+                      expect(assetRefCompactCols[11].name).toBe("col_asset_4", "invalid name for compact");
+                      expect(assetRefCompactCols[11].isPseudo).toBe(false, "invalid isPseudo for compact");
+                      expect(assetRefEntry.columns[7].name).toBe("col_asset_4", "invalid name for entry");
+                      expect(assetRefEntry.columns[7].isPseudo).toBe(false, "invalid isPseudo for entry");
                     });
 
                     it('if columns has been used as the keyReferenceColumn, should ignore the asset annotation.', function () {

--- a/test/specs/reference/tests/15.reference_column.js
+++ b/test/specs/reference/tests/15.reference_column.js
@@ -160,14 +160,14 @@ exports.execute = function (options) {
 
         describe('.isAsset, ', function () {
             it ('for PseudoColumns that are asset should return true.', function () {
-                for (var i = 9; i < 11; i++) {
-                    expect(assetRefCompactCols[i].isAsset).toBe(true);
+                for (var i = 8; i < 11; i++) {
+                    expect(assetRefCompactCols[i].isAsset).toBe(true, "invalid isAsset for index="+ i);
                 }
             });
 
             it ('for other columns should return undefined.', function () {
-                for (var i = 0; i < 9; i++) {
-                    expect(assetRefCompactCols[i].isAsset).toBe(undefined);
+                for (var i = 0; i < 8; i++) {
+                    expect(assetRefCompactCols[i].isAsset).toBe(undefined, "invalid isAsset for index="+ i);
                 }
             });
         });
@@ -411,6 +411,18 @@ exports.execute = function (options) {
                     }).toThrow("can not use this type of column in entry mode.");
                 });
 
+                describe("for assets,", function () {
+                    it ("if url_pattern is invalid, return true.", function () {
+                        expect(assetRefEntryCols[4].isAsset).toBe(true, "isAsset invalid");
+                        expect(assetRefEntryCols[4].inputDisabled).toBe(true, "inputDisabled invalid");
+                    });
+
+                    it ("otherwise return the base column's result.", function () {
+                        expect(assetRefEntryCols[5].inputDisabled).toBe(true, "input disabled invalid for col_asset_2");
+                        expect(assetRefEntryCols[6].inputDisabled).toBe(false, "input disabled invalid for col_asset_3");
+                    });
+                });
+
                 it('if it\'s based on one column (simple), should return base column\`s result.', function () {
                     // has generated
                     expect(entryCreateRef.columns[0].inputDisabled).toEqual({
@@ -651,7 +663,7 @@ exports.execute = function (options) {
 
                 describe('for assets, ', function() {
                     it('if in entry context, return the original underlying data, even if colummn-display annotation is present.', function() {
-                        val = assetRefEntryCols[5].formatPresentation({"col_asset_3": "https://example.com"}, "entry", {"formattedValues":{"col_asset_3": "https://example.com"}}).value;
+                        val = assetRefEntryCols[6].formatPresentation({"col_asset_3": "https://example.com"}, "entry", {"formattedValues":{"col_asset_3": "https://example.com"}}).value;
                         expect(val).toEqual("https://example.com");
 
                         val = assetRefCompactCols[9].formatPresentation({"col_filename": "filename", "col_asset_2": "value"}, "entry", {"formattedValues":{"col_filename": "filename"}}).value;

--- a/test/specs/upload/conf/upload/schema.json
+++ b/test/specs/upload/conf/upload/schema.json
@@ -110,11 +110,25 @@
                         "typename": "text"
                     },
                     "annotations": {}
+                },
+                {
+                    "comment": "asset column with url_pattern that doesn't start with hatrac",
+                    "name": "uri_wo_hatrac",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2017:asset": {
+                            "url_pattern" : "/ermrestjs/{{{_timestamp}}}/{{{_uri_wo_hatrac}}"
+                        }
+                    }
                 }
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns" : {
-                    "*" : ["id", "uri", "fk_id"]
+                    "*" : ["id", "uri", "fk_id", "uri_wo_hatrac"]
                 }
             }
         },


### PR DESCRIPTION
Change the addColumn logic (function responsible for choosing between assetColumn or column) to:

- If asset annotation was present:
  - In entity mode:
    - If `url_pattern` is invalid (not string) or `browser_upload = false` create a disabled asset column.
   - Otherwise create an asset column.
  - In non-entity contexts create an asset column (download link).
- Otherwise it's not an asset column.


Issue: #1314