### PR TITLE
added custom base32 decode function for version snapshots.

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -544,8 +544,8 @@
         },
 
         /**
-         *  version is a 64-bit integer representing microseconds since the Unix "epoch"
-         *  The 64-bit integer is encoded using a custom base32 encoding scheme
+         * version is a 64-bit integer representing microseconds since the Unix "epoch"
+         * The 64-bit integer is encoded using a custom base32 encoding scheme
          * @returns {String} the version decoded to it's time since epoch in milliseconds
          */
         get versionAsMillis() {

--- a/js/parser.js
+++ b/js/parser.js
@@ -544,6 +544,18 @@
         },
 
         /**
+         *  version is a 64-bit integer representing microseconds since the Unix "epoch"
+         *  The 64-bit integer is encoded using a custom base32 encoding scheme
+         * @returns {String} the version decoded to it's time since epoch in milliseconds
+         */
+        get versionAsMillis() {
+            if (this._versionAsMillis === undefined) {
+                this._versionAsMillis = module._versionDecodeBase32(this._version);
+            }
+            return this._versionAsMillis;
+        },
+
+        /**
          *
          * @returns {String} API of the ermrest service.
          * API includes entity, attribute, aggregate, attributegroup
@@ -581,7 +593,7 @@
 
         /**
          *
-         * @type {string} the table name which the uri referres to
+         * @type {string} tablename - the table name which the uri referres to
          */
         get tableName() {
             if (this._tableName === undefined) {

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -2948,6 +2948,50 @@
         return unescape(module._fixedEncodeURIComponent(JSON.stringify(obj)));
     };
 
+    module._versionDecodeBase32 = function (version) {
+        // use 5-bit value as index to find symbol
+        // e.g. b32_symbols[15] == 'F'
+        var b32Symbols = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+        // reverse mapping symbol -> 5-bit value
+        var b32Values = {};
+        for (var i=0; i<b32Symbols.length; i++) {
+            var symbol = b32Symbols[i];
+            b32Values[symbol] = i;
+        }
+
+        // """Decode 64-bit integer as approximate float value."""
+
+        // map to canonical symbols w/o separators
+        var s = version.toUpperCase()
+            .replaceAll('-', '')
+            .replaceAll('O', '0')
+            .replaceAll('I', '1')
+            .replaceAll('L', '1');
+
+        if (s.length > 13) {
+            // throw error maybe?
+            throw new Error("Invalid Version String", s.length + " symbols exceedlimit of 13");
+            // raise ValueError('%d symbols exceeds limit of 13' % len(s))
+        } else if (s.length < 13) {
+            // normalize to full 13-symbol format as general case
+            s = '0'.repeat(13 - s.length) + s;
+        }
+
+        // interpret first symbol as 2's complement signed value
+        var accum = parseFloat(b32Values[s[0]]);
+        if (accum >= 16) accum -= 32;
+
+        // interpret remaining symbols as unsigned values
+        for (var k=1; k<s.length; k++) {
+            var char = s[k];
+            accum = accum * 32 + b32Values[char];
+        }
+
+        // remove least significant pad bit and convert to milliseconds for precision
+        return (accum / 2.0)/1000;
+    };
+
     /**
      * Given a header value, will encode and truncate if its length is more than the allowed length.
      * These are the allowed and expected values in a header:

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -2948,6 +2948,11 @@
         return unescape(module._fixedEncodeURIComponent(JSON.stringify(obj)));
     };
 
+    /**
+     *  version is a 64-bit integer representing microseconds since the Unix "epoch"
+     *  The 64-bit integer is encoded using a custom base32 encoding scheme
+     *  @returns {String} the version decoded to it's time since epoch in milliseconds
+     */
     module._versionDecodeBase32 = function (version) {
         // use 5-bit value as index to find symbol
         // e.g. b32_symbols[15] == 'F'

--- a/test/specs/parser/tests/01.parser.js
+++ b/test/specs/parser/tests/01.parser.js
@@ -1007,6 +1007,25 @@ exports.execute = function(options) {
             });
         });
 
+        describe("Decoding Version snapshot, ", function () {
+            var decode = options.ermRest._versionDecodeBase32;
+
+            it("should decode snapshot values to milliseconds from epoch.", function() {
+                expect(decode('0')*1000).toBe(0.0);
+                expect(decode('2')*1000).toBe(1.0);
+                expect(decode('Z-ZZZZ-ZZZZ-ZZZY')*1000).toBe(-1.0);
+                expect(decode('G-0000-0000-0000')*1000).toBe(-9.223372036854776e+18);
+                expect(decode('Z-M9DK-J8QS-NN80')*1000).toBe(-210866774822000000.0);
+            });
+
+            it("should decode to a value that we can properly convert to a datetime.", function () {
+                expect(options.ermRest._moment(decode('Z-ZZZZ-ZZZY-2YW0')).utc().format("YYYY-MM-DDTHH:mm:ss")).toBe('1969-12-31T23:59:59');
+                expect(options.ermRest._moment(decode('0')).utc().format("YYYY-MM-DDTHH:mm:ss")).toBe('1970-01-01T00:00:00');
+                expect(options.ermRest._moment(decode('1-X140')).utc().format("YYYY-MM-DDTHH:mm:ss")).toBe('1970-01-01T00:00:01');
+                expect(options.ermRest._moment(decode('2R6-QAMZ-AB8W')).utc().format("YYYY-MM-DDTHH:mm:ss.SSS")).toBe('2019-03-05T18:49:24.459');
+            });
+        });
+
         // NOTE: search test cases are in refererence/13.search.js
         // NOTE: more facet test cases are in faceting test specs
     };


### PR DESCRIPTION
Added the base32 custom decode function to ermrestJS for ease of use and for testing. This is to help resolve [issue #1673](https://github.com/informatics-isi-edu/chaise/issues/1673) and [issue #1733](https://github.com/informatics-isi-edu/chaise/issues/1733) in the chaise repo.