### PR TITLE
add tag:isrd.isi.edu,2019:export support

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -120,8 +120,8 @@ to use for ERMrest JavaScript agents.
             * [.shortestKey](#ERMrest.Table+shortestKey)
             * [.displayKey](#ERMrest.Table+displayKey) : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
             * [.uri](#ERMrest.Table+uri) : <code>string</code>
-            * [.exportTemplates](#ERMrest.Table+exportTemplates) : <code>Array</code> \| <code>null</code>
             * [._getRowDisplayKey(context)](#ERMrest.Table+_getRowDisplayKey)
+            * [.getExportTemplates()](#ERMrest.Table+getExportTemplates) : <code>Array</code> \| <code>null</code>
         * _static_
             * [.Entity](#ERMrest.Table.Entity)
                 * [new Entity(server, table)](#new_ERMrest.Table.Entity_new)
@@ -1021,8 +1021,8 @@ get table by table name
         * [.shortestKey](#ERMrest.Table+shortestKey)
         * [.displayKey](#ERMrest.Table+displayKey) : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
         * [.uri](#ERMrest.Table+uri) : <code>string</code>
-        * [.exportTemplates](#ERMrest.Table+exportTemplates) : <code>Array</code> \| <code>null</code>
         * [._getRowDisplayKey(context)](#ERMrest.Table+_getRowDisplayKey)
+        * [.getExportTemplates()](#ERMrest.Table+getExportTemplates) : <code>Array</code> \| <code>null</code>
     * _static_
         * [.Entity](#ERMrest.Table.Entity)
             * [new Entity(server, table)](#new_ERMrest.Table.Entity_new)
@@ -1133,14 +1133,6 @@ The columns that create the shortest key that can be used for display purposes.
 uri to the table in ermrest with entity api
 
 **Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
-<a name="ERMrest.Table+exportTemplates"></a>
-
-#### table.exportTemplates : <code>Array</code> \| <code>null</code>
-Returns the export templates that are defined on this table.
-NOTE If this returns `null`, then the exportTemplates is not defined on the table or schema
-NOTE The returned template might not have `outputs` attribute.
-
-**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+_getRowDisplayKey"></a>
 
 #### table.\_getRowDisplayKey(context)
@@ -1154,6 +1146,14 @@ It's the same as displaykey but with extra restrictions. It might return undefin
 | --- | --- | --- |
 | context | <code>string</code> | used to figure out if the column has markdown_pattern annoation or not. |
 
+<a name="ERMrest.Table+getExportTemplates"></a>
+
+#### table.getExportTemplates() : <code>Array</code> \| <code>null</code>
+Returns the export templates that are defined on this table.
+NOTE If this returns `null`, then the exportTemplates is not defined on the table or schema
+NOTE The returned template might not have `outputs` attribute.
+
+**Kind**: instance method of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table.Entity"></a>
 
 #### Table.Entity

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -56,14 +56,15 @@ here is a quick matrix to locate them.
 | [2017 Key Display](#tag-2017-key-display) | - | - | - | X | - | Key augmentation |
 | [2016 Foreign Key](#tag-2016-foreign-key) | - | - | - | - | X | Foreign key augmentation |
 | [2016 Generated](#tag-2016-generated) | X | X | X | - | - | Generated model element |
-| [2016 Ignore](#tag-2016-ignore) | X | X | X | - | - | Ignore model element |
+| [2016 Ignore](#tag-2016-ignore) (_deprecated_) | X | X | X | - | - | Ignore model element |
 | [2016 Immutable](#tag-2016-immutable) | X | X | X | - | - | Immutable model element |
 | [2016 Non Deletable](#tag-2016-non-deletable) | X | X | - | - | - | Non-deletable model element |
 | [2016 App Links](#tag-2016-app-links) | X | X | - | - | - | Intra-Chaise app links |
 | [2016 Table Display](#tag-2016-table-display) | - | X | - | - | - | Table-specific display options |
 | [2016 Visible Columns](#tag-2016-visible-columns) | - | X | - | - | - | Column visibility and presentation order |
 | [2016 Visible Foreign Keys](#tag-2016-visible-foreign-keys) | - | X | - | - | - | Foreign key visibility and presentation order |
-| [2016 Export](#tag-2016-export) | X | X | - | - | - | Describes export templates |
+| [2019 Export](#tag-2019-export) | X | X | - | - | - | Describes export templates |
+| [2016 Export](#tag-2016-export) (_deprecated_) | X | X | - | - | - | Describes export templates |
 | [2017 Asset](#tag-2017-asset) | - | - | X | - | - | Describes assets |
 | [2018 Citation](#tag-2018-citation) | - | X | - | - | - | Describes citation |
 | [2018 Required](#tag-2018-required) | - | X | - | - | - | Required model column |
@@ -178,7 +179,7 @@ often used in prose, long-form presentations, tool tips, or other
 scenarios where a user may need more natural language understanding of
 the concept.
 
-### Tag: 2016 Ignore
+### Tag: 2016 Ignore (_Deprecated_)
 
 `tag:isrd.isi.edu,2016:ignore`
 
@@ -606,15 +607,16 @@ A alternative table or view which abstracts another table _SHOULD_ have a non-nu
 
 See [Context Names](#context-names) section for the list of supported _context_ names. It is assumed that any application context that is performing mutation (record creation, deletion, or editing) MUST use a base entity storage table that is not an abstraction over another table. However, the use of the `detailed` or `compact` context MAY offer an abstraction that augments the presentation of an existing record. An application offering mutation options while displaying an existing entity record might then present the data from the `detailed` or `compact` abstraction but only offer editing or data-entry controls on the fields available from the base storage table.
 
-### Tag: 2016 Export
+### Tag: 2019 Export
 
-`tag:isrd.isi.edu,2016:export`
+`tag:isrd.isi.edu,2019:export`
 
 This key can be used to define export templates that will be used for `ioboxd` service integration with the client tools. For more information about the annotation payload please visit [the iobodx integration document](https://github.com/informatics-isi-edu/ioboxd/blob/master/doc/integration.md).
 
 Supported JSON payload patterns:
 
-- `{` `"templates":` `[`_template_`]` `}`: An array of _template_ objects to export.
+- `{` ... _context_ `:` `{` `"templates":` `[`_template_`]` `}` `,` ... `}`: An array of template objects to export.
+- `{` ... _context1_ `:` _context2_ ... `}`: Short-hand to allow _context1_ to use the same templates configured for _context2_.
 
 Supported _template_ patterns:
 - `{` ... `"displayname:"` _displayname_ ... `}`: The display name that will be used to populate the Chaise export drop-down for this _template_.
@@ -637,6 +639,20 @@ Supported _destinationentry_ patterns:
 #### Export Annotation Hierarchy
 
 This annotation only applies to table but MAY be annotated at the schema level to set a schema-wide default. If the annotation is missing on the table, we will get the export definition from the schema.
+
+### Tag: 2016 Export (_Deprecated_)
+
+`tag:isrd.isi.edu,2016:export`
+
+> This tag is the old version of [2019 Export](#tag-2019-export) tag. The new tag supports contextualization and is preferred. Templates defined under this tag will be interpreted as `"*"` context of `tag:isrd.isi.edu,2019:export`. If both `tag:isrd.isi.edu,2016:export` and `tag:isrd.isi.edu,2019:export` for `"*"` context are defined, the `tag:isrd.isi.edu,2016:export` will be ignored.
+
+This key can be used to define export templates that will be used for `ioboxd` service integration with the client tools. For more information about the annotation payload please visit [the iobodx integration document](https://github.com/informatics-isi-edu/ioboxd/blob/master/doc/integration.md).
+
+Supported JSON payload pattern:
+
+- `{` `"templates":` `[`_template_`]` `}`: An array of _template_ objects to export.
+
+Please refer to [2019 Export](#tag-2019-export) for more information about the supported _template_ patterns.
 
 ### Tag: 2017 Asset
 

--- a/docs/user-docs/export.md
+++ b/docs/user-docs/export.md
@@ -1,6 +1,6 @@
 # Export Annotation
 
-Using the [export annotation](annotation.md#tag-2016-export) you can define expor templates that will be used for `ioboxd` service integration with the client tools. For detailed information please refer to [the ioboxd documentation](https://github.com/informatics-isi-edu/ioboxd/blob/master/doc/integration.md).
+Using the [export annotation](annotation.md#tag-2019-export) you can define export templates that will be used for `ioboxd` service integration with the client tools. For detailed information please refer to [the ioboxd documentation](https://github.com/informatics-isi-edu/ioboxd/blob/master/doc/integration.md).
 
 
 ## Structure
@@ -8,20 +8,20 @@ Using the [export annotation](annotation.md#tag-2016-export) you can define expo
 The following is how ERMrestJS and Chaise leverage the different values defined in the export annotation:
 
 ```js
-templates: [
+"templates": [
   {
-    displayname: <chaise-display-name>, // name displayed in dropdown menu in the client
-    type: <FILE or BAG>,
-    outputs: [
+    "displayname": <chaise-display-name>, // name displayed in dropdown menu in the client
+    "type": <FILE or BAG>,
+    "outputs": [
       {
-        source: {
-          api: <ermrest-query-type>, // entity, attribute, attribute-group
-          path: <optional-ermrest-predicate> // used to represent more complex queries
+        "source": {
+          "api": <ermrest-query-type>, // entity, attribute, attribute-group
+          "path": <optional-ermrest-predicate> // used to represent more complex queries
         },
         destination: {
-          name: <output-file-base-name>,
-          type: <output-format-suffix>, // FILE supports csv, json; BAG supports csv, json, fetch(?), download(?)
-          params: <not-sure> // conditionally optional
+          "name": <output-file-base-name>,
+          "type": <output-format-suffix>, // FILE supports csv, json; BAG supports csv, json, fetch(?), download(?)
+          "params": <not-sure> // conditionally optional
         }
       }, ...
     ]

--- a/js/core.js
+++ b/js/core.js
@@ -827,6 +827,8 @@
         if (this.annotations.contains(module._annotations.APP_LINKS)) {
             this._appLinksAnnotation = this.annotations.get(module._annotations.APP_LINKS).content;
         }
+
+        this._exportTemplates = {};
     }
 
     Table.prototype = {
@@ -1036,34 +1038,75 @@
          * NOTE The returned template might not have `outputs` attribute.
          * @type {Array|null}
          */
-        get exportTemplates() {
-            if (this._exportTemplates === undefined) {
-                var self = this, exp = module._annotations.EXPORT, annot;
+        getExportTemplates: function (context) {
+            context = context || "*";
+            if (!(context in this._exportTemplates)) {
+                this._exportTemplates[context] = this._getExportTemplates(context);
+            }
+            return this._exportTemplates[context];
+        },
 
-                var getValidTemplates = function (templates) {
-                    // make sure it's an array
-                    if (!Array.isArray(templates) || templates.length === 0) {
-                        return [];
-                    }
+        // the logic for getExportTemplates function
+        _getExportTemplates: function (context) {
+            var self = this,
+                exp = module._annotations.EXPORT,
+                expCtx = module._annotations.EXPORT_CONTEXTED,
+                annotDefinition = {}, hasAnnot = false,
+                chosenAnnot, annotTemplates;
 
-                    // filter only templates that are valid
-                    return templates.filter(function (temp) {
-                        return module.validateExportTemplate(temp);
-                    });
-                };
+            var getValidTemplates = function (templates) {
+                // make sure it's an array
+                if (!Array.isArray(templates) || templates.length === 0) {
+                    return [];
+                }
 
-                self._exportTemplates = [];
-                if (self.annotations.contains(exp) || self.schema.annotations.contains(exp)) {
-                    annot = self.annotations.contains(exp) ? self.annotations : self.schema.annotations;
-                    self._exportTemplates = getValidTemplates(annot.get(exp).content.templates);
-                } else {
-                    // annotation is not defined
-                    self._exportTemplates = null;
+                // filter only templates that are valid
+                return templates.filter(function (temp) {
+                    return module.validateExportTemplate(temp);
+                });
+            };
+
+            // get from table annotation
+            if (self.annotations.contains(exp)) {
+                annotDefinition = {"*": self.annotations.get(exp).content};
+                hasAnnot = true;
+            }
+
+            // get from table contextualized annotation
+            if (self.annotations.contains(expCtx)) {
+                annotDefinition = Object.assign({}, annotDefinition, self.annotations.get(expCtx).content);
+                hasAnnot = true;
+            }
+
+            if (hasAnnot) {
+                chosenAnnot = module._getAnnotationValueByContext(context, annotDefinition);
+                if (chosenAnnot !== -1 && typeof chosenAnnot === "object") {
+                    return getValidTemplates(chosenAnnot.templates);
                 }
             }
 
-            return this._exportTemplates;
-         },
+            //get from schema annoation
+            if (self.schema.annotations.contains(exp)) {
+                hasAnnot = true;
+                annotDefinition = {"*": self.schema.annotations.get(exp).content};
+            }
+
+            // get from schema contextualized annotation
+            if (self.schema.annotations.contains(expCtx)) {
+                annotDefinition = Object.assign({}, annotDefinition, self.schema.annotations.get(expCtx).content);
+                hasAnnot = true;
+            }
+
+            // annotation is not defined on schema and table
+            if (!hasAnnot) {
+                return null;
+            }
+
+            chosenAnnot = module._getAnnotationValueByContext(context, annotDefinition);
+            if (chosenAnnot !== -1 && typeof chosenAnnot === "object") {
+                return getValidTemplates(chosenAnnot.templates);
+            }
+        },
 
         // build foreignKeys of this table and referredBy of corresponding tables.
         _buildForeignKeys: function () {

--- a/js/reference.js
+++ b/js/reference.js
@@ -2077,7 +2077,7 @@
             var self = this;
 
             // either null or array
-            var res = self.table.exportTemplates;
+            var res = self.table.getExportTemplates(self._context);
 
             // annotation is missing
             if (res === null) {

--- a/js/utilities.js
+++ b/js/utilities.js
@@ -653,7 +653,7 @@
 
     /**
     * @param {string} context the context that we want the value of.
-    * @param {ERMrest.Annotation} annotation the annotation object.
+    * @param {Object} annotation the annotation object.
     * @desc returns the annotation value based on the given context.
     */
     module._getAnnotationValueByContext = function (context, annotation) {
@@ -3206,6 +3206,7 @@
         COLUMN_DISPLAY: "tag:isrd.isi.edu,2016:column-display",
         DISPLAY: "tag:misd.isi.edu,2015:display",
         EXPORT: "tag:isrd.isi.edu,2016:export",
+        EXPORT_CONTEXTED: "tag:isrd.isi.edu,2019:export",
         FOREIGN_KEY: "tag:isrd.isi.edu,2016:foreign-key",
         GENERATED: "tag:isrd.isi.edu,2016:generated",
         HIDDEN: "tag:misd.isi.edu,2015:hidden", //TODO deprecated and should be deleted.

--- a/test/specs/export/conf/export_schema_annot_schema/schema.json
+++ b/test/specs/export/conf/export_schema_annot_schema/schema.json
@@ -646,6 +646,49 @@
                     }
                 }
             ]
+        },
+        "table_w_contextualized_export": {
+            "kind": "table",
+            "table_name": "table_w_contextualized_export",
+            "schema_name": "export_schema_annot_schema",
+            "keys": [
+                {"unique_columns": ["id"]}
+            ],
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col",
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2019:export": {
+                    "compact": {
+                        "templates": [
+                            {
+                                "displayname": "contextualized table template",
+                                "type": "BAG"
+                            }
+                        ]
+                    }
+                },
+                "tag:isrd.isi.edu,2016:export": {
+                    "templates": [
+                        {
+                            "displayname": "default table template",
+                            "type": "BAG"
+                        }
+                    ]
+                }
+            }
         }
     },
     "schema_name": "export_schema_annot_schema",
@@ -658,6 +701,16 @@
                     "post_processors": "someFn"
                 }
             ]
+        },
+        "tag:isrd.isi.edu,2019:export": {
+            "compact": {
+                "templates": [
+                    {
+                        "displayname": "contextualized schema template",
+                        "type": "BAG"
+                    }
+                ]
+            }
         }
     }
 }


### PR DESCRIPTION
This PR will add support for the new `tag:isrd.isi.edu,2019:export` annotation. As it is described in [chaise#1621](https://github.com/informatics-isi-edu/chaise/issues/1621) this is how the new and old annotation are going to be processed:

The old annotation
```
"tag:isrd.isi.edu,2016:export": {
  "templates": [<some templates>]
}
```

Is going to be treated the same as 

```
"tag:isrd.isi.edu,2019:export": {
  "*": {
      "templates": [<some templates>]
  }
}
```
And if the new annotation with "*" context is already defined on table/schema, the old annotation will be ignored.
