### PR TITLE
Empty hatrac files

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -492,8 +492,8 @@ to use for ERMrest JavaScript agents.
         * [new upload(file, {otherInfo})](#new_ERMrest.upload_new)
         * [.validateURL(row)](#ERMrest.upload+validateURL) ⇒ <code>boolean</code>
         * [.calculateChecksum(row)](#ERMrest.upload+calculateChecksum) ⇒ <code>Promise</code>
-        * [.createUploadJob()](#ERMrest.upload+createUploadJob) ⇒ <code>Promise</code>
         * [.fileExists()](#ERMrest.upload+fileExists) ⇒ <code>Promise</code>
+        * [.createUploadJob()](#ERMrest.upload+createUploadJob) ⇒ <code>Promise</code>
         * [.start()](#ERMrest.upload+start) ⇒ <code>Promise</code>
         * [.completeUpload()](#ERMrest.upload+completeUpload) ⇒ <code>Promise</code>
         * [.pause()](#ERMrest.upload+pause)
@@ -4912,8 +4912,8 @@ Calculates  MD5 checksum for a file using spark-md5 library
     * [new upload(file, {otherInfo})](#new_ERMrest.upload_new)
     * [.validateURL(row)](#ERMrest.upload+validateURL) ⇒ <code>boolean</code>
     * [.calculateChecksum(row)](#ERMrest.upload+calculateChecksum) ⇒ <code>Promise</code>
-    * [.createUploadJob()](#ERMrest.upload+createUploadJob) ⇒ <code>Promise</code>
     * [.fileExists()](#ERMrest.upload+fileExists) ⇒ <code>Promise</code>
+    * [.createUploadJob()](#ERMrest.upload+createUploadJob) ⇒ <code>Promise</code>
     * [.start()](#ERMrest.upload+start) ⇒ <code>Promise</code>
     * [.completeUpload()](#ERMrest.upload+completeUpload) ⇒ <code>Promise</code>
     * [.pause()](#ERMrest.upload+pause)
@@ -4928,8 +4928,8 @@ upload Object
 Create a new instance with new upload(file, otherInfo)
 To validate url generation for a file call validateUrl(row) with row of data
 To calculate checksum call calculateChecksum(row) with row of data
-To create an upload call createUploadJob()
 To check for existing file call fileExists()
+To create an upload call createUploadJob()
 To start uploading, call start()
 To complete upload job call completeUploadJob()
 You can pause with pause()
@@ -4968,14 +4968,6 @@ and notified with a progress handler, sending number in bytes done
 | --- | --- | --- |
 | row | <code>object</code> | row object containing keyvalues of entity |
 
-<a name="ERMrest.upload+createUploadJob"></a>
-
-#### upload.createUploadJob() ⇒ <code>Promise</code>
-Call this function to create an upload job for chunked uploading
-
-**Kind**: instance method of [<code>upload</code>](#ERMrest.upload)  
-**Returns**: <code>Promise</code> - A promise resolved with a url where we will upload the file
-or rejected with error if unable to calculate checkum  
 <a name="ERMrest.upload+fileExists"></a>
 
 #### upload.fileExists() ⇒ <code>Promise</code>
@@ -4984,6 +4976,14 @@ If it doesn't then resolve the promise with url.
 If it does then set isPaused, completed and jobDone to true
 
 **Kind**: instance method of [<code>upload</code>](#ERMrest.upload)  
+<a name="ERMrest.upload+createUploadJob"></a>
+
+#### upload.createUploadJob() ⇒ <code>Promise</code>
+Call this function to create an upload job for chunked uploading
+
+**Kind**: instance method of [<code>upload</code>](#ERMrest.upload)  
+**Returns**: <code>Promise</code> - A promise resolved with a url where we will upload the file
+or rejected with error if unable to calculate checkum  
 <a name="ERMrest.upload+start"></a>
 
 #### upload.start() ⇒ <code>Promise</code>

--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -382,8 +382,10 @@ var ERMrest = (function(module) {
             self.jobDone = true;
             deferred.resolve(self.url);
         }, function(response) {
-
-            if (response.status == 404 || response.status == 409) {
+            // 403 - file exists but user can't read it -> create a new one
+            // 404 - file doesn't exist -> create new one
+            // 409 - The parent path does not denote a namespace OR the namespace already exists (from hatrac docs)
+            if (response.status == 403 || response.status == 404 || response.status == 409) {
               deferred.resolve(self.url);
             } else {
               deferred.reject(module._responseToError(response));

--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -350,14 +350,11 @@ var ERMrest = (function(module) {
             headers: _generateContextHeader(contextHeaderParams)
         };
 
-        console.log(this);
         this.http.head(this._getAbsoluteUrl(this.url), config).then(function(response) {
 
             var headers = response.headers();
-            console.log(headers);
             var md5 = headers["content-md5"];
             var length = headers["content-length"];
-            var filename = headers["content-disposition"].replace("filename*=UTF-8''","");
 
             // If the file is not same, then simply resolve the promise without setting completed and jobDone
             if ((md5 != self.hash.md5_base64) || (length != self.file.size)) {


### PR DESCRIPTION
Another change that was discussed. I do not think this change should be made as it causes some further issues down the line that need to be fixed in chaise. Not doing this means that the error would be returned from the file exists check and never create any extra upload jobs (in the case where 2 files are trying to be uploaded but one namespace is 403 and the other doesn't exist yet).

This means cleanup would not need to be done and therefore the version info that chaise holds won't need to be fixed. But maybe that is a bug that should actually be fixed. See PR [#1556](https://github.com/informatics-isi-edu/chaise/pull/1556) in `chaise` for more info.