### PR TITLE
Conflict link

### DIFF
--- a/js/errors.js
+++ b/js/errors.js
@@ -32,14 +32,18 @@
      * @param  {string} redirectPath path that would be added to the host to create full redirect link in Chaise
      * @constructor
      */
-    function ERMrestError(code, status, message, subMessage, redirectPath) {
+    function ERMrestError(code, status, message, subMessage, redirectPath, reference) {
+        this.errorData = {};
         this.code = code;
         this.status = status;
         this.message = message;
         this.subMessage = subMessage;
-        if(redirectPath !== undefined && redirectPath !== null){
-           this.errorData = {};
+        if(redirectPath !== undefined && redirectPath !== null) {
            this.errorData.redirectPath = redirectPath;
+        }
+
+        if(reference !== undefined && reference !== null) {
+           this.errorData.reference = reference;
         }
     }
 
@@ -136,8 +140,8 @@
      * @param  {type} subMessage technical message returned by http request
      * @constructor
      */
-    function ConflictError(status, message, subMessage) {
-        ERMrestError.call(this, module._HTTPErrorCodes.CONFLICT, status, message, subMessage);
+    function ConflictError(status, message, subMessage, reference) {
+        ERMrestError.call(this, module._HTTPErrorCodes.CONFLICT, status, message, subMessage, null, reference);
     }
 
     ConflictError.prototype = Object.create(ERMrestError.prototype);
@@ -168,8 +172,8 @@
      * @param  {type} subMessage  technical message returned by http request
      * @constructor
      */
-    function DuplicateConflictError(status, message, subMessage) {
-        ConflictError.call(this, status, message, subMessage);
+    function DuplicateConflictError(status, message, subMessage, duplicateReference) {
+        ConflictError.call(this, status, message, subMessage, duplicateReference);
     }
 
     DuplicateConflictError.prototype = Object.create(ConflictError.prototype);

--- a/js/errors.js
+++ b/js/errors.js
@@ -32,18 +32,14 @@
      * @param  {string} redirectPath path that would be added to the host to create full redirect link in Chaise
      * @constructor
      */
-    function ERMrestError(code, status, message, subMessage, redirectPath, reference) {
+    function ERMrestError(code, status, message, subMessage, redirectPath) {
         this.errorData = {};
         this.code = code;
         this.status = status;
         this.message = message;
         this.subMessage = subMessage;
         if(redirectPath !== undefined && redirectPath !== null) {
-           this.errorData.redirectPath = redirectPath;
-        }
-
-        if(reference !== undefined && reference !== null) {
-           this.errorData.reference = reference;
+            this.errorData.redirectPath = redirectPath;
         }
     }
 
@@ -140,8 +136,8 @@
      * @param  {type} subMessage technical message returned by http request
      * @constructor
      */
-    function ConflictError(status, message, subMessage, reference) {
-        ERMrestError.call(this, module._HTTPErrorCodes.CONFLICT, status, message, subMessage, null, reference);
+    function ConflictError(status, message, subMessage) {
+        ERMrestError.call(this, module._HTTPErrorCodes.CONFLICT, status, message, subMessage);
     }
 
     ConflictError.prototype = Object.create(ERMrestError.prototype);
@@ -173,7 +169,8 @@
      * @constructor
      */
     function DuplicateConflictError(status, message, subMessage, duplicateReference) {
-        ConflictError.call(this, status, message, subMessage, duplicateReference);
+        ConflictError.call(this, status, message, subMessage);
+        this.duplicateReference = duplicateReference;
     }
 
     DuplicateConflictError.prototype = Object.create(ConflictError.prototype);

--- a/js/reference.js
+++ b/js/reference.js
@@ -1124,10 +1124,9 @@
                       "failed": null
                     });
                 }, function error(response) {
-                    var error = module.responseToError(response);
-                    return defer.reject(error);
+                    return defer.reject(module.responseToError(response, self));
                 }).catch(function (error) {
-                    return defer.reject(error);
+                    return defer.reject(module.responseToError(error, self));
                 });
 
                 return defer.promise;
@@ -1713,10 +1712,9 @@
                         "failed": failedPage
                     });
                 }, function error(response) {
-                    var error = module.responseToError(response);
-                    return defer.reject(error);
+                    return defer.reject(module.responseToError(response, self));
                 }).catch(function (error) {
-                    return defer.reject(error);
+                    return defer.reject(module.responseToError(error, self));
                 });
 
                 return defer.promise;

--- a/js/reference.js
+++ b/js/reference.js
@@ -1123,8 +1123,6 @@
                       "successful": page,
                       "failed": null
                     });
-                }, function error(response) {
-                    return defer.reject(module.responseToError(response, self));
                 }).catch(function (error) {
                     return defer.reject(module.responseToError(error, self));
                 });
@@ -1711,8 +1709,6 @@
                         "successful": successfulPage,
                         "failed": failedPage
                     });
