### PR TITLE
always hide the null choice

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -2254,7 +2254,8 @@ FacetColumn.prototype = {
      */
     get hideNullChoice() {
         if (this._hideNullChoice === undefined) {
-            this._hideNullChoice = (this._facetObject.hide_null_choice === true);
+            // this._hideNullChoice = (this._facetObject.hide_null_choice === true);
+            this._hideNullChoice = true;
         }
         return this._hideNullChoice;
     },

--- a/test/specs/faceting/tests/01.faceting.js
+++ b/test/specs/faceting/tests/01.faceting.js
@@ -1420,15 +1420,22 @@ exports.execute = function (options) {
             });
 
             describe("hideNullChoice, ", function () {
-                it ('should return false if hide_not_null_choice is not `true`.', function () {
-                    expect(mainFacets[0].hideNullChoice).toBe(false, "missmatch for index=0");
-                    expect(mainFacets[2].hideNullChoice).toBe(false, "missmatch for index=2");
-                });
-
-                it ("otherwise should return true.", function () {
+                it ("should always return true.", function () {
+                    expect(mainFacets[0].hideNullChoice).toBe(true, "missmatch for index=0");
+                    expect(mainFacets[2].hideNullChoice).toBe(true, "missmatch for index=2");
                     expect(mainFacets[1].hideNullChoice).toBe(true, "missmatch for index=1");
                     expect(mainFacets[7].hideNullChoice).toBe(true, "missmatch for index=7");
                 });
+
+                xit ('should return false if hide_not_null_choice is not `true`.', function () {
+                    expect(mainFacets[0].hideNullChoice).toBe(false, "missmatch for index=0");
+                    expect(mainFacets[2].hideNullChoice).toBe(false, "missmatch for index=2");
+                }).pend("temporarily disabling this feature.");
+
+                xit ("otherwise should return true.", function () {
+                    expect(mainFacets[1].hideNullChoice).toBe(true, "missmatch for index=1");
+                    expect(mainFacets[7].hideNullChoice).toBe(true, "missmatch for index=7");
+                }).pend("temporarily disabling this feature.");
             });
 
             describe("hideNotNullChoice, ", function () {


### PR DESCRIPTION
@hongsudt  asked me to disable this feature for now so we can avoid some degraded (and possibly confusing) functionality.