### PR TITLE
unify column_order and row_order syntax

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -2673,7 +2673,7 @@ An object which contains row display properties for this reference.
 It is determined based on the `table-display` annotation. It has the
 following properties:
 
-  - `rowOrder`: `[{ column: '`_column name_`', descending:` {`true` | `false` } `}`...`]` or `undefined`,
+  - `rowOrder`: `[{ column: '`_column object_`', descending:` {`true` | `false` } `}`...`]` or `undefined`,
   - `type`: {`'table'` | `'markdown'` | `'module'`} (default: `'table'`)
 
 If type is `'markdown'`, the object will also these additional
@@ -5604,7 +5604,7 @@ An object which contains row display properties for this reference.
 It is determined based on the `table-display` annotation. It has the
 following properties:
 
-  - `rowOrder`: `[{ column: '`_column name_`', descending:` {`true` | `false` } `}`...`]` or `undefined`,
+  - `rowOrder`: `[{ column: '`_column object_`', descending:` {`true` | `false` } `}`...`]` or `undefined`,
   - `type`: {`'table'` | `'markdown'` | `'module'`} (default: `'table'`)
 
 If type is `'markdown'`, the object will also these additional

--- a/js/column.js
+++ b/js/column.js
@@ -263,7 +263,8 @@ ReferenceColumn.prototype = {
 
     /**
      * @private
-     * @desc A list of columns that will be used for sorting
+     * @desc An array of objects that have `column` which is a Column object, and `descending` which is true/false
+     * The `descending` boolean indicates whether we should change the direction of sort or not.
      * @type {Array}
      */
     get _sortColumns() {
@@ -730,12 +731,7 @@ PseudoColumn.prototype._determineSortable = function () {
             }
 
             if (this.reference.display._rowOrder !== undefined) {
-                var rowOrder = this.reference.display._rowOrder;
-                for (var i = 0; i < rowOrder.length; i++) {
-                    try{
-                        this._sortColumns_cached.push(this.table.columns.get(rowOrder[i].column));
-                    } catch(exception) {}
-                }
+                this._sortColumns_cached = this.reference.display._rowOrder;
                 this._sortable = true;
                 return;
             }
@@ -1245,12 +1241,7 @@ ForeignKeyPseudoColumn.prototype._determineSortable = function () {
 
     // use row-order of the table
     if (this.reference.display._rowOrder !== undefined) {
-        var rowOrder = this.reference.display._rowOrder;
-        for (var i = 0; i < rowOrder.length; i++) {
-            try{
-                this._sortColumns_cached.push(this.table.columns.get(rowOrder[i].column));
-            } catch(exception) {}
-        }
+        this._sortColumns_cached = this.reference.display._rowOrder;
         this._sortable = true;
         return;
     }

--- a/js/core.js
+++ b/js/core.js
@@ -2102,33 +2102,12 @@
          */
         getDisplay: function (context) {
             if (!(context in this._display)) {
-                var annotation = -1, columnOrder = [], hasPreformat;
+                var annotation = -1, columnOrder, hasPreformat;
                 if (this.annotations.contains(module._annotations.COLUMN_DISPLAY)) {
                     annotation = module._getRecursiveAnnotationValue(context, this.annotations.get(module._annotations.COLUMN_DISPLAY).content);
                 }
 
-                if (Array.isArray(annotation.column_order)) {
-                    var col;
-                    for (var i = 0 ; i < annotation.column_order.length; i++) {
-                        try {
-                            col = this.table.columns.get(annotation.column_order[i]);
-
-                            // make sure it's sortable
-                            if (module._nonSortableTypes.indexOf(col.type.name) !== -1) {
-                                continue;
-                            }
-
-                            // avoid duplicates
-                            if (columnOrder.indexOf(col) !== -1) {
-                                continue;
-                            }
-
-                            columnOrder.push(col);
-                        } catch(exception) {}
-                    }
-                } else {
-                    columnOrder = annotation.column_order;
-                }
+                columnOrder = _processColumnOrderList(annotation.column_order, this.table);
 
                 if (typeof annotation.pre_format === 'object') {
                     if (typeof annotation.pre_format.format !== 'string') {
@@ -2151,7 +2130,15 @@
             return this._display[context];
         },
 
-        // get the sort columns using the context
+        /**
+         * Returns the columns that this column should be sorted based on and its direction.
+         * It will return an array of objects that has:
+         * - `column`: The {@link ERMrest.Column} object.
+         * - `descending`: Whether we should change the order of sort or not.
+         * @private
+         * @param  {string} context the context that we want the sort columns for
+         * @return {Array}
+         */
         _getSortColumns: function (context) {
             var display = this.getDisplay(context);
 
@@ -2167,7 +2154,7 @@
                 return undefined;
             }
 
-            return [this];
+            return [{column: this}];
         }
     };
 
@@ -2514,34 +2501,12 @@
 
         getDisplay: function(context) {
             if (!(context in this._display)) {
-                var annotation = -1, columnOrder = [];
+                var annotation = -1, columnOrder;
                 if (this.annotations.contains(module._annotations.KEY_DISPLAY)) {
                     annotation = module._getAnnotationValueByContext(context, this.annotations.get(module._annotations.KEY_DISPLAY).content);
                 }
 
-                if (Array.isArray(annotation.column_order)) {
-                    columnOrder = [];
-                    for (var i = 0 ; i < annotation.column_order.length; i++) {
-                        try {
-                            // column-order is just a list of column names
-                            var col = this.table.columns.get(annotation.column_order[i]);
-
-                            // make sure it's sortable
-                            if (module._nonSortableTypes.indexOf(col.type.name) !== -1) {
-                                continue;
-                            }
-
-                            // avoid duplicates
-                            if (columnOrder.indexOf(col) !== -1) {
-                                continue;
-                            }
-
-                            columnOrder.push(col);
-                        } catch(exception) {}
-                    }
-                } else {
-                    columnOrder = annotation.column_order;
-                }
+                columnOrder = _processColumnOrderList(annotation.column_order, this.table);
 
                 this._display[context] = {
                     "columnOrder": columnOrder,
@@ -3113,29 +3078,7 @@
 
                 }
 
-                if (Array.isArray(annotation.column_order)) {
-                    columnOrder = [];
-                    for (var i = 0 ; i < annotation.column_order.length; i++) {
-                        try {
-                            // column-order is just a list of column names
-                            var col = this.key.table.columns.get(annotation.column_order[i]);
-
-                            // make sure it's sortable
-                            if (module._nonSortableTypes.indexOf(col.type.name) !== -1) {
-                                continue;
-                            }
-
-                            // avoid duplicates
-                            if (columnOrder.indexOf(col) !== -1) {
-                                continue;
-                            }
-
-                            columnOrder.push(col);
-                        } catch(exception) {}
-                    }
-                } else {
-                    columnOrder = annotation.column_order;
-                }
+                columnOrder = _processColumnOrderList(annotation.column_order, this.key.table);
 
                 this._display[context] = {
                     "columnOrder": columnOrder,

--- a/js/reference.js
+++ b/js/reference.js
@@ -1118,7 +1118,7 @@
                 var processSortObject= function (self) {
                     var foreignKeys = self._table.foreignKeys,
                         colName,
-                        fkIndex, fk;
+                        fkIndex, fk, desc;
 
                     for (i = 0, k = 1, l = 1; i < sortObject.length; i++) {
                         // find the column in ReferenceColumns
@@ -1148,24 +1148,30 @@
                             if (col.isForeignKey || (col.isPathColumn && col.isUnique && col.foreignKeys.length === 1)) {
                                 fkIndex = foreignKeys.all().indexOf(col.isForeignKey ? col.foreignKey : col.foreignKeys[0].obj);
                                 colName = "F" + (foreignKeys.length() + k++);
-                                sortMap[colName] = ["F" + (fkIndex+1), module._fixedEncodeURIComponent(sortCols[j].name)].join(":");
+                                sortMap[colName] = ["F" + (fkIndex+1), module._fixedEncodeURIComponent(sortCols[j].column.name)].join(":");
                             } else if (col.isPathColumn && col.hasPath && col.isUnique && col.foreignKeys.length > 0) {
                                 // we have added it to the projection list
                                 fkIndex = oneToOnePseudos.indexOf(col);
                                 colName = "P" + (oneToOnePseudos.length + l++);
-                                sortMap[colName] = ["P" + (fkIndex+1), module._fixedEncodeURIComponent(sortCols[j].name)].join(":");
+                                sortMap[colName] = ["P" + (fkIndex+1), module._fixedEncodeURIComponent(sortCols[j].column.name)].join(":");
                             } else {
-                                colName = sortCols[j].name;
+                                colName = sortCols[j].column.name;
                                 if (colName in sortColNames) {
                                     addSort = false;
                                 }
                                 sortColNames[colName] = true;
                             }
 
+                            desc = sortObject[i].descending !== undefined ? sortObject[i].descending : false;
+                            // if descending is true on the column_order, then the sort should be reverted
+                            if (sortCols[j].descending) {
+                                desc = !desc;
+                            }
+
                             if (addSort) {
                                 _modifiedSortObject.push({
                                     "column": colName,
-                                    "descending": sortObject[i].descending !== undefined ? sortObject[i].descending : false
+                                    "descending": desc
                                 });
                             }
                          }
@@ -1178,10 +1184,12 @@
                 }
                 // use row-order if sort was not provided
                 else if (this.display._rowOrder){
-                    sortObject = this.display._rowOrder;
+                    sortObject = this.display._rowOrder.map(function (ro) {
+                        return {"column": ro.column.name, "descending": ro.descending};
+                    });
                     sortColNames = {};
                     sortObject.forEach(function (so) {
-                        sortColNames[so.column] = true;
+                        sortColNames[so.column.name] = true;
                     });
                 }
 
@@ -1850,7 +1858,7 @@
          * It is determined based on the `table-display` annotation. It has the
          * following properties:
          *
-         *   - `rowOrder`: `[{ column: '`_column name_`', descending:` {`true` | `false` } `}`...`]` or `undefined`,
+         *   - `rowOrder`: `[{ column: '`_column object_`', descending:` {`true` | `false` } `}`...`]` or `undefined`,
          *   - `type`: {`'table'` | `'markdown'` | `'module'`} (default: `'table'`)
          *
          * If type is `'markdown'`, the object will also these additional
@@ -1911,26 +1919,7 @@
                     // This will take care of that and will return the actual columns that
                     // we want sort to be based on.
                     if (Array.isArray(annotation.row_order)) {
-                        var rowOrder = [], col, sortObjectNames = {}, sortColNames = {};
-                        annotation.row_order.forEach(function (ro) {
-                            if (!ro.column || ro.column in sortObjectNames) return;
-                            sortObjectNames[ro.column] = true;
-
-                            // make sure column exists and is sortable
-                            if (!self.table.columns.has(ro.column)) return;
-                            col = self.getColumnByName(ro.column);
-                            if (!col.sortable) return;
-
-                            col._sortColumns.forEach(function (sc) {
-                                if (sc.name in sortColNames) return;
-                                sortColNames[sc.name] = true;
-                                rowOrder.push({
-                                    "column": sc.name,
-                                    "descending": (ro.descending === true) ? true : false
-                                });
-                            });
-                        });
-                        this._display._rowOrder = rowOrder;
+                        this._display._rowOrder = _processColumnOrderList(annotation.row_order, this._table);
                     }
 
 

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -749,7 +749,7 @@
             }
 
             for (j = 0; j < col._sortColumns.length; j++) {
-                sortCol = col._sortColumns[j];
+                sortCol = col._sortColumns[j].column;
 
                 // avoid duplciate columns
                 if (sortCol in addedCols) continue;
@@ -768,6 +768,59 @@
             }
         }
         return values;
+    };
+
+    /**
+     * @private
+     * Process the given list of column order, and return the appropriate list
+     * of objects that have:
+     * - `column`: The {@link ERMrest.Column} object.
+     * - `descending`: The boolean that Indicates whether we should reverse sort order or not.
+     *
+     * @param  {string} columnOrder The object that defines the column/row order
+     * @param  {ERMrest.Table} table
+     * @return {Array=} If it's undefined, the column_order that is defined is not valid
+     */
+    _processColumnOrderList = function (columnOrder, table) {
+        if (columnOrder === false) {
+            return false;
+        }
+
+        var res, colName, descending, colNames = {};
+        if (Array.isArray(columnOrder)) {
+            res = [];
+            for (var i = 0 ; i < columnOrder.length; i++) {
+                try {
+                    if (typeof columnOrder[i] === "string") {
+                        colName = columnOrder[i];
+                    } else if (columnOrder[i] && columnOrder[i].column) {
+                        colName = columnOrder[i].column;
+                    } else {
+                        continue; // invalid syntax
+                    }
+
+                    col = table.columns.get(colName);
+
+                    // make sure it's sortable
+                    if (module._nonSortableTypes.indexOf(col.type.name) !== -1) {
+                        continue;
+                    }
+
+                    // avoid duplicates
+                    if (colName in colNames) {
+                        continue;
+                    }
+                    colNames[colName] = true;
+
+                    descending = (columnOrder[i] && columnOrder[i].descending === true);
+                    res.push({
+                        column: col,
+                        descending: descending,
+                    });
+                } catch(exception) {}
+            }
+        }
+        return res; // it might be undefined
     };
 
     /**

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -824,7 +824,7 @@ exports.execute = function (options) {
                 it ("if column defined in `column_order` is json or jsonb, should ignore those.", function () {
                     expect(diffColTypeColumns[0].sortable).toBe(true, "sortable missmatch.");
                     expect(compactColumns[0]._sortColumns.length).toBe(1, "sort column length missmatch.");
-                    expect(compactColumns[0]._sortColumns[0].name).toBe("id", "sort column name missmatch.");
+                    expect(compactColumns[0]._sortColumns[0].column.name).toBe("id", "sort column name missmatch.");
                 });
 
                 it("when column doesn't have `column_order ` annotation, should return true and use the presented column for sort.", function () {

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -740,7 +740,7 @@ exports.execute = function (options) {
                     // outbound_fk_4
                     expect(compactColumns[4].sortable).toBe(true);
                     expect(compactColumns[4]._sortColumns.length).toBe(1);
-                    expect(compactColumns[4]._sortColumns[0].name).toBe("name");
+                    expect(compactColumns[4]._sortColumns[0].column.name).toBe("name");
                 });
 
                 it("when foreignKey doesn't have any `column_order` annotation and referenced table has `row_order`, should use the table's row_order.", function () {
@@ -748,7 +748,7 @@ exports.execute = function (options) {
                     expect(compactColumns[12].sortable).toBe(true);
                     expect(compactColumns[12]._sortColumns.length).toBe(1);
                     expect(compactColumns[12]._sortColumns.map(function (col) {
-                        return col.name
+                        return col.column.name
                     })).toEqual(['id_2']);
                 });
 
@@ -757,7 +757,7 @@ exports.execute = function (options) {
                     expect(compactColumns[2].sortable).toBe(true);
                     expect(compactColumns[2]._sortColumns.length).toBe(1);
                     expect(compactColumns[2]._sortColumns.map(function (col) {
-                        return col.name
+                        return col.column.name
                     })).toEqual(['id']);
                 });
 
@@ -787,7 +787,7 @@ exports.execute = function (options) {
                     expect(compactBriefRef.columns[1].sortable).toBe(true);
                     expect(compactBriefRef.columns[1]._sortColumns.length).toBe(2);
                     expect(compactBriefRef.columns[1]._sortColumns.map(function (col) {
-                        return col.name
+                        return col.column.name
                     })).toEqual(['col_1', 'col_2']);
                 });
 
@@ -795,7 +795,7 @@ exports.execute = function (options) {
                     expect(compactColumns[0].sortable).toBe(true);
                     expect(compactColumns[0]._sortColumns.length).toBe(1);
                     expect(compactColumns[0]._sortColumns.map(function (col) {
-                        return col.name
+                        return col.column.name
                     })).toEqual(['id']);
                 });
 
@@ -817,7 +817,7 @@ exports.execute = function (options) {
                     expect(compactColumns[6].sortable).toBe(true);
                     expect(compactColumns[6]._sortColumns.length).toBe(1);
                     expect(compactColumns[6]._sortColumns.map(function (col) {
-                        return col.name
+                        return col.column.name
                     })).toEqual(['columns_schema_outbound_fk_7']);
                 });
 
@@ -832,7 +832,7 @@ exports.execute = function (options) {
                     expect(compactColumns[10].sortable).toBe(true);
                     expect(compactColumns[10]._sortColumns.length).toBe(1);
                     expect(compactColumns[10]._sortColumns.map(function (col) {
-                        return col.name
+                        return col.column.name
                     })).toEqual(['columns_schema_outbound_fk_7']);
                 });
 

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -853,7 +853,7 @@ exports.execute = function (options) {
         expect(col._sortColumns.length).toBe(sortColumns ? sortColumns.length : 0, "sortColumns length missmatch" + (colStr ? (" for " + colStr) : "."));
         if (sortColumns) {
             expect(col._sortColumns.map(function (col) {
-                return col.name;
+                return col.column.name;
             })).toEqual(sortColumns, "_sortColumn missmatch" +  (colStr ? (" for " + colStr) : "."));
         }
     }

--- a/test/specs/reference/conf/reference_schema/data/sorted_table_w_fk.json
+++ b/test/specs/reference/conf/reference_schema/data/sorted_table_w_fk.json
@@ -8,7 +8,10 @@
         "col_w_order": "01",
         "col": "04",
         "col w space": "03",
-        "col_w_slash/": "02"
+        "col_w_slash/": "02",
+        "col_w_order_multiple": "01",
+        "col_w_order_multiple_1": "04",
+        "col_w_order_multiple_2": "04"
     },
     {
         "id": "02",
@@ -19,7 +22,10 @@
         "col_w_order": "02",
         "col": "05",
         "col w space": "04",
-        "col_w_slash/": "03"
+        "col_w_slash/": "03",
+        "col_w_order_multiple": "02",
+        "col_w_order_multiple_1": "05",
+        "col_w_order_multiple_2": "05"
     },
     {
         "id": "03",
@@ -30,7 +36,10 @@
         "col_w_order": "03",
         "col": "06",
         "col w space": "05",
-        "col_w_slash/": "04"
+        "col_w_slash/": "04",
+        "col_w_order_multiple": "03",
+        "col_w_order_multiple_1": "06",
+        "col_w_order_multiple_2": "06"
     },
     {
         "id": "04",
@@ -41,7 +50,10 @@
         "col_w_order": "04",
         "col": "07",
         "col w space": "06",
-        "col_w_slash/": "05"
+        "col_w_slash/": "05",
+        "col_w_order_multiple": "04",
+        "col_w_order_multiple_1": "07",
+        "col_w_order_multiple_2": "07"
     },
     {
         "id": "05",
@@ -52,7 +64,10 @@
         "col_w_order": "05",
         "col": "08",
         "col w space": "07",
-        "col_w_slash/": "06"
+        "col_w_slash/": "06",
+        "col_w_order_multiple": "05",
+        "col_w_order_multiple_1": "01",
+        "col_w_order_multiple_2": "08"
     },
     {
         "id": "06",
@@ -63,7 +78,10 @@
         "col_w_order": "06",
         "col": "01",
         "col w space": "08",
-        "col_w_slash/": "07"
+        "col_w_slash/": "07",
+        "col_w_order_multiple": "06",
+        "col_w_order_multiple_1": "01",
+        "col_w_order_multiple_2": "01"
     },
     {
         "id": "07",
@@ -74,7 +92,10 @@
         "col_w_order": "07",
         "col": "02",
         "col w space": "01",
-        "col_w_slash/": "08"
+        "col_w_slash/": "08",
+        "col_w_order_multiple": "07",
+        "col_w_order_multiple_1": "02",
+        "col_w_order_multiple_2": "02"
     },
     {
         "id": "08",
@@ -85,6 +106,9 @@
         "col_w_order": "08",
         "col": "03",
         "col w space": "02",
-        "col_w_slash/": "01"
+        "col_w_slash/": "01",
+        "col_w_order_multiple": "08",
+        "col_w_order_multiple_1": "03",
+        "col_w_order_multiple_2": "03"
     }
 ]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -663,6 +663,34 @@
                     }
                 },
                 {
+                    "name": "col_w_order_multiple",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:column-display": {
+                            "*": {
+                                "column_order": [
+                                    {"column": "col_w_order_multiple_1", "descending": true},
+                                    "col_w_order_multiple_2"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "col_w_order_multiple_1",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col_w_order_multiple_2",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
                     "name": "col_not_sortable",
                     "type": {
                         "typename": "text"
@@ -863,7 +891,7 @@
             "annotations": {
                 "tag:isrd.isi.edu,2016:table-display": {
                     "*" : {
-                        "row_order": [{"column":"name x", "descending":false}]
+                        "row_order": ["name x"]
                     }
                 }
             }

--- a/test/specs/reference/tests/03.reference_sort.js
+++ b/test/specs/reference/tests/03.reference_sort.js
@@ -208,7 +208,8 @@ exports.execute = function (options) {
                 });
 
                 it("if foreignkey doesn't have `column_order` annotation and table has `row_order`, should sort based on table's row_order", function (done) {
-                    checkSort([{"column": "reference_schema_sorted_table_w_fk_fk2", "descending": false}], "03", done);
+                    // it should honor the row_order as is, and don't apply column_order to that
+                    checkSort([{"column": "reference_schema_sorted_table_w_fk_fk2", "descending": false}], "02", done);
                 });
 
                 it("if foreignkey doesn't have `column_order` and is simple, should sort based on the constituent column.", function (done) {
@@ -220,6 +221,12 @@ exports.execute = function (options) {
 
                 it("if column has a `column_order` other than false, should sort based on that.", function (done) {
                     checkSort([{"column": "col_w_order", "descending": false}], "06", done);
+                });
+
+                it ("if column has a `column_order` other than false with descending, should sort based on that column and change the order.", function (done) {
+                    // the column_order has [{col_w_order_multiple_1, descending}, col_w_order_multiple_2] which should turned into
+                    // [col_w_order_multiple_1, {col_w_order_multiple_2, descending}]
+                    checkSort([{"column": "col_w_order_multiple", "descending": true}], "05", done);
                 });
 
                 it("if column doesn't have `column_order`, should sort based on column value.", function (done) {
@@ -250,14 +257,13 @@ exports.execute = function (options) {
                 expect(response.tuples[0].values[0]).toEqual(ExpectedFirstId);
                 done();
             }, function (err) {
-                console.dir(err);
-                done.fail();
+                done.fail(err);
             });
         }
 
         function checkError(sortColumns, error, done) {
             outboundRef.sort(sortColumns).read(1).then(function(response) {
-                done.fail();
+                done.fail("expected function to throw error");
             }).catch(function (err) {
                 expect(err.toString()).toEqual("Error: " + error);
                 done();


### PR DESCRIPTION
Changes in this PR:
- Revert row_order change to just use the list as is (without applying column_order logic).
- Unify the column_order and row_order syntax.
- Modify the test cases.

(refer to the #647 issue for more information)

I need to update the annotation document too.