### PR TITLE
added logging information for file upload requests

### DIFF
--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -367,7 +367,7 @@ var ERMrest = (function(module) {
 
                 if (!contextHeaderParams || !_isObject(contextHeaderParams)) {
                     contextHeaderParams = {
-                        action: "create-upload-job",
+                        action: "upload/create",
                         referrer: self.reference.defaultLogInfo
                     };
                     contextHeaderParams.referrer.column = self.column.name;
@@ -408,7 +408,7 @@ var ERMrest = (function(module) {
 
         if (!contextHeaderParams || !_isObject(contextHeaderParams)) {
             contextHeaderParams = {
-                action: "file-exists",
+                action: "upload/file-exists",
                 referrer: this.reference.defaultLogInfo
             };
             contextHeaderParams.referrer.column = this.column.name;
@@ -535,7 +535,7 @@ var ERMrest = (function(module) {
 
         if (!contextHeaderParams || !_isObject(contextHeaderParams)) {
             contextHeaderParams = {
-                action: "complete-upload",
+                action: "upload/complete",
                 referrer: this.reference.defaultLogInfo
             };
             contextHeaderParams.referrer.column = this.column.name;
@@ -651,7 +651,7 @@ var ERMrest = (function(module) {
 
         if (!contextHeaderParams || !_isObject(contextHeaderParams)) {
             contextHeaderParams = {
-                action: "delete-file",
+                action: "upload/delete",
                 referrer: this.reference.defaultLogInfo
             };
             contextHeaderParams.referrer.column = this.column.name;
@@ -761,7 +761,7 @@ var ERMrest = (function(module) {
 
 
         var contextHeaderParams = {
-            action: "existing-status",
+            action: "upload/status",
             referrer: this.reference.defaultLogInfo
         };
         contextHeaderParams.referrer.column = this.column.name;
@@ -844,7 +844,7 @@ var ERMrest = (function(module) {
         var deferred = module._q.defer();
 
         var contextHeaderParams = {
-            action: "cancel-upload-job",
+            action: "upload/cancel",
             referrer: this.reference.defaultLogInfo
         };
         contextHeaderParams.referrer.column = this.column.name;
@@ -938,7 +938,7 @@ var ERMrest = (function(module) {
 
         // set content-type to "application/octet-stream"
         var contextHeaderParams = {
-            action: "file-exists",
+            action: "upload/chunk",
             referrer: upload.reference.defaultLogInfo
         };
         contextHeaderParams.referrer.column = upload.column.name;

--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -183,7 +183,7 @@ var ERMrest = (function(module) {
 
     var _isObject = function(obj) {
         return obj === Object(obj) && !Array.isArray(obj);
-    }
+    };
 
     var _generateContextHeader = function(contextHeaderParams) {
         if (!contextHeaderParams || !_isObject(contextHeaderParams)) {
@@ -943,7 +943,7 @@ var ERMrest = (function(module) {
         };
         contextHeaderParams.referrer.column = upload.column.name;
 
-        var headers = _generateContextHeader(contextHeaderParams)
+        var headers = _generateContextHeader(contextHeaderParams);
         headers["content-type"] = "application/octet-stream";
 
         self.xhr  = module._q.defer();

--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -195,7 +195,7 @@ var ERMrest = (function(module) {
         var headers = {};
         headers[module._contextHeaderName] = contextHeaderParams;
         return headers;
-    }
+    };
 
     /**
      * @desc upload Object
@@ -365,7 +365,7 @@ var ERMrest = (function(module) {
                     size: self.file.size,
                     lastModified: self.file.lastModified,
                     md5: self.hash.md5_hex
-                }
+                };
 
                 var data = {
                     "chunk-length" : self.PART_SIZE,
@@ -529,7 +529,7 @@ var ERMrest = (function(module) {
             size: this.file.size,
             lastModified: this.file.lastModified,
             md5: this.hash.md5_hex
-        }
+        };
 
         var config = {
             headers: _generateContextHeader(this.reference.defaultLogInfo, contextHeaderParams)


### PR DESCRIPTION
This PR adds the logging for file upload that was mentioned in issue #554. 

When the job is created in hatrac, we log info about the file. 
When the job is complete and we verify the file exists (with it's versioned url returned), we log info about the file