### PR TITLE
removed filename check

### DIFF
--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -350,14 +350,11 @@ var ERMrest = (function(module) {
             headers: _generateContextHeader(contextHeaderParams)
         };
 
-        console.log(this);
         this.http.head(this._getAbsoluteUrl(this.url), config).then(function(response) {
 
             var headers = response.headers();
-            console.log(headers);
             var md5 = headers["content-md5"];
             var length = headers["content-length"];
-            var filename = headers["content-disposition"].replace("filename*=UTF-8''","");
 
             // If the file is not same, then simply resolve the promise without setting completed and jobDone
             if ((md5 != self.hash.md5_base64) || (length != self.file.size)) {


### PR DESCRIPTION
Changes to accompany `chaise` changes for issue #649. Removed check for filename in `fileExists` function after getting a response for the HEAD request. This should be merged before the corresponding `chaise` [PR](https://github.com/informatics-isi-edu/chaise/pull/1556).