### PR TITLE
Google closure compiler js package upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,10 @@ $(BUILD)/$(PKG): $(SOURCE)
 	cat $(SOURCE) > $(BUILD)/$(PKG)
 
 # Rule to build the minified package
+# we should list all the tags that jsDoc accepst but the gccjs doesn't.
 $(BUILD)/$(MIN): $(SOURCE) $(BIN)
 	mkdir -p $(BUILD)
-	$(BIN)/google-closure-compiler-js $(BUILD)/$(PKG) > $(BUILD)/$(MIN)
+	$(BIN)/google-closure-compiler-js $(BUILD)/$(PKG) > $(BUILD)/$(MIN) --extraAnnotationNames callback --extraAnnotationNames async
 
 # Rule to lint the source (terminate build on errors)
 $(LINT): $(SOURCE) $(BIN)

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ $(BUILD)/$(PKG): $(SOURCE)
 # Rule to build the minified package
 $(BUILD)/$(MIN): $(SOURCE) $(BIN)
 	mkdir -p $(BUILD)
-	$(BIN)/ccjs $(BUILD)/$(PKG) --language_in=ECMASCRIPT5_STRICT > $(BUILD)/$(MIN)
+	$(BIN)/google-closure-compiler-js $(BUILD)/$(PKG) > $(BUILD)/$(MIN)
 
 # Rule to lint the source (terminate build on errors)
 $(LINT): $(SOURCE) $(BIN)

--- a/doc/api.md
+++ b/doc/api.md
@@ -13,17 +13,24 @@ to use for ERMrest JavaScript agents.</p>
 ## Typedefs
 
 <dl>
-<dt><a href="#httpUnauthorizedFn">httpUnauthorizedFn</a> : <code>function</code></dt>
-<dd><p>set callback function which will be called when a HTTP 401 Error occurs</p>
-</dd>
 <dt><a href="#appLinkFn">appLinkFn</a> : <code>function</code></dt>
-<dd><p>set callback function that converts app tag to app URL</p>
+<dd><p>Given an app tag, location object and context will return the full url.</p>
 </dd>
 <dt><a href="#onHTTPSuccess">onHTTPSuccess</a> : <code>function</code></dt>
-<dd><p>set callback function that triggers when a request returns with success</p>
+<dd><p>This function will be called on success of http calls.</p>
 </dd>
-<dt><a href="#onError">onError</a> ⇒ <code>Promise</code></dt>
-<dd><p>Calculates  MD5 checksum for a file using spark-md5 library</p>
+<dt><a href="#httpUnauthorizedFn">httpUnauthorizedFn</a> : <code>function</code></dt>
+<dd><p>The callback that will be called whenever 401 HTTP error is encountered,
+unless there is already login flow in progress.</p>
+</dd>
+<dt><a href="#checksumOnProgres">checksumOnProgres</a> : <code>function</code></dt>
+<dd><p>This callback will be called for progress during checksum calculation</p>
+</dd>
+<dt><a href="#checksumOnSuccess">checksumOnSuccess</a> : <code>function</code></dt>
+<dd><p>This callback will be called for success of checksum calculation</p>
+</dd>
+<dt><a href="#checksumOnError">checksumOnError</a> : <code>function</code></dt>
+<dd><p>This callback will be called when we counter an error during checksum calculation</p>
 </dd>
 </dl>
 
