### PR TITLE
remove encoding of the catalog id

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -1076,7 +1076,7 @@ function ForeignKeyPseudoColumn (reference, fk, sourceObject, name) {
     var table = fk.key.table;
     var ermrestURI = [
         table.schema.catalog.server.uri ,"catalog" ,
-        module._fixedEncodeURIComponent(table.schema.catalog.id), "entity",
+        table.schema.catalog.id, "entity",
         [module._fixedEncodeURIComponent(table.schema.name),module._fixedEncodeURIComponent(table.name)].join(":")
     ].join("/");
 
@@ -1185,7 +1185,7 @@ ForeignKeyPseudoColumn.prototype._determineDefaultValue = function () {
 
         var refURI = [
             table.schema.catalog.server.uri ,"catalog" ,
-            module._fixedEncodeURIComponent(table.schema.catalog.id), this._baseReference.location.api,
+            table.schema.catalog.id, this._baseReference.location.api,
             [module._fixedEncodeURIComponent(table.schema.name),module._fixedEncodeURIComponent(table.name)].join(":"),
             keyPairs.join("&")
         ].join("/");
@@ -2120,7 +2120,7 @@ FacetColumn.prototype = {
 
             var uri = [
                 table.schema.catalog.server.uri ,"catalog" ,
-                module._fixedEncodeURIComponent(table.schema.catalog.id), "entity",
+                table.schema.catalog.id, "entity",
                 pathFromSource.join("/")
             ].join("/");
 
@@ -2272,7 +2272,7 @@ FacetColumn.prototype = {
             // create a url
             var uri = [
                 table.schema.catalog.server.uri ,"catalog" ,
-                module._fixedEncodeURIComponent(table.schema.catalog.id), "entity",
+                table.schema.catalog.id, "entity",
                 module._fixedEncodeURIComponent(table.schema.name) + ":" + module._fixedEncodeURIComponent(table.name),
                 filterStr.join(";")
             ].join("/");

--- a/js/parser.js
+++ b/js/parser.js
@@ -39,7 +39,7 @@
         verify(typeof catalogId === "string" && catalogId.length > 0, "catalogId must be an string.");
         verify(typeof tableName === "string" && tableName.length > 0, "tableName must be an string.");
 
-        var compactPath = "#" + module._fixedEncodeURIComponent(catalogId) + "/";
+        var compactPath = "#" + catalogId + "/";
         if (schemaName) {
             compactPath += module._fixedEncodeURIComponent(schemaName) + ":";
         }

--- a/js/reference.js
+++ b/js/reference.js
@@ -2071,7 +2071,7 @@
             var table = this._table;
             var refURI = [
                 table.schema.catalog.server.uri ,"catalog" ,
-                module._fixedEncodeURIComponent(table.schema.catalog.id), this.location.api,
+                table.schema.catalog.id, this.location.api,
                 [module._fixedEncodeURIComponent(table.schema.name),module._fixedEncodeURIComponent(table.name)].join(":"),
             ].join("/");
             return new Reference(module.parse(refURI), table.schema.catalog);
@@ -2941,7 +2941,7 @@
 
                 var domainUri = [
                     fkrTable.schema.catalog.server.uri ,"catalog" ,
-                    module._fixedEncodeURIComponent(fkrTable.schema.catalog.id), this.location.api,
+                    fkrTable.schema.catalog.id, this.location.api,
                     [module._fixedEncodeURIComponent(fkrTable.schema.name),module._fixedEncodeURIComponent(fkrTable.name)].join(":"),
                     "right" + otherFK.toString(true)
                 ].join("/");
@@ -2982,7 +2982,7 @@
                 var table = newRef._table;
                 newRef._location = module.parse([
                     table.schema.catalog.server.uri ,"catalog" ,
-                    module._fixedEncodeURIComponent(table.schema.catalog.id), "entity",
+                    table.schema.catalog.id, "entity",
                     module._fixedEncodeURIComponent(table.schema.name) + ":" + module._fixedEncodeURIComponent(table.name)
                 ].join("/") + subset);
 
@@ -3314,13 +3314,13 @@
                         });
                     }
 
-                    newLocationString = source._location.service + "/catalog/" + module._fixedEncodeURIComponent(source._location.catalog) + "/" +
+                    newLocationString = source._location.service + "/catalog/" + source._location.catalog + "/" +
                                         source._location.api + "/" + module._fixedEncodeURIComponent(newTable.schema.name) + ":" + module._fixedEncodeURIComponent(newTable.name);
                 }
                 else {
                     if (source._location.filter === undefined) {
                         // 4.1 no filter
-                        newLocationString = source._location.service + "/catalog/" + module._fixedEncodeURIComponent(source._location.catalog) + "/" +
+                        newLocationString = source._location.service + "/catalog/" + source._location.catalog + "/" +
                                             source._location.api + "/" + module._fixedEncodeURIComponent(newTable.schema.name) + ":" + module._fixedEncodeURIComponent(newTable.name);
                     } else {
                         // 4.2.1 single entity key filter (without any join), swap table and switch to mapping key
@@ -3346,7 +3346,7 @@
                                     filterString = module._fixedEncodeURIComponent(sharedKey.colset.columns[0].name) + "=" + filter.value;
                                 }
 
-                                newLocationString = source._location.service + "/catalog/" + module._fixedEncodeURIComponent(source._location.catalog) + "/" +
+                                newLocationString = source._location.service + "/catalog/" + source._location.catalog + "/" +
                                                     source._location.api + "/" + module._fixedEncodeURIComponent(newTable.schema.name) + ":" + module._fixedEncodeURIComponent(newTable.name) + "/" +
                                                     filterString;
                             }
@@ -3414,7 +3414,7 @@
                                         filterString += (j === 0? "" : "&") + module._fixedEncodeURIComponent(mapping[f.column]) + "=" + module._fixedEncodeURIComponent(f.value);
                                     }
 
-                                    newLocationString = source._location.service + "/catalog/" + module._fixedEncodeURIComponent(source._location.catalog) + "/" +
+                                    newLocationString = source._location.service + "/catalog/" + source._location.catalog + "/" +
                                         source._location.api + "/" + module._fixedEncodeURIComponent(newTable.schema.name) + ":" + module._fixedEncodeURIComponent(newTable.name) + "/" +
                                         filterString;
                                 }
@@ -3875,7 +3875,7 @@
             if (this._ref === undefined) {
                 this._ref = _referenceCopy(this._pageRef);
 
-                var uri = this._pageRef._location.service + "/catalog/" + module._fixedEncodeURIComponent(this._pageRef._location.catalog) + "/" +
+                var uri = this._pageRef._location.service + "/catalog/" + this._pageRef._location.catalog + "/" +
                     this._pageRef._location.api + "/";
 
                 // if this is an alternative table, use base table

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -1091,7 +1091,7 @@
         // create a url that points to the current ReferenceColumn
         var ermrestUri = [
             table.schema.catalog.server.uri ,"catalog" ,
-            module._fixedEncodeURIComponent(table.schema.catalog.id), "entity",
+            table.schema.catalog.id, "entity",
             [module._fixedEncodeURIComponent(table.schema.name),module._fixedEncodeURIComponent(table.name)].join(":"),
             createKeyPair(uriKey)
         ].join("/");


### PR DESCRIPTION
It is returned from `ermrest` as encoded so it should still be decoded. But there's no need to re-encode the catalog id before using it in the urls.