-                }, function error(response) {
-                    return defer.reject(module.responseToError(response, self));
                 }).catch(function (error) {
                     return defer.reject(module.responseToError(error, self));
                 });

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1265,9 +1265,21 @@
               var numberOfKeys = primaryColumns.length;
 
               if (numberOfKeys > 1){
-                msgTail = " combination of " + primaryColumns;
+                  // trim first because sort will put strings with whitespace in front of them before other strings, i.e. " id"
+                  primaryColumns.forEach(function (col, index) {
+                      primaryColumns[index] = col.trim();
+                  });
+
+                  var columnString = "";
+                  // sort the keys because ermrest returns them in a random order every time
+                  primaryColumns.sort();
+                  primaryColumns.forEach(function (col, index) {
+                      columnString += (index != 0 ? ', ' : "") + col;
+                  });
+
+                  msgTail = "combination of " + columnString;
               } else {
-                msgTail = primaryColumns;
+                  msgTail = primaryColumns;
               }
           }
 
@@ -1291,9 +1303,9 @@
           });
 
           var uri = reference.unfilteredReference.uri + '/' + conflictKeyValues.join('&');
-          var error = new module.DuplicateConflictError(errorStatusText, mappedErrMessage, generatedErrMessage);
-          error.uri = uri;
-          return error;
+          // Reference for the conflicting row that already exists with the unique constraints
+          var duplicateReference = new Reference(module.parse(uri),  reference.table.schema.catalog);
+          return new module.DuplicateConflictError(errorStatusText, mappedErrMessage, generatedErrMessage, duplicateReference);
       } else {
           mappedErrMessage = generatedErrMessage;
 

--- a/test/specs/errors/conf/error_schema/data/duplicate_composite_key_conflict.json
+++ b/test/specs/errors/conf/error_schema/data/duplicate_composite_key_conflict.json
@@ -1,0 +1,1 @@
+[{"duplicate_id": 1, "another_id": 2}]

--- a/test/specs/errors/conf/error_schema/data/duplicate_key_conflict.json
+++ b/test/specs/errors/conf/error_schema/data/duplicate_key_conflict.json
@@ -1,2 +1,2 @@
-[{"duplicate_id": 1},
-{"duplicate_id": 2}]
+[{"duplicate id": 1},
+{"duplicate id": 2}]

--- a/test/specs/errors/conf/error_schema/data/duplicate_key_conflict.json
+++ b/test/specs/errors/conf/error_schema/data/duplicate_key_conflict.json
@@ -1,0 +1,2 @@
+[{"duplicate_id": 1},
+{"duplicate_id": 2}]

--- a/test/specs/errors/conf/error_schema/error_schema.json
+++ b/test/specs/errors/conf/error_schema/error_schema.json
@@ -416,6 +416,21 @@
                    "type": {"typename":"serial4"}
                }
            ]
+       },
+       "duplicate_key_conflict": {
+           "kind": "table",
+           "table_name": "duplicate_key_conflict",
+           "schema_name": "error_schema",
+           "keys": [{
+               "unique_columns": ["duplicate_id"]
+           }],
+           "column_definitions": [
+               {
+                   "name": "duplicate_id",
+                   "nullok": false,
+                   "type": {"typename":"int4"}
+               }
+           ]
        }
   },
   "annotations": {},

--- a/test/specs/errors/conf/error_schema/error_schema.json
+++ b/test/specs/errors/conf/error_schema/error_schema.json
@@ -422,11 +422,11 @@
            "table_name": "duplicate_key_conflict",
            "schema_name": "error_schema",
            "keys": [{
-               "unique_columns": ["duplicate_id"]
+               "unique_columns": ["duplicate id"]
            }],
            "column_definitions": [
                {
-                   "name": "duplicate_id",
+                   "name": "duplicate id",
                    "nullok": false,
                    "type": {"typename":"int4"}
                }

--- a/test/specs/errors/conf/error_schema/error_schema.json
+++ b/test/specs/errors/conf/error_schema/error_schema.json
@@ -431,6 +431,26 @@
                    "type": {"typename":"int4"}
                }
            ]
+       },
+       "duplicate_composite_key_conflict": {
+           "kind": "table",
+           "table_name": "duplicate_composite_key_conflict",
+           "schema_name": "error_schema",
+           "keys": [{
+               "unique_columns": ["duplicate_id", "another_id"]
+           }],
+           "column_definitions": [
+               {
+                   "name": "duplicate_id",
+                   "nullok": false,
+                   "type": {"typename":"int4"}
+               },
+               {
+                   "name": "another_id",
+                   "nullok": false,
+                   "type": {"typename":"int4"}
+               }
+           ]
        }
   },
   "annotations": {},

