### PR TITLE
remove reference to FacetColumns in _referenceCopy

### DIFF
--- a/js/utilities.js
+++ b/js/utilities.js
@@ -214,7 +214,7 @@
     };
 
     module.decodeFacet = function (blob, path) {
-        var err = new module.InvalidFacetOperatorError('', path);
+        var err = new module.InvalidFacetOperatorError('', typeof path === "string" ? path : "");
 
         try {
             var str = module._LZString.decompressFromEncodedURIComponent(blob);

--- a/test/specs/faceting/tests/01.faceting.js
+++ b/test/specs/faceting/tests/01.faceting.js
@@ -1662,5 +1662,19 @@ exports.execute = function (options) {
                 });
             });
         });
+
+        describe("integration with other APIs, ", function () {
+
+            it ("changing facet should not remove the sort on the reference.", function () {
+                var refSorted = refMain.sort([{"column": "int_col", "descending": false}]);
+                var refSortedWithFilter = refSorted.facetColumns[10].addChoiceFilters(["1", "2"]);
+                expect(refSortedWithFilter.location.ermrestCompactPath).toBe(
+                    "M:=faceting_schema:main/id=1/$M/int_col::geq::-2/$M/left(fk_to_f1)=(faceting_schema:f1:id)/id=1;id=2/$M",
+                    "path missmatch."
+                );
+                expect(refSortedWithFilter.location.sortObject.length).toEqual(1, "sort length missmatch.");
+                expect(refSortedWithFilter.location.sortObject[0].column).toEqual("int_col", "sort column missmatch.");
+            });
+        });
     });
 };


### PR DESCRIPTION
We're using `_referenceCopy` in most places for creating new `Reference` object. This function will only do a shallow copy of current `Reference`, therefore all the references to the attributes of this `Reference` object will still remain.

This was causing problem in sort and faceting. Since each facet keeps track of its `Reference`, after doing sort (therefore creating a new `Reference`), the `FacetColumn.Reference`
still refers to the old object. To fix this issue for now, I am deleting the `_facetColumns` to force the new object to create its own `_facetColumns` list.

Technically `_referenceColumns` should be removed too. Each `ReferenceColumn` is keeping track of its `Reference` too. But doing so, caused client to throw "Maximum call stack size exceeded".
This is happening because in ERMrestJS we're blindly using the `_referenceCopy` while we could
just create a new `Reference` from scratch. Fixing that would require a lot of time that we decided to not fix this for now.

This PR is not an attempt to fix the `_referenceCopy` or its miss-use. It's only a fix for the #608 bug.