### PR TITLE
Increase URL Limit

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -322,7 +322,6 @@ to use for ERMrest JavaScript agents.
         * [.removeAllFacetFilters(sameFilter, sameCustomFacet, sameFacet)](#ERMrest.Reference+removeAllFacetFilters) ⇒ <code>ERMrest.reference</code>
         * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
         * [.read(limit, contextHeaderParams, useEntity)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
-            * [~processSortObject()](#ERMrest.Reference+read..processSortObject)
         * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
         * [.update(tuples, contextHeaderParams)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
         * [.delete(contextHeaderParams)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
@@ -334,6 +333,8 @@ to use for ERMrest JavaScript agents.
         * [.setSamePaging(page)](#ERMrest.Reference+setSamePaging) ⇒ [<code>Reference</code>](#ERMrest.Reference)
         * [.getColumnByName(name)](#ERMrest.Reference+getColumnByName) ⇒ [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)
         * [.generateColumnsList(tuple)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+        * [._getReadPath()](#ERMrest.Reference+_getReadPath) : <code>Object</code>
+            * [~processSortObject()](#ERMrest.Reference+_getReadPath..processSortObject)
     * [.Page](#ERMrest.Page)
         * [new Page(reference, etag, data, hasPrevious, hasNext, extraData)](#new_ERMrest.Page_new)
         * [.reference](#ERMrest.Page+reference) : [<code>Reference</code>](#ERMrest.Reference)
@@ -609,7 +610,6 @@ to use for ERMrest JavaScript agents.
         * [.removeAllFacetFilters(sameFilter, sameCustomFacet, sameFacet)](#ERMrest.Reference+removeAllFacetFilters) ⇒ <code>ERMrest.reference</code>
         * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
         * [.read(limit, contextHeaderParams, useEntity)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
-            * [~processSortObject()](#ERMrest.Reference+read..processSortObject)
         * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
         * [.update(tuples, contextHeaderParams)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
         * [.delete(contextHeaderParams)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
@@ -621,6 +621,8 @@ to use for ERMrest JavaScript agents.
         * [.setSamePaging(page)](#ERMrest.Reference+setSamePaging) ⇒ [<code>Reference</code>](#ERMrest.Reference)
         * [.getColumnByName(name)](#ERMrest.Reference+getColumnByName) ⇒ [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)
         * [.generateColumnsList(tuple)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+        * [._getReadPath()](#ERMrest.Reference+_getReadPath) : <code>Object</code>
+            * [~processSortObject()](#ERMrest.Reference+_getReadPath..processSortObject)
     * [.AttributeGroupReference](#ERMrest.AttributeGroupReference) : <code>object</code>
         * [new AttributeGroupReference(keyColumns, aggregateColumns, location, catalog, sourceTable, context)](#new_ERMrest.AttributeGroupReference_new)
         * [._keyColumns](#ERMrest.AttributeGroupReference+_keyColumns) : <code>Array.&lt;ERMrest.AttributeGroupColumn&gt;</code>
@@ -2592,7 +2594,6 @@ Constructor for a ParsedFilter.
     * [.removeAllFacetFilters(sameFilter, sameCustomFacet, sameFacet)](#ERMrest.Reference+removeAllFacetFilters) ⇒ <code>ERMrest.reference</code>
     * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
     * [.read(limit, contextHeaderParams, useEntity)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
-        * [~processSortObject()](#ERMrest.Reference+read..processSortObject)
     * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
     * [.update(tuples, contextHeaderParams)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
     * [.delete(contextHeaderParams)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
@@ -2604,6 +2605,8 @@ Constructor for a ParsedFilter.
     * [.setSamePaging(page)](#ERMrest.Reference+setSamePaging) ⇒ [<code>Reference</code>](#ERMrest.Reference)
     * [.getColumnByName(name)](#ERMrest.Reference+getColumnByName) ⇒ [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)
     * [.generateColumnsList(tuple)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+    * [._getReadPath()](#ERMrest.Reference+_getReadPath) : <code>Object</code>
+        * [~processSortObject()](#ERMrest.Reference+_getReadPath..processSortObject)
 
 <a name="new_ERMrest.Reference_new"></a>
 
@@ -2958,18 +2961,6 @@ or rejected with any of these errors:
 | contextHeaderParams | <code>Object</code> | the object that we want to log. |
 | useEntity | <code>Boolean</code> | whether we should use entity api or not (if true, we won't get foreignkey data) |
 
-<a name="ERMrest.Reference+read..processSortObject"></a>
-
-##### read~processSortObject()
-Check the sort object. Does not change the `this._location` object.
-  - Throws an error if the column doesn't exist or is not sortable.
-  - maps the sorting to its sort columns.
-      - for columns it's straighforward and uses the actual column name.
-      - for PseudoColumns we need
-          - A new alias: F# where the # is a positive integer.
-          - The sort column name must be the "foreignkey_alias:column_name".
-
-**Kind**: inner method of [<code>read</code>](#ERMrest.Reference+read)  
 <a name="ERMrest.Reference+sort"></a>
 
 #### reference.sort(sort) ⇒ <code>Reference</code>
@@ -3182,6 +3173,29 @@ NOTE:
 | --- | --- | --- |
 | tuple | [<code>Tuple</code>](#ERMrest.Tuple) | the data for the current refe |
 
+<a name="ERMrest.Reference+_getReadPath"></a>
+
+#### reference.\_getReadPath() : <code>Object</code>
+The actual path that will be used for read request.
+ It will return an object that will have:
+  - value: the string value of the path
+  - isAttributeGroup: whether we should use attributegroup api or not.
+                      (if the reference doesn't have any fks, we don't need to use attributegroup)
+NOTE Might throw an error if modifiers are not valid
+
+**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
+<a name="ERMrest.Reference+_getReadPath..processSortObject"></a>
+
+##### _getReadPath~processSortObject()
+Check the sort object. Does not change the `this._location` object.
+  - Throws an error if the column doesn't exist or is not sortable.
+  - maps the sorting to its sort columns.
+      - for columns it's straighforward and uses the actual column name.
+      - for PseudoColumns we need
+          - A new alias: F# where the # is a positive integer.
+          - The sort column name must be the "foreignkey_alias:column_name".
+
+**Kind**: inner method of [<code>\_getReadPath</code>](#ERMrest.Reference+_getReadPath)  
 <a name="ERMrest.Page"></a>
 
 ### ERMrest.Page
@@ -5762,7 +5776,6 @@ get PathColumn object by column name
     * [.removeAllFacetFilters(sameFilter, sameCustomFacet, sameFacet)](#ERMrest.Reference+removeAllFacetFilters) ⇒ <code>ERMrest.reference</code>
     * [.create(data, contextHeaderParams)](#ERMrest.Reference+create) ⇒ <code>Promise</code>
     * [.read(limit, contextHeaderParams, useEntity)](#ERMrest.Reference+read) ⇒ <code>Promise</code>
-        * [~processSortObject()](#ERMrest.Reference+read..processSortObject)
     * [.sort(sort)](#ERMrest.Reference+sort) ⇒ <code>Reference</code>
     * [.update(tuples, contextHeaderParams)](#ERMrest.Reference+update) ⇒ <code>Promise</code>
     * [.delete(contextHeaderParams)](#ERMrest.Reference+delete) ⇒ <code>Promise</code>
@@ -5774,6 +5787,8 @@ get PathColumn object by column name
     * [.setSamePaging(page)](#ERMrest.Reference+setSamePaging) ⇒ [<code>Reference</code>](#ERMrest.Reference)
     * [.getColumnByName(name)](#ERMrest.Reference+getColumnByName) ⇒ [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)
     * [.generateColumnsList(tuple)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+    * [._getReadPath()](#ERMrest.Reference+_getReadPath) : <code>Object</code>
+        * [~processSortObject()](#ERMrest.Reference+_getReadPath..processSortObject)
 
 <a name="new_ERMrest.Reference_new"></a>
 
@@ -6128,18 +6143,6 @@ or rejected with any of these errors:
 | contextHeaderParams | <code>Object</code> | the object that we want to log. |
 | useEntity | <code>Boolean</code> | whether we should use entity api or not (if true, we won't get foreignkey data) |
 
-<a name="ERMrest.Reference+read..processSortObject"></a>
-
-##### read~processSortObject()
-Check the sort object. Does not change the `this._location` object.
-  - Throws an error if the column doesn't exist or is not sortable.
-  - maps the sorting to its sort columns.
-      - for columns it's straighforward and uses the actual column name.
-      - for PseudoColumns we need
-          - A new alias: F# where the # is a positive integer.
-          - The sort column name must be the "foreignkey_alias:column_name".
-
-**Kind**: inner method of [<code>read</code>](#ERMrest.Reference+read)  
 <a name="ERMrest.Reference+sort"></a>
 
 #### reference.sort(sort) ⇒ <code>Reference</code>
@@ -6352,6 +6355,29 @@ NOTE:
 | --- | --- | --- |
 | tuple | [<code>Tuple</code>](#ERMrest.Tuple) | the data for the current refe |
 
+<a name="ERMrest.Reference+_getReadPath"></a>
+
+#### reference.\_getReadPath() : <code>Object</code>
+The actual path that will be used for read request.
+ It will return an object that will have:
+  - value: the string value of the path
+  - isAttributeGroup: whether we should use attributegroup api or not.
+                      (if the reference doesn't have any fks, we don't need to use attributegroup)
+NOTE Might throw an error if modifiers are not valid
+
+**Kind**: instance method of [<code>Reference</code>](#ERMrest.Reference)  
+<a name="ERMrest.Reference+_getReadPath..processSortObject"></a>
+
+##### _getReadPath~processSortObject()
+Check the sort object. Does not change the `this._location` object.
+  - Throws an error if the column doesn't exist or is not sortable.
+  - maps the sorting to its sort columns.
+      - for columns it's straighforward and uses the actual column name.
+      - for PseudoColumns we need
+          - A new alias: F# where the # is a positive integer.
+          - The sort column name must be the "foreignkey_alias:column_name".
+
+**Kind**: inner method of [<code>\_getReadPath</code>](#ERMrest.Reference+_getReadPath)  
 <a name="ERMrest.AttributeGroupReference"></a>
 
 ### ERMrest.AttributeGroupReference : <code>object</code>

--- a/js/ag_reference.js
+++ b/js/ag_reference.js
@@ -425,20 +425,14 @@ AttributeGroupReference.prototype = {
     getAggregates: function (aggregateList) {
         var defer = module._q.defer();
         var url;
-
-        var URL_LENGTH_LIMIT = 2048;
-
         var urlSet = [];
         var loc = this.location;
-        var baseUri = [
-            loc.service, "catalog", loc.catalogId, "aggregate", loc.path
-        ];
 
+        var baseUri = loc.path;
         if (typeof loc.searchFilter === "string" && loc.searchFilter.length > 0) {
-            baseUri.push(loc.searchFilter);
+            baseUri += "/" + loc.searchFilter;
         }
-
-        baseUri = baseUri.join("/") + "/";
+        baseUri += "/";
 
         for (var i = 0; i < aggregateList.length; i++) {
             var agg = aggregateList[i];
@@ -451,7 +445,7 @@ AttributeGroupReference.prototype = {
             }
 
             // if adding the next aggregate to the url will push it past url length limit, push url onto the urlSet and reset the working url
-            if ((url + i + ":=" + agg).length > URL_LENGTH_LIMIT) {
+            if ((url + i + ":=" + agg).length > module.URL_PATH_LENGTH_LIMIT) {
                 // strip off an extra ','
                 if (url.charAt(url.length-1) === ',') {
                     url = url.substring(0, url.length-1);
@@ -473,7 +467,7 @@ AttributeGroupReference.prototype = {
         var aggregatePromises = [];
         var http = this._server._http;
         for (var j = 0; j < urlSet.length; j++) {
-            aggregatePromises.push(http.get(urlSet[j]));
+            aggregatePromises.push(http.get(loc.service + "/catalog/" + loc.catalogId + "/aggregate/" + urlSet[j]));
         }
 
         module._q.all(aggregatePromises).then(function getAggregates(response) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -233,6 +233,13 @@
             return this._location.compactUri;
         },
 
+        get readPath() {
+            if (this._readPath === undefined) {
+                this._readPath = this._getReadPath(false).value;
+            }
+            return this._readPath;
+        },
+
         /**
          * The session object from the server
          * @param {Object} session - the session object
@@ -1190,254 +1197,13 @@
                 verify(typeof(limit) == 'number', "'limit' must be a number");
                 verify(limit > 0, "'limit' must be greater than 0");
 
-                // the pseudo-columns that their path is all outbound and Therefore
-                // creates a one-to-one relation between source and destination, hence
-                // we can just add them to the projection list to get the single value.
-                var oneToOnePseudos = this.columns.filter(function (c) {
-                    return c.isPseudo && c.isPathColumn && c.hasPath && c.isUnique && c.foreignKeys.length > 1;
-                });
-
-                var hasSort = Array.isArray(this._location.sortObject) && (this._location.sortObject.length !== 0),
-                    locationPath = this.location.path,
-                    _modifiedSortObject = [], // the sort object that is used for url creation (if location has sort).
-                    sortMap = {}, // maps an alias to PseudoColumn, used for sorting
-                    sortObject,  // the sort that will be accessible by this._location.sortObject
-                    sortColNames = {}, // to avoid adding duplciate columns
-                    sortObjectNames = {}, // to avoid computing sortObject logic more than once
-                    addSort,
-                    sortCols,
-                    col, i, j, k, l;
-
-                // make sure the page and modified sort object have teh same length
-                var checkPageObject = function (loc, sortObject) {
-                    sortObject = sortObject || loc.sortObject;
-                    if (loc.afterObject && loc.afterObject.length !== sortObject.length) {
-                        throw new module.InvalidPageCriteria("sort and after should have the same number of columns.", locationPath);
-                    }
-
-                    if (loc.beforeObject && loc.beforeObject.length !== sortObject.length) {
-                        throw new module.InvalidPageCriteria("sort and before should have the same number of columns.", locationPath);
-                    }
-
-                    return true;
-                };
-
-                /** Check the sort object. Does not change the `this._location` object.
-                 *   - Throws an error if the column doesn't exist or is not sortable.
-                 *   - maps the sorting to its sort columns.
-                 *       - for columns it's straighforward and uses the actual column name.
-                 *       - for PseudoColumns we need
-                 *           - A new alias: F# where the # is a positive integer.
-                 *           - The sort column name must be the "foreignkey_alias:column_name".
-                 * */
-                var processSortObject= function (self) {
-                    var foreignKeys = self._table.foreignKeys,
-                        colName,
-                        fkIndex, fk, desc;
-
-                    for (i = 0, k = 1, l = 1; i < sortObject.length; i++) {
-                        // find the column in ReferenceColumns
-                        try {
-                            col = self.getColumnByName(sortObject[i].column);
-                        } catch (e) {
-                            throw new module.InvalidSortCriteria("Given column name `" + sortObject[i].column + "` in sort is not valid.",  locationPath);
-                        }
-                        // sortObject[i].column = col.name;
-
-                        // column is not sortable
-                        if (!col.sortable) {
-                            throw new module.InvalidSortCriteria("Column " + sortObject[i].column + " is not sortable.",  locationPath);
-                        }
-
-                        // avoid computing columns twice
-                        if (sortObject[i].column in sortObjectNames) {
-                            continue;
-                        }
-                        sortObjectNames[sortObject[i].column] = true;
-                        addSort = true;
-
-                        sortCols = col._sortColumns;
-
-                        // use the sort columns instead of the actual column.
-                        for (j = 0; j < sortCols.length; j++) {
-                            if (col.isForeignKey || (col.isPathColumn && col.isUnique && col.foreignKeys.length === 1)) {
-                                if (useEntity) addSort = false;
-
-                                fkIndex = foreignKeys.all().indexOf(col.isForeignKey ? col.foreignKey : col.foreignKeys[0].obj);
-                                colName = "F" + (foreignKeys.length() + k++);
-                                sortMap[colName] = ["F" + (fkIndex+1), module._fixedEncodeURIComponent(sortCols[j].column.name)].join(":");
-                            } else if (col.isPathColumn && col.hasPath && col.isUnique && col.foreignKeys.length > 0) {
-                                if (useEntity) addSort = false;
-
-                                // we have added it to the projection list
-                                fkIndex = oneToOnePseudos.indexOf(col);
-                                colName = "P" + (oneToOnePseudos.length + l++);
-                                sortMap[colName] = ["P" + (fkIndex+1), module._fixedEncodeURIComponent(sortCols[j].column.name)].join(":");
-                            } else {
-                                colName = sortCols[j].column.name;
-                                if (colName in sortColNames) {
-                                    addSort = false;
-                                }
-                                sortColNames[colName] = true;
-                            }
-
-                            desc = sortObject[i].descending !== undefined ? sortObject[i].descending : false;
-                            // if descending is true on the column_order, then the sort should be reverted
-                            if (sortCols[j].descending) {
-                                desc = !desc;
-                            }
-
-                            if (addSort) {
-                                _modifiedSortObject.push({
-                                    "column": colName,
-                                    "descending": desc
-                                });
-                            }
-                         }
-                    }
-                };
-
-                if (hasSort) {
-                    sortObject = this._location.sortObject;
-                    processSortObject(this);
+                var uri = [this._location.service, "catalog", this._location.catalog].join("/");
+                var readPath = this._getReadPath(useEntity);
+                if (readPath.isAttributeGroup) {
+                    uri += "/attributegroup/" + readPath.value;
+                } else {
+                    uri += "/entity/" + readPath.value;
                 }
-                // use row-order if sort was not provided
-                else if (this.display._rowOrder){
-                    sortObject = this.display._rowOrder.map(function (ro) {
-                        return {"column": ro.column.name, "descending": ro.descending};
-                    });
-                    processSortObject(this);
-                }
-
-                // ermrest requires key columns to be in sort param for paging
-                if (typeof sortObject !== 'undefined') {
-                    // if any of the sortCols is a key, then we don't neede to add the shortest key
-                    var hasKey = this._table.keys.all().some(function (key) {
-                        return key.colset.columns.every(function(c) {
-                            return (c.name in sortColNames);
-                        });
-                    });
-
-                    if (!hasKey) {
-                        for (i = 0; i < this._shortestKey.length; i++) { // all the key columns
-                            col = this._shortestKey[i].name;
-                            // add if key col is not in the sortby list
-                            if (!(col in sortColNames)) {
-                                sortObject.push({"column": col, "descending":false}); // add key to sort
-                                _modifiedSortObject.push({"column": col, "descending":false});
-                            }
-                        }
-                    }
-                } else { // no sort provieded: use shortest key for sort
-                    sortObject = [];
-                    for (var sk = 0; sk < this._shortestKey.length; sk++) {
-                        col = this._shortestKey[sk].name;
-                        sortObject.push({"column":col, "descending":false});
-                    }
-                }
-
-                // this will update location.sort and all the uri and path
-                this._location.sortObject = sortObject;
-
-                var uri = this._location.ermrestCompactUri; // used for the http request
-
-                /** Change api to attributegroup for retrieving extra information
-                 * These information include:
-                 * - Values for the foreignkeys.
-                 * - Value for one-to-one pseudo-columns. These are the columns
-                 * that their defined path is all in the outbound direction.
-                 *
-                 * This will just affect the http request and not this._location
-                 *
-                 * NOTE:
-                 * This piece of code is dependent on the same assumptions as the current parser, which are:
-                 *   0. There is no table called `T`, `M`, `F1`, `F2`, ..., `P1`, `P2`, ...
-                 *   1. There is no alias in url (more precisely `T`, `M`, `F1`, `F2`, `F3`, `P1`, `P2`, ...)
-                 *   2. Filter comes before the link syntax.
-                 *   3. There is no trailing `/` in uri (as it will break the ermrest too).
-                 * */
-                if (!useEntity && (this._table.foreignKeys.length() > 0 || oneToOnePseudos.length > 0)) {
-                    var compactPath = this._location.ermrestCompactPath,
-                        mainTableAlias = this._location.mainTableAlias,
-                        aggList = [],
-                        sortColumn,
-                        addedCols,
-                        aggFn = "array_d";
-
-                    // generate the projection for given pseudo column
-                    var getPseudoPath = function (l) {
-                        var pseudoPath = [];
-                        oneToOnePseudos[l].foreignKeys.forEach(function (f, index, arr) {
-                            pseudoPath.push(((index === arr.length-1) ? ("P" + (k+1) + ":=") : "") + f.obj.toString(!f.isInbound,true));
-                        });
-                        return pseudoPath.join("/");
-                    };
-
-                    // create the uri with attributegroup and alias
-                    uri = [this._location.service, "catalog", this._location.catalog, "attributegroup", compactPath].join("/") + "/";
-
-                    // add joins for foreign keys
-                    for (k = this._table.foreignKeys.length() - 1;k >= 0 ; k--) {
-                        // /F2:=left(id)=(s:t:c)/$M/F1:=left(id2)=(s1:t1:c1)/
-                        uri += "F" + (k+1) + ":=left" + this._table.foreignKeys.all()[k].toString(true) + "/$" + mainTableAlias + "/";
-
-                        // F2:array_d(F2:*),F1:array_d(F1:*)
-                        aggList.push("F" + (k+1) + ":=" + aggFn +"(F" + (k+1) + ":*)");
-                    }
-
-                    // add pseudo paths
-                    for (k = oneToOnePseudos.length - 1; k >= 0; k--) {
-                        uri += getPseudoPath(k) + "/$" + mainTableAlias + "/";
-
-                        aggList.push("P" + (k+1) + ":=" + aggFn + "(P" + (k+1) + ":*)");
-                    }
-
-                    // add sort columns (it will include the key)
-                    if (hasSort) {
-                        sortCols = _modifiedSortObject.map(function(sort) {return sort.column;});
-                    } else {
-                        sortCols = sortObject.map(function(sort) {return sort.column;});
-                    }
-
-                    addedCols = {};
-                    for(k = 0; k < sortCols.length; k++) {
-                        if (sortCols[k] in sortMap) {
-                            // sort column has been created via PseudoColumn, so we should use a new alias
-                            sortColumn = module._fixedEncodeURIComponent(sortCols[k]) + ":=" + sortMap[sortCols[k]];
-                        } else {
-                            sortColumn = module._fixedEncodeURIComponent(sortCols[k]);
-                        }
-
-                        // don't add duplicate columns
-                        if (!(sortColumn in addedCols)) {
-                            addedCols[sortColumn] = 1;
-                        }
-                    }
-
-                    uri += Object.keys(addedCols).join(",") + ";"+mainTableAlias+":=" + aggFn + "("+mainTableAlias+":*)," + aggList.join(",");
-                }
-
-                // insert @sort()
-                if (hasSort) { // then we have modified the sort
-                    // if sort is modified, we should use the modified sort Object for uri,
-                    // and the actual sort object for this._location.sortObject
-                    this._location.sortObject = _modifiedSortObject; // this will change the this._location.sort
-                    uri = uri + this._location.sort;
-
-                    this._location.sortObject = sortObject;
-                } else if (this._location.sort) { // still there will be sort (shortestkey)
-                    uri = uri + this._location.sort;
-                }
-
-                // check that page object is valid
-                checkPageObject(this._location, hasSort ? _modifiedSortObject : null);
-
-
-                // insert paging
-                if (this._location.paging) {
-                    uri = uri + this._location.paging;
-                }
-
                 // add limit
                 uri = uri + "?limit=" + (limit + 1); // read extra row, for determining whether the returned page has next/previous page
 
@@ -3339,6 +3105,269 @@
             var headers = {};
             headers[module._contextHeaderName] = contextHeaderParams;
             return headers;
+        },
+
+
+        /**
+         * The actual path that will be used for read request.
+         *  It will return an object that will have:
+         *   - value: the string value of the path
+         *   - isAttributeGroup: whether we should use attributegroup api or not.
+         *                       (if the reference doesn't have any fks, we don't need to use attributegroup)
+         * NOTE Might throw an error if modifiers are not valid
+         * @type {Object}
+         */
+         _getReadPath: function(useEntity) {
+            // the pseudo-columns that their path is all outbound and Therefore
+            // creates a one-to-one relation between source and destination, hence
+            // we can just add them to the projection list to get the single value.
+            var oneToOnePseudos = this.columns.filter(function (c) {
+                return c.isPseudo && c.isPathColumn && c.hasPath && c.isUnique && c.foreignKeys.length > 1;
+            });
+
+            var hasSort = Array.isArray(this._location.sortObject) && (this._location.sortObject.length !== 0),
+                locationPath = this.location.path,
+                _modifiedSortObject = [], // the sort object that is used for url creation (if location has sort).
+                sortMap = {}, // maps an alias to PseudoColumn, used for sorting
+                sortObject,  // the sort that will be accessible by this._location.sortObject
+                sortColNames = {}, // to avoid adding duplciate columns
+                sortObjectNames = {}, // to avoid computing sortObject logic more than once
+                addSort,
+                sortCols,
+                col, i, j, k, l;
+
+            // make sure the page and modified sort object have teh same length
+            var checkPageObject = function (loc, sortObject) {
+                sortObject = sortObject || loc.sortObject;
+                if (loc.afterObject && loc.afterObject.length !== sortObject.length) {
+                    throw new module.InvalidPageCriteria("sort and after should have the same number of columns.", locationPath);
+                }
+
+                if (loc.beforeObject && loc.beforeObject.length !== sortObject.length) {
+                    throw new module.InvalidPageCriteria("sort and before should have the same number of columns.", locationPath);
+                }
+
+                return true;
+            };
+
+            /** Check the sort object. Does not change the `this._location` object.
+             *   - Throws an error if the column doesn't exist or is not sortable.
+             *   - maps the sorting to its sort columns.
+             *       - for columns it's straighforward and uses the actual column name.
+             *       - for PseudoColumns we need
+             *           - A new alias: F# where the # is a positive integer.
+             *           - The sort column name must be the "foreignkey_alias:column_name".
+             * */
+            var processSortObject= function (self) {
+                var foreignKeys = self._table.foreignKeys,
+                    colName,
+                    fkIndex, fk, desc;
+
+                for (i = 0, k = 1, l = 1; i < sortObject.length; i++) {
+                    // find the column in ReferenceColumns
+                    try {
+                        col = self.getColumnByName(sortObject[i].column);
+                    } catch (e) {
+                        throw new module.InvalidSortCriteria("Given column name `" + sortObject[i].column + "` in sort is not valid.",  locationPath);
+                    }
+                    // sortObject[i].column = col.name;
+
+                    // column is not sortable
+                    if (!col.sortable) {
+                        throw new module.InvalidSortCriteria("Column " + sortObject[i].column + " is not sortable.",  locationPath);
+                    }
+
+                    // avoid computing columns twice
+                    if (sortObject[i].column in sortObjectNames) {
+                        continue;
+                    }
+                    sortObjectNames[sortObject[i].column] = true;
+                    addSort = true;
+
+                    sortCols = col._sortColumns;
+
+                    // use the sort columns instead of the actual column.
+                    for (j = 0; j < sortCols.length; j++) {
+                        if (col.isForeignKey || (col.isPathColumn && col.isUnique && col.foreignKeys.length === 1)) {
+                            if (useEntity) addSort = false;
+
+                            fkIndex = foreignKeys.all().indexOf(col.isForeignKey ? col.foreignKey : col.foreignKeys[0].obj);
+                            colName = "F" + (foreignKeys.length() + k++);
+                            sortMap[colName] = ["F" + (fkIndex+1), module._fixedEncodeURIComponent(sortCols[j].column.name)].join(":");
+                        } else if (col.isPathColumn && col.hasPath && col.isUnique && col.foreignKeys.length > 0) {
+                            if (useEntity) addSort = false;
+
+                            // we have added it to the projection list
+                            fkIndex = oneToOnePseudos.indexOf(col);
+                            colName = "P" + (oneToOnePseudos.length + l++);
+                            sortMap[colName] = ["P" + (fkIndex+1), module._fixedEncodeURIComponent(sortCols[j].column.name)].join(":");
+                        } else {
+                            colName = sortCols[j].column.name;
+                            if (colName in sortColNames) {
+                                addSort = false;
+                            }
+                            sortColNames[colName] = true;
+                        }
+
+                        desc = sortObject[i].descending !== undefined ? sortObject[i].descending : false;
+                        // if descending is true on the column_order, then the sort should be reverted
+                        if (sortCols[j].descending) {
+                            desc = !desc;
+                        }
+
+                        if (addSort) {
+                            _modifiedSortObject.push({
+                                "column": colName,
+                                "descending": desc
+                            });
+                        }
+                     }
+                }
+            };
+
+            if (hasSort) {
+                sortObject = this._location.sortObject;
+                processSortObject(this);
+            }
+            // use row-order if sort was not provided
+            else if (this.display._rowOrder){
+                sortObject = this.display._rowOrder.map(function (ro) {
+                    return {"column": ro.column.name, "descending": ro.descending};
+                });
+                processSortObject(this);
+            }
+
+            // ermrest requires key columns to be in sort param for paging
+            if (typeof sortObject !== 'undefined') {
+                // if any of the sortCols is a key, then we don't neede to add the shortest key
+                var hasKey = this._table.keys.all().some(function (key) {
+                    return key.colset.columns.every(function(c) {
+                        return (c.name in sortColNames);
+                    });
+                });
+
+                if (!hasKey) {
+                    for (i = 0; i < this._shortestKey.length; i++) { // all the key columns
+                        col = this._shortestKey[i].name;
+                        // add if key col is not in the sortby list
+                        if (!(col in sortColNames)) {
+                            sortObject.push({"column": col, "descending":false}); // add key to sort
+                            _modifiedSortObject.push({"column": col, "descending":false});
+                        }
+                    }
+                }
+            } else { // no sort provieded: use shortest key for sort
+                sortObject = [];
+                for (var sk = 0; sk < this._shortestKey.length; sk++) {
+                    col = this._shortestKey[sk].name;
+                    sortObject.push({"column":col, "descending":false});
+                }
+            }
+
+            // this will update location.sort and all the uri and path
+            this._location.sortObject = sortObject;
+
+            var uri = this._location.ermrestCompactPath; // used for the http request
+            var isAttributeGroup = !useEntity && (this._table.foreignKeys.length() > 0 || oneToOnePseudos.length > 0);
+
+            /** Change api to attributegroup for retrieving extra information
+             * These information include:
+             * - Values for the foreignkeys.
+             * - Value for one-to-one pseudo-columns. These are the columns
+             * that their defined path is all in the outbound direction.
+             *
+             * This will just affect the http request and not this._location
+             *
+             * NOTE:
+             * This piece of code is dependent on the same assumptions as the current parser, which are:
+             *   0. There is no table called `T`, `M`, `F1`, `F2`, ..., `P1`, `P2`, ...
+             *   1. There is no alias in url (more precisely `T`, `M`, `F1`, `F2`, `F3`, `P1`, `P2`, ...)
+             *   2. Filter comes before the link syntax.
+             *   3. There is no trailing `/` in uri (as it will break the ermrest too).
+             * */
+            if (isAttributeGroup) {
+                var compactPath = this._location.ermrestCompactPath,
+                    mainTableAlias = this._location.mainTableAlias,
+                    aggList = [],
+                    sortColumn,
+                    addedCols,
+                    aggFn = "array_d";
+
+                // generate the projection for given pseudo column
+                var getPseudoPath = function (l) {
+                    var pseudoPath = [];
+                    oneToOnePseudos[l].foreignKeys.forEach(function (f, index, arr) {
+                        pseudoPath.push(((index === arr.length-1) ? ("P" + (k+1) + ":=") : "") + f.obj.toString(!f.isInbound,true));
+                    });
+                    return pseudoPath.join("/");
+                };
+
+                // create the uri with attributegroup and alias
+                uri = compactPath + "/";
+
+                // add joins for foreign keys
+                for (k = this._table.foreignKeys.length() - 1;k >= 0 ; k--) {
+                    // /F2:=left(id)=(s:t:c)/$M/F1:=left(id2)=(s1:t1:c1)/
+                    uri += "F" + (k+1) + ":=left" + this._table.foreignKeys.all()[k].toString(true) + "/$" + mainTableAlias + "/";
+
+                    // F2:array_d(F2:*),F1:array_d(F1:*)
+                    aggList.push("F" + (k+1) + ":=" + aggFn +"(F" + (k+1) + ":*)");
+                }
+
+                // add pseudo paths
+                for (k = oneToOnePseudos.length - 1; k >= 0; k--) {
+                    uri += getPseudoPath(k) + "/$" + mainTableAlias + "/";
+
+                    aggList.push("P" + (k+1) + ":=" + aggFn + "(P" + (k+1) + ":*)");
+                }
+
+                // add sort columns (it will include the key)
+                if (hasSort) {
+                    sortCols = _modifiedSortObject.map(function(sort) {return sort.column;});
+                } else {
+                    sortCols = sortObject.map(function(sort) {return sort.column;});
+                }
+
+                addedCols = {};
+                for(k = 0; k < sortCols.length; k++) {
+                    if (sortCols[k] in sortMap) {
+                        // sort column has been created via PseudoColumn, so we should use a new alias
+                        sortColumn = module._fixedEncodeURIComponent(sortCols[k]) + ":=" + sortMap[sortCols[k]];
+                    } else {
+                        sortColumn = module._fixedEncodeURIComponent(sortCols[k]);
+                    }
+
+                    // don't add duplicate columns
+                    if (!(sortColumn in addedCols)) {
+                        addedCols[sortColumn] = 1;
+                    }
+                }
+
+                uri += Object.keys(addedCols).join(",") + ";"+mainTableAlias+":=" + aggFn + "("+mainTableAlias+":*)," + aggList.join(",");
+            }
+
+            // insert @sort()
+            if (hasSort) { // then we have modified the sort
+                // if sort is modified, we should use the modified sort Object for uri,
+                // and the actual sort object for this._location.sortObject
+                this._location.sortObject = _modifiedSortObject; // this will change the this._location.sort
+                uri = uri + this._location.sort;
+
+                this._location.sortObject = sortObject;
+            } else if (this._location.sort) { // still there will be sort (shortestkey)
+                uri = uri + this._location.sort;
+            }
+
+            // check that page object is valid
+            checkPageObject(this._location, hasSort ? _modifiedSortObject : null);
+
+
+            // insert paging
+            if (this._location.paging) {
+                uri = uri + this._location.paging;
+            }
+
+            return {value: uri, isAttributeGroup: isAttributeGroup};
         }
     };
 
@@ -3374,6 +3403,7 @@
         delete referenceCopy._canDelete;
         delete referenceCopy._defaultExportTemplate;
         delete referenceCopy._exportTemplates;
+        delete referenceCopy._readPath;
 
         referenceCopy.contextualize = new Contextualize(referenceCopy);
         return referenceCopy;

--- a/js/reference.js
+++ b/js/reference.js
@@ -2536,10 +2536,8 @@
                 headers: this._generateContextHeader(contextHeaderParams)
             };
 
-            var URL_LENGTH_LIMIT = 2048;
-
             var urlSet = [];
-            var baseUri = this.location.service + "/catalog/" + this.location.catalog + "/aggregate/" + this.location.ermrestCompactPath + "/";
+            var baseUri = this.location.ermrestCompactPath + "/";
             // create a url: ../aggregate/../0:=fn(),1:=fn()..
             // TODO could be re-written
             for (var i = 0; i < aggregateList.length; i++) {
@@ -2553,7 +2551,7 @@
                 }
 
                 // if adding the next aggregate to the url will push it past url length limit, push url onto the urlSet and reset the working url
-                if ((url + i + ":=" + agg).length > URL_LENGTH_LIMIT) {
+                if ((url + i + ":=" + agg).length > module.URL_PATH_LENGTH_LIMIT) {
                     // if cannot even add the first one
                     if (i === 0) {
                         defer.reject(new module.InvalidInputError("Cannot send the request because of URL length limit."));
@@ -2581,7 +2579,9 @@
             var aggregatePromises = [];
             var http = this._server._http;
             for (var j = 0; j < urlSet.length; j++) {
-                aggregatePromises.push(http.get(urlSet[j], config));
+                aggregatePromises.push(
+                    http.get(this.location.service + "/catalog/" + this.location.catalog + "/aggregate/" + urlSet[j], config)
+                );
             }
 
             module._q.all(aggregatePromises).then(function getAggregates(response) {

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -502,6 +502,16 @@
     };
 
     /**
+     * Strip the trailing slash if there's any
+     * @private
+     * @param  {String} str
+     * @return {String}
+     */
+    module._stripTrailingSlash = function (str) {
+        return str.endsWith("/") ? str.slice(0, -1) : str;
+    };
+
+    /**
      * @function
      * @param {String} str string to be encoded.
      * @desc
@@ -3057,6 +3067,18 @@
         // take care of facet and fitler
         return truncateFacet(obj, header).res;
     };
+
+    // for more information on url length limit refer to the following issue:
+    // https://github.com/informatics-isi-edu/chaise/issues/1669
+    module.URL_PATH_LENGTH_LIMIT = 4000;
+    var isNode =  typeof process !== 'undefined' && process.versions != null && process.versions.node != null;
+    if (!isNode) {
+        var isIE = /*@cc_on!@*/false || !!document.documentMode, // Internet Explorer 6-11
+        isEdge = !isIE && !!window.StyleMedia; // Edge
+        if(isIE || isEdge) {
+            module.URL_PATH_LENGTH_LIMIT = 2000;
+        }
+    }
 
     module._constraintTypes = Object.freeze({
         KEY: "k",


### PR DESCRIPTION
This PR will increase the url path limit in ermestjs to 4000 characters. A summary of changes:

- Create a global variable to store the path limit length. It will be 2000 or 4000 based on the browser. As I explained in the issue I decided to round it up because of path vs. url length.

- Introduce a new api to get the actual url that will be used for read request. This path might be different from the `location.ermrestPath`. The modifiers might change. Also if we change to attributegroup, the whole path will change and the path will include the projection list of foreignkey columns. This API is going to be used in chaise for testing the url limit. Previously we were just looking at the `location.ermrestPath` which was fine because we were testing for a number way below the actual limit of our servers (2000 vs 4050). But now that we are actually checking for the server limit I had to make the chaise check to be accurate.

related issue: [chaise#1669](https://github.com/informatics-isi-edu/chaise/issues/1669)