--- a/test/specs/errors/tests/07.http_409_error.js
+++ b/test/specs/errors/tests/07.http_409_error.js
@@ -13,7 +13,8 @@ exports.execute = function (options) {
             agreement_table = "child_agreement_table",
             document_table_for_fromname = "parent_document_table_for_fromname",
             duplicate_key_table = "duplicate_key_conflict",
-            reference1, reference2, reference3, reference4, duplicateReference, duplicateReferenceUpdate;
+            duplicate_composite_key_table = "duplicate_composite_key_conflict",
+            reference1, reference2, reference3, reference4, duplicateReference, duplicateReferenceUpdate, duplicateCompositeKeyReference;
 
         var integrityErrorServerResponse = '409 Conflict\nThe request conflicts with the state of the server. ' +
             'The request conflicts with the state of the server. update or delete on table "dataset" violates foreign key constraint "dataset_human_age_dataset_id_fkey" on table "dataset_human_age" DETAIL:  Key (id)=(269) is still referenced from table "dataset_human_age".';
@@ -31,6 +32,7 @@ exports.execute = function (options) {
             integrityErrorMappedFromnameMessage = "This entry cannot be deleted as it is still referenced from the <code>from_name_value</code> table. \n All dependent entries must be removed before this item can be deleted.",
             integrityErrorMappedSiteAdminMessage = "This entry cannot be deleted as it is still referenced from the <code>1dataset_human_age</code> table. \n All dependent entries must be removed before this item can be deleted.\nIf you have trouble removing dependencies please contact the site administrator.",
             duplicateErrorMappedMessage = "The entry cannot be created/updated. Please use a different duplicate_id for this record.",
+            duplicateCompositeKeyErrorMappedMessage = "The entry cannot be created/updated. Please use a different combination of another_id, duplicate_id for this record.",
             generalConflictMappedMessage = "ERROR: the provided site_name is not consistent with your login profile. Please enter an appropriate site",
             integrityErrorWithoutDelMessage = 'The request conflicts with the state of the server. update or delete on table "dataset" violates foreign key constraint "dataset_human_age_dataset_id_fkey" on table "dataset_human_age" DETAIL:  Key (id)=(269) is still referenced from table "dataset_human_age".';
 
@@ -39,7 +41,8 @@ exports.execute = function (options) {
           pureBinaryUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":" + agreement_table,
           fromNameUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":" + document_table_for_fromname,
           duplicateCreateUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":" + duplicate_key_table,
-          duplicateUpdateUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":" + duplicate_key_table + "/duplicate_id=1";
+          duplicateUpdateUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":" + duplicate_key_table + "/duplicate_id=1",
+          duplicateCompositeKeyCreateUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":" + duplicate_composite_key_table;
 
         beforeAll(function (done) {
             server = options.server;
@@ -59,10 +62,13 @@ exports.execute = function (options) {
                 reference4 = response4;
                 return options.ermRest.resolve(duplicateCreateUri, {cid:"test"})
             }).then(function (response5) {
-                duplicateReference = response5;
+                duplicateReference = response5.contextualize.entryCreate;
                 return options.ermRest.resolve(duplicateUpdateUri, {cid:"test"})
             }).then(function (response6) {
                 duplicateReferenceUpdate = response6.contextualize.entryEdit;
+                return options.ermRest.resolve(duplicateCompositeKeyCreateUri, {cid:"test"})
+            }).then(function (response7) {
+                duplicateCompositeKeyReference = response7.contextualize.entryCreate;
                 done();
             }).catch(function(err) {
                 console.log(err);
@@ -147,9 +153,10 @@ exports.execute = function (options) {
        });
 
         it("on create, if it's a duplicate key error, we should generate a more readable message.", function (done) {
-            duplicateReference.contextualize.entryCreate.create([{duplicate_id: 1}]).then(null, function (err) {
+            duplicateReference.create([{duplicate_id: 1}]).then(null, function (err) {
                 expect(err.code).toBe(409, "invalid error code");
                 expect(err.message).toBe(duplicateErrorMappedMessage, "invalid error message");
+                expect(err.errorData.reference).toBeDefined();
                 done();
             }).catch(function(err) {
                 console.log(err);
@@ -168,6 +175,19 @@ exports.execute = function (options) {
             }).then(null, function (err) {
                 expect(err.code).toBe(409, "invalid error code");
                 expect(err.message).toBe(duplicateErrorMappedMessage, "invalid error message");
+                expect(err.errorData.reference).toBeDefined();
+                done();
+            }).catch(function(err) {
+                console.log(err);
+                done.fail();
+            });
+        });
+
+        it("on create, if it's a duplicate composite key error, we should generate a more readable message.", function (done) {
+            duplicateCompositeKeyReference.create([{duplicate_id: 1, another_id: 2}]).then(null, function (err) {
+                expect(err.code).toBe(409, "invalid error code");
+                expect(err.message).toBe(duplicateCompositeKeyErrorMappedMessage, "invalid error message");
+                expect(err.errorData.reference).toBeDefined();
                 done();
             }).catch(function(err) {
                 console.log(err);


### PR DESCRIPTION
Made changes to when create or update error out by passing the reference to the error mapping function. When it's a duplicate error, a uri is generated that's attached to the error object so chase can resolve a reference from it to generate an appLink.