### PR TITLE
 Buggy Logic in Read And SetSamePaging

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -290,6 +290,7 @@ to use for ERMrest JavaScript agents.
         * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
             * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
         * [.read(limit, contextHeaderParams)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
+            * [~processSortObject()](#ERMrest.Reference+read..processSortObject)
         * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
         * [.update(tuples, contextHeaderParams)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
         * [.delete(contextHeaderParams)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
@@ -555,6 +556,7 @@ to use for ERMrest JavaScript agents.
         * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
             * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
         * [.read(limit, contextHeaderParams)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
+            * [~processSortObject()](#ERMrest.Reference+read..processSortObject)
         * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
         * [.update(tuples, contextHeaderParams)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
         * [.delete(contextHeaderParams)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
@@ -2448,6 +2450,7 @@ Constructor for a ParsedFilter.
     * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
         * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
     * [.read(limit, contextHeaderParams)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
+        * [~processSortObject()](#ERMrest.Reference+read..processSortObject)
     * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
     * [.update(tuples, contextHeaderParams)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
     * [.delete(contextHeaderParams)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
@@ -2780,6 +2783,18 @@ or rejected with any of these errors:
 | limit | <code>number</code> | The limit of results to be returned by the read request. __required__ |
 | contextHeaderParams | <code>Object</code> | the object that we want to log. |
 
+<a name="ERMrest.Reference+read..processSortObject"></a>
+
+##### read~processSortObject()
+Check the sort object. Does not change the `this._location` object.
+  - Throws an error if the column doesn't exist or is not sortable.
+  - maps the sorting to its sort columns.
+      - for columns it's straighforward and uses the actual column name.
+      - for PseudoColumns we need
+          - A new alias: F# where the # is a positive integer.
+          - The sort column name must be the "foreignkey_alias:column_name".
+
+**Kind**: inner method of [<code>read</code>](#ERMrest.Reference+read)  
 <a name="ERMrest.Reference+sort"></a>
 
 #### reference.sort(sort) ⇒ <code>Reference</code>
@@ -5353,6 +5368,7 @@ get PathColumn object by column name
     * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
         * [~columnDiff()](#ERMrest.Reference+create..columnDiff)
     * [.read(limit, contextHeaderParams)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
+        * [~processSortObject()](#ERMrest.Reference+read..processSortObject)
     * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
     * [.update(tuples, contextHeaderParams)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
     * [.delete(contextHeaderParams)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
@@ -5685,6 +5701,18 @@ or rejected with any of these errors:
 | limit | <code>number</code> | The limit of results to be returned by the read request. __required__ |
 | contextHeaderParams | <code>Object</code> | the object that we want to log. |
 
+<a name="ERMrest.Reference+read..processSortObject"></a>
+
+##### read~processSortObject()
+Check the sort object. Does not change the `this._location` object.
+  - Throws an error if the column doesn't exist or is not sortable.
+  - maps the sorting to its sort columns.
+      - for columns it's straighforward and uses the actual column name.
+      - for PseudoColumns we need
+          - A new alias: F# where the # is a positive integer.
+          - The sort column name must be the "foreignkey_alias:column_name".
+
+**Kind**: inner method of [<code>read</code>](#ERMrest.Reference+read)  
 <a name="ERMrest.Reference+sort"></a>
 
 #### reference.sort(sort) ⇒ <code>Reference</code>

--- a/js/reference.js
+++ b/js/reference.js
@@ -1117,21 +1117,16 @@
                  *       - for PseudoColumns we need
                  *           - A new alias: F# where the # is a positive integer.
                  *           - The sort column name must be the "foreignkey_alias:column_name".
-                 *
-                 * Assumption: there is no column/alias with `F#` name where # is a positive integer.
                  * */
-                if (hasSort) {
-                    sortObject = this._location.sortObject;
-
-                    var foreignKeys = this._table.foreignKeys,
+                var processSortObject= function (self) {
+                    var foreignKeys = self._table.foreignKeys,
                         colName,
                         fkIndex, fk;
 
                     for (i = 0, k = 1, l = 1; i < sortObject.length; i++) {
-
                         // find the column in ReferenceColumns
                         try {
-                            col = this.getColumnByName(sortObject[i].column);
+                            col = self.getColumnByName(sortObject[i].column);
                         } catch (e) {
                             throw new module.InvalidSortCriteria("Given column name `" + sortObject[i].column + "` in sort is not valid.",  locationPath);
                         }
@@ -1178,10 +1173,18 @@
                             }
                          }
                     }
+                };
+
+                if (hasSort) {
+                    sortObject = this._location.sortObject;
+                    processSortObject(this);
                 }
                 // use row-order if sort was not provided
                 else if (this.display._rowOrder){
                     sortObject = this.display._rowOrder;
+                    sortColNames = sortObject.map(function (so) {
+                        return so.column;
+                    });
                 }
 
                 // ermrest requires key columns to be in sort param for paging
@@ -1906,15 +1909,27 @@
                 if (annotation) {
 
                     // Set row_order value
+                    // columns defined in row_order can have column_order
+                    // This will take care of that and will return the actual columns that
+                    // we want sort to be based on.
                     if (Array.isArray(annotation.row_order)) {
-                        var rowOrder = [];
+                        var rowOrder = [], col, sortObjectNames = {}, sortColNames = {};
                         annotation.row_order.forEach(function (ro) {
-                            // make sure column exists
-                            if (!self.table.columns.has(ro.column)) return;
+                            if (!ro.column || ro.column in sortObjectNames) return;
+                            sortObjectNames[ro.column] = true;
 
-                            rowOrder.push({
-                                "column": ro.column,
-                                "descending": (ro.descending === true) ? true : false
+                            // make sure column exists and is sortable
+                            if (!self.table.columns.has(ro.column)) return;
+                            col = self.getColumnByName(ro.column);
+                            if (!col.sortable) return;
+
+                            col._sortColumns.forEach(function (sc) {
+                                if (sc.name in sortColNames) return;
+                                sortColNames[sc.name] = true;
+                                rowOrder.push({
+                                    "column": sc.name,
+                                    "descending": (ro.descending === true) ? true : false
+                                });
                             });
                         });
                         this._display._rowOrder = rowOrder;
@@ -2300,37 +2315,7 @@
 
             // if we have extra data, and one of before/after is not available
             if (page._extraData && (!pageRef._location.beforeObject || !pageRef._location.afterObject)) {
-                var pageValues = [], colName, data, pseudoCol, j, i;
-
-                // get list of values based on sort list
-                for (i = 0; i < newRef._location.sortObject.length; i++) {
-                    colName = newRef._location.sortObject[i].column;
-
-                    // if data is from a non-pseudo column
-                    data = page._extraData[colName];
-                    if (typeof data !== 'undefined') { // normal column
-                        pageValues.push(data);
-                    } else { // pseudo column
-
-                        // find the column
-                        for (j = 0; j < newRef.columns.length; j++) {
-                            if (this.columns[j].name == colName) {
-                                pseudoCol = newRef.columns[j];
-                                break;
-                            }
-                        }
-
-                        // find the values from the sortColumn
-                        for(j = 0; j < pseudoCol._sortColumns.length; j++) {
-                            if (pseudoCol.isForeignKey) {
-                                data = page._extraLinkedData[colName][pseudoCol._sortColumns[j].name];
-                            } else {
-                                data = page._extraData[pseudoCol._sortColumns[j].name];
-                            }
-                            pageValues.push(data);
-                        }
-                    }
-                }
+                var pageValues = _getPagingValues(newRef, page._extraData, page._extraLinkedData);
 
                 // add before based on extra data
                 if (!pageRef._location.beforeObject) {
@@ -3694,9 +3679,21 @@
         _getSiblingReference: function(next) {
             var loc = this._ref.location;
 
+            // there's no sort, so no paging is possible
             if (!Array.isArray(loc.sortObject) || (loc.sortObject.length === 0)) {
                 return null;
             }
+
+            // data is not available
+            if (!this._data || this._data.length === 0) {
+                return null;
+            }
+
+            var newReference = _referenceCopy(this._ref);
+
+            // update paging by creating a new location
+            newReference._location = this._ref._location._clone();
+
 
             /* This will return the values that should be used for after/before
              * Let's assume the current page of data for the sort column is  [v1, v2, v3],
@@ -3706,65 +3703,8 @@
              * the sort columns. So that it will be used for after/before in location object.
              * It is also taking care of duplicate columns, so it will be aligned with the read logic.
              */
-            var getNewPageValues = function (self) {
-
-                // if data doesn't exist, then we cannot get the next/previous page
-                if (!self._data || self._data.length === 0) {
-                    return null;
-                }
-
-                var rowIndex = next ? (self._data.length - 1) : 0;
-                var rowData = self._data[rowIndex];
-                var rowLinkedData = self._linkedData[rowIndex];
-
-                var values = [], addedCols = {}, sortObjectNames = {};
-                var col, fkData, data, i, j, sortCol, colName;
-
-                for (i = 0; i < loc.sortObject.length; i++) {
-                    colName = loc.sortObject[i].column;
-
-                    try {
-                        col = self._ref.getColumnByName(colName);
-                    } catch (e) {
-                        return null; // column doesn't exist return null.
-                    }
-
-                    // avoid duplicate sort columns
-                    if (col.name in sortObjectNames) continue;
-                    sortObjectNames[col.name] = true;
-
-                    if (!col.sortable) {
-                        return null;
-                    }
-
-                    for (j = 0; j < col._sortColumns.length; j++) {
-                        sortCol = col._sortColumns[j];
-
-                        // avoid duplciate columns
-                        if (sortCol in addedCols) continue;
-                        addedCols[sortCol] = true;
-
-                        if (col.isForeignKey || (col.isPathColumn && col.isUnique && col.hasPath)) {
-                            fkData = rowLinkedData[col.name];
-                            data = null;
-                            if (isObjectAndNotNull(fkData)) {
-                                data =  fkData[sortCol.name];
-                            }
-                        } else {
-                            data = rowData[sortCol.name];
-                        }
-                        values.push(data);
-                    }
-                }
-                return values;
-            };
-
-            var newReference = _referenceCopy(this._ref);
-
-            // update paging by creating a new location
-            newReference._location = this._ref._location._clone();
-
-            var pageValues = getNewPageValues(this);
+            var rowIndex = next ? (this._data.length - 1) : 0;
+            var pageValues = _getPagingValues(this._ref, this._data[rowIndex], this._linkedData[rowIndex]);
             if (pageValues === null) {
                 return null;
             }

--- a/test/specs/reference/conf/reference_schema/data/sorted_table.json
+++ b/test/specs/reference/conf/reference_schema/data/sorted_table.json
@@ -1,8 +1,8 @@
-[{"id":9000,"name":"Hank","value":12},
-  {"id":9001,"name":"Harold","value":17},
-  {"id":9002,"name":"Heather","value":26},
-  {"id":9003,"name":"Henry","value":4},
-  {"id":9004,"name":"Helga","value":66},
-  {"id":9005,"name":"Harry","value":23},
-  {"id":9006,"name":"Ramona","value":1},
-  {"id":9007,"name":"Ralph","value":160}]
+[{"id":9000,"name":"Hank","value":12, "row_order_col": 99},
+  {"id":9001,"name":"Harold","value":17, "row_order_col": 98},
+  {"id":9002,"name":"Heather","value":26, "row_order_col": 97},
+  {"id":9003,"name":"Henry","value":4, "row_order_col": 96},
+  {"id":9004,"name":"Helga","value":66, "row_order_col": 95},
+  {"id":9005,"name":"Harry","value":23, "row_order_col": 94},
+  {"id":9006,"name":"Ramona","value":1, "row_order_col": 93},
+  {"id":9007,"name":"Ralph","value":160, "row_order_col": 92}]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -505,12 +505,25 @@
                     "type": {
                         "typename": "integer"
                     }
+                },
+                {
+                    "name": "row_order_col",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:column-display": {
+                            "*": {
+                                "column_order": ["name"]
+                            }
+                        }
+                    }
                 }
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:table-display": {
                     "*" : {
-                        "row_order": [{"column":"name", "descending":false}]
+                        "row_order": [{"column":"row_order_col", "descending":false}]
                     }
                 }
             }

--- a/test/specs/reference/tests/04.paging.js
+++ b/test/specs/reference/tests/04.paging.js
@@ -779,6 +779,7 @@ exports.execute = function (options) {
         describe("setSamePaging, ", function () {
             var baseUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":";
             var refUri = baseUri + tableNameInboundRelated + "@sort(id)",
+                refUriWithoutSort = baseUri + tableNameInboundRelated,
                 refUriJoin = baseUri + "/(id)=(reference_schema:inbound_related_reference_table:fk_to_reference_with_fromname)";
 
             var currRef, newRef;
@@ -866,6 +867,22 @@ exports.execute = function (options) {
                 }).catch(function (err) {
                     done.fail();
                     console.log(err);
+                });
+            });
+
+
+            describe("when page is sorted based on foreignkey column, ", function () {
+                var url = refUriWithoutSort + "@sort(reference_schema_fromname_fk_inbound_related_to_reference)";
+                it ("if page didn't have any paging options should return a reference with before.", function (done) {
+                    testUri(done, url, 5, null, ["9005", "6"]); // since the fk value is not the key, its appending the shortestkey
+                });
+
+                it ("if page had before, should return a reference with same before and new after.", function (done) {
+                    testUri(done, url + "@before(9005,7)", 5, ["9001", "1"], ["9005", "7"]);
+                });
+
+                it ("if page had after, should return a reference with same after and new before.", function (done) {
+                    testUri(done, url + "@after(9003,3)", 5, ["9003", "3"], ["9005", "9"]);
                 });
             });
         });


### PR DESCRIPTION
- Fixed setSamePaging to be aligned with `next` and `previous` functions in retrieving data. I updated those functions a while ago, but forgot to update this function too.

- In `read`, where the reference doesn't have any sort modifiers and we're getting the sort modifiers from `row_order` we were not capturing the sort column names. This was causing issues in adding duplicate column names for the shortest key. The shortestkey logic is relying on that object.

- Changed the `reference.display._rowOrder` to take care of `column_order` annotation. If the table has row_order of `a`, and `a` has column_order of `b`; this API will return the column `b` instead.