### PR TITLE
add entity aggregate support

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -2584,7 +2584,7 @@
                         sourceCol = _getFacetSourceColumn(col.source, this._table, module._constraintNames);
 
                         // invalid source
-                        if (logCol(!sourceCol, wm.INVALID_SOURCE)) {
+                        if (logCol(!sourceCol, wm.INVALID_SOURCE, i)) {
                             continue;
                         }
 
@@ -2601,12 +2601,10 @@
                         // 2. column/foreignkey that needs to be hidden.
                         // 3. The generated hash is a column for the table in database
                         // 4. invalid aggregate function
-                        // 5. in entity mode with scalar aggregate functions
                         ignore = logCol((pseudoName in consideredColumns), wm.DUPLICATE_PC, i) ||
                                  hideFKRByName(pseudoName) ||
                                  (!hasPath && hideColumn(sourceCol)) ||
                                  logCol((col.aggregate && module._pseudoColAggregateFns.indexOf(col.aggregate) === -1), wm.INVALID_AGG, i) ||
-                                 logCol((module._pseudoColScalarAggregateFns.indexOf(col.aggregate) !== -1 && isEntity), wm.NO_SCALAR_AGG_IN_ENT, i) ||
                                  logCol((!col.aggregate && hasInbound && !isEntity), wm.MULTI_SCALAR_NEED_AGG, i) ||
                                  logCol((!col.aggregate && hasInbound && isEntity && context !== module._contexts.DETAILED), wm.MULTI_ENT_NEED_AGG, i) ||
                                  logCol(col.aggregate && isEntry, wm.NO_AGG_IN_ENTRY, i) ||

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -812,8 +812,8 @@
         if (linkedData && typeof linkedData === "object" && table.foreignKeys.length() > 0) {
             keyValues.$fkeys = {};
             table.foreignKeys.all().forEach(function (fk) {
-                presentation = module._generateForeignKeyPresentation(fk, context, linkedData[fk.name]);
-                if (!presentation) return;
+                var p = module._generateRowLinkProperties(fk.key, linkedData[fk.name], context);
+                if (!p) return;
 
                 cons = fk.constraint_names[0];
                 if (!keyValues.$fkeys[cons[0]]) {
@@ -822,9 +822,9 @@
 
                 keyValues.$fkeys[cons[0]][cons[1]] = {
                     "values": getTableValues(linkedData[fk.name], fk.key.table),
-                    "rowName": presentation.unformatted,
+                    "rowName": p.unformatted,
                     "uri": {
-                        "detailed": presentation.reference.contextualize.detailed.appLink
+                        "detailed": p.reference.contextualize.detailed.appLink
                     }
                 };
 
@@ -970,6 +970,18 @@
 
     };
 
+    /**
+     * @function
+     * @private
+     * @desc Given a key object, will return the presentation object that can bse used for it
+     * @param  {ERMrest.Key} key    the key object
+     * @param  {object} data        the data for the table that key is from
+     * @param  {string} context     the context string
+     * @param  {object=} options
+     * @return {object} the presentation object that can be used for the key
+     * (it has `isHTML`, `value`, and `unformatted`).
+     * NOTE the function might return `null`.
+     */
     module._generateKeyPresentation = function (key, data, context, options) {
         // if data is empty
         if (typeof data === "undefined" || data === null || Object.keys(data).length === 0) {
@@ -1008,15 +1020,15 @@
             return null;
         }
 
+        // make sure that formattedValues is defined
+        options = options || {};
+        if (options.formattedValues === undefined) {
+           options.formattedValues = module._getFormattedKeyValues(key.table, context, data);
+        }
+
         // use the markdown_pattern that is defiend in key-display annotation
         var display = key.getDisplay(context);
         if (display.isMarkdownPattern) {
-
-            // make sure that formattedValues is defined
-            if (options === undefined || options.formattedValues === undefined) {
-               options.formattedValues = module._getFormattedKeyValues(key.table, context, data);
-            }
-
             unformatted = module._renderTemplate(display.markdownPattern, options.formattedValues, key.table, context, {formatted:true});
             unformatted = (unformatted === null || unformatted.trim() === '') ? "" : unformatted;
             caption = module._formatUtils.printMarkdown(unformatted, { inline: true });
@@ -1063,12 +1075,51 @@
     /**
      * @function
      * @private
-     * @param  {ERMrest.foreignKeyRef} foreignKey the foriengkey object
+     * @desc Given the key of a table, and data for one row will return the
+     * presentation object for the row.
+     * @param  {ERMrest.Key} key   the key of the table
      * @param  {String} context    Current context
-     * @param  {object} data       Data for the table that this foreignKey is referring to.
+     * @param  {object} data       Data for the table that this key is referring to.
      * @return {Object}            an object with `caption`, and `reference` object which can be used for getting uri.
      */
-    module._generateForeignKeyPresentation = function (foreignKey, context, data) {
+    module._generateRowPresentation = function (key, data, context) {
+        var presentation = module._generateRowLinkProperties(key, data, context);
+
+        if (!presentation) {
+            return null;
+        }
+
+        var value, unformatted, appLink;
+
+        // if column is hidden, or caption has a link, or  or context is EDIT: don't add the link.
+        // create the link using reference.
+        if (presentation.caption.match(/<a/) || module._isEntryContext(context)) {
+            value = presentation.caption;
+            unformatted = presentation.unformatted;
+        } else {
+            appLink = presentation.reference.contextualize.detailed.appLink;
+            value = '<a href="' + appLink + '">' + presentation.caption + '</a>';
+            unformatted = "[" + presentation.unformatted + "](" + appLink + ")";
+        }
+
+        return {isHTML: true, value: value, unformatted: unformatted};
+    };
+
+    /**
+     * @function
+     * @private
+     * @param  {ERMrest.Key} key     key of the table
+     * @param  {string} context current context
+     * @param  {object} data    data for the table that this key is referring to
+     * @return {object} an object with the following attributes:
+     * - `caption`: The caption that can be used to refer to this row in a link
+     * - `unformatted`: The unformatted version of caption.
+     * - `refernece`: The reference object that can be used for generating link to the row
+     * @desc
+     * Creates the properies for generating a link to the given row of data.
+     * It might return `null`.
+     */
+    module._generateRowLinkProperties = function (key, data, context) {
 
         // if data is empty
         if (typeof data === "undefined" || data === null || Object.keys(data).length === 0) {
@@ -1099,12 +1150,10 @@
         };
 
         var value, rowname, i, caption, unformatted;
-
-        var fkey = foreignKey.key; // the key that creates this PseudoColumn
-        var table = fkey.table;
+        var table = key.table;
 
         // if any of key columns don't have data, this link is not valid.
-        if (!hasData(fkey.colset.columns)) {
+        if (!hasData(key.colset.columns)) {
             return null;
         }
 
@@ -1120,8 +1169,8 @@
                 unformattedKeyCols = [],
                 pres, col;
 
-            for (i = 0; i < fkey.colset.columns.length; i++) {
-                col = fkey.colset.columns[i];
+            for (i = 0; i < key.colset.columns.length; i++) {
+                col = key.colset.columns[i];
                 pres = col.formatPresentation(formattedValues[col.name], context, {formattedValues: formattedValues});
                 formattedKeyCols.push(pres.value);
                 unformattedKeyCols.push(pres.unformatted);
@@ -1135,7 +1184,7 @@
         }
 
         // use the shortest key if it has data (for shorter url).
-        var uriKey = hasData(table.shortestKey) ? table.shortestKey: fkey.colset.columns;
+        var uriKey = hasData(table.shortestKey) ? table.shortestKey: key.colset.columns;
 
         // create a url that points to the current ReferenceColumn
         var ermrestUri = [
@@ -2708,7 +2757,6 @@
     ];
 
     module._pseudoColAggregateFns = ["min", "max", "cnt", "cnt_d", "array"];
-    module._pseudoColScalarAggregateFns = ["min", "max"];
     module._pseudoColAggregateNames = ["Min", "Max", "#", "#", ""];
     module._pseudoColAggregateExplicitName = ["Minimum", "Maximum", "Number of", "Number of distinct", "List of"];
 
@@ -2776,7 +2824,6 @@
         FK_NOT_RELATED: "given foreignkey is not inbound or outbound related to the table.",
         INVALID_FK: "given foreignkey definition is invalid.",
         AGG_NOT_ALLOWED: "aggregate functions are not allowed here.",
-        SCALAR_NOT_ALLOWED: "only entity mode is allowed here.",
         MULTI_SCALAR_NEED_AGG: "aggregate functions are required for scalar inbound-included paths.",
         MULTI_ENT_NEED_AGG: "aggregate functions are required for entity inbound-included paths in non-detailed contexts.",
         NO_AGG_IN_ENTRY: "aggregate functions are not allowed in entry contexts.",

--- a/test/specs/column/conf/pseudo_column_schema/schema.json
+++ b/test/specs/column/conf/pseudo_column_schema/schema.json
@@ -135,6 +135,11 @@
                             {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
                             "id"
                         ], "aggregate": "array", "entity": false},
+                        {"source": [
+                            {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                            {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                            "id"
+                        ], "aggregate": "array"},
                         {"source": [{"inbound": ["pseudo_column_schema", "inbound_4_long_table_name_fk"]}, "foreign key column name to main"], "aggregate": "cnt", "markdown_name": "**Count Agg**", "comment": "has long values"},
                         {"source": "asset", "markdown_name": "Asset name", "comment": "asset cm", "markdown_name": "**asset**"},
                         {"source": "asset_filename", "markdown_name": "filename"}
@@ -282,8 +287,6 @@
                         {"source": [{"outbound": ["pseudo_column_schema", "invalid constraint name"]}, "id"]},
                         {"source": [{"inbound": ["pseudo_column_schema", "table_w_invalid_pseudo_cols_fk1"]}, "id"]},
                         {"source": [{"outbound": ["pseudo_column_schema", "table_w_invalid_pseudo_cols_fk1"]}, "id"], "aggregate": "invalid"},
-                        {"source": [{"outbound": ["pseudo_column_schema", "table_w_invalid_pseudo_cols_fk1"]}, "id"], "aggregate": "min"},
-                        {"source": [{"outbound": ["pseudo_column_schema", "table_w_invalid_pseudo_cols_fk1"]}, "id"], "aggregate": "max"},
                         {"source": [{"outbound": ["pseudo_column_schema", "table_w_invalid_pseudo_cols_fk1"]}, {"inbound": ["pseudo_column_schema", "inbound_1_fk1"]}, "id"], "entity": false},
                         {"source": [{"outbound": ["pseudo_column_schema", "table_w_invalid_pseudo_cols_fk1"]}, {"inbound": ["pseudo_column_schema", "inbound_1_fk1"]}, "id"]}
                     ],
@@ -521,7 +524,14 @@
                     "name": "col",
                     "type": {"typename": "text"}
                 }
-            ]
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2016:table-display": {
+                    "row_name": {
+                        "row_markdown_pattern": "{{{id}}} with {{{col}}}"
+                    }
+                }
+            }
         },
         "inbound_2_outbound_1": {
             "table_name": "inbound_2_outbound_1",

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -18,9 +18,10 @@
  * 13: same as 10 in non-entity mode with `min` aggregate (PseudoColumn)
  * 14: col - max (PseudoColumn)
  * 15: same as 8 with `array` in non entity mode
- * 16: inbound for testing long aggregate request (PseudoColumn)
- * 17: asset (AssetPseudoColumn)
- * 18: asset_filename (ReferenceColumn)
+ * 16: same as 8 with `array` in entity mode
+ * 17: inbound for testing long aggregate request (PseudoColumn)
+ * 18: asset (AssetPseudoColumn)
+ * 19: asset_filename (ReferenceColumn)
  *
  * Only the followin indeces are PseudoColumn:
  * 4 (outbound len 1, scalar)
@@ -33,6 +34,7 @@
  * 14(col - agg max)
  * 15 (same as 8, agg array)
  * 16 (inbound, agg cnt)
+ * 17 (inbound, agg cnt, entity)
  *
  * For entry:
  * 0: main_table_id_col
@@ -104,7 +106,7 @@ exports.execute = function (options) {
             '<a href="https://dev.isrd.isi.edu/chaise/record/pseudo_column_schema:main/main_table_id_col=01">01</a>',
             '<a href="https://dev.isrd.isi.edu/chaise/record/pseudo_column_schema:outbound_1/id=01">01</a>',
             '<p>01: 10</p>\n', '<a href="https://dev.isrd.isi.edu/chaise/record/pseudo_column_schema:outbound_1_outbound_1/id=01">01</a>',
-            '01', '', '', '', '', '', '', '', '', '', '', '', ''
+            '01', '', '', '', '', '', '', '', '', '', '', '', '', ''
         ];
 
         var detailedExpectedNames = [
@@ -113,18 +115,18 @@ exports.execute = function (options) {
              'GUABhSm2h_kaHHPGkzYWeA', 'gNTPCP0bGB0GRwFKEATipw', 'nGwW9Kpx5sLf8cpX-24WNQ',
              '0utuimdZvz8kTU4GI7tzWw', 'PEQDZ38621T5Y9J3P2Te2Q', 'plpeoINYqVjmca9rYYtFuw',
              'OpHtewN91L9_3b1Vq-jkOg', 'LHC_G9Tm_jYXQXyNNrZIGA', 'H3B-cJhnO5kI08bThBIMxw',
-             'MJVZnQ5mBRdCFPfjIOMvkA', "asset", "asset_filename"
+             'ZJll4WjE6eMk_g5e9WE1rg', 'MJVZnQ5mBRdCFPfjIOMvkA', "asset", "asset_filename"
         ];
 
         var detailedPseudoColumnIndices = [
-            4, 5, 6, 9, 11,12, 13, 14, 15, 16
+            4, 5, 6, 9, 11,12, 13, 14, 15, 16, 17
         ];
 
         var detailedColumnTypes = [
             "", "", "isKey", "isForeignKey", "isPathColumn", "isPathColumn",
             "isPathColumn", "isInboundForeignKey", "isInboundForeignKey", "isPathColumn",
             "isInboundForeignKey", "isPathColumn", "isPathColumn", "isPathColumn", "isPathColumn",
-            "isPathColumn", "isPathColumn", "isAsset", ""
+            "isPathColumn", "isPathColumn", "isPathColumn", "isAsset", ""
         ];
 
         var mainRef, mainRefDetailed, invalidRef, mainRefEntry,
@@ -222,7 +224,7 @@ exports.execute = function (options) {
             });
 
             it ("should create the correct columns for valid list of sources.", function () {
-                expect(mainRefDetailed.columns.length).toBe(19, "length missmatch");
+                expect(mainRefDetailed.columns.length).toBe(20, "length missmatch");
                 checkReferenceColumns([{
                     "ref": mainRefDetailed,
                     "expected": [
@@ -261,6 +263,11 @@ exports.execute = function (options) {
                         ],
                         [{"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]}, "id"],
                         "col",
+                        [
+                            {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                            {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                            "id"
+                        ],
                         [
                             {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
                             {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
@@ -430,7 +437,7 @@ exports.execute = function (options) {
                         "3": "main fk cm",
                         "7": "inbound cm",
                         "8": "association table cm",
-                        "17": "asset cm"
+                        "18": "asset cm"
                     };
 
                     for (var i in expectedComments) {
@@ -445,7 +452,7 @@ exports.execute = function (options) {
                         "3": "main fk",
                         "7": "inbound",
                         "8": "<strong>association table</strong>",
-                        "17": "<strong>asset</strong>"
+                        "18": "<strong>asset</strong>"
                     };
 
                     for (var i in expectedComments) {
@@ -531,7 +538,7 @@ exports.execute = function (options) {
                 it ("if `markdown_name` is defined, should use it.", function () {
                     checkDisplayname(detailedColsWTuple[6], "<strong>Outbound Len 2</strong>", true, "for index=6");
 
-                    checkDisplayname(detailedColsWTuple[16], "<strong>Count Agg</strong>", true, "for index=15");
+                    checkDisplayname(detailedColsWTuple[17], "<strong>Count Agg</strong>", true, "for index=15");
                 });
 
                 describe("if it has aggreagte.", function () {
@@ -557,7 +564,7 @@ exports.execute = function (options) {
             describe("comment, ", function () {
                 it ('if `comment` is defined, should use it.', function () {
                     expect(detailedColsWTuple[6].comment).toBe("outbound len 2 cm", "missmatch for index=6");
-                    expect(detailedColsWTuple[16].comment).toBe("has long values", "missmatch for index=6");
+                    expect(detailedColsWTuple[17].comment).toBe("has long values", "missmatch for index=6");
                 });
 
                 it ("if it has aggregate, should append the aggregate function to the column comment.", function () {
@@ -588,7 +595,8 @@ exports.execute = function (options) {
                         'inbound_1', 'inbound_2', 'inbound_2_outbound_1',
                         'main_inbound_2_association', 'inbound_2',
                         'inbound_2_outbound_1', 'main_inbound_2_association',
-                        'main', 'inbound_2', 'inbound 4 long table name', 'main', 'main'
+                        'main', 'inbound_2', 'inbound_2',
+                        'inbound 4 long table name', 'main', 'main'
                     ]);
                 });
             });
@@ -701,10 +709,27 @@ exports.execute = function (options) {
                     });
                 });
 
-                it ("should handle array aggregate.", function (done) {
+                it ("should handle array aggregate in scalar mode.", function (done) {
                     detailedColsWTuple[15].getAggregatedValue(mainPage).then(function (val) {
                         expect(val.length).toBe(1, "length missmatch.");
-                        expect(val[0].value).toEqual('01 ,02 ,03 ,04 ,05', "value missmatch.");
+                        expect(val[0].value).toEqual('01, 02, 03, 04, 05', "value missmatch.");
+                        done();
+                    }).catch(function (e) {
+                        done.fail(e);
+                    });
+                });
+
+                it ("should handle array aggregate in entity mode.", function (done) {
+                    detailedColsWTuple[16].getAggregatedValue(mainPage).then(function (val) {
+                        expect(val.length).toBe(1, "length missmatch.");
+                        var value = [
+                            '<a href="https://dev.isrd.isi.edu/chaise/record/pseudo_column_schema:inbound_2/id=01">01 with inbound_2 col 01</a>',
+                            '<a href="https://dev.isrd.isi.edu/chaise/record/pseudo_column_schema:inbound_2/id=02">02 with inbound_2 col 02</a>',
+                            '<a href="https://dev.isrd.isi.edu/chaise/record/pseudo_column_schema:inbound_2/id=03">03 with inbound_2 col 03</a>',
+                            '<a href="https://dev.isrd.isi.edu/chaise/record/pseudo_column_schema:inbound_2/id=04">04 with inbound_2 col 04</a>',
+                            '<a href="https://dev.isrd.isi.edu/chaise/record/pseudo_column_schema:inbound_2/id=05">05 with inbound_2 col 05</a>'
+                        ];
+                        expect(val[0].value).toEqual(value.join(", "), "value missmatch.");
                         done();
                     }).catch(function (e) {
                         done.fail(e);
@@ -713,7 +738,7 @@ exports.execute = function (options) {
 
                 it ("should handle big page of data.", function (done) {
                     mainRefDetailed.read(22).then(function (page) {
-                        return detailedColsWTuple[16].getAggregatedValue(page);
+                        return detailedColsWTuple[17].getAggregatedValue(page);
                     }).then(function (val) {
                         // the whole intention of test was testing the logic of url limitation,
                         // the values is not important. since all of them are just one row, it will


### PR DESCRIPTION
This PR adds proper entity support to `array` aggregates. Using `array` aggregate in entity mode will return the linkable row-names separated with comma. Other changes in PR:

- Since the logic for getting presentation of a row has been used in multiple places I created a function for it called `_generateRowPresentation`.

- Renamed the `_generateForeignKeyPresentation` to `_generateRowLinkProperties` since it's not returning the presentation alone (The presentation definiton in ermerstjs is an object with `unformatted`, `value`, and `isHTML`). I don't like the name that I used but couldn't think of a better name. It's generating the set of properties that can be used to generate a link to the row.

- Removed the scalar aggregate function list. All the aggregate functions are now allowed in scalar and entity mode.

issue: #654 