### PR TITLE
filenameExtFilter always returns an Array now

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -685,7 +685,7 @@ PseudoColumn.prototype.getAggregatedValue = function (page, contextHeaderParams)
                     } catch(e) {
                         // if sort threw any erros, we just leave it as is
                     }
-                    
+
                     res = value.v.map(function (v) {
                         return getFormattedValue(v);
                     }).join(" ,");
@@ -1744,10 +1744,12 @@ Object.defineProperty(AssetPseudoColumn.prototype, "sha256", {
 Object.defineProperty(AssetPseudoColumn.prototype, "filenameExtFilter", {
     get: function () {
         if (this._filenameExtFilter === undefined) {
+            this._filenameExtFilter = [];
+
             var ext = this._annotation.filename_ext_filter;
-            if (typeof ext !== 'string' && !Array.isArray(ext)) {
-                this._filenameExtFilter = null;
-            } else {
+            if (typeof ext == 'string') {
+                this._filenameExtFilter.push(ext);
+            } else if (Array.isArray(ext)) {
                 this._filenameExtFilter = ext;
             }
         }

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -890,8 +890,8 @@ exports.execute = function (options) {
             });
 
             describe('.filenameExtFilter', function() {
-                it('should return null if file_name_ext is not present.', function () {
-                    expect(assetRefCompactCols[9].filenameExtFilter).toBe(null);
+                it('should return empty array if file_name_ext is not present.', function () {
+                    expect(assetRefCompactCols[9].filenameExtFilter.length).toBe(0, "Returned value is not an empty array");
                 });
 
                 it('otherwise should return the defined array of file name extensions.', function () {


### PR DESCRIPTION
This change is being done so that `chaise` can consume this API much easier. This is related to `chaise` issue [#1463](https://github.com/informatics-isi-edu/chaise/issues/1463).

This PR needs to be merged before the corresponding [chaise PR](https://github.com/informatics-isi-edu/chaise/pull/1534).