@@ -480,6 +487,7 @@ to use for ERMrest JavaScript agents.
         * [.countAgg](#ERMrest.AttributeGroupReferenceAggregateFn+countAgg) : <code>Object</code>
     * [.Checksum](#ERMrest.Checksum)
         * [new Checksum({file}, {options})](#new_ERMrest.Checksum_new)
+        * [.calculate(chunkSize, fn, fn, fn)](#ERMrest.Checksum+calculate) ⇒ <code>Promise</code>
     * [.upload](#ERMrest.upload)
         * [new upload(file, {otherInfo})](#new_ERMrest.upload_new)
         * [.validateURL(row)](#ERMrest.upload+validateURL) ⇒ <code>boolean</code>
@@ -4859,6 +4867,11 @@ Therefore the returned count might not be exactly the same as number of returned
 
 ### ERMrest.Checksum
 **Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+
+* [.Checksum](#ERMrest.Checksum)
+    * [new Checksum({file}, {options})](#new_ERMrest.Checksum_new)
+    * [.calculate(chunkSize, fn, fn, fn)](#ERMrest.Checksum+calculate) ⇒ <code>Promise</code>
+
 <a name="new_ERMrest.Checksum_new"></a>
 
 #### new Checksum({file}, {options})
@@ -4867,6 +4880,21 @@ Therefore the returned count might not be exactly the same as number of returned
 | --- | --- | --- |
 | {file} | <code>Object</code> | A browser file object |
 | {options} | <code>Object</code> | An optional parameters object. The (key, value) |
+
+<a name="ERMrest.Checksum+calculate"></a>
+
+#### checksum.calculate(chunkSize, fn, fn, fn) ⇒ <code>Promise</code>
+Calculates  MD5 checksum for a file using spark-md5 library
+
+**Kind**: instance method of [<code>Checksum</code>](#ERMrest.Checksum)  
+**Returns**: <code>Promise</code> - if the schema exists or not  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| chunkSize | <code>number</code> | size of the chunks, in which the file is supposed to be broken |
+| fn | <code>checksumOnProgress</code> | callback function to be called for progress |
+| fn | [<code>checksumOnSuccess</code>](#checksumOnSuccess) | callback function to be called for success |
+| fn | [<code>checksumOnError</code>](#checksumOnError) | callback function to be called for error |
 
 <a name="ERMrest.upload"></a>
 
@@ -6295,51 +6323,58 @@ ERMrest.resolve('https://example.org/catalog/42/entity/s:t/k=123').then(
 | uri | <code>string</code> | An ERMrest resource URI, such as `https://example.org/ermrest/catalog/1/entity/s:t/k=123`. |
 | [contextHeaderParams] | <code>Object</code> | An optional context header parameters object. The (key, value) pairs from the object are converted to URL `key=value` query parameters and appended to every request to the ERMrest service. |
 
-<a name="httpUnauthorizedFn"></a>
-
-## httpUnauthorizedFn : <code>function</code>
-set callback function which will be called when a HTTP 401 Error occurs
-
-**Kind**: global typedef  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| fn | [<code>httpUnauthorizedFn</code>](#httpUnauthorizedFn) | callback function |
-
 <a name="appLinkFn"></a>
 
 ## appLinkFn : <code>function</code>
-set callback function that converts app tag to app URL
+Given an app tag, location object and context will return the full url.
 
 **Kind**: global typedef  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| fn | [<code>appLinkFn</code>](#appLinkFn) | callback function |
+| tag | <code>string</code> | the tag that is defined in the annotation. If null, should use context. |
+| location | <code>ERMrest.Location</code> | the location object that ERMrest will return. |
+| context | <code>string</code> | optional, used to determine default app if tag is null/undefined |
 
 <a name="onHTTPSuccess"></a>
 
 ## onHTTPSuccess : <code>function</code>
-set callback function that triggers when a request returns with success
+This function will be called on success of http calls.
+
+**Kind**: global typedef  
+<a name="httpUnauthorizedFn"></a>
+
+## httpUnauthorizedFn : <code>function</code>
+The callback that will be called whenever 401 HTTP error is encountered,
+unless there is already login flow in progress.
+
+**Kind**: global typedef  
+<a name="checksumOnProgres"></a>
+
+## checksumOnProgres : <code>function</code>
+This callback will be called for progress during checksum calculation
 
 **Kind**: global typedef  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| fn | [<code>onHTTPSuccess</code>](#onHTTPSuccess) | callback function |
+| uploaded | <code>number</code> | the amount that has been uploaded |
+| fileSize | <code>number</code> | the total size of the file. |
 
-<a name="onError"></a>
+<a name="checksumOnSuccess"></a>
 
-## onError ⇒ <code>Promise</code>
-Calculates  MD5 checksum for a file using spark-md5 library
+## checksumOnSuccess : <code>function</code>
+This callback will be called for success of checksum calculation
 
 **Kind**: global typedef  
-**Returns**: <code>Promise</code> - if the schema exists or not  
+<a name="checksumOnError"></a>
+
+## checksumOnError : <code>function</code>
+This callback will be called when we counter an error during checksum calculation
+
+**Kind**: global typedef  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| chunkSize | <code>number</code> | size of the chunks, in which the file is supposed to be broken |
-| fn | <code>onProgress</code> | callback function to be called for progress |
-| fn | <code>onSuccess</code> | callback function to be called for success |
-| fn | [<code>onError</code>](#onError) | callback function to be called for error |
+| err | <code>Error</code> | the error object |
 

--- a/js/core.js
+++ b/js/core.js
@@ -26,20 +26,31 @@
 
     /**
      * function that converts app tag to app URL
-     * @callback appLinkFn
      * @type {appLinkFn}
      * @private
      */
     module._appLinkFn = null;
 
     /**
+     * Given an app tag, location object and context will return the full url.
+     * @callback appLinkFn
+     * @param {string} tag the tag that is defined in the annotation. If null, should use context.
+     * @param {ERMrest.Location} location the location object that ERMrest will return.
+     * @param {string} context - optional, used to determine default app if tag is null/undefined
+     */
+
+    /**
      * function that resets the storage expiration time
      * initialized to empty function so function runs properly when not defined in `chaise`
-     * @callback onHTTPSuccess
      * @type {onHTTPSuccess}
      * @private
      */
     module._onHTTPSuccess = function () {};
+
+    /**
+     * This function will be called on success of http calls.
+     * @callback onHTTPSuccess
+     */
 
     /**
      * @memberof ERMrest

--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -94,13 +94,28 @@ var ERMrest = (function(module) {
     };
 
     /**
+     * This callback will be called for progress during checksum calculation
+     * @callback checksumOnProgres
+     * @param {number} uploaded the amount that has been uploaded
+     * @param {number} fileSize the total size of the file.
+     */
+
+    /**
+     * This callback will be called for success of checksum calculation
+     * @callback checksumOnSuccess
+     */
+
+    /**
+     * This callback will be called when we counter an error during checksum calculation
+     * @callback checksumOnError
+     * @param {Error} err the error object
+     */
+
+    /**
      * @param {number} chunkSize size of the chunks, in which the file is supposed to be broken
-     * @callback onProgress
-     * @param {onProgress} fn callback function to be called for progress
-     * @callback onSuccess
-     * @param {onSuccess} fn callback function to be called for success
-     * @callback onError
-     * @param {onError} fn callback function to be called for error
+     * @param {checksumOnProgress} fn callback function to be called for progress
+     * @param {checksumOnSuccess} fn callback function to be called for success
+     * @param {checksumOnError} fn callback function to be called for error
      * @returns {Promise} if the schema exists or not
      * @desc Calculates  MD5 checksum for a file using spark-md5 library
      */

--- a/js/http.js
+++ b/js/http.js
@@ -60,7 +60,6 @@
 
     /**
      * function that is called when a HTTP 401 Error occurs
-     * @callback httpUnauthorizedFn
      * @type {httpUnauthorizedFn}: Should return a promise
      * @private
      */
@@ -68,12 +67,18 @@
 
     /**
      * set callback function which will be called when a HTTP 401 Error occurs
-     * @callback httpUnauthorizedFn
      * @param {httpUnauthorizedFn} fn callback function
      */
     module.setHttpUnauthorizedFn = function(fn) {
         module._httpUnauthorizedFn = fn;
     };
+
+
+    /**
+     * The callback that will be called whenever 401 HTTP error is encountered,
+     * unless there is already login flow in progress.
+     * @callback httpUnauthorizedFn
+     */
 
     /*
      * A flag to determine whether emrest authorization error has occured

--- a/js/parser.js
+++ b/js/parser.js
@@ -799,8 +799,7 @@
         },
 
         /**
-         * String representation of before
-         * @before(..)
+         * String representation of before: @before(..)
          * @type {string}
          */
         get before () {
@@ -808,8 +807,7 @@
         },
 
         /**
-         * String representation of before
-         * @after(..)
+         * String representation of before: @after(..)
          * @type {string}
          */
         get after () {

--- a/js/reference.js
+++ b/js/reference.js
@@ -1,7 +1,6 @@
 
     /**
      * set callback function that converts app tag to app URL
-     * @callback appLinkFn
      * @param {appLinkFn} fn callback function
      */
     module.appLinkFn = function(fn) {
@@ -10,7 +9,6 @@
 
     /**
      * set callback function that triggers when a request returns with success
-     * @callback onHTTPSuccess
      * @param {onHTTPSuccess} fn callback function
      */
     module.onHTTPSuccess = function(fn) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "bower": "x",
-    "closurecompiler": "x",
+    "google-closure-compiler-js": "x",
     "jasmine": "2.5.3",
     "jasmine-spec-reporter": "^2.5.0",
     "jsdoc": "x",


### PR DESCRIPTION
1. Changed package of Closure Compiler to the java independent "google-closure-compiler-js".
2. Fixed the usage of **@callback** in Documentation.
3. Added extra annotation tag "callback" as gccjs doesn't recognize this tag.
4. This java-script version of the closure compiler is slower than the corresponding  java version. ("google-closure-compiler")
5. **Note** for the package "google-closure-compiler-js": This is an experimental release - meaning some features are not available and performance may not be on-par with the Java implementation - [details here](https://github.com/google/closure-compiler-js#transpilation).