### PR TITLE
change related references location

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -955,7 +955,7 @@ Object.defineProperty(PseudoColumn.prototype, "reference", {
         if (this._reference === undefined) {
             var self = this;
             if (!self.hasPath) {
-                self._reference = self._baseReference;
+                self._reference = _referenceCopy(self._baseReference);
             } else {
 
                 // attach the parent displayname
@@ -968,14 +968,7 @@ Object.defineProperty(PseudoColumn.prototype, "reference", {
                     parentDisplayname = this._baseReference.table.displayname;
                 }
 
-                var subset = "";
-                if (typeof self._mainTuple !== 'undefined') {
-                    subset = "?subset=" + module._fixedEncodeURIComponent(
-                        parentDisplayname.unformatted + ": " + self._mainTuple.displayname.unformatted
-                    );
-                }
-
-                self._reference = new Reference(module.parse(self.table.uri + subset), self.table.schema.catalog);
+                self._reference = new Reference(module.parse(self.table.uri), self.table.schema.catalog);
                 self._reference.parentDisplayname = parentDisplayname;
 
                 var source = [], i, fk, columns, noData = false;

--- a/js/reference.js
+++ b/js/reference.js
@@ -2011,7 +2011,7 @@
 
                 var currentColumns = {};
                 this._referenceColumns.forEach(function (col) {
-                    if (col.isPath || col.isInboundForeignKey) {
+                    if (col.isPathColumn || col.isInboundForeignKey) {
                         currentColumns[col.name] = true;
                     }
                 });
@@ -2830,7 +2830,7 @@
          * 0. keep track of the linkage and save some attributes:
          *      0.1 origFKR: the foreign key that created this related reference (used in chaise for autofill)
          *      0.2 origColumnName: the name of pseudocolumn that represents origFKR (used in chaise for autofill)
-         *      0.3 parentDisplayname: the displayname of parent (used in subset to show in chaise)
+         *      0.3 parentDisplayname: the displayname of parent
          *          - logic: foriengkey's to_name or this.displayname
          *
          *
@@ -2840,15 +2840,13 @@
          *      1.3 derivedAssociationReference: points to the association table (A)
          *      1.4 location (uri):
          *          2.1.4.1 Uses the linkage to get to the T2.
-         *          2.1.4.2 if tuple was given, it will include a subset queryparam that proviedes more information
-         *                  the subset is in form of `for "parentDisplayname" = "tuple.displayname"`
+         *          2.1.4.2 if tuple was given, it will use the value of shortestKey to create the facet
          * 2. Otherwise.
          *      2.1 displayname: F1.from_name or T2.displayname
          *      2.2 table: T2
          *      2.3 location (uri):
          *          2.3.1 Uses the linkage to get to the T2.
-         *          2.3.2 if tuple was given, it will include a subset queryparam that proviedes more information
-         *                  the subset is in form of `for "parentDisplayname" = "tuple.displayname"`
+         *          2.3.2 if tuple was given, it will use the value of shortestKey to create the facet
          *
          *
          * @private
@@ -2859,7 +2857,7 @@
          * @return {ERMrest.Reference}  a reference which is related to current reference with the given fkr
          */
         _generateRelatedReference: function (fkr, tuple, checkForAssociation, sourceObject) {
-            var j, col, uri, source, subset = "";
+            var j, col, uri, source;
 
             var useFaceting = (typeof tuple === 'object');
 
@@ -2890,13 +2888,6 @@
                 newRef.parentDisplayname = this.displayname;
             }
 
-            // create the subset that will be added for visibility
-            if (typeof tuple !== 'undefined') {
-                subset = "?subset=" + module._fixedEncodeURIComponent(
-                    newRef.parentDisplayname.unformatted + ": " + tuple.displayname.unformatted
-                );
-            }
-
             var fkrTable = fkr.colset.columns[0].table;
             if (checkForAssociation && fkrTable._isPureBinaryAssociation()) { // Association Table
 
@@ -2921,7 +2912,7 @@
 
                 // uri and location
                 if (!useFaceting) {
-                    newRef._location = module.parse(this._location.compactUri + "/" + fkr.toString() + "/" + otherFK.toString(true) + subset);
+                    newRef._location = module.parse(this._location.compactUri + "/" + fkr.toString() + "/" + otherFK.toString(true));
                 } else {
                     // build source
                     source = [
@@ -2959,7 +2950,7 @@
 
                 // uri and location
                 if (!useFaceting) {
-                    newRef._location = module.parse(this._location.compactUri + "/" + fkr.toString() + subset);
+                    newRef._location = module.parse(this._location.compactUri + "/" + fkr.toString());
                 } else {
                     source = [];
                 }
@@ -2984,18 +2975,19 @@
                     table.schema.catalog.server.uri ,"catalog" ,
                     module._fixedEncodeURIComponent(table.schema.catalog.id), "entity",
                     module._fixedEncodeURIComponent(table.schema.name) + ":" + module._fixedEncodeURIComponent(table.name)
-                ].join("/") + subset);
+                ].join("/"));
 
                 //filters
                 var filters = [];
                 source.push({"outbound": fkr.constraint_names[0]});
-                fkr.key.colset.columns.forEach(function (col) {
+                fkr.key.table.shortestKey.forEach(function (col) {
                     filters.push({
                         "source": source.concat(col.name),
                         "choices": [tuple.data[col.name]]
                     });
                 });
 
+                // the facets are basd on the value of shortest key of current table
                 newRef._location.facets = {"and": filters};
             }
 

--- a/test/specs/parser/tests/01.parser.js
+++ b/test/specs/parser/tests/01.parser.js
@@ -389,7 +389,7 @@ exports.execute = function(options) {
     });
 
     describe("Query parameters", function() {
-        var queryParamsString = "subset=SOMESUBSET&limit=2";
+        var queryParamsString = "qp=SOMEVAL&limit=2";
         var path = schemaName + ":" + tableName;
         var uriWithoutQuery = options.url + "/catalog/" + catalogId + "/entity/" + path;
         var ermrestUriWithoutQuery = options.url + "/catalog/" + catalogId + "/entity/" + "M:=" + path;
@@ -415,7 +415,7 @@ exports.execute = function(options) {
 
         it("parser should create a dictionary of query params.", function() {
             expect(location.queryParams).toBeDefined("queryParams is not defined.");
-            expect(location.queryParams.subset).toBe("SOMESUBSET", "subset mismatch.");
+            expect(location.queryParams.qp).toBe("SOMEVAL", "qp mismatch.");
             expect(location.queryParams.limit).toBe("2", "limit mismatch.");
         });
     });

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -95,11 +95,10 @@ exports.execute = function(options) {
 
                 describe("regarding column objects defining path.", function () {
                     var pathRelated, compactSelectRef;
-                    var checkRelated = function (ref, schema, table, facet, subset) {
+                    var checkRelated = function (ref, schema, table, facet) {
                         expect(ref.table.schema.name).toBe(schema, "schema missmatch.");
                         expect(ref.table.name).toBe(table, "table missmatch.");
                         expect(JSON.stringify(ref.location.facets.decoded)).toEqual(JSON.stringify(facet), "facet missmatch.");
-                        expect(ref.location.queryParams['subset']).toBe(subset, "subset missmatch.");
                     };
                     beforeAll(function (done) {
                         compactSelectRef = reference.contextualize.compactSelect;
@@ -119,9 +118,7 @@ exports.execute = function(options) {
                     it ('should create the reference based on the given path and ignore the pure and binary assocation logic.', function () {
                         checkRelated(
                             pathRelated[0], "reference_schema", "association table with id",
-                            {"and": [{"source" :[{"outbound": ["reference_schema","id_fk_association_related_to_reference"]}, "id"], "choices": ["9003"]}]},
-                            "reference_table: 9003 and Henry"
-                        );
+                            {"and": [{"source" :[{"outbound": ["reference_schema","id_fk_association_related_to_reference"]}, "id"], "choices": ["9003"]}]}                        );
                     });
 
                     it ('should be able to support path with longer length.', function () {
@@ -132,8 +129,7 @@ exports.execute = function(options) {
                                 {"inbound":["reference_schema","fk_to_inbound_related_reference_table"]},
                                 {"outbound":["reference_schema","id_fk_association_related_to_reference"]},
                                 "id"
-                            ], "choices":["9003"]}]},
-                            "reference_table: 9003 and Henry"
+                            ], "choices":["9003"]}]}
                         );
                     });
                 });
@@ -197,24 +193,22 @@ exports.execute = function(options) {
                     describe("with tuple defined, ", function () {
                         it('should create the link using faceting.', function() {
 
-                            var checkUri = function (index, expectedTable, expectedFacets, expectedQueryParam) {
+                            var checkUri = function (index, expectedTable, expectedFacets) {
                                 var loc = relatedWithTuple[index].location;
                                 expect(loc.facets).not.toBeNull("facets was null for tuple index=" + index);
                                 expect(JSON.stringify(loc.facets.decoded['and'], null, 0)).toEqual(JSON.stringify(expectedFacets, null, 0), "facets was not as expected for tuple index="+ index);
                                 expect(loc.tableName).toBe(expectedTable, "table name was not as expected for tuple index="+ index);
-                                expect(loc.queryParams['subset']).toBeDefined();
-                                expect(loc.queryParams['subset']).toBe(expectedQueryParam);
                             }
 
                             checkUri(0, "inbound_related_reference_table", [{
                                 "source":[{"outbound":["reference_schema","fromname_fk_inbound_related_to_reference"]},"id"],
                                 "choices":["9003"]
-                            }], "to_name_value: 9003 and Henry");
+                            }]);
 
                             checkUri(1, "inbound_related_reference_table", [{
                                 "source":[{"outbound":["reference_schema","fk_inbound_related_to_reference"]},"id"],
                                 "choices":["9003"]
-                            }], "reference_table: 9003 and Henry");
+                            }]);
                         });
                     });
                 });


### PR DESCRIPTION
- This PR removes the subset query parameter since it's not needed anymore.
- In chaise record page, we're getting the list of related references only once, and if we want to update the page we keep reading the same reference. But the value of the key that is being used for generating the related reference might change. To reduce the probability of this, in this PR I am generating the related references based on shortestkey. Which eventually this will be the `RID` column that we can be sure that it won't change.