### PR TITLE
add getDefaultDisplay function

### DIFF
--- a/js/export.js
+++ b/js/export.js
@@ -312,7 +312,7 @@ var ERMrest = (function(module) {
      * These are the same column names that we are using for row-name generation.
      *
      * @private
-     * @param  {ERMrest.referene} ref       the reference that we want the output for
+     * @param  {ERMrest.reference} ref       the reference that we want the output for
      * @param  {String} tableAlias          the alias that is used for projecting table (last table in path)
      * @param  {String=} path               the string that will be prepended to the path
      * @param  {String=} addMainKey         whether we want to add the key of the main table.

--- a/js/reference.js
+++ b/js/reference.js
@@ -2853,10 +2853,8 @@
          *
          * 0. keep track of the linkage and save some attributes:
          *      0.1 origFKR: the foreign key that created this related reference (used in chaise for autofill)
-         *      0.2 origColumnName: the name of pseudocolumn that represents origFKR (used in chaise for autofill)
-         *      0.3 parentDisplayname: the displayname of parent
+         *      0.2 parentDisplayname: the displayname of parent
          *          - logic: foriengkey's to_name or this.displayname
-         *
          *
          * 1. If it's pure and binary association. (current reference: T1) <-F1-(A)-F2-> (T2)
          *      1.1 displayname: F2.to_name or T2.displayname
@@ -2902,7 +2900,7 @@
             // the foreignkey that has created this link (link from this.reference to relatedReference)
             newRef.origFKR = fkr; // it will be used to trace back the reference
 
-            // the name of pseudocolumn that represents origFKR
+            // TODO should be removed (not needed anymore)
             newRef.origColumnName = _generateForeignKeyName(fkr);
 
             // the tuple of the main table

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -483,7 +483,7 @@
             if (!obj.hasOwnProperty(k)) continue;
             val = obj[k];
 
-            // we don't accept custom type objects (we're not detecting circular referene)
+            // we don't accept custom type objects (we're not detecting circular reference)
             if (isObject(val) && (val.constructor && val.constructor.name !== "Object")) continue;
 
             newK = k;
@@ -801,10 +801,6 @@
 
     _generateForeignKeyName = function (fk, isInbound) {
         var eTable = isInbound ? fk._table : fk.key.table;
-
-        if (!fk.simple) {
-            return module.generatePseudoColumnHashName(fk._constraintName);
-        }
 
         if (!isInbound) {
             return module.generatePseudoColumnHashName({

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -228,11 +228,11 @@ exports.execute = function (options) {
                 //ref_table_outbound_fks_key
                 expect(compactColumns[0].name).toBe("l-7AKq6z2IDzE63S0vQNPg", "name missmatch for compact, index=0");
                 //outbound_fk_8
-                expect(compactColumns[19].name).toBe("xJcbAuoxdRZ08TEXbbZ5VQ", "name missmatch for compact, index=13");
+                expect(compactColumns[19].name).toBe("Q5M6jdxFlTp2p682Kn-2UQ", "name missmatch for compact, index=13");
                 //inbound_related_to_columns_table_2_fkey
                 expect(detailedColumns[3].name).toBe("tKEjVbHI9RPuBFya-7_j6Q", "name missmatch for detailed, index=3");
                 //outbound_fk_7
-                expect(compactColumns[20].name).toBe("9CKS172K3jKYzR5qgRLvVw", "name missmatch for compact, index=14");
+                expect(compactColumns[20].name).toBe("kAAK8J6ar0hTrADb36nOIw", "name missmatch for compact, index=14");
             });
 
             it('for other columns should return the base column\'s name.', function () {
@@ -625,6 +625,56 @@ exports.execute = function (options) {
                 });
             });
         });
+
+        describe(".getDefaultDisplay", function () {
+            var urlPrefix = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":",
+                data = {"id": 1, "col_3": "v3", "col_4": "v4", "col 5": "v5", "col_6": "v6"};
+
+            var testDefaultDisplay = function (result, rowname, values, refUri) {
+                expect(result.rowname.value).toEqual(rowname, "rowname missmatch.");
+                expect(result.values).toEqual(values, "values missmatch.");
+                if (refUri == null) {
+                    expect(result.reference).toEqual(null, "reference missmatch.");
+                } else {
+                    expect(result.reference.uri).toEqual(refUri, "reference.uri missmatch.");
+                }
+            };
+
+            describe("for foreign key pseudo columns, ", function () {
+                it ("should return null value if the given values are not sufficient.", function () {
+                    testDefaultDisplay(
+                        compactColumns[20].getDefaultDisplay({"id": 1}),
+                        null, {}, null
+                    );
+                });
+
+                it ("should return the row-name if data is sufficient.", function () {
+                    testDefaultDisplay(
+                        compactColumns[20].getDefaultDisplay(data),
+                        "v4 , v5",
+                        {"id_1": "v4", "id_2": "v5"},
+                        urlPrefix + "table_w_composite_key/id_1=v4&id_2=v5"
+                    );
+                });
+
+                it ("should return a default col1:col2 if data is sufficient for link but not for rowname.", function () {
+                    testDefaultDisplay(
+                        compactColumns[18].getDefaultDisplay(data),
+                        "v3:v6",
+                        {"id_1": "v3", "id_2": "v6"},
+                        urlPrefix + "table_w_composite_key_2/id_1=v3&id_2=v6"
+                    );
+                });
+            });
+
+            it ("should not be available for other column types.", function () {
+                expect(compactColumns[0].getDefaultDisplay).toBe(undefined, "missmatch for index=0");
+                for (var i = 5; i < 17; i++) {
+                    expect(compactColumns[i].getDefaultDisplay).toBe(undefined, "missmatch for index=" + i);
+                }
+            });
+        });
+
 
         describe('.formatPresentation, ', function () {
             var val;

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -1036,15 +1036,6 @@ exports.execute = function (options) {
         })).toEqual(fks, "fks missmatch" + (colStr ? (" for " + colStr) : "."));
     }
 
-    function checkRelatedReference (ref, table, facets, origFKR, origColumnName, displayname, parentDisplayname, colStr) {
-        expect(ref.origFKR.toString()).toEqual(origFKR, "origFKR missmatch" + (colStr ? (" for " + colStr) : "."));
-        expect(ref.table.name).toEqual(table, "table missmatch" + (colStr ? (" for " + colStr) : "."));
-        expect(ref.location.facets.decoded).toEqual(facets, "facets missmatch" + (colStr ? (" for " + colStr) : "."));
-        expect(ref.origColumnName).toEqual(origColumnName, "origColumnName missmatch" + (colStr ? (" for " + colStr) : "."));
-        expect(ref.displayname.value).toEqual(displayname, "displayname missmatch" + (colStr ? (" for " + colStr) : "."));
-        expect(ref.parentDisplayname.value).toEqual(parentDisplayname, "parentDisplayname missmatch" + (colStr ? (" for " + colStr) : "."));
-    }
-
     function checkReference (ref, table, facets, colStr) {
         expect(ref.table.name).toEqual(table, "table missmatch" + (colStr ? (" for " + colStr) : "."));
         if (facets) {

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -198,17 +198,6 @@ exports.execute = function(options) {
                 expect(related[3].origFKR.toString()).toBe('(id)=(reference_schema:association%20table%20with%20id:id%20from%20ref%20table)');
             });
 
-            it('.origColumnName should have the correct value', function() {
-                // reference_schema_fromname_fk_inbound_related_to_reference
-                expect(related[0].origColumnName).toBe("arrj660yVmGl_vfSb9G4QQ", "missmatch for index = 0");
-                // reference_schema_fk_inbound_related_to_reference
-                expect(related[1].origColumnName).toBe("8kRTvQE9l_TdHX86eumVqg", "missmatch for index = 1");
-                //reference_schema_toname_fk_association_related_to_reference
-                expect(related[2].origColumnName).toBe("J-dn3Y5dmuvHdyOXn8Sihw", "missmatch for index = 2");
-                //reference_schema_id_fk_association_related_to_reference
-                expect(related[3].origColumnName).toBe("yzGY61pXr0wjqRuOQfHHfw", "missmatch for index = 3");
-            });
-
             describe('for inbound foreign keys, ', function() {
                 it('should have the correct catalog, schema, and table.', function() {
                     expect(related[0]._location.catalog).toBe(catalog_id.toString());


### PR DESCRIPTION
This PR will add a set of changes that are required for the [chaise#1730](https://github.com/informatics-isi-edu/chaise/pull/1730) PR. To summarize:

 - The new `getDefaultDisplay` function has been added that given a key-value pair will return the necessary objects to create a foreign key display in chaise.
- Modified the `name` logic of composite foreign keys to be aligned with source syntax. 
- Deprecated the `origColumnName` attribute in related reference since it's not needed anymore. I am going to completely delete it once chaise changes are complete and merged.