### PR TITLE
Export api update

### DIFF
--- a/js/export.js
+++ b/js/export.js
@@ -79,8 +79,8 @@ var ERMrest = (function(module) {
                 return false;
             }
 
-            // output.destination must have name and type
-            if (!module.ObjectHasAllKeys(output.destination, ['name', 'type'])) {
+            // output.destination must have at least a type
+            if (!module.ObjectHasAllKeys(output.destination, ['type'])) {
                 errMessage("output.destination index=" + i + " has missing required attributes.");
                 return false;
             }
@@ -171,6 +171,7 @@ var ERMrest = (function(module) {
                 } else {
                     var outputs = template.outputs;
                     var predicate = this.reference.location.ermrestCompactPath;
+                    var output_path = this.reference.displayname.unformatted; // needs call to sanitize first, i think
 
                     outputs.forEach(function (output) {
                         var source = output.source, dest = output.destination;
@@ -187,7 +188,7 @@ var ERMrest = (function(module) {
                         }
 
                         query.processor = dest.type || bagOptions.table_format;
-                        queryParams.output_path = dest.name;
+                        queryParams.output_path = dest.name || output_path;
                         queryParams.query_path = "/" + queryFrags.join("/") + "?limit=none";
                         if (dest.impl != null) {
                             query.processor_type = dest.impl;
@@ -204,6 +205,9 @@ var ERMrest = (function(module) {
                 }
                 if (template.postprocessors != null) {
                     exportParameters.post_processors = template.postprocessors;
+                }
+                if (template.public != null) {
+                    exportParameters.public = template.public
                 }
                 this._exportParameters = exportParameters;
             }
@@ -241,6 +245,9 @@ var ERMrest = (function(module) {
                 headers[module._contextHeaderName] = contextHeaderParams;
 
                 self.canceled = false;
+                if (self.exportParameters.public != null) {
+                    serviceUrl += "?public=" + self.exportParameters.public
+                }
                 self.reference._server._http.post(serviceUrl, self.exportParameters, {headers: headers}).then(function success(response) {
                     return defer.resolve({data: response.data.split("\n"), canceled: self.canceled});
                 }).catch(function (err) {

--- a/js/export.js
+++ b/js/export.js
@@ -209,6 +209,9 @@ var ERMrest = (function(module) {
                 if (template.public != null) {
                     exportParameters.public = template.public;
                 }
+                if (template.bag_archiver != null) {
+                    exportParameters.bag.bag_archiver = template.bag_archiver;
+                }
                 this._exportParameters = exportParameters;
             }
 

--- a/js/export.js
+++ b/js/export.js
@@ -171,7 +171,7 @@ var ERMrest = (function(module) {
                 } else {
                     var outputs = template.outputs;
                     var predicate = this.reference.location.ermrestCompactPath;
-                    var output_path = this.reference.displayname.unformatted; // needs call to sanitize first, i think
+                    var output_path = module._sanitizeFilename(this.reference.displayname.unformatted);
 
                     outputs.forEach(function (output) {
                         var source = output.source, dest = output.destination;

--- a/js/export.js
+++ b/js/export.js
@@ -207,7 +207,7 @@ var ERMrest = (function(module) {
                     exportParameters.post_processors = template.postprocessors;
                 }
                 if (template.public != null) {
-                    exportParameters.public = template.public
+                    exportParameters.public = template.public;
                 }
                 this._exportParameters = exportParameters;
             }
@@ -246,7 +246,7 @@ var ERMrest = (function(module) {
 
                 self.canceled = false;
                 if (self.exportParameters.public != null) {
-                    serviceUrl += "?public=" + self.exportParameters.public
+                    serviceUrl += "?public=" + self.exportParameters.public;
                 }
                 self.reference._server._http.post(serviceUrl, self.exportParameters, {headers: headers}).then(function success(response) {
                     return defer.resolve({data: response.data.split("\n"), canceled: self.canceled});

--- a/test/specs/export/conf/export_table_annot_schema/schema.json
+++ b/test/specs/export/conf/export_table_annot_schema/schema.json
@@ -66,6 +66,9 @@
                 "tag:isrd.isi.edu,2016:visible-columns" : {
                     "*": ["id", "text_col", "lgt", "markdown_col", "int_col", "float_col", "date_col", "timestamp_col"]
                 },
+                "tag:misd.isi.edu,2015:display": {
+                  "name": "Main / table"
+                },
                 "tag:isrd.isi.edu,2016:export": {
                     "templates": [
                         {
@@ -75,8 +78,7 @@
                                         "api": "entity"
                                     },
                                     "destination": {
-                                        "type": "csv",
-                                        "name": "export_test_bag"
+                                        "type": "csv"
                                     }
                                 }
                             ],
@@ -287,7 +289,7 @@
                             "md5": "asset_1_md5"
                         },
                         "tag:misd.isi.edu,2015:display": {
-                          "displayname": "asset_1_displayname"
+                          "name": "asset_1_displayname"
                         }
                     }
                 },

--- a/test/specs/export/tests/01.export.js
+++ b/test/specs/export/tests/01.export.js
@@ -252,7 +252,7 @@ exports.execute = function (options) {
                         },
                         "destination": {
                             "type": "csv",
-                            "name": "export_test_bag"
+                            "name": "Main _ table"
                         }
                     }
                     expect(exportParams.catalog.query_processors.length).toBe(1);


### PR DESCRIPTION
This PR includes 4 changes to `export.js`:

1. The addition of a `public` variable to the export template/parameters structure. This variable is a boolean value that gets appended as a query parameter to the url of the POST request sent to the export service. It indicates to the service that the created resource should be readable by unauthenticated (anonymous) clients.

2. The removal of the non-null parameter validation of `destination.name` in the export template, since there are export query processors that can be invoked that do not require an output destination name (e.g., the `env` query processor).

3. The automatic generation of `destination.name` (if not specified) based on the value of `this.reference.displayname.unformatted`, similar to how it is implemented by the `defaultExportTemplate` in `reference.js`. The code I added for this differs from the implementation in `defaultExportTemplate` in that it does not call `sanitize` on `this.reference.displayname.unformatted`. This is only due to the fact that I was not sure of the correct procedure for importing this function into the code. If you guys want to add the correct code for doing this to this branch before merging the PR I would appreciate it.

4.  Added `bag_archiver` to the top level template parameters so that the default bag archive type can be overridden by the template creator.