### PR TITLE
public renderHandlebarsTemplate function

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -2903,12 +2903,8 @@ The default information that we want to be logged including catalog, schema_tabl
 #### reference.defaultExportTemplate : <code>string</code>
 Returns a object, that can be used as a default export template.
 It will include:
-- csv of entity API request to the main table.
--  csv of entity API requests for all the related entities that are one level away from the main.
-- csv of attributegroup API requests for all the other related entities.
-  The projection list should include all the columns of the table plus
-  the foreignkey value to the main entity.
-  The request should be grouped by the value of table's key + foreign key value.
+- csv of the main table.
+- csv of all the related entities
 - fetch all the assets. For fetch, we need to provide url, length, and md5 (or other checksum types).
   if these columns are missing from the asset annotation, they won't be added.
 - fetch all the assetes of related tables.
@@ -6141,12 +6137,8 @@ The default information that we want to be logged including catalog, schema_tabl
 #### reference.defaultExportTemplate : <code>string</code>
 Returns a object, that can be used as a default export template.
 It will include:
-- csv of entity API request to the main table.
--  csv of entity API requests for all the related entities that are one level away from the main.
-- csv of attributegroup API requests for all the other related entities.
-  The projection list should include all the columns of the table plus
-  the foreignkey value to the main entity.
-  The request should be grouped by the value of table's key + foreign key value.
+- csv of the main table.
+- csv of all the related entities
 - fetch all the assets. For fetch, we need to provide url, length, and md5 (or other checksum types).
   if these columns are missing from the asset annotation, they won't be added.
 - fetch all the assetes of related tables.

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -2642,8 +2642,8 @@
      * @return {string} A string produced after templating
      * @desc Calls the private function to return a string produced as a result of templating using `Handlebars`.
      */
-    module.renderHandlebarsTemplate = function (template, keyValues, catalog, options) {
-        return module._renderHandlebarsTemplate(template, keyValues, catalog, options);
+    module._renderHandlebarsTemplate = function (template, keyValues, catalog, options) {
+        return module.renderHandlebarsTemplate(template, keyValues, catalog, options);
     };
 
     /*
@@ -2656,7 +2656,7 @@
      * @return {string} A string produced after templating
      * @desc Returns a string produced as a result of templating using `Handlebars`.
      */
-    module._renderHandlebarsTemplate = function(template, keyValues, catalog, options) {
+    module.renderHandlebarsTemplate = function(template, keyValues, catalog, options) {
 
         options = options || {};
 
@@ -2817,7 +2817,7 @@
 
         if (options.templateEngine === module.HANDLEBARS) {
             // render the template using Handlebars
-            return module._renderHandlebarsTemplate(template, keyValues, table.schema.catalog, options);
+            return module.renderHandlebarsTemplate(template, keyValues, table.schema.catalog, options);
         }
 
         // render the template using Mustache

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -2634,9 +2634,24 @@
 
     /*
      * @function
+     * @public
+     * @param {String} template The template string to transform
+     * @param {Object} keyValues The key-value pair of object to be used for template tags replacement.
+     * @param {Object} catalog The catalog object created by ermrestJS representing the current catalog from the url
+     * @param {Object} [options] Configuration options.
+     * @return {string} A string produced after templating
+     * @desc Calls the private function to return a string produced as a result of templating using `Handlebars`.
+     */
+    module.renderHandlebarsTemplate = function (template, keyValues, catalog, options) {
+        return module._renderHandlebarsTemplate(template, keyValues, catalog, options);
+    };
+
+    /*
+     * @function
      * @private
      * @param {String} template The template string to transform
      * @param {Object} keyValues The key-value pair of object to be used for template tags replacement.
+     * @param {Object} catalog The catalog object created by ermrestJS representing the current catalog from the url
      * @param {Object} [options] Configuration options.
      * @return {string} A string produced after templating
      * @desc Returns a string produced as a result of templating using `Handlebars`.

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -372,81 +372,81 @@ exports.execute = function (options) {
             });
         });
 
-        describe('module._renderHandlebarsTemplate() should function correctly for', function () {
+        describe('module.renderHandlebarsTemplate() should function correctly for', function () {
             it('Null and Non-null values', function() {
-                expect(module._renderHandlebarsTemplate("My name is {{name}}", { name: 'Chloe' })).toBe("My name is Chloe");
-                expect(module._renderHandlebarsTemplate("My name is {{name}}", { name: null })).toBe(null);
-                expect(module._renderHandlebarsTemplate("My name is {{name}}", {})).toBe(null);
-                expect(module._renderHandlebarsTemplate("My name is {{#if name}}{{name}}{{/if}}", {})).toBe("My name is ");
-                expect(module._renderHandlebarsTemplate("My name is {{^if name}}{{name}}{{/if}}", {})).toBe("My name is ", "For inverted if with variable");
-                expect(module._renderHandlebarsTemplate("My name is {{^if name}}John{{/if}}", {})).toBe("My name is John", "For inverted if with string");
-                expect(module._renderHandlebarsTemplate("My name is {{#unless name}}Jona{{/unless}}", {})).toBe("My name is Jona", "For unless");
+                expect(module.renderHandlebarsTemplate("My name is {{name}}", { name: 'Chloe' })).toBe("My name is Chloe");
+                expect(module.renderHandlebarsTemplate("My name is {{name}}", { name: null })).toBe(null);
+                expect(module.renderHandlebarsTemplate("My name is {{name}}", {})).toBe(null);
+                expect(module.renderHandlebarsTemplate("My name is {{#if name}}{{name}}{{/if}}", {})).toBe("My name is ");
+                expect(module.renderHandlebarsTemplate("My name is {{^if name}}{{name}}{{/if}}", {})).toBe("My name is ", "For inverted if with variable");
+                expect(module.renderHandlebarsTemplate("My name is {{^if name}}John{{/if}}", {})).toBe("My name is John", "For inverted if with string");
+                expect(module.renderHandlebarsTemplate("My name is {{#unless name}}Jona{{/unless}}", {})).toBe("My name is Jona", "For unless");
             });
 
             it('ifCond helper', function() {
-                expect(module._renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
-                expect(module._renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
+                expect(module.renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
+                expect(module.renderHandlebarsTemplate("Name {{#ifCond name \"===\" 'Chloe'}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/ifCond}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
             });
 
             it('each helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#each values}}{{this}}\n{{/each}}", { values: [2, 3, 7, 9] })).toBe("2\n3\n7\n9\n");
+                expect(module.renderHandlebarsTemplate("{{#each values}}{{this}}\n{{/each}}", { values: [2, 3, 7, 9] })).toBe("2\n3\n7\n9\n");
             });
 
             it('formatDate helper', function () {
-                expect(module._renderHandlebarsTemplate("{{formatDate '2018-07-26' 'YYYY'}}")).toBe("2018");
-                expect(module._renderHandlebarsTemplate("{{formatDate '02-16-97' 'YYYY'}}")).toBe("1997");
+                expect(module.renderHandlebarsTemplate("{{formatDate '2018-07-26' 'YYYY'}}")).toBe("2018");
+                expect(module.renderHandlebarsTemplate("{{formatDate '02-16-97' 'YYYY'}}")).toBe("1997");
             });
 
             it('encodeFacet helper', function () {
                 var facet = '{"and": [{"source": "id", "choices": ["1"]}]}';
-                expect(module._renderHandlebarsTemplate("{{#encodeFacet}}" + facet + "{{/encodeFacet}}")).toBe('N4IghgdgJiBcAEBtUBnA9gVwE4GMCmc8IAljADRE4AWax+KhiIAjCALoC+nQA');
+                expect(module.renderHandlebarsTemplate("{{#encodeFacet}}" + facet + "{{/encodeFacet}}")).toBe('N4IghgdgJiBcAEBtUBnA9gVwE4GMCmc8IAljADRE4AWax+KhiIAjCALoC+nQA');
             });
 
             it('if eq (equals) helper', function () {
-                expect(module._renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
-                expect(module._renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
+                expect(module.renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
+                expect(module.renderHandlebarsTemplate("Name {{#if (eq name 'Chloe')}}{{name}} is equal to Chloe{{else}}{{name}} is not equal to Chloe{{/if}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
             });
 
             it('if ne (not equals) helper', function () {
-                expect(module._renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
-                expect(module._renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
+                expect(module.renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'John' })).toBe("Name John is not equal to Chloe");
+                expect(module.renderHandlebarsTemplate("Name {{#if (ne name 'Chloe')}}{{name}} is not equal to Chloe{{else}}{{name}} is equal to Chloe{{/if}}", { name: 'Chloe' })).toBe("Name Chloe is equal to Chloe");
             });
 
             it('if lt (less than) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 3 })).toBe("3 is less than 10");
-                expect(module._renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 17 })).toBe("17 is not less than 10");
+                expect(module.renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 3 })).toBe("3 is less than 10");
+                expect(module.renderHandlebarsTemplate("{{#if (lt value '10')}}{{value}} is less than 10{{else}}{{value}} is not less than 10{{/if}}", { value: 17 })).toBe("17 is not less than 10");
             });
 
             it('if gt (greater than) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 17 })).toBe("17 is greater than 10");
-                expect(module._renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 3 })).toBe("3 is not greater than 10");
+                expect(module.renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 17 })).toBe("17 is greater than 10");
+                expect(module.renderHandlebarsTemplate("{{#if (gt value '10')}}{{value}} is greater than 10{{else}}{{value}} is not greater than 10{{/if}}", { value: 3 })).toBe("3 is not greater than 10");
             });
 
             it('if lte (less than or equal to) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 3 })).toBe("3 is less than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 10 })).toBe("10 is less than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 17 })).toBe("17 is not less than or equal to 10");
+                expect(module.renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 3 })).toBe("3 is less than or equal to 10");
+                expect(module.renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 10 })).toBe("10 is less than or equal to 10");
+                expect(module.renderHandlebarsTemplate("{{#if (lte value '10')}}{{value}} is less than or equal to 10{{else}}{{value}} is not less than or equal to 10{{/if}}", { value: 17 })).toBe("17 is not less than or equal to 10");
             });
 
             it('if gte (greater than or equal to) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 17 })).toBe("17 is greater than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 10 })).toBe("10 is greater than or equal to 10");
-                expect(module._renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 3 })).toBe("3 is not greater than or equal to 10");
+                expect(module.renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 17 })).toBe("17 is greater than or equal to 10");
+                expect(module.renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 10 })).toBe("10 is greater than or equal to 10");
+                expect(module.renderHandlebarsTemplate("{{#if (gte value '10')}}{{value}} is greater than or equal to 10{{else}}{{value}} is not greater than or equal to 10{{/if}}", { value: 3 })).toBe("3 is not greater than or equal to 10");
             });
 
             it('if and (conjunction) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: true })).toBe("both booleans are true");
-                expect(module._renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: false })).toBe("one or more booleans are false");
+                expect(module.renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: true })).toBe("both booleans are true");
+                expect(module.renderHandlebarsTemplate("{{#if (and bool1 bool2)}}both booleans are true{{else}}one or more booleans are false{{/if}}", { bool1: true, bool2: false })).toBe("one or more booleans are false");
             });
 
             it('if or (disjunction) helper', function () {
-                expect(module._renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: true })).toBe("one or more booleans are true");
-                expect(module._renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: false })).toBe("both booleans are false");
+                expect(module.renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: true })).toBe("one or more booleans are true");
+                expect(module.renderHandlebarsTemplate("{{#if (or bool1 bool2)}}one or more booleans are true{{else}}both booleans are false{{/if}}", { bool1: false, bool2: false })).toBe("both booleans are false");
             });
 
             it('suppressed default helper log', function () {
                 try {
-                    module._renderHandlebarsTemplate("{{log 'Hello World'}}", {});
+                    module.renderHandlebarsTemplate("{{log 'Hello World'}}", {});
                 } catch (err) {
                     expect(err.message).toBe("You specified knownHelpersOnly, but used the unknown helper log - 1:0");
                 }
@@ -455,25 +455,25 @@ exports.execute = function (options) {
             it('injecting $moment obj', function() {
                 var moment = module._currDate;
                 expect(moment).toBeDefined();
-                expect(module._renderHandlebarsTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' })).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
-                expect(module._renderHandlebarsTemplate("Todays date is {{$moment.dateString}}", {})).toBe("Todays date is " + moment.dateString);
+                expect(module.renderHandlebarsTemplate("{{name}} was born on {{$moment.day}} {{$moment.date}}/{{$moment.month}}/{{$moment.year}}", { name: 'John' })).toBe("John was born on " + moment.day + " " + moment.date + "/" + moment.month + "/" + moment.year);
+                expect(module.renderHandlebarsTemplate("Todays date is {{$moment.dateString}}", {})).toBe("Todays date is " + moment.dateString);
 
-                expect(module._renderHandlebarsTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {})).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
-                expect(module._renderHandlebarsTemplate("Current time is {{$moment.timeString}}", {})).toBe("Current time is " + moment.timeString);
+                expect(module.renderHandlebarsTemplate("Current time is {{$moment.hours}}:{{$moment.minutes}}:{{$moment.seconds}}:{{$moment.milliseconds}} with timestamp {{$moment.timestamp}}", {})).toBe("Current time is " + moment.hours + ":" + moment.minutes + ":" + moment.seconds + ":" + moment.milliseconds + " with timestamp " + moment.timestamp);
+                expect(module.renderHandlebarsTemplate("Current time is {{$moment.timeString}}", {})).toBe("Current time is " + moment.timeString);
 
-                expect(module._renderHandlebarsTemplate("ISO string is {{$moment.ISOString}}", {})).toBe("ISO string is " + moment.ISOString);
-                expect(module._renderHandlebarsTemplate("GMT string is {{$moment.GMTString}}", {})).toBe("GMT string is " + moment.GMTString);
-                expect(module._renderHandlebarsTemplate("UTC string is {{$moment.UTCString}}", {})).toBe("UTC string is " + moment.UTCString);
+                expect(module.renderHandlebarsTemplate("ISO string is {{$moment.ISOString}}", {})).toBe("ISO string is " + moment.ISOString);
+                expect(module.renderHandlebarsTemplate("GMT string is {{$moment.GMTString}}", {})).toBe("GMT string is " + moment.GMTString);
+                expect(module.renderHandlebarsTemplate("UTC string is {{$moment.UTCString}}", {})).toBe("UTC string is " + moment.UTCString);
 
-                expect(module._renderHandlebarsTemplate("Local time string is {{$moment.localeTimeString}}", {})).toBe("Local time string is " + moment.localeTimeString);
+                expect(module.renderHandlebarsTemplate("Local time string is {{$moment.localeTimeString}}", {})).toBe("Local time string is " + moment.localeTimeString);
             });
 
             it('injecting $catalog obj', function() {
-                expect(module._renderHandlebarsTemplate("catalog snapshot: {{$catalog.snapshot}}, catalog id: {{$catalog.id}}", {}, options.catalog)).toBe("catalog snapshot: " + process.env.DEFAULT_CATALOG + ", catalog id: " + process.env.DEFAULT_CATALOG);
+                expect(module.renderHandlebarsTemplate("catalog snapshot: {{$catalog.snapshot}}, catalog id: {{$catalog.id}}", {}, options.catalog)).toBe("catalog snapshot: " + process.env.DEFAULT_CATALOG + ", catalog id: " + process.env.DEFAULT_CATALOG);
             });
 
             it("NOT injecting $catalog obj", function() {
-                expect(module._renderHandlebarsTemplate("catalog snapshot:{{#if $catalog.snapshot}} {{$catalog.snapshot}}{{/if}}", {})).toBe("catalog snapshot:");
+                expect(module.renderHandlebarsTemplate("catalog snapshot:{{#if $catalog.snapshot}} {{$catalog.snapshot}}{{/if}}", {})).toBe("catalog snapshot:");
             });
 
             var handlebarTemplateCases = [{
@@ -564,7 +564,7 @@ exports.execute = function (options) {
                 var printMarkdown = formatUtils.printMarkdown;
 
                 handlebarTemplateCases.forEach(function(ex) {
-                    var template = module._renderHandlebarsTemplate(ex.template, obj);
+                    var template = module.renderHandlebarsTemplate(ex.template, obj);
                     expect(template).toBe(ex.after_mustache, "For template => " + ex.template);
                     var html = printMarkdown(template);
                     expect(html).toBe(ex.after_render + '\n', "For template => " + ex.template);
@@ -572,15 +572,9 @@ exports.execute = function (options) {
             });
         });
 
-        describe('module.renderHandlebarsTemplate() should behave the same as module._renderHandlebarsTemplate() for', function () {
-            it('Null and Non-null values', function() {
-                expect(module.renderHandlebarsTemplate("My name is {{name}}", { name: 'Chloe' })).toBe("My name is Chloe");
-                expect(module.renderHandlebarsTemplate("My name is {{name}}", { name: null })).toBe(null);
-                expect(module.renderHandlebarsTemplate("My name is {{name}}", {})).toBe(null);
-                expect(module.renderHandlebarsTemplate("My name is {{#if name}}{{name}}{{/if}}", {})).toBe("My name is ");
-                expect(module.renderHandlebarsTemplate("My name is {{^if name}}{{name}}{{/if}}", {})).toBe("My name is ", "For inverted if with variable");
-                expect(module.renderHandlebarsTemplate("My name is {{^if name}}John{{/if}}", {})).toBe("My name is John", "For inverted if with string");
-                expect(module.renderHandlebarsTemplate("My name is {{#unless name}}Jona{{/unless}}", {})).toBe("My name is Jona", "For unless");
+        describe('module._renderHandlebarsTemplate() should behave the same as module.renderHandlebarsTemplate() for', function () {
+            it('injecting $catalog obj', function() {
+                expect(module._renderHandlebarsTemplate("catalog snapshot: {{$catalog.snapshot}}, catalog id: {{$catalog.id}}", {}, options.catalog)).toBe("catalog snapshot: " + process.env.DEFAULT_CATALOG + ", catalog id: " + process.env.DEFAULT_CATALOG);
             });
         });
 

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -572,5 +572,17 @@ exports.execute = function (options) {
             });
         });
 
+        describe('module.renderHandlebarsTemplate() should behave the same as module._renderHandlebarsTemplate() for', function () {
+            it('Null and Non-null values', function() {
+                expect(module.renderHandlebarsTemplate("My name is {{name}}", { name: 'Chloe' })).toBe("My name is Chloe");
+                expect(module.renderHandlebarsTemplate("My name is {{name}}", { name: null })).toBe(null);
+                expect(module.renderHandlebarsTemplate("My name is {{name}}", {})).toBe(null);
+                expect(module.renderHandlebarsTemplate("My name is {{#if name}}{{name}}{{/if}}", {})).toBe("My name is ");
+                expect(module.renderHandlebarsTemplate("My name is {{^if name}}{{name}}{{/if}}", {})).toBe("My name is ", "For inverted if with variable");
+                expect(module.renderHandlebarsTemplate("My name is {{^if name}}John{{/if}}", {})).toBe("My name is John", "For inverted if with string");
+                expect(module.renderHandlebarsTemplate("My name is {{#unless name}}Jona{{/unless}}", {})).toBe("My name is Jona", "For unless");
+            });
+        });
+
     });
 };


### PR DESCRIPTION
Added public function for `_renderHandlebarsTemplate()`. I have 2 questions about this:
 1. Right now the catalog object is included but only for the purpose of providing the catalog ID
  - should that continue to be the case?
  - or should we allow the public API to pass just an ID that gets added to a faux catalog object?

 2. What should the tests for this feature look like? 
   - If we keep the function as is, the tests would be redundant after making sure that the API does work for one case. 
   - If we change the function to just pass in the catalog ID, then testing that case would make sense.