### PR TITLE
Don't show null and not-null for scalar not-null columns 

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -4286,6 +4286,8 @@ otherwise it will true if filter is based on key.
 #### facetColumn.isAllOutboundNotNull : <code>Boolean</code>
 Whether the facet is defining an all outbound path that the columns used
 in the path are all not-null.
+NOTE even if the column.nullok is false, ermrest could return null value for it
+if the user rights to select that column is `null`.
 
 **Kind**: instance property of [<code>FacetColumn</code>](#ERMrest.FacetColumn)  
 <a name="ERMrest.FacetColumn+barPlot"></a>
@@ -4378,6 +4380,8 @@ Other types of facet that null won't be applicable to them and therefore
 we shouldn't even offer the option:
   1. (G4) Scalar columns of main table that are not-null.
   2. (G5) All outbound foreignkey facets that all the columns invloved are not-null
+Although if user is vewing a snapshot of catalog, ermrest might actually return null
+value for a not-null column, and therefore we should not do this check if user is in that state.
 
 Based on this, the following will be the logic for this function:
     - If facet has `null` filter: `false`

--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -4400,7 +4400,8 @@ value for a not-null column, and therefore we should not do this check if user i
 Based on this, the following will be the logic for this function:
     - If facet has `null` filter: `false`
     - If facet has `"hide_null_choice": true`: `true`
-    - If G1: `true` if the column is not-null otherwise `false`
+    - If G1: `true` if the column is not-null and user has select right otherwise `false`
+    - If G5: `true`
     - If G2: `true`
     - If G3.1: `false`
     - If G3 and no other G3 has null: `false`

--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -438,6 +438,7 @@ to use for ERMrest JavaScript agents.
         * [.ermrestHasPath](#ERMrest.FacetColumn+ermrestHasPath) : <code>Boolean</code>
         * [.preferredMode](#ERMrest.FacetColumn+preferredMode) : <code>string</code>
         * [.isEntityMode](#ERMrest.FacetColumn+isEntityMode) : <code>Boolean</code>
+        * [.isAllOutboundNotNull](#ERMrest.FacetColumn+isAllOutboundNotNull) : <code>Boolean</code>
         * [.barPlot](#ERMrest.FacetColumn+barPlot) : <code>Boolean</code>
         * [.histogramBucketCount](#ERMrest.FacetColumn+histogramBucketCount) : <code>Integer</code>
         * [.column](#ERMrest.FacetColumn+column) : [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)
@@ -4147,6 +4148,7 @@ Indicates that this ReferenceColumn is an inbound foreign key.
     * [.ermrestHasPath](#ERMrest.FacetColumn+ermrestHasPath) : <code>Boolean</code>
     * [.preferredMode](#ERMrest.FacetColumn+preferredMode) : <code>string</code>
     * [.isEntityMode](#ERMrest.FacetColumn+isEntityMode) : <code>Boolean</code>
+    * [.isAllOutboundNotNull](#ERMrest.FacetColumn+isAllOutboundNotNull) : <code>Boolean</code>
     * [.barPlot](#ERMrest.FacetColumn+barPlot) : <code>Boolean</code>
     * [.histogramBucketCount](#ERMrest.FacetColumn+histogramBucketCount) : <code>Integer</code>
     * [.column](#ERMrest.FacetColumn+column) : [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)
@@ -4275,6 +4277,13 @@ If facetObject['entity'] is defined as false, it will return false,
 otherwise it will true if filter is based on key.
 
 **Kind**: instance property of [<code>FacetColumn</code>](#ERMrest.FacetColumn)  
+<a name="ERMrest.FacetColumn+isAllOutboundNotNull"></a>
+
+#### facetColumn.isAllOutboundNotNull : <code>Boolean</code>
+Whether the facet is defining an all outbound path that the columns used
+in the path are all not-null.
+
+**Kind**: instance property of [<code>FacetColumn</code>](#ERMrest.FacetColumn)  
 <a name="ERMrest.FacetColumn+barPlot"></a>
 
 #### facetColumn.barPlot : <code>Boolean</code>
@@ -4361,11 +4370,15 @@ Based on this, we can categorize facets into these three groups:
   3. (G3) Facets with path where the column is not nullable. Here `null` can only mean path existence.
   3. (G3.1) Facets with only one hop where the column used in foreignkey is the same column for faceting.
      In this case, we can completely ignore the foreignkey path and just do a value check on main table.
+Other types of facet that null won't be applicable to them and therefore
+we shouldn't even offer the option:
+  1. (G4) Scalar columns of main table that are not-null.
+  2. (G5) All outbound foreignkey facets that all the columns invloved are not-null
 
 Based on this, the following will be the logic for this function:
     - If facet has `null` filter: `false`
     - If facet has `"hide_null_choice": true`: `true`
-    - If G1: `false`
+    - If G1: `true` if the column is not-null otherwise `false`
     - If G2: `true`
     - If G3.1: `false`
     - If G3 and no other G3 has null: `false`
@@ -4375,7 +4388,12 @@ Based on this, the following will be the logic for this function:
 <a name="ERMrest.FacetColumn+hideNotNullChoice"></a>
 
 #### facetColumn.hideNotNullChoice : <code>Boolean</code>
-Whether client should hide the not-null choice
+Whether client should hide the not-null choice. The logic is as follows:
+- `false` if facet has not-null filter.
+- `true` if facet has hide_not_null_choice in it's definition
+- `true` if facet is from the same table and it's not-nullable.
+- `true` if facet is all outbound not null.
+- otherwise `false`
 
 **Kind**: instance property of [<code>FacetColumn</code>](#ERMrest.FacetColumn)  
 <a name="ERMrest.FacetColumn+hideNumOccurrences"></a>

--- a/js/column.js
+++ b/js/column.js
@@ -2387,7 +2387,8 @@ FacetColumn.prototype = {
      * Based on this, the following will be the logic for this function:
      *     - If facet has `null` filter: `false`
      *     - If facet has `"hide_null_choice": true`: `true`
-     *     - If G1: `true` if the column is not-null otherwise `false`
+     *     - If G1: `true` if the column is not-null and user has select right otherwise `false`
+     *     - If G5: `true`
      *     - If G2: `true`
      *     - If G3.1: `false`
      *     - If G3 and no other G3 has null: `false`
@@ -2407,13 +2408,15 @@ FacetColumn.prototype = {
                     return true;
                 }
 
+                var versioned = self.reference.table.schema.catalog.version;
+
                 // G1 / G4
                 if (self.foreignKeys.length < 1) {
-                    return !self._column.nullok;
+                    return !versioned && !self._column.nullok && self._column.rights.select === true;
                 }
 
                 // G5
-                if (!self.reference.table.schema.catalog.version && self.isAllOutboundNotNull) {
+                if (!versioned && self.isAllOutboundNotNull) {
                     return true;
                 }
 
@@ -2459,13 +2462,15 @@ FacetColumn.prototype = {
                 // if hide_not_null_choice is available in facet definition
                 if (self._facetObject.hide_not_null_choice === true) return true;
 
+                var versioned = self.reference.table.schema.catalog.version;
+
                 //if from the same column, don't show if it's not-null
                 if (self.foreignKeys.length === 0) {
-                    return !self._column.nullok;
+                    return !versioned && !self._column.nullok && self._column.rights.select === true;
                 }
 
                 //if all outbound not-null don't show it.
-                return !self.reference.table.schema.catalog.version && self.isAllOutboundNotNull;
+                return !versioned && self.isAllOutboundNotNull;
             };
 
             this._hideNotNullChoice = getHideNotNull(this);

--- a/js/core.js
+++ b/js/core.js
@@ -225,6 +225,11 @@
          */
         this.id = id;
 
+        var catalogSnapshot = id.split("@");
+        if (catalogSnapshot.length === 2) {
+            this.version = catalogSnapshot[1];
+        }
+
         this._uri = server.uri + "/catalog/" + id;
 
         /**

--- a/test/specs/faceting/conf/faceting_schema/schema.json
+++ b/test/specs/faceting/conf/faceting_schema/schema.json
@@ -145,13 +145,15 @@
                     "comment": "comment",
                     "type": {
                         "typename": "serial4"
-                    }
+                    },
+                    "nullok": true
                 },
                 {
                     "name": "fk_to_f2",
                     "type": {
                         "typename": "serial4"
-                    }
+                    },
+                    "nullok": false
                 },
                 {
                     "name": "unfaceted_column",
@@ -166,8 +168,8 @@
                     "filter": {
                         "and": [
                             {"source": "*", "choices": ["test"]},
-                            {"source": "id", "ux_mode": "ranges", "choices": ["1"], "hide_num_occurrences": false, "hide_not_null_choice": true, "hide_null_choice": true},
-                            {"source": "int_col", "ux_mode": "choices", "ranges": [{"min": -2}], "order": [{"column": "id", "descending": true}], "hide_num_occurrences": true},
+                            {"source": "id", "ux_mode": "ranges", "choices": ["1"], "hide_num_occurrences": false},
+                            {"source": "int_col", "ux_mode": "choices", "ranges": [{"min": -2}], "order": [{"column": "id", "descending": true}], "hide_num_occurrences": true, "hide_not_null_choice": true},
                             {"source": ["float_col"], "ux_mode": "invalid mode", "order": [{"column": "id"}, {"column": "float_col", "descending": true}], "hide_not_null_choice": true},
                             {"source": "date_col"},
                             {"source": "timestamp_col"},
@@ -179,7 +181,7 @@
                             {"source": ["jsonb_col"]},
                             {"source": [{"outbound": ["faceting_schema", "main_fk1"]}, "id"], "markdown_name": "**F1**", "hide_null_choice": true},
                             {"source": [{"outbound": ["faceting_schema", "main_fk2"]}, "id"], "open": true},
-                            {"source": [{"inbound": ["faceting_schema", "main_f3_assoc_fk1"]}, {"outbound": ["faceting_schema", "main_f3_assoc_fk2"]}, "term"]},
+                            {"source": [{"inbound": ["faceting_schema", "main_f3_assoc_fk1"]}, {"outbound": ["faceting_schema", "main_f3_assoc_fk2"]}, "term"], "hide_not_null_choice":  true},
                             {"source": [{"inbound": ["faceting_schema", "f4_fk1"]}, "id"], "entity": false, "ux_mode": "check_presence"},
                             {"source": [
                                 {"inbound": ["faceting_schema", "longpath_1_fk1"]},

--- a/test/specs/faceting/tests/01.faceting.js
+++ b/test/specs/faceting/tests/01.faceting.js
@@ -1419,11 +1419,19 @@ exports.execute = function (options) {
                 });
 
                 it ("should return `true` if hide_null_choice is set to `true`.", function () {
-                    testHideNullChoice([0, 10, 15], true);
+                    testHideNullChoice([10, 15], true);
                 });
 
-                it ("should return `false` if source doesn't have any path.", function () {
+                it ("should return `true` if source doesn't have any patha nd it's not-null.", function () {
+                    testHideNullChoice([0], true);
+                });
+
+                it ("should return `false` if source doesn't have any path and it's nullable.", function () {
                     testHideNullChoice([1, 2, 3, 4, 5, 6, 7, 8, 9, 19], false);
+                });
+
+                it ("should return `true` if it's an all outbound path with all the columns being not-null.", function () {
+                    testHideNullChoice([11], true);
                 });
 
                 it ("should return `true` if source has a path and column is nullable.", function () {
@@ -1431,7 +1439,7 @@ exports.execute = function (options) {
                 });
 
                 it ("should return `false` if column is not nullable, and source has path one and foreignkey can be ignored.", function () {
-                    testHideNullChoice([11, 13], false);
+                    testHideNullChoice([13], false);
                 });
 
                 describe("otherwise for facets with column not-null and path, ", function () {
@@ -1448,15 +1456,37 @@ exports.execute = function (options) {
             });
 
             describe("hideNotNullChoice, ", function () {
-                it ('should return false if hide_null_choice is not `true`.', function () {
-                    expect(mainFacets[1].hideNotNullChoice).toBe(false, "missmatch for index=1");
-                    expect(mainFacets[7].hideNotNullChoice).toBe(false, "missmatch for index=7");
+                var testHideNotNullChoice = function (indices, res) {
+                    indices.forEach(function (index) {
+                        expect(mainFacets[index].hideNotNullChoice).toBe(res, "missmatch for index=" + index);
+                    });
+                };
+
+                var newRefWithNull;
+                beforeAll(function () {
+                    newRefWithNull = mainFacets[2].addNotNullFilter().contextualize.detailed;
                 });
 
-                it ("otherwise should return true.", function () {
-                    expect(mainFacets[0].hideNotNullChoice).toBe(true, "missmatch for index=0");
-                    expect(mainFacets[2].hideNotNullChoice).toBe(true, "missmatch for index=2");
+                it ("should return `false` if facet has not-null.", function () {
+                    expect(newRefWithNull.facetColumns[2].hideNullChoice).toBe(false, "missmatch for index=10");
                 });
+
+                it ("should return true if hide_not_null_choice is `true`.", function () {
+                    testHideNotNullChoice([1,2,12], true);
+                });
+
+                it ("should return `true` if facet doesn't have any path and is not-null.", function () {
+                    testHideNotNullChoice([0], true);
+                });
+
+                it ("should return `true` for all-outbound facets that all the column in path are not-null.", function () {
+                    testHideNotNullChoice([10, 11], true);
+                });
+
+                it ('otherwise should return `false`.', function () {
+                    testHideNotNullChoice([3,4,5,6,7,8,9,13,14,15,16,17,18,19], false);
+                });
+
             });
 
             describe("sortColumns", function () {


### PR DESCRIPTION
We want to make sure we're not showing these two options when it's not applicable. This will help the data-modelers to reduce the amount of customization that they need to do.

Please refer to the issue for more information: #742 