### PR TITLE
add getMetadata function to AssetPseudoColumn

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -424,6 +424,7 @@ to use for ERMrest JavaScript agents.
         * [.sha256](#ERMrest.AssetPseudoColumn+sha256) : [<code>Column</code>](#ERMrest.Column)
         * [.filenameExtFilter](#ERMrest.AssetPseudoColumn+filenameExtFilter) : [<code>Column</code>](#ERMrest.Column)
         * [._determineInputDisabled(context)](#ERMrest.AssetPseudoColumn+_determineInputDisabled) ⇒ <code>boolean</code> \| <code>object</code>
+        * [.getMetadata()](#ERMrest.AssetPseudoColumn+getMetadata)
     * [.InboundForeignKeyPseudoColumn](#ERMrest.InboundForeignKeyPseudoColumn)
         * [new InboundForeignKeyPseudoColumn(reference, fk)](#new_ERMrest.InboundForeignKeyPseudoColumn_new)
         * [.reference](#ERMrest.InboundForeignKeyPseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
@@ -4079,6 +4080,7 @@ The following is the logic:
     * [.sha256](#ERMrest.AssetPseudoColumn+sha256) : [<code>Column</code>](#ERMrest.Column)
     * [.filenameExtFilter](#ERMrest.AssetPseudoColumn+filenameExtFilter) : [<code>Column</code>](#ERMrest.Column)
     * [._determineInputDisabled(context)](#ERMrest.AssetPseudoColumn+_determineInputDisabled) ⇒ <code>boolean</code> \| <code>object</code>
+    * [.getMetadata()](#ERMrest.AssetPseudoColumn+getMetadata)
 
 <a name="new_ERMrest.AssetPseudoColumn_new"></a>
 
@@ -4152,6 +4154,12 @@ If url_pattern is invalid or browser_upload=false the input will be disabled.
 | --- | --- | --- |
 | context | <code>string</code> | the context |
 
+<a name="ERMrest.AssetPseudoColumn+getMetadata"></a>
+
+#### assetPseudoColumn.getMetadata()
+Given the data, return the appropriate filename that should be used for the asset
+
+**Kind**: instance method of [<code>AssetPseudoColumn</code>](#ERMrest.AssetPseudoColumn)  
 <a name="ERMrest.InboundForeignKeyPseudoColumn"></a>
 
 ### ERMrest.InboundForeignKeyPseudoColumn

--- a/js/column.js
+++ b/js/column.js
@@ -1835,6 +1835,69 @@ AssetPseudoColumn.prototype._determineInputDisabled = function (context) {
     return AssetPseudoColumn.super._determineInputDisabled.call(this, context);
 };
 
+/**
+ * Given the data, return the appropriate filename that should be used for the asset
+ */
+AssetPseudoColumn.prototype.getMetadata = function (data, context, options) {
+    data = data || {};
+    if (!context) {
+        context = this._context;
+    }
+
+    var self = this;
+
+    var result = {
+        url: "", filename: "", byteCount: "", md5: "", sha256: ""
+    };
+
+    // if null, return null value
+    if (typeof data[this._baseCol.name] === 'undefined' || data[this._baseCol.name] === null) {
+        return result;
+    }
+
+    result.url = data[this._baseCol.name];
+
+    // get the filename
+    var col = this.filenameColumn ? this.filenameColumn : this._baseCol;
+    var filename = col.formatvalue(data[col.name], context, options);
+
+    // if we got the filename from column and it resulted in empty, try with the data
+    if (this.filenameColumn && (!filename || !data[this.filenameColumn.name])) {
+        filename = col.formatvalue(data[this._baseCol.name], context, options);
+    }
+
+    // if filenameColumn doesn't exists, then we want to show that value
+    if (!this.filenameColumn) {
+        // if value matches the expected format, just show the file name
+        var parts = filename.match(/^\/hatrac\/([^\/]+\/)*([^\/:]+)(:[^:]+)?$/);
+        if (parts && parts.length === 4) {
+            filename = parts[2];
+        }
+        // in compact contexts, just return the last part of url (filename)
+        else if (typeof context === "string" && context.indexOf("compact") === 0) {
+            var newCaption = filename.split("/").pop();
+            if (newCaption.length !== 0) {
+                filename = newCaption;
+            }
+        }
+    }
+
+    result.filename = filename;
+
+    if (this.byteCountColumn && data[this.byteCountColumn.name] && data[this.byteCountColumn.name] != null) {
+        result.byteCount = data[this.byteCountColumn.name];
+    }
+
+    if (this.md5 && data[this.md5.name] && data[this.md5.name] != null) {
+        result.md5 = data[this.md5.name];
+    }
+
+    if (this.sha256 && data[this.sha256.name] && data[this.sha256.name] != null) {
+        result.sha256 = data[this.sha256.name];
+    }
+    return result;
+};
+
 // properties to be overriden:
 AssetPseudoColumn.prototype.formatPresentation = function(data, context, options) {
     data = data || {};
@@ -1855,30 +1918,8 @@ AssetPseudoColumn.prototype.formatPresentation = function(data, context, options
 
     // otherwise return a download link
     var template = "[{{{caption}}}]({{{url}}}){download .download}";
-    var col = this.filenameColumn ? this.filenameColumn : this._baseCol;
     var url = data[this._baseCol.name];
-    var caption = col.formatvalue(data[col.name], context, options);
-
-    // if we got the caption from filename and it resulted in empty, try with the data
-    if (this.filenameColumn && (!caption || !data[this.filenameColumn.name])) {
-        caption = col.formatvalue(data[this._baseCol.name], context, options);
-    }
-
-    // if filenameColumn exists, then we want to show that value
-    if (!this.filenameColumn) {
-        // if value matches the expected format, just show the file name
-        var parts = caption.match(/^\/hatrac\/([^\/]+\/)*([^\/:]+)(:[^:]+)?$/);
-        if (parts && parts.length === 4) {
-            caption = parts[2];
-        }
-        // in compact contexts, just return the last part of url (filename)
-        else if (typeof context === "string" && context.indexOf("compact") === 0) {
-            var newCaption = caption.split("/").pop();
-            if (newCaption.length !== 0) {
-                caption = newCaption;
-            }
-        }
-    }
+    var caption = this.getMetadata(data, context, options).filename;
 
     // add the uinit=1 query params
     url += ( url.indexOf("?") !== -1 ? "&": "?") + "uinit=1";

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -786,13 +786,13 @@ exports.execute = function (options) {
                                 val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "detailed").value;
                                 expect(val).toEqual('<a href="' + url +'?uinit=1" download="" class="download">' + url + '</a>', "value missmatch for detailed");
 
-                                val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "https://example.com"}).value;
+                                val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "https://example.com"}, "detailed").value;
                                 expect(val).toEqual('<a href="https://example.com?uinit=1" download="" class="download">https://example.com</a>', "value missmatch for unknown context");
                             });
                         });
 
                         it ('if url has invalid characets in it and markdown cannot be parsed, it should return the produced markdown string.', function () {
-                            val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "https://exam\nple.com"}).value;
+                            val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "https://exam\nple.com"}, "detailed").value;
                             expect(val).toEqual('[https://exam\nple.com](https://exam\nple.com?uinit=1){download .download}', "value missmatch.");
                         });
                     });
@@ -975,6 +975,69 @@ exports.execute = function (options) {
 
                 it('otherwise should return the defined array of file name extensions.', function () {
                     expect(assetRefCompactCols[10].filenameExtFilter).toEqual(["*.jpg"]);
+                });
+            });
+
+            describe(".getMetadata", function () {
+                var testMetadata = function (col, data, message, expectedFilename, expectedByte, expectedMd5, expectedSha256) {
+                    var m = col.getMetadata(data);
+                    if (expectedFilename != null) {
+                        expect(m.filename).toBe(expectedFilename, "title missmatch for " + message);
+                    }
+
+                    if (expectedByte != null) {
+                        expect(m.byteCount).toEqual(expectedByte, "byteCount missmatch for " + message);
+                    }
+
+                    if (expectedMd5 != null) {
+                        expect(m.md5).toBe(expectedMd5, "md5 missmatch for " + message);
+                    }
+
+                    if (expectedSha256 != null) {
+                        expect(m.sha256).toBe(expectedSha256, "sha256 missmatch for " + message);
+                    }
+                };
+
+                var assetMetadataTestData = {
+                    col_asset_3: "/hatrac/testurl",
+                    col_filename: "filenamevalue.png",
+                    col_byte: 12400000,
+                    col_md5: "md5value",
+                    col_sha256: "sha256value"
+                };
+
+                it ("should return empty values if the asset is null.", function () {
+                    testMetadata(assetRefCompactCols[9], {}, "empty asset index=9.", "", "", "", "");
+
+                    testMetadata(assetRefCompactCols[10], {}, "empty asset index=10.", "", "", "", "");
+                });
+
+                describe("regarding byteCount, md5, sha256.", function () {
+                    it ("if annotation has metadata columns, should return their values.", function () {
+                        testMetadata(assetRefCompactCols[10], assetMetadataTestData, "empty asset index=10.", null, 12400000, "md5value", "sha256value");
+                    });
+
+                    it ("otherwise should return empty string.", function () {
+                        testMetadata(assetRefCompactCols[9], {"col_asset_2": "/hatrac/testurl"}, "empty asset index=10.", null, "", "", "");
+                    });
+                });
+
+                describe("regarding filename, ", function () {
+                    it ("if asset column has filename column and its value is not empty, should return it.", function () {
+                        testMetadata(assetRefCompactCols[10], assetMetadataTestData, "asset with filename value", "filenamevalue.png");
+                    });
+
+                    it ("otherwise, if the url value matches the format, should extract the filename.", function () {
+                        testMetadata(assetRefCompactCols[8], {col_asset_1: "/hatrac/Zf/ZfDsy20170915D/file-test.csv:2J7IIX63WQRUDIALUGYDKDO36A"}, "hatrac file", "file-test.csv");
+                    });
+
+                    it ("otherwise, in compact context should return the last part of url.", function () {
+                        testMetadata(assetRefCompactCols[8], {col_asset_1: "http://example.com/folder/next/folder/image.png"}, "non-hatrac compact file", "image.png");
+                    });
+
+                    it ("otherwise, should return the whole url.", function () {
+                        testMetadata(assetRefEntryCols[4], {col_asset_1: "http://example.com/folder/next/folder/image.png"}, "non-hatrac entry file", "http://example.com/folder/next/folder/image.png");
+                    });
                 });
             });
         })


### PR DESCRIPTION
This function will return the `filename` that can be used to represent an asset. It is used internally for returning the value of an asset too. It will also return other metadata columns (`md5`, `sha256`, and `byteCount`).