### PR TITLE
add exportServicePath parameter

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -521,7 +521,7 @@ to use for ERMrest JavaScript agents.
         * [new AttributeGroupReferenceAggregateFn(reference)](#new_ERMrest.AttributeGroupReferenceAggregateFn_new)
         * [.countAgg](#ERMrest.AttributeGroupReferenceAggregateFn+countAgg) : <code>Object</code>
     * [.exporter](#ERMrest.exporter)
-        * [new exporter(reference, template)](#new_ERMrest.exporter_new)
+        * [new exporter(reference, bagName, template, servicePath)](#new_ERMrest.exporter_new)
         * [.exportParameters](#ERMrest.exporter+exportParameters)
         * [.run(contextHeaderParams)](#ERMrest.exporter+run) ⇒ <code>Promise</code>
         * [.cancel()](#ERMrest.exporter+cancel) ⇒ <code>boolean</code>
@@ -5150,21 +5150,23 @@ Therefore the returned count might not be exactly the same as number of returned
 **Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.exporter](#ERMrest.exporter)
-    * [new exporter(reference, template)](#new_ERMrest.exporter_new)
+    * [new exporter(reference, bagName, template, servicePath)](#new_ERMrest.exporter_new)
     * [.exportParameters](#ERMrest.exporter+exportParameters)
     * [.run(contextHeaderParams)](#ERMrest.exporter+run) ⇒ <code>Promise</code>
     * [.cancel()](#ERMrest.exporter+cancel) ⇒ <code>boolean</code>
 
 <a name="new_ERMrest.exporter_new"></a>
 
-#### new exporter(reference, template)
+#### new exporter(reference, bagName, template, servicePath)
 Export Object
 
 
 | Param | Type | Description |
 | --- | --- | --- |
 | reference | [<code>Reference</code>](#ERMrest.Reference) |  |
+| bagName | <code>String</code> | the name that will be used for the bag |
 | template | <code>Object</code> | the tempalte must be in the valid format. |
+| servicePath | <code>String</code> | the path to the service, i.e. "/deriva/export/" |
 
 <a name="ERMrest.exporter+exportParameters"></a>
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -1712,7 +1712,7 @@
              * The ermrset string path that will be appended to the url
              * @type {String}
              */
-            this.ermrestPath = obj.ermrest_path.replace(/^\/|\/$/g, '');
+            this.ermrestPath = module.trimSlashes(obj.ermrest_path);
         }
 
         /**

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -506,6 +506,15 @@
     };
 
     /**
+     * trim the slashes that might exist at the begining or end of the string
+     * @param  {String} str
+     * @return {String}
+     */
+    module.trimSlashes = function (str) {
+        return str.replace(/^\/+|\/+$/g, '');
+    };
+
+    /**
      * @function
      * @param {String} str string to be encoded.
      * @desc

--- a/test/specs/export/tests/01.export.js
+++ b/test/specs/export/tests/01.export.js
@@ -226,7 +226,7 @@ exports.execute = function (options) {
 
             describe("for BDBag template", function () {
                 it("should create an exporter object", function() {
-                    exportObj = new ermRest.Exporter(reference, "bag-name", reference.table.exportTemplates[0]);
+                    exportObj = new ermRest.Exporter(reference, "bag-name", reference.table.exportTemplates[0], "/iobox/export/");
 
                     expect(exportObj instanceof ermRest.Exporter).toBe(true);
                     expect(exportObj.template).toEqual(reference.table.exportTemplates[0]);
@@ -276,7 +276,7 @@ exports.execute = function (options) {
 
             describe("for BDBag CSV template", function () {
                 it("should create an exporter object", function() {
-                    exportObj = new ermRest.Exporter(reference, "bag-name", reference.table.exportTemplates[1]);
+                    exportObj = new ermRest.Exporter(reference, "bag-name", reference.table.exportTemplates[1], "iobox/export/");
 
                     expect(exportObj instanceof ermRest.Exporter).toBe(true);
                     expect(exportObj.template).toEqual(reference.table.exportTemplates[1]);
@@ -326,7 +326,7 @@ exports.execute = function (options) {
 
             describe("for BDBag JSON template", function () {
                 it("should create an exporter object", function() {
-                    exportObj = new ermRest.Exporter(reference, "bag-name", reference.table.exportTemplates[2]);
+                    exportObj = new ermRest.Exporter(reference, "bag-name", reference.table.exportTemplates[2], "/iobox/export/");
 
                     expect(exportObj instanceof ermRest.Exporter).toBe(true);
                     expect(exportObj.template).toEqual(reference.table.exportTemplates[2]);


### PR DESCRIPTION
It's a very simple change. I just added a parameter to the `Exporter` which will be used for the `servicePath`. 

related issue: [chaise#1687](https://github.com/informatics-isi-edu/chaise/issues/1687)