### PR TITLE
Remove file size comparison and check chunks.complete

### DIFF
--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -834,14 +834,16 @@ var ERMrest = (function(module) {
      */
     upload.prototype._updateProgressBar = function(xhr) {
         var length = this.chunks.length;
-        var done = 0;
-        for (var i = 0; i < this.chunks.length; i++) {
-            done = done + this.chunks[i].progress;
+        var progressDone = 0;
+        var chunksComplete = 0;
+        for (var i = 0; i < length; i++) {
+            progressDone = progressDone + this.chunks[i].progress;
+            if (this.chunks[i].completed) chunksComplete++;
         }
 
-        if (this.uploadPromise) this.uploadPromise.notify(this.completed ? this.file.size : done, this.file.size);
+        if (this.uploadPromise) this.uploadPromise.notify(this.completed ? this.file.size : progressDone, this.file.size);
 
-        if (done >= this.file.size && !this.completed && (!xhr || (xhr && (xhr.status >= 200 && xhr.status < 300)))) {
+        if (chunksComplete === length && !this.completed && (!xhr || (xhr && (xhr.status >= 200 && xhr.status < 300)))) {
             this.completed = true;
             if (this.uploadPromise) this.uploadPromise.resolve(this.url);
         }


### PR DESCRIPTION
Changed updateProgressBar function to check for the total number of chunks that have `complete == true` rather than relying on the uploadEventHandler progress function when it updates the current progress for each chunk.

The uploadEventHandler triggers when the browser has sent bytes to the server which will return to the client before the actual bytes have been written to the file. Locally this happens pretty quickly, but when there is a long delay over the network that may fluctuate, the client may report uploaded bytes much sooner than those bytes have been written.

We saw a case where 3 chunks finished uploading after the POST for the file. One can assume that the uploadEventHandler progress function was returning that it had finished uploading the chunk much sooner than when the callback to upload the chunk actually occurred. 

We wrongly based the completion of a file upload job based on the total size that had been transferred to the server rather than when every chunk's success callback function was invoked.