### PR TITLE
add catalog snapshot, version, and id to mustache and handlebars environments

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -1126,10 +1126,8 @@ ForeignKeyPseudoColumn.prototype.filteredRef = function(data, linkedData) {
     if (this.foreignKey.annotations.contains(module._annotations.FOREIGN_KEY)){
 
         var keyValues = module._getFormattedKeyValues(this._baseReference.table, this._context, data, linkedData);
-        var uriFilter = module._renderTemplate(
-            this.foreignKey.annotations.get(module._annotations.FOREIGN_KEY).content.domain_filter_pattern,
-            keyValues
-        );
+        var template = this.foreignKey.annotations.get(module._annotations.FOREIGN_KEY).content.domain_filter_pattern;
+        var uriFilter = module._renderTemplate(template, keyValues, this._baseReference.table);
 
         // should ignore the annotation if it's invalid
         if (typeof uriFilter === "string" && uriFilter.trim() !== '') {

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -2378,13 +2378,15 @@
     module._addErmrestVarsToTemplate = function(obj, catalog) {
         obj.$moment = module._currDate;
 
-        var catalogSnapshot = catalog.id.split('@');
-        obj.$catalog = {
-            snapshot: catalog.id,
-            id: catalogSnapshot[0]
-        };
+        if (catalog) {
+            var catalogSnapshot = catalog.id.split('@');
+            obj.$catalog = {
+                snapshot: catalog.id,
+                id: catalogSnapshot[0]
+            };
 
-        if (catalogSnapshot.length === 2) obj.$catalog.version = catalogSnapshot[1];
+            if (catalogSnapshot.length === 2) obj.$catalog.version = catalogSnapshot[1];
+        }
     };
 
     /**

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -2375,12 +2375,12 @@
      * Add utility objects such as date (Computed value) to mustache data obj
      * so that they can be accessed in the template
      */
-    module._addErmrestVarsToTemplate = function(obj, table) {
+    module._addErmrestVarsToTemplate = function(obj, catalog) {
         obj.$moment = module._currDate;
 
-        var catalogSnapshot = table.schema.catalog.id.split('@');
+        var catalogSnapshot = catalog.id.split('@');
         obj.$catalog = {
-            snapshot: table.schema.catalog.id,
+            snapshot: catalog.id,
             id: catalogSnapshot[0]
         };
 
@@ -2396,7 +2396,7 @@
      *
      * @return {Object} obj
      */
-    module._addTemplateVars = function(keyValues, table, options) {
+    module._addTemplateVars = function(keyValues, catalog, options) {
 
         var obj = {};
         if (keyValues && isObject(keyValues)) {
@@ -2412,7 +2412,7 @@
         }
 
         // Inject ermrest internal utility objects such as date
-        module._addErmrestVarsToTemplate(obj, table);
+        module._addErmrestVarsToTemplate(obj, catalog);
 
         // Inject other functions provided in the options.functions array if needed
         if (options.functions && options.functions.length) {
@@ -2435,11 +2435,11 @@
      * @return {string} A string produced after templating
      * @desc Returns a string produced as a result of templating using `Mustache`.
      */
-    module._renderMustacheTemplate = function(template, keyValues, table, options) {
+    module._renderMustacheTemplate = function(template, keyValues, catalog, options) {
 
         options = options || {};
 
-        var obj = module._addTemplateVars(keyValues, table, options), content;
+        var obj = module._addTemplateVars(keyValues, catalog, options), content;
 
         // Inject the encode function in the obj object
         obj.encode = module._encodeForMustacheTemplate;
@@ -2448,7 +2448,7 @@
         obj.escape = module._escapeForMustacheTemplate;
 
         // If we should validate, validate the template and if returns false, return null.
-        if (!options.avoidValidation && !module._validateMustacheTemplate(template, obj, table)) {
+        if (!options.avoidValidation && !module._validateMustacheTemplate(template, obj, catalog)) {
             return null;
         }
 
@@ -2474,11 +2474,11 @@
      * @param  {Array.<string>=} ignoredColumns the columns that should be ignored (optional)
      * @return {boolean} true if all the used keys have values
      */
-    module._validateMustacheTemplate = function (template, keyValues, table, ignoredColumns) {
+    module._validateMustacheTemplate = function (template, keyValues, catalog, ignoredColumns) {
 
         // Inject ermrest internal utility objects such as date
         // needs to be done in the case _validateTemplate is called without first calling _renderTemplate
-        module._addErmrestVarsToTemplate(keyValues, table);
+        module._addErmrestVarsToTemplate(keyValues, catalog);
 
         var conditionalRegex = /\{\{(#|\^)([^\{\}]+)\}\}/, i, key, value;
 
@@ -2529,14 +2529,14 @@
      * @return {string} A string produced after templating
      * @desc Returns a string produced as a result of templating using `Handlebars`.
      */
-    module._renderHandlebarsTemplate = function(template, keyValues, table, options) {
+    module._renderHandlebarsTemplate = function(template, keyValues, catalog, options) {
 
         options = options || {};
 
-        var obj = module._addTemplateVars(keyValues, table, options), content, _compiledTemplate;
+        var obj = module._addTemplateVars(keyValues, catalog, options), content, _compiledTemplate;
 
         // If we should validate, validate the template and if returns false, return null.
-        if (!options.avoidValidation && !module._validateHandlebarsTemplate(template, obj, table)) {
+        if (!options.avoidValidation && !module._validateHandlebarsTemplate(template, obj, catalog)) {
             return null;
         }
 
@@ -2580,12 +2580,12 @@
      * @param  {Array.<string>=} ignoredColumns the columns that should be ignored (optional)
      * @return {boolean} true if all the used keys have values
      */
-    module._validateHandlebarsTemplate = function (template, keyValues, table, ignoredColumns) {
+    module._validateHandlebarsTemplate = function (template, keyValues, catalog, ignoredColumns) {
         var conditionalRegex = /\{\{(((#|\^)([^\{\}]+))|(if|unless|else))([^\{\}]+)\}\}/, i, key, value;
 
         // Inject ermrest internal utility objects such as date
         // needs to be done in the case _validateTemplate is called without first calling _renderTemplate
-        module._addErmrestVarsToTemplate(keyValues, table);
+        module._addErmrestVarsToTemplate(keyValues, catalog);
 
         // If no conditional handlebars statements of the form {{#if VARNAME}}{{/if}} or {{^if VARNAME}}{{/if}} or {{#unless VARNAME}}{{/unless}} or {{^unless VARNAME}}{{/unless}} not found then do direct null check
         if (!conditionalRegex.exec(template)) {
@@ -2688,11 +2688,11 @@
 
         if (options.templateEngine === module.HANDLEBARS) {
             // render the template using Handlebars
-            return module._renderHandlebarsTemplate(template, keyValues, table, options);
+            return module._renderHandlebarsTemplate(template, keyValues, table.schema.catalog, options);
         }
 
         // render the template using Mustache
-        return module._renderMustacheTemplate(template, keyValues, table, options);
+        return module._renderMustacheTemplate(template, keyValues, table.schema.catalog, options);
     };
 
     /**
@@ -2729,11 +2729,11 @@
 
         if (options.templateEngine === module.HANDLEBARS) {
             // call the actual Handlebar validator
-            return module._validateHandlebarsTemplate(template, data, table, ignoredColumns);
+            return module._validateHandlebarsTemplate(template, data, table.schema.catalog, ignoredColumns);
         }
 
         // call the actual mustache validator
-        return module._validateMustacheTemplate(template, data, table, ignoredColumns);
+        return module._validateMustacheTemplate(template, data, table.schema.catalog, ignoredColumns);
     };
 
     // module._constraintNames[catalogId][schemaName][constraintName] will return an object.

--- a/test/specs/annotation/conf/table_display/data/table_w_rowname_catalog_snapshot.json
+++ b/test/specs/annotation/conf/table_display/data/table_w_rowname_catalog_snapshot.json
@@ -1,0 +1,1 @@
+[{"id": 1,"text_col": "value"}]

--- a/test/specs/annotation/conf/table_display/schema.json
+++ b/test/specs/annotation/conf/table_display/schema.json
@@ -585,11 +585,42 @@
             }
         ],
         "annotations": {
-          "tag:isrd.isi.edu,2016:table-display": {
-            "row_name": {
-              "row_markdown_pattern": "{{ $fkeys.schema_table_display.table_w_rowname_fkeys3_fk1.values.col_ w_ dot_ }}: {{$fkeys.schema_table_display.table_w_rowname_fkeys3_fk1.values._col_ w_ dot_}}"
+            "tag:isrd.isi.edu,2016:table-display": {
+                "row_name": {
+                    "row_markdown_pattern": "{{ $fkeys.schema_table_display.table_w_rowname_fkeys3_fk1.values.col_ w_ dot_ }}: {{$fkeys.schema_table_display.table_w_rowname_fkeys3_fk1.values._col_ w_ dot_}}"
+                }
             }
-          }
+        }
+    },
+    "table_w_rowname_catalog_snapshot": {
+        "table_name": "table_w_rowname_catalog_snapshot",
+        "schema_name": "schema_table_display",
+        "kind": "table",
+        "keys": [
+            {"unique_columns": ["id"]}
+        ],
+        "foreign_keys": [],
+        "column_definitions": [
+            {
+                "name": "id",
+                "nullok": false,
+                "type": {
+                    "typename": "integer"
+                }
+            },
+            {
+                "name": "text_col",
+                "type": {
+                    "typename": "text"
+                }
+            }
+        ],
+        "annotations": {
+            "tag:isrd.isi.edu,2016:table-display": {
+                "row_name": {
+                    "row_markdown_pattern": "catalog_snapshot:{{$catalog.snapshot}}, catalog_id:{{$catalog.id}}"
+                }
+            }
         }
     }
   },

--- a/test/specs/annotation/conf/table_display/schema.json
+++ b/test/specs/annotation/conf/table_display/schema.json
@@ -430,7 +430,7 @@
       "annotations" : {
         "tag:isrd.isi.edu,2016:table-display": {
           "*" : {
-            "row_markdown_pattern": ":::iframe [{{title}}{{#$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}(with {{{rowName}}}){{/$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}](https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id={{_id}}) \n:::",
+            "row_markdown_pattern": ":::iframe [{{title}}{{#$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}(with {{{rowName}}} from catalog {{{$catalog.snapshot}}}){{/$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}](https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id={{_id}}) \n:::",
             "prefix_markdown": "## Movie titles \n\n",
             "page_size": 10
           }

--- a/test/specs/annotation/tests/03.table_display.js
+++ b/test/specs/annotation/tests/03.table_display.js
@@ -16,7 +16,8 @@ exports.execute = function (options) {
             tableName9 = "table_w_rowname_fkeys2",
             tableName10 = "table_w_rowname_fkeys3",
             tableName11 = "table_w_table_display_annotation_w_title",
-            tableNameWoAnnot = "table_wo_annotation";
+            tableNameWoAnnot = "table_wo_annotation",
+            tableNameCatalogAnnot = "table_w_rowname_catalog_snapshot";
 
         var table1EntityUri = options.url + "/catalog/" + catalog_id + "/entity/" +
             schemaName + ":" + tableName1 + "/@sort(id)";
@@ -57,6 +58,9 @@ exports.execute = function (options) {
 
         var tableWoAnnotEntityUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":" +
             tableNameWoAnnot;
+
+        var tableCatalogAnnotEntityUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":" +
+            tableNameCatalogAnnot;
 
         var findRID = function (tableName, id) {
             return options.entities[schemaName][tableName].filter(function (e) {
@@ -247,8 +251,7 @@ exports.execute = function (options) {
             });
         });
 
-
-         describe('table entities without name/title nor table-display:row_name context annotation with composite key, ', function() {
+        describe('table entities without name/title nor table-display:row_name context annotation with composite key, ', function() {
             var reference, page, tuple;
             var limit = 10;
 
@@ -619,6 +622,22 @@ exports.execute = function (options) {
                     page.tuples.forEach(function (t, index) {
                         expect(t.displayname.value).toEqual(expected[index], "index= " + index + ". displayname missmatch.");
                     });
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+            });
+        });
+
+        describe("table entities with $catalog in their row_markdown_pattern.", function () {
+            it ('should be able to access row-name and detailed uri of outbound foreign keys in annotation.', function (done) {
+                options.ermRest.resolve(tableCatalogAnnotEntityUri, {cid: "test"}).then(function (ref) {
+                    return ref.read(1);
+                }).then(function (page) {
+                    var expected = "catalog_snapshot:" + catalog_id + ", catalog_id:" + catalog_id;
+
+                    expect(page.tuples[0].displayname.value).toEqual(expected, "catalog snapshot displayname missmatch.");
                     done();
                 }).catch(function (err) {
                     console.log(err);

--- a/test/specs/annotation/tests/03.table_display.js
+++ b/test/specs/annotation/tests/03.table_display.js
@@ -631,13 +631,13 @@ exports.execute = function (options) {
         });
 
         describe("table entities with $catalog in their row_markdown_pattern.", function () {
-            it ('should be able to access row-name and detailed uri of outbound foreign keys in annotation.', function (done) {
+            it ('should be able to access row-name in annotation.', function (done) {
                 options.ermRest.resolve(tableCatalogAnnotEntityUri, {cid: "test"}).then(function (ref) {
                     return ref.read(1);
                 }).then(function (page) {
                     var expected = "catalog_snapshot:" + catalog_id + ", catalog_id:" + catalog_id;
 
-                    expect(page.tuples[0].displayname.value).toEqual(expected, "catalog snapshot displayname missmatch.");
+                    expect(page.tuples[0].displayname.value).toEqual(expected, "catalog snapshot displayname mismatch.");
                     done();
                 }).catch(function (err) {
                     console.log(err);

--- a/test/specs/annotation/tests/03.table_display.js
+++ b/test/specs/annotation/tests/03.table_display.js
@@ -483,7 +483,7 @@ exports.execute = function (options) {
                 expect(display.type).toEqual('markdown');
             });
 
-            var markdownPattern = ":::iframe [{{title}}{{#$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}(with {{{rowName}}}){{/$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}](https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id={{_id}}) \n:::";
+            var markdownPattern = ":::iframe [{{title}}{{#$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}(with {{{rowName}}} from catalog {{{$catalog.snapshot}}}){{/$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}](https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id={{_id}}) \n:::";
             it("reference.display._markdownPattern should be '" + markdownPattern + "' ", function() {
                 expect(reference.display._markdownPattern).toEqual(markdownPattern);
             });
@@ -518,10 +518,10 @@ exports.execute = function (options) {
             });
 
             var content = '<h2>Movie titles</h2>\n' +
-            '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Hamlet(with <strong>William Shakespeare</strong>)</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20001" ></iframe></figure>' +
-            '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">The Adventures of Huckleberry Finn(with <strong>Mark Twain</strong>)</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20002" ></iframe></figure>' +
-            '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Alice in Wonderland(with <strong>Lewis Carroll</strong>)</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20003" ></iframe></figure>' +
-            '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Pride and Prejudice(with <strong>Jane Austen</strong>)</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20004" ></iframe></figure>' +
+            '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Hamlet(with <strong>William Shakespeare</strong> from catalog '+catalog_id+')</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20001" ></iframe></figure>' +
+            '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">The Adventures of Huckleberry Finn(with <strong>Mark Twain</strong> from catalog '+catalog_id+')</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20002" ></iframe></figure>' +
+            '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Alice in Wonderland(with <strong>Lewis Carroll</strong> from catalog '+catalog_id+')</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20003" ></iframe></figure>' +
+            '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Pride and Prejudice(with <strong>Jane Austen</strong> from catalog '+catalog_id+')</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20004" ></iframe></figure>' +
             '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Great Expectations</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20005" ></iframe></figure>' +
             '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">David Copperfield</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20006" ></iframe></figure>' +
             '<figure class="embed-block" style=""><figcaption class="embed-caption" style="">Emma</figcaption><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20007" ></iframe></figure>' +

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -2,7 +2,6 @@ exports.execute = function (options) {
     var module = options.includes.ermRest;
     var formatUtils = module._formatUtils;
     describe("Print utils, For pretty printing values based on a value's type, ", function () {
-        var catalog = {id: process.env.DEFAULT_CATALOG};
         // Test Cases:
         it('printFloat() should format floats correctly.', function () {
             var printFloat = formatUtils.printFloat;
@@ -246,46 +245,50 @@ exports.execute = function (options) {
         });
 
         it('module._renderMustacheTemplate() should function correctly for Null and Non-null values', function() {
-            expect(module._renderMustacheTemplate("My name is {{name}}", {name: 'John'}, catalog)).toBe("My name is John");
-            expect(module._renderMustacheTemplate("My name is {{name}}", { name: null }, catalog)).toBe(null);
-            expect(module._renderMustacheTemplate("My name is {{name}}", {}, catalog)).toBe(null);
-            expect(module._renderMustacheTemplate("My name is {{#name}}{{name}}{{/name}}", {}, catalog)).toBe("My name is ");
-            expect(module._renderMustacheTemplate("My name is {{^name}}{{name}}{{/name}}", {}, catalog)).toBe("My name is ");
-            expect(module._renderMustacheTemplate("My name is {{^name}}John{{/name}}", {}, catalog)).toBe("My name is John");
+            expect(module._renderMustacheTemplate("My name is {{name}}", {name: 'John'})).toBe("My name is John");
+            expect(module._renderMustacheTemplate("My name is {{name}}", { name: null })).toBe(null);
+            expect(module._renderMustacheTemplate("My name is {{name}}", {})).toBe(null);
+            expect(module._renderMustacheTemplate("My name is {{#name}}{{name}}{{/name}}", {})).toBe("My name is ");
+            expect(module._renderMustacheTemplate("My name is {{^name}}{{name}}{{/name}}", {})).toBe("My name is ");
+            expect(module._renderMustacheTemplate("My name is {{^name}}John{{/name}}", {})).toBe("My name is John");
         });
 
         it('module._renderMustacheTemplate() should inject $moment obj', function() {
             var moment = module._currDate;
             expect(moment).toBeDefined();
-            expect(module._renderMustacheTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' }, catalog)).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
-            expect(module._renderMustacheTemplate("Todays date is {{$moment.dateString}}", {}, catalog)).toBe("Todays date is " + moment.dateString);
+            expect(module._renderMustacheTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' })).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
+            expect(module._renderMustacheTemplate("Todays date is {{$moment.dateString}}", {})).toBe("Todays date is " + moment.dateString);
 
-            expect(module._renderMustacheTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {}, catalog)).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
-            expect(module._renderMustacheTemplate("Current time is {{$moment.timeString}}", {}, catalog)).toBe("Current time is " + moment.timeString);
+            expect(module._renderMustacheTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {})).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
+            expect(module._renderMustacheTemplate("Current time is {{$moment.timeString}}", {})).toBe("Current time is " + moment.timeString);
 
-            expect(module._renderMustacheTemplate("ISO string is {{$moment.ISOString}}", {}, catalog)).toBe("ISO string is " + moment.ISOString);
-            expect(module._renderMustacheTemplate("GMT string is {{$moment.GMTString}}", {}, catalog)).toBe("GMT string is " + moment.GMTString);
-            expect(module._renderMustacheTemplate("UTC string is {{$moment.UTCString}}", {}, catalog)).toBe("UTC string is " + moment.UTCString);
+            expect(module._renderMustacheTemplate("ISO string is {{$moment.ISOString}}", {})).toBe("ISO string is " + moment.ISOString);
+            expect(module._renderMustacheTemplate("GMT string is {{$moment.GMTString}}", {})).toBe("GMT string is " + moment.GMTString);
+            expect(module._renderMustacheTemplate("UTC string is {{$moment.UTCString}}", {})).toBe("UTC string is " + moment.UTCString);
 
-            expect(module._renderMustacheTemplate("Local time string is {{$moment.localeTimeString}}", {}, catalog)).toBe("Local time string is " + moment.localeTimeString);
+            expect(module._renderMustacheTemplate("Local time string is {{$moment.localeTimeString}}", {})).toBe("Local time string is " + moment.localeTimeString);
         });
 
         it('module._valdiateMustacheTemplate() should accept templates that have $moment in them.', function () {
-            expect(module._validateMustacheTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' }, catalog)).toBe(true);
-            expect(module._validateMustacheTemplate("Todays date is {{$moment.dateString}}", {}, catalog)).toBe(true);
+            expect(module._validateMustacheTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' })).toBe(true);
+            expect(module._validateMustacheTemplate("Todays date is {{$moment.dateString}}", {})).toBe(true);
 
-            expect(module._validateMustacheTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {}, catalog)).toBe(true);
-            expect(module._validateMustacheTemplate("Current time is {{$moment.timeString}}", {}, catalog)).toBe(true);
+            expect(module._validateMustacheTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {})).toBe(true);
+            expect(module._validateMustacheTemplate("Current time is {{$moment.timeString}}", {})).toBe(true);
 
-            expect(module._validateMustacheTemplate("ISO string is {{$moment.ISOString}}", {}, catalog)).toBe(true);
-            expect(module._validateMustacheTemplate("GMT string is {{$moment.GMTString}}", {}, catalog)).toBe(true);
-            expect(module._validateMustacheTemplate("UTC string is {{$moment.UTCString}}", {}, catalog)).toBe(true);
+            expect(module._validateMustacheTemplate("ISO string is {{$moment.ISOString}}", {})).toBe(true);
+            expect(module._validateMustacheTemplate("GMT string is {{$moment.GMTString}}", {})).toBe(true);
+            expect(module._validateMustacheTemplate("UTC string is {{$moment.UTCString}}", {})).toBe(true);
 
-            expect(module._validateMustacheTemplate("Local time string is {{$moment.localeTimeString}}", {}, catalog)).toBe(true);
+            expect(module._validateMustacheTemplate("Local time string is {{$moment.localeTimeString}}", {})).toBe(true);
         });
 
         it('module._renderMustacheTemplate() should inject $catalog obj', function() {
-            expect(module._renderMustacheTemplate("catalog snapshot: {{$catalog.snapshot}}, catalog id: {{$catalog.id}}", {}, catalog)).toBe("catalog snapshot: " + process.env.DEFAULT_CATALOG + ", catalog id: " + process.env.DEFAULT_CATALOG);
+            expect(module._renderMustacheTemplate("catalog snapshot: {{$catalog.snapshot}}, catalog id: {{$catalog.id}}", {}, options.catalog)).toBe("catalog snapshot: " + process.env.DEFAULT_CATALOG + ", catalog id: " + process.env.DEFAULT_CATALOG);
+        });
+
+        it("module._renderMustacheTemplate() should NOT inject $catalog obj if 'catalog' is not passed to the function", function() {
+            expect(module._renderMustacheTemplate("catalog snapshot:{{# $catalog.snapshot}} {{$catalog.snapshot}}{{/$catalog.snapshot}}", {})).toBe("catalog snapshot:");
         });
 
         var obj = {
@@ -362,7 +365,7 @@ exports.execute = function (options) {
             var printMarkdown = formatUtils.printMarkdown;
 
             templateCases.forEach(function(ex) {
-                var template = module._renderMustacheTemplate(ex.template, obj, catalog);
+                var template = module._renderMustacheTemplate(ex.template, obj);
                 expect(template).toBe(ex.after_mustache);
                 var html = printMarkdown(template);
                 expect(html).toBe(ex.after_render + '\n');
@@ -371,69 +374,69 @@ exports.execute = function (options) {
 
         describe('module._renderHandlebarsTemplate() should function correctly for', function () {
             it('Null and Non-null values', function() {
-                expect(module._renderHandlebarsTemplate("My name is {{name}}", { name: 'Chloe' }, catalog)).toBe("My name is Chloe");
-                expect(module._renderHandlebarsTemplate("My name is {{name}}", { name: null }, catalog)).toBe(null);
-                expect(module._renderHandlebarsTemplate("My name is {{name}}", {}, catalog)).toBe(null);
-                expect(module._renderHandlebarsTemplate("My name is {{#if name}}{{name}}{{/if}}", {}, catalog)).toBe("My name is ");
-                expect(module._renderHandlebarsTemplate("My name is {{^if name}}{{name}}{{/if}}", {}, catalog)).toBe("My name is ", "For inverted if with variable");
-                expect(module._renderHandlebarsTemplate("My name is {{^if name}}John{{/if}}", {}, catalog)).toBe("My name is John", "For inverted if with string");
-                expect(module._renderHandlebarsTemplate("My name is {{#unless name}}Jona{{/unless}}", {}, catalog)).toBe("My name is Jona", "For unless");
+                expect(module._renderHandlebarsTemplate("My name is {{name}}", { name: 'Chloe' })).toBe("My name is Chloe");
+                expect(module._renderHandlebarsTemplate("My name is {{name}}", { name: null })).toBe(null);
+                expect(module._renderHandlebarsTemplate("My name is {{name}}", {})).toBe(null);
+                expect(module._renderHandlebarsTemplate("My name is {{#if name}}{{name}}{{/if}}", {})).toBe("My name is ");
+                expect(module._renderHandlebarsTemplate("My name is {{^if name}}{{name}}{{/if}}", {})).toBe("My name is ", "For inverted if with variable");
+                expect(module._renderHandlebarsTemplate("My name is {{^if name}}John{{/if}}", {})).toBe("My name is John", "For inverted if with string");
+                expect(module._renderHandlebarsTemplate("My name is {{#unless name}}Jona{{/unless}}", {})).toBe("My name is Jona", "For unless");
             });
 
             it('ifCond helper', function() {
-                expect(module._renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'Chloe' }, catalog)).toBe("Name Chloe is equal to Chloe");
-                expect(module._renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'John' }, catalog)).toBe("Name John is not equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
             });
 
             it('each helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#each values}}{{this}}\n{{/each}}", { values: [2, 3, 7, 9] }, catalog)).toBe("2\n3\n7\n9\n");
+                expect(module._renderHandlebarsTemplate("{{#each values}}{{this}}\n{{/each}}", { values: [2, 3, 7, 9] })).toBe("2\n3\n7\n9\n");
             });
 
             it('if eq (equals) helper', function () {
-                expect(module._renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'Chloe' }, catalog)).toBe("Name Chloe is equal to Chloe");
-                expect(module._renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'John' }, catalog)).toBe("Name John is not equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
             });
 
             it('if ne (not equals) helper', function () {
-                expect(module._renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'John' }, catalog)).toBe("Name John is not equal to Chloe");
-                expect(module._renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'Chloe' }, catalog)).toBe("Name Chloe is equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
             });
 
             it('if lt (less than) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 3 }, catalog)).toBe("3 is less than 10");
-                expect(module._renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 17 }, catalog)).toBe("17 is not less than 10");
+                expect(module._renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 3 })).toBe("3 is less than 10");
+                expect(module._renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 17 })).toBe("17 is not less than 10");
             });
 
             it('if gt (greater than) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 17 }, catalog)).toBe("17 is greater than 10");
-                expect(module._renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 3 }, catalog)).toBe("3 is not greater than 10");
+                expect(module._renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 17 })).toBe("17 is greater than 10");
+                expect(module._renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 3 })).toBe("3 is not greater than 10");
             });
 
             it('if lte (less than or equal to) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 3 }, catalog)).toBe("3 is less than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 10 }, catalog)).toBe("10 is less than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 17 }, catalog)).toBe("17 is not less than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 3 })).toBe("3 is less than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 10 })).toBe("10 is less than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 17 })).toBe("17 is not less than or equal to 10");
             });
 
             it('if gte (greater than or equal to) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 17 }, catalog)).toBe("17 is greater than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 10 }, catalog)).toBe("10 is greater than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 3 }, catalog)).toBe("3 is not greater than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 17 })).toBe("17 is greater than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 10 })).toBe("10 is greater than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 3 })).toBe("3 is not greater than or equal to 10");
             });
 
             it('if and (conjunction) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: true }, catalog)).toBe("both booleans are true");
-                expect(module._renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: false }, catalog)).toBe("one or more booleans are false");
+                expect(module._renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: true })).toBe("both booleans are true");
+                expect(module._renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: false })).toBe("one or more booleans are false");
             });
 
             it('if or (disjunction) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: true }, catalog)).toBe("one or more booleans are true");
-                expect(module._renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: false }, catalog)).toBe("both booleans are false");
+                expect(module._renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: true })).toBe("one or more booleans are true");
+                expect(module._renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: false })).toBe("both booleans are false");
             });
 
             it('suppressed default helper log', function () {
                 try {
-                    module._renderHandlebarsTemplate("{{log 'Hello World'}}", {}, catalog);
+                    module._renderHandlebarsTemplate("{{log 'Hello World'}}", {});
                 } catch (err) {
                     expect(err.message).toBe("You specified knownHelpersOnly, but used the unknown helper log - 1:0");
                 }
@@ -442,21 +445,25 @@ exports.execute = function (options) {
             it('injecting $moment obj', function() {
                 var moment = module._currDate;
                 expect(moment).toBeDefined();
-                expect(module._renderHandlebarsTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' }, catalog)).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
-                expect(module._renderHandlebarsTemplate("Todays date is {{$moment.dateString}}", {}, catalog)).toBe("Todays date is " + moment.dateString);
+                expect(module._renderHandlebarsTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' })).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
+                expect(module._renderHandlebarsTemplate("Todays date is {{$moment.dateString}}", {})).toBe("Todays date is " + moment.dateString);
 
-                expect(module._renderHandlebarsTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {}, catalog)).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
-                expect(module._renderHandlebarsTemplate("Current time is {{$moment.timeString}}", {}, catalog)).toBe("Current time is " + moment.timeString);
+                expect(module._renderHandlebarsTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {})).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
+                expect(module._renderHandlebarsTemplate("Current time is {{$moment.timeString}}", {})).toBe("Current time is " + moment.timeString);
 
-                expect(module._renderHandlebarsTemplate("ISO string is {{$moment.ISOString}}", {}, catalog)).toBe("ISO string is " + moment.ISOString);
-                expect(module._renderHandlebarsTemplate("GMT string is {{$moment.GMTString}}", {}, catalog)).toBe("GMT string is " + moment.GMTString);
-                expect(module._renderHandlebarsTemplate("UTC string is {{$moment.UTCString}}", {}, catalog)).toBe("UTC string is " + moment.UTCString);
+                expect(module._renderHandlebarsTemplate("ISO string is {{$moment.ISOString}}", {})).toBe("ISO string is " + moment.ISOString);
+                expect(module._renderHandlebarsTemplate("GMT string is {{$moment.GMTString}}", {})).toBe("GMT string is " + moment.GMTString);
+                expect(module._renderHandlebarsTemplate("UTC string is {{$moment.UTCString}}", {})).toBe("UTC string is " + moment.UTCString);
 
-                expect(module._renderHandlebarsTemplate("Local time string is {{$moment.localeTimeString}}", {}, catalog)).toBe("Local time string is " + moment.localeTimeString);
+                expect(module._renderHandlebarsTemplate("Local time string is {{$moment.localeTimeString}}", {})).toBe("Local time string is " + moment.localeTimeString);
             });
 
             it('injecting $catalog obj', function() {
-                expect(module._renderHandlebarsTemplate("catalog snapshot: {{$catalog.snapshot}}, catalog id: {{$catalog.id}}", {}, catalog)).toBe("catalog snapshot: " + process.env.DEFAULT_CATALOG + ", catalog id: " + process.env.DEFAULT_CATALOG);
+                expect(module._renderHandlebarsTemplate("catalog snapshot: {{$catalog.snapshot}}, catalog id: {{$catalog.id}}", {}, options.catalog)).toBe("catalog snapshot: " + process.env.DEFAULT_CATALOG + ", catalog id: " + process.env.DEFAULT_CATALOG);
+            });
+
+            it("NOT injecting $catalog obj", function() {
+                expect(module._renderHandlebarsTemplate("catalog snapshot:{{#if $catalog.snapshot}} {{$catalog.snapshot}}{{/if}}", {})).toBe("catalog snapshot:");
             });
 
             var handlebarTemplateCases = [{
@@ -547,7 +554,7 @@ exports.execute = function (options) {
                 var printMarkdown = formatUtils.printMarkdown;
 
                 handlebarTemplateCases.forEach(function(ex) {
-                    var template = module._renderHandlebarsTemplate(ex.template, obj, catalog);
+                    var template = module._renderHandlebarsTemplate(ex.template, obj);
                     expect(template).toBe(ex.after_mustache, "For template => " + ex.template);
                     var html = printMarkdown(template);
                     expect(html).toBe(ex.after_render + '\n', "For template => " + ex.template);

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -2,6 +2,7 @@ exports.execute = function (options) {
     var module = options.includes.ermRest;
     var formatUtils = module._formatUtils;
     describe("Print utils, For pretty printing values based on a value's type, ", function () {
+        var catalog = {id: process.env.DEFAULT_CATALOG};
         // Test Cases:
         it('printFloat() should format floats correctly.', function () {
             var printFloat = formatUtils.printFloat;
@@ -245,42 +246,46 @@ exports.execute = function (options) {
         });
 
         it('module._renderMustacheTemplate() should function correctly for Null and Non-null values', function() {
-            expect(module._renderMustacheTemplate("My name is {{name}}", {name: 'John'})).toBe("My name is John");
-            expect(module._renderMustacheTemplate("My name is {{name}}", { name: null })).toBe(null);
-            expect(module._renderMustacheTemplate("My name is {{name}}", {})).toBe(null);
-            expect(module._renderMustacheTemplate("My name is {{#name}}{{name}}{{/name}}", {})).toBe("My name is ");
-            expect(module._renderMustacheTemplate("My name is {{^name}}{{name}}{{/name}}", {})).toBe("My name is ");
-            expect(module._renderMustacheTemplate("My name is {{^name}}John{{/name}}", {})).toBe("My name is John");
+            expect(module._renderMustacheTemplate("My name is {{name}}", {name: 'John'}, catalog)).toBe("My name is John");
+            expect(module._renderMustacheTemplate("My name is {{name}}", { name: null }, catalog)).toBe(null);
+            expect(module._renderMustacheTemplate("My name is {{name}}", {}, catalog)).toBe(null);
+            expect(module._renderMustacheTemplate("My name is {{#name}}{{name}}{{/name}}", {}, catalog)).toBe("My name is ");
+            expect(module._renderMustacheTemplate("My name is {{^name}}{{name}}{{/name}}", {}, catalog)).toBe("My name is ");
+            expect(module._renderMustacheTemplate("My name is {{^name}}John{{/name}}", {}, catalog)).toBe("My name is John");
         });
 
         it('module._renderMustacheTemplate() should inject $moment obj', function() {
             var moment = module._currDate;
             expect(moment).toBeDefined();
-            expect(module._renderMustacheTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' })).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
-            expect(module._renderMustacheTemplate("Todays date is {{$moment.dateString}}", {})).toBe("Todays date is " + moment.dateString);
+            expect(module._renderMustacheTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' }, catalog)).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
+            expect(module._renderMustacheTemplate("Todays date is {{$moment.dateString}}", {}, catalog)).toBe("Todays date is " + moment.dateString);
 
-            expect(module._renderMustacheTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {})).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
-            expect(module._renderMustacheTemplate("Current time is {{$moment.timeString}}", {})).toBe("Current time is " + moment.timeString);
+            expect(module._renderMustacheTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {}, catalog)).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
+            expect(module._renderMustacheTemplate("Current time is {{$moment.timeString}}", {}, catalog)).toBe("Current time is " + moment.timeString);
 
-            expect(module._renderMustacheTemplate("ISO string is {{$moment.ISOString}}", {})).toBe("ISO string is " + moment.ISOString);
-            expect(module._renderMustacheTemplate("GMT string is {{$moment.GMTString}}", {})).toBe("GMT string is " + moment.GMTString);
-            expect(module._renderMustacheTemplate("UTC string is {{$moment.UTCString}}", {})).toBe("UTC string is " + moment.UTCString);
+            expect(module._renderMustacheTemplate("ISO string is {{$moment.ISOString}}", {}, catalog)).toBe("ISO string is " + moment.ISOString);
+            expect(module._renderMustacheTemplate("GMT string is {{$moment.GMTString}}", {}, catalog)).toBe("GMT string is " + moment.GMTString);
+            expect(module._renderMustacheTemplate("UTC string is {{$moment.UTCString}}", {}, catalog)).toBe("UTC string is " + moment.UTCString);
 
-            expect(module._renderMustacheTemplate("Local time string is {{$moment.localeTimeString}}", {})).toBe("Local time string is " + moment.localeTimeString);
+            expect(module._renderMustacheTemplate("Local time string is {{$moment.localeTimeString}}", {}, catalog)).toBe("Local time string is " + moment.localeTimeString);
         });
 
         it('module._valdiateMustacheTemplate() should accept templates that have $moment in them.', function () {
-            expect(module._validateMustacheTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' })).toBe(true);
-            expect(module._validateMustacheTemplate("Todays date is {{$moment.dateString}}", {})).toBe(true);
+            expect(module._validateMustacheTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' }, catalog)).toBe(true);
+            expect(module._validateMustacheTemplate("Todays date is {{$moment.dateString}}", {}, catalog)).toBe(true);
 
-            expect(module._validateMustacheTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {})).toBe(true);
-            expect(module._validateMustacheTemplate("Current time is {{$moment.timeString}}", {})).toBe(true);
+            expect(module._validateMustacheTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {}, catalog)).toBe(true);
+            expect(module._validateMustacheTemplate("Current time is {{$moment.timeString}}", {}, catalog)).toBe(true);
 
-            expect(module._validateMustacheTemplate("ISO string is {{$moment.ISOString}}", {})).toBe(true);
-            expect(module._validateMustacheTemplate("GMT string is {{$moment.GMTString}}", {})).toBe(true);
-            expect(module._validateMustacheTemplate("UTC string is {{$moment.UTCString}}", {})).toBe(true);
+            expect(module._validateMustacheTemplate("ISO string is {{$moment.ISOString}}", {}, catalog)).toBe(true);
+            expect(module._validateMustacheTemplate("GMT string is {{$moment.GMTString}}", {}, catalog)).toBe(true);
+            expect(module._validateMustacheTemplate("UTC string is {{$moment.UTCString}}", {}, catalog)).toBe(true);
 
-            expect(module._validateMustacheTemplate("Local time string is {{$moment.localeTimeString}}", {})).toBe(true);
+            expect(module._validateMustacheTemplate("Local time string is {{$moment.localeTimeString}}", {}, catalog)).toBe(true);
+        });
+
+        it('module._renderMustacheTemplate() should inject $catalog obj', function() {
+            expect(module._renderMustacheTemplate("catalog snapshot: {{$catalog.snapshot}}, catalog id: {{$catalog.id}}", {}, catalog)).toBe("catalog snapshot: " + process.env.DEFAULT_CATALOG + ", catalog id: " + process.env.DEFAULT_CATALOG);
         });
 
         var obj = {
@@ -357,7 +362,7 @@ exports.execute = function (options) {
             var printMarkdown = formatUtils.printMarkdown;
 
             templateCases.forEach(function(ex) {
-                var template = module._renderMustacheTemplate(ex.template, obj);
+                var template = module._renderMustacheTemplate(ex.template, obj, catalog);
                 expect(template).toBe(ex.after_mustache);
                 var html = printMarkdown(template);
                 expect(html).toBe(ex.after_render + '\n');
@@ -366,69 +371,69 @@ exports.execute = function (options) {
 
         describe('module._renderHandlebarsTemplate() should function correctly for', function () {
             it('Null and Non-null values', function() {
-                expect(module._renderHandlebarsTemplate("My name is {{name}}", { name: 'Chloe' })).toBe("My name is Chloe");
-                expect(module._renderHandlebarsTemplate("My name is {{name}}", { name: null })).toBe(null);
-                expect(module._renderHandlebarsTemplate("My name is {{name}}", {})).toBe(null);
-                expect(module._renderHandlebarsTemplate("My name is {{#if name}}{{name}}{{/if}}", {})).toBe("My name is ");
-                expect(module._renderHandlebarsTemplate("My name is {{^if name}}{{name}}{{/if}}", {})).toBe("My name is ", "For inverted if with variable");
-                expect(module._renderHandlebarsTemplate("My name is {{^if name}}John{{/if}}", {})).toBe("My name is John", "For inverted if with string");
-                expect(module._renderHandlebarsTemplate("My name is {{#unless name}}Jona{{/unless}}", {})).toBe("My name is Jona", "For unless");
+                expect(module._renderHandlebarsTemplate("My name is {{name}}", { name: 'Chloe' }, catalog)).toBe("My name is Chloe");
+                expect(module._renderHandlebarsTemplate("My name is {{name}}", { name: null }, catalog)).toBe(null);
+                expect(module._renderHandlebarsTemplate("My name is {{name}}", {}, catalog)).toBe(null);
+                expect(module._renderHandlebarsTemplate("My name is {{#if name}}{{name}}{{/if}}", {}, catalog)).toBe("My name is ");
+                expect(module._renderHandlebarsTemplate("My name is {{^if name}}{{name}}{{/if}}", {}, catalog)).toBe("My name is ", "For inverted if with variable");
+                expect(module._renderHandlebarsTemplate("My name is {{^if name}}John{{/if}}", {}, catalog)).toBe("My name is John", "For inverted if with string");
+                expect(module._renderHandlebarsTemplate("My name is {{#unless name}}Jona{{/unless}}", {}, catalog)).toBe("My name is Jona", "For unless");
             });
 
             it('ifCond helper', function() {
-                expect(module._renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
-                expect(module._renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'Chloe' }, catalog)).toBe("Name Chloe is equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'John' }, catalog)).toBe("Name John is not equal to Chloe");
             });
 
             it('each helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#each values}}{{this}}\n{{/each}}", { values: [2, 3, 7, 9] })).toBe("2\n3\n7\n9\n");
+                expect(module._renderHandlebarsTemplate("{{#each values}}{{this}}\n{{/each}}", { values: [2, 3, 7, 9] }, catalog)).toBe("2\n3\n7\n9\n");
             });
 
             it('if eq (equals) helper', function () {
-                expect(module._renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
-                expect(module._renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'Chloe' }, catalog)).toBe("Name Chloe is equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'John' }, catalog)).toBe("Name John is not equal to Chloe");
             });
 
             it('if ne (not equals) helper', function () {
-                expect(module._renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
-                expect(module._renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'John' }, catalog)).toBe("Name John is not equal to Chloe");
+                expect(module._renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'Chloe' }, catalog)).toBe("Name Chloe is equal to Chloe");
             });
 
             it('if lt (less than) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 3 })).toBe("3 is less than 10");
-                expect(module._renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 17 })).toBe("17 is not less than 10");
+                expect(module._renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 3 }, catalog)).toBe("3 is less than 10");
+                expect(module._renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 17 }, catalog)).toBe("17 is not less than 10");
             });
 
             it('if gt (greater than) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 17 })).toBe("17 is greater than 10");
-                expect(module._renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 3 })).toBe("3 is not greater than 10");
+                expect(module._renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 17 }, catalog)).toBe("17 is greater than 10");
+                expect(module._renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 3 }, catalog)).toBe("3 is not greater than 10");
             });
 
             it('if lte (less than or equal to) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 3 })).toBe("3 is less than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 10 })).toBe("10 is less than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 17 })).toBe("17 is not less than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 3 }, catalog)).toBe("3 is less than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 10 }, catalog)).toBe("10 is less than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 17 }, catalog)).toBe("17 is not less than or equal to 10");
             });
 
             it('if gte (greater than or equal to) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 17 })).toBe("17 is greater than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 10 })).toBe("10 is greater than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 3 })).toBe("3 is not greater than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 17 }, catalog)).toBe("17 is greater than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 10 }, catalog)).toBe("10 is greater than or equal to 10");
+                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 3 }, catalog)).toBe("3 is not greater than or equal to 10");
             });
 
             it('if and (conjunction) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: true })).toBe("both booleans are true");
-                expect(module._renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: false })).toBe("one or more booleans are false");
+                expect(module._renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: true }, catalog)).toBe("both booleans are true");
+                expect(module._renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: false }, catalog)).toBe("one or more booleans are false");
             });
 
             it('if or (disjunction) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: true })).toBe("one or more booleans are true");
-                expect(module._renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: false })).toBe("both booleans are false");
+                expect(module._renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: true }, catalog)).toBe("one or more booleans are true");
+                expect(module._renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: false }, catalog)).toBe("both booleans are false");
             });
 
             it('suppressed default helper log', function () {
                 try {
-                    module._renderHandlebarsTemplate("{{log 'Hello World'}}");
+                    module._renderHandlebarsTemplate("{{log 'Hello World'}}", {}, catalog);
                 } catch (err) {
                     expect(err.message).toBe("You specified knownHelpersOnly, but used the unknown helper log - 1:0");
                 }
@@ -437,17 +442,21 @@ exports.execute = function (options) {
             it('injecting $moment obj', function() {
                 var moment = module._currDate;
                 expect(moment).toBeDefined();
-                expect(module._renderHandlebarsTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' })).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
-                expect(module._renderHandlebarsTemplate("Todays date is {{$moment.dateString}}", {})).toBe("Todays date is " + moment.dateString);
+                expect(module._renderHandlebarsTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' }, catalog)).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
+                expect(module._renderHandlebarsTemplate("Todays date is {{$moment.dateString}}", {}, catalog)).toBe("Todays date is " + moment.dateString);
 
-                expect(module._renderHandlebarsTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {})).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
-                expect(module._renderHandlebarsTemplate("Current time is {{$moment.timeString}}", {})).toBe("Current time is " + moment.timeString);
+                expect(module._renderHandlebarsTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {}, catalog)).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
+                expect(module._renderHandlebarsTemplate("Current time is {{$moment.timeString}}", {}, catalog)).toBe("Current time is " + moment.timeString);
 
-                expect(module._renderHandlebarsTemplate("ISO string is {{$moment.ISOString}}", {})).toBe("ISO string is " + moment.ISOString);
-                expect(module._renderHandlebarsTemplate("GMT string is {{$moment.GMTString}}", {})).toBe("GMT string is " + moment.GMTString);
-                expect(module._renderHandlebarsTemplate("UTC string is {{$moment.UTCString}}", {})).toBe("UTC string is " + moment.UTCString);
+                expect(module._renderHandlebarsTemplate("ISO string is {{$moment.ISOString}}", {}, catalog)).toBe("ISO string is " + moment.ISOString);
+                expect(module._renderHandlebarsTemplate("GMT string is {{$moment.GMTString}}", {}, catalog)).toBe("GMT string is " + moment.GMTString);
+                expect(module._renderHandlebarsTemplate("UTC string is {{$moment.UTCString}}", {}, catalog)).toBe("UTC string is " + moment.UTCString);
 
-                expect(module._renderHandlebarsTemplate("Local time string is {{$moment.localeTimeString}}", {})).toBe("Local time string is " + moment.localeTimeString);
+                expect(module._renderHandlebarsTemplate("Local time string is {{$moment.localeTimeString}}", {}, catalog)).toBe("Local time string is " + moment.localeTimeString);
+            });
+
+            it('injecting $catalog obj', function() {
+                expect(module._renderHandlebarsTemplate("catalog snapshot: {{$catalog.snapshot}}, catalog id: {{$catalog.id}}", {}, catalog)).toBe("catalog snapshot: " + process.env.DEFAULT_CATALOG + ", catalog id: " + process.env.DEFAULT_CATALOG);
             });
 
             var handlebarTemplateCases = [{
@@ -538,7 +547,7 @@ exports.execute = function (options) {
                 var printMarkdown = formatUtils.printMarkdown;
 
                 handlebarTemplateCases.forEach(function(ex) {
-                    var template = module._renderHandlebarsTemplate(ex.template, obj);
+                    var template = module._renderHandlebarsTemplate(ex.template, obj, catalog);
                     expect(template).toBe(ex.after_mustache, "For template => " + ex.template);
                     var html = printMarkdown(template);
                     expect(html).toBe(ex.after_render + '\n', "For template => " + ex.template);

--- a/test/specs/reference/conf/reference_schema/data/reference_values.json
+++ b/test/specs/reference/conf/reference_schema/data/reference_values.json
@@ -1,4 +1,4 @@
-[{"id":4000, "some_markdown": "**date is :**", "name":"Hank", "url": "https://www.google.com", "some_gene_sequence": "GATCGATCGCGTATT", "video_col": "http://techslides.com/demos/sample-videos/small.mp4" },
+[{"id":4000, "some_markdown": "**date is :**", "name":"Hank", "url": "https://www.google.com", "some_gene_sequence": "GATCGATCGCGTATT", "video_col": "http://techslides.com/demos/sample-videos/small.mp4", "catalog_snapshot": "schema:table"},
  {"id":4001, "name":"Harold","some_invisible_column": "Junior", "fk_col": 1},
  {"id":4002, "url": "https://www.google.com", "fk_col": 2},
  {"id":4003 ,"some_invisible_column": "Freshmen", "fk_col": 3},

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -1139,6 +1139,19 @@
                   }
               },
               {
+                  "name": "catalog_snapshot",
+                  "type": {
+                      "typename": "text"
+                  },
+                  "annotations": {
+                      "tag:isrd.isi.edu,2016:column-display" : {
+                          "*" : {
+                              "markdown_pattern" : "{{# catalog_snapshot}}{{$catalog.snapshot}}: {{$catalog.id}}/{{catalog_snapshot}}{{/catalog_snapshot}}"
+                          }
+                      }
+                  }
+              },
+              {
                   "name": "array_int",
                   "type": {
                       "typename": "int4[]",
@@ -1151,7 +1164,7 @@
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns": {
-                  "*": ["id", "name", "url", "image", "image_with_size", "download_link", "iframe","some_markdown", "some_markdown_with_pattern", "some_gene_sequence", "column_using_invisble_column", "video_col", "fkeys_col", "moment_col"]
+                  "*": ["id", "name", "url", "image", "image_with_size", "download_link", "iframe","some_markdown", "some_markdown_with_pattern", "some_gene_sequence", "column_using_invisble_column", "video_col", "fkeys_col", "catalog_snapshot", "moment_col"]
                 }
             }
         },

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -56,7 +56,7 @@ exports.execute = function (options) {
         var expectedMomentValue = "<p>" + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year + "</p>\n";
         var testObjects ={
             "test1": {
-                    "rowValue" : ["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4" ],
+                    "rowValue" : ["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4, catalog_snapshot_uri=schema:table, catalog_id_uri=schema:table" ],
                     "expectedValue" : [ '4000',
                                         '<h2>Hank</h2>\n',
                                         '<p><a href="https://www.google.com/Hank">link</a></p>\n',
@@ -69,10 +69,11 @@ exports.execute = function (options) {
                                         '<code>GATCGATCGC GTATT</code>',
                                         'NA',
                                         '<video controls height=500 width=600 loop ><source src="http://techslides.com/demos/sample-videos/small.mp4" type="video/mp4"></video>',
-                                        '',
+                                        '', // This value is set later by setLinkRID()
+                                        '<p>'+catalog_id+': '+catalog_id+'/schema:table</p>\n',
                                         expectedMomentValue
                                          ],
-                    "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true, false, true]
+                    "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true, false, true, true]
                     },
             "test2": {
                 "rowValue" :["id=4001, name=Harold,some_invisible_column= Junior"],
@@ -90,9 +91,10 @@ exports.execute = function (options) {
                                 '<p><a href="http://example.com/Junior">Junior</a></p>\n',
                                 '',
                                 '',  // This value is set later by setLinkRID()
+                                '',
                                 expectedMomentValue
                             ],
-                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, true]
+                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, false, true]
                 },
             "test3": {
                 "rowValue" : ["id=4002, url= https://www.google.com, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
@@ -110,9 +112,10 @@ exports.execute = function (options) {
                                 'NA',
                                 '',
                                 '', // This value is set later by setLinkRID()
+                                '',
                                 expectedMomentValue
                                 ],
-                "isHTML" : [false, false, false, true, true, true, false, true, false, true, false, true, true, true]
+                "isHTML" : [false, false, false, true, true, true, false, true, false, true, false, true, true, false, true]
                 },
             "test4": {
                 "rowValue" : ["id=4003 ,some_invisible_column= Freshmen"],
@@ -130,9 +133,10 @@ exports.execute = function (options) {
                                 '<p><a href="http://example.com/Freshmen">Freshmen</a></p>\n',
                                 '',
                                 '', // This value is set later by setLinkRID()
+                                '',
                                 expectedMomentValue
                                 ],
-                "isHTML" : [false, false, false, true, true, true, false, true, false, true, true, true, true, true]
+                "isHTML" : [false, false, false, true, true, true, false, true, false, true, true, true, true, false, true]
                 },
             "test5": {
                 "rowValue" :  ["id=4004, name= weird & HTML < "],
@@ -150,9 +154,10 @@ exports.execute = function (options) {
                                 'NA',
                                 '',
                                 '', // This value is set later by setLinkRID()
+                                '',
                                 expectedMomentValue
                                 ],
-                "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true, true, true]
+                "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true, true, false, true]
                 },
             "test6": {
                 "rowValue" : ["id=4005, name= <a href='javascript:alert();'></a>, some_invisible_column= Senior"],
@@ -170,9 +175,10 @@ exports.execute = function (options) {
                                 '<p><a href="http://example.com/Senior">Senior</a></p>\n',
                                 '',
                                 '', // This value is set later by setLinkRID()
+                                '',
                                 expectedMomentValue
                                 ],
-                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, true]
+                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, false, true]
                 },
             "test7": {
                 "rowValue" : ["id=4006, name= <script>alert();</script>, some_gene_sequence= GATCGATCGCGTATT, some_invisible_column= Sophomore"],
@@ -190,9 +196,10 @@ exports.execute = function (options) {
                                 '<p><a href="http://example.com/Sophomore">Sophomore</a></p>\n',
                                 '',
                                 '', // This value is set later by setLinkRID()
+                                '',
                                 expectedMomentValue
                                 ],
-                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, true]
+                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, false, true]
             }
         };
 
@@ -299,14 +306,14 @@ exports.execute = function (options) {
              * This function calls checkValueAndIsHTML for each column value at the specified tupleIndex
              */
             var testTupleValidity = function(tupleIndex, key) {
-                it("should return 14 values for a tuple", function() {
+                it("should return 15 values for a tuple", function() {
                     // get the RID value that was set on options.entities[schema_name][table_name]
                     setLinkRID(key);
 
-                    expect(tuples[tupleIndex].values.length).toBe(14);
+                    expect(tuples[tupleIndex].values.length).toBe(15);
                 });
 
-                var columnNames = ["id", "name", "url", "image", "image_with_size", "download_link", "iframe", "some_markdown", "some_markdown_with_pattern", "some_gene_sequence", "", "video_col", "fkeys_col", "moment_col"]
+                var columnNames = ["id", "name", "url", "image", "image_with_size", "download_link", "iframe", "some_markdown", "some_markdown_with_pattern", "some_gene_sequence", "", "video_col", "fkeys_col", "catalog_snapshot_uri", "catalog_id_uri", "moment_col"]
                 for (var j=0; j<columnNames.length; j++) {
                     (function (columnIndex) {
                         // NOTE: There was no index 10 in checkValueAndIsHTML functions defined before

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -106,6 +106,7 @@ exports.execute = function (options) {
                 var isHTML = tuple.isHTML[valueIndex];
 
                 // Check isHTML is same as expected; either true or false
+                // none of the values should be presented as html values, so isHTML is false for all
                 expect(isHTML).toBe(false, columnName + " column isHTML should be set to false but was found to be true" );
             });
 
@@ -120,10 +121,10 @@ exports.execute = function (options) {
          */
         var testTupleValidity = function(tupleIndex, expectedValues) {
 
-            it("should return 14 values for a tuple", function() {
+            it("should return 15 values for a tuple", function() {
                 var values = tuples[tupleIndex].values;
 
-                expect(values.length).toBe(14);
+                expect(values.length).toBe(15);
             });
 
             checkValueAndIsHTML("id", tupleIndex, 0, expectedValues);
@@ -138,7 +139,8 @@ exports.execute = function (options) {
             checkValueAndIsHTML("some_gene_sequence", tupleIndex, 9, expectedValues);
             checkValueAndIsHTML("video_col", tupleIndex, 11, expectedValues);
             checkValueAndIsHTML("fkeys_col", tupleIndex, 12, expectedValues);
-            checkValueAndIsHTML("moment_col", tupleIndex, 13, expectedValues);
+            checkValueAndIsHTML("catalog_snapshot", tupleIndex, 13, expectedValues);
+            checkValueAndIsHTML("moment_col", tupleIndex, 14, expectedValues);
 
         };
 
@@ -149,32 +151,32 @@ exports.execute = function (options) {
         describe("Testing tuples values", function() {
             var testObjects ={
                 "test1": {
-                        "rowValue" : ["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4" ],
-                        "expectedValue": ["4000", "Hank", "https://www.google.com", null, null, null, null, '**date is :**', '**Name is :**', "GATCGATCGCGTATT",null, "http://techslides.com/demos/sample-videos/small.mp4", null, null]
+                        "rowValue" : ["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4, catalog_snapshot=schema:table" ],
+                        "expectedValue": ["4000", "Hank", "https://www.google.com", null, null, null, null, '**date is :**', '**Name is :**', "GATCGATCGCGTATT",null, "http://techslides.com/demos/sample-videos/small.mp4", null, "schema:table", null]
                         },
                 "test2": {
                         "rowValue" : ["id=4001, name=Harold,some_invisible_column= Junior, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-                        "expectedValue" : ["4001", "Harold", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null]
+                        "expectedValue" : ["4001", "Harold", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null]
                         },
                 "test3": {
                         "rowValue" : ["id=4002, url= https://www.google.com, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-                        "expectedValue" : ["4002", null, "https://www.google.com", null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null]
+                        "expectedValue" : ["4002", null, "https://www.google.com", null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null]
                         },
                 "test4": {
                         "rowValue" : ["id=4003 ,some_invisible_column= Freshmen, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-                        "expectedValue" :["4003", null, null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**',null, null, null, null, null]
+                        "expectedValue" :["4003", null, null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**',null, null, null, null, null, null]
                         },
                 "test5": {
                         "rowValue" :["id=4004, name= weird & HTML < , video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-                        "expectedValue" :["4004", "weird & HTML < ", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null]
+                        "expectedValue" :["4004", "weird & HTML < ", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null]
                         },
                 "test6": {
                         "rowValue": ["id=4005, name= <a href='javascript:alert();'></a>, some_invisible_column= Senior, video_col= http://techslides.com//small.mp4"],
-                        "expectedValue": ["4005", "<a href='javascript:alert();'></a>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null]
+                        "expectedValue": ["4005", "<a href='javascript:alert();'></a>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null]
                         },
                 "test7": {
                         "rowValue" :["id=4006, name= <script>alert();</script>, some_gene_sequence= GATCGATCGCGTATT, some_invisible_column= Sophomore, video_col= http://techs.com/sample/small.mp4"],
-                        "expectedValue": ["4006", "<script>alert();</script>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', "GATCGATCGCGTATT", null, null, null, null]
+                        "expectedValue": ["4006", "<script>alert();</script>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', "GATCGATCGCGTATT", null, null, null, null, null]
                         }
                 }
             var i =0;


### PR DESCRIPTION
This PR includes the first set of changes for [history support](https://github.com/informatics-isi-edu/chaise/issues/1502).

The changes included add 3 new variables to the markdown environment. These new variables are all nested under the `$catalog` object. These variables allow the data modeler to specify a full `snapshot` value for a catalog or each individual part, `id` and `version`.

For example, a catalog with snapshot `1@1234` will be defined as the following:
```js
$catalog: {
  snapshot: "1@1234",
  id: "1",
  version: "1234"
}
```