### PR TITLE
added catalog id and version to location object

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -106,7 +106,11 @@
         this._service = parts[1];
 
         // catalog id
-        this._catalog = parts[2];
+        this._catalogSnapshot = parts[2];
+
+        var catalogParts = this._catalogSnapshot.split('@');
+        this._catalog = catalogParts[0];
+        this._version = catalogParts[1] || null;
 
         // api
         this._api = parts[3];
@@ -492,6 +496,22 @@
          */
         get catalog() {
             return this._catalog;
+        },
+
+        /**
+         *
+         * @returns {String} just the catalog id
+         */
+        get catalogId() {
+            return this._catalog;
+        },
+
+        /**
+         *
+         * @returns {String} just the catalog version
+         */
+        get version() {
+            return this._version;
         },
 
         /**

--- a/js/parser.js
+++ b/js/parser.js
@@ -495,7 +495,7 @@
          * @returns {String} catalog id
          */
         get catalog() {
-            return this._catalog;
+            return this._catalogSnapshot;
         },
 
         /**

--- a/test/specs/parser/tests/01.parser.js
+++ b/test/specs/parser/tests/01.parser.js
@@ -22,6 +22,8 @@ exports.execute = function(options) {
                 expect(location.path).toBe(schemaName + ":" + tableName + "/id=" + entityId);
                 expect(location.compactPath).toBe(schemaName + ":" + tableName + "/id=" + entityId);
                 expect(location.catalog).toBe(catalogId.toString());
+                expect(location.catalogId).toBe(catalogId.toString());
+                expect(location.version).toBeNull();
                 expect(location.sort).toBeUndefined();
                 expect(location.sortObject).toBe(null);
                 expect(location.paging).toBeUndefined();
@@ -61,6 +63,8 @@ exports.execute = function(options) {
                 expect(location.path).toBe(schemaName + ":" + tableName + "/id=");
                 expect(location.compactPath).toBe(schemaName + ":" + tableName + "/id=");
                 expect(location.catalog).toBe(catalogId.toString());
+                expect(location.catalogId).toBe(catalogId.toString());
+                expect(location.version).toBeNull();
                 expect(location.sort).toBeUndefined();
                 expect(location.sortObject).toBe(null);
                 expect(location.paging).toBeUndefined();
@@ -113,6 +117,8 @@ exports.execute = function(options) {
                 expect(location.afterObject.length).toBe(1);
                 expect(location.afterObject[0]).toBe("some random text");
                 expect(location.catalog).toBe(catalogId.toString());
+                expect(location.catalogId).toBe(catalogId.toString());
+                expect(location.version).toBeNull();
                 expect(location.schemaName).toBe(schemaName);
                 expect(location.tableName).toBe(tableName);
                 expect(location.filter instanceof options.ermRest.ParsedFilter).toBe(true);
@@ -158,6 +164,8 @@ exports.execute = function(options) {
                 expect(location.compactPath).toBe(schemaName + ":" +
                     tableName + "/id=" + firstEntityId + ";id=" + secondEntityId);
                 expect(location.catalog).toBe(catalogId.toString());
+                expect(location.catalogId).toBe(catalogId.toString());
+                expect(location.version).toBeNull();
                 expect(location.sort).toBeUndefined();
                 expect(location.sortObject).toBe(null);
                 expect(location.paging).toBeUndefined();
@@ -361,6 +369,8 @@ exports.execute = function(options) {
             expect(location.afterObject.length).toBe(2);
             expect(location.afterObject[1]).toBe("some random text");
             expect(location.catalog).toBe(catalogId.toString());
+            expect(location.catalog).toBe(catalogId.toString());
+            expect(location.version).toBeNull();
             expect(location.projectionSchemaName).toBe(schemaName);
             expect(location.projectionTableName).toBe(tableName);
             expect(location.schemaName).toBe(schemaName);


### PR DESCRIPTION
This PR has changes that chaise relies on to resolve issue #715. The location object has 2 new APIs, `catalogId` and `version` which can be used to get the individual parts of the the catalog identifier provided.