### PR TITLE
add support for rid markdown template

### DIFF
--- a/docs/user-docs/markdown-formatting.md
+++ b/docs/user-docs/markdown-formatting.md
@@ -546,21 +546,19 @@ You can also have empty span. You can use this to display glyphicons.
 
 ### 13. RID link
 
-Takes an RID of an existing record and generates a resolvable link for that record. This is not part of commonMark specification. It will result in an [inline](#inline-vs-block) element. You have to follow the syntax completely (notice the newline in the closing tag).
+Takes an RID of an existing record and generates a resolvable link for that record. This is not part of commonMark specification. It will result in an [inline](#inline-vs-block) element. You have to follow the syntax completely.
 
 ```md
-:::rid <RID> \n:::
+[[<RID>]]
 ```
-
-**There must be a space before `\n:::`**.
 
 - **RID**: A valid RID to an existing record
 
 **Example**
 ```html
-:::rid 1-3X0H \n:::
+[[1-3X0H]]
 
 # OUTPUT:
-<a href="/id/1-3X0H">1-3X0H</a>\n
+<a href="/id/1-3X0H">1-3X0H</a>
 ```
 > <a href="/id/1-3X0H">1-3X0H</a>

--- a/docs/user-docs/markdown-formatting.md
+++ b/docs/user-docs/markdown-formatting.md
@@ -549,4 +549,4 @@ Takes an RID of an existing record and generates a resolvable link for that reco
 # OUTPUT:
 <a href="/id/1-3X0H">1-3X0H</a>\n
 ```
-> <a href="/id/1-3X0H">1-3X0H</a>\n
+> <a href="/id/1-3X0H">1-3X0H</a>

--- a/docs/user-docs/markdown-formatting.md
+++ b/docs/user-docs/markdown-formatting.md
@@ -103,7 +103,7 @@ You can attach attributes to the link.
 	<a href="https://dev.isrd.isi.edu/chaise/search" target="_blank">ChaiseLink</a>
 </p>
 ```
-> <p><a href="https://dev.isrd.isi.edu/chaise/search" target="_blank">ChaiseLink</a></p>
+> <p><a href="https://dev.isrd.isi.edu/chaise/search" target="\_blank">ChaiseLink</a></p>
 
 ### 2. Download Button
 
@@ -116,7 +116,7 @@ Download button is a link with some predefined attributes. You can use these att
 	<a href="https://code.jquery.com/jquery-3.1.0.js" download="" class="btn btn-primary" target="_blank">Jquery Download</a>
 </p>
 ```
-> <p><a href="https://code.jquery.com/jquery-3.1.0.js" download="" class="btn btn-primary" target="_blank">Jquery Download</a></p>
+> <p><a href="https://code.jquery.com/jquery-3.1.0.js" download="" class="btn btn-primary" target="\_blank">Jquery Download</a></p>
 
 **NOTE:** please stick to the above format only to generate a download link.
 
@@ -165,7 +165,7 @@ You can also add extra styles to the image to ensure it is displayed correctly.
 
 ### 4. Thumbnail Image With Aspect Ratio and Height
 
-With attributes height=400 and target=_blank is to open it in new tab
+With attributes height=400 and target=\_blank is to open it in new tab
 ```html
 # [![alt text](thumbnail-URL){height=400}](destination-URL){target=_blank}
 
@@ -179,11 +179,11 @@ With attributes height=400 and target=_blank is to open it in new tab
 </p>
 ```
 
-> <p><a href="https://static.pexels.com/photos/2324/skyline-buildings-new-york-skyscrapers.jpg" target="_blank"><img src="http://assets.barcroftmedia.com.s3-website-eu-west-1.amazonaws.com/assets/images/recent-images-11.jpg" alt="Image" height="400"></a></p>
+> <p><a href="https://static.pexels.com/photos/2324/skyline-buildings-new-york-skyscrapers.jpg" target="\_blank"><img src="http://assets.barcroftmedia.com.s3-website-eu-west-1.amazonaws.com/assets/images/recent-images-11.jpg" alt="Image" height="400"></a></p>
 
 #### Multiple Adjacent Images
 
-With attributes height=200 and target=_blank is to open it in new tab
+With attributes height=200 and target=\_blank is to open it in new tab
 ```html
 # [![alt text](thumbnail-URL){height=200}](destination-URL){target=_blank}
 
@@ -200,7 +200,7 @@ With attributes height=200 and target=_blank is to open it in new tab
 </p>
 ```
 
-> <p><a href="https://static.pexels.com/photos/2324/skyline-buildings-new-york-skyscrapers.jpg" target="_blank"><img src="http://assets.barcroftmedia.com.s3-website-eu-west-1.amazonaws.com/assets/images/recent-images-11.jpg" alt="Image" height="200"></a> <a href="https://static.pexels.com/photos/2324/skyline-buildings-new-york-skyscrapers.jpg" target="_blank"><img src="https://c.fastcompany.net/multisite_files/fastcompany/imagecache/1280/poster/2015/06/3046722-poster-p-1-the-psychology-of-living-in-skyscrapers.jpg" alt="Image" height="200"></a></p>
+> <p><a href="https://static.pexels.com/photos/2324/skyline-buildings-new-york-skyscrapers.jpg" target="\_blank"><img src="http://assets.barcroftmedia.com.s3-website-eu-west-1.amazonaws.com/assets/images/recent-images-11.jpg" alt="Image" height="200"></a> <a href="https://static.pexels.com/photos/2324/skyline-buildings-new-york-skyscrapers.jpg" target="\_blank"><img src="https://c.fastcompany.net/multisite_files/fastcompany/imagecache/1280/poster/2015/06/3046722-poster-p-1-the-psychology-of-living-in-skyscrapers.jpg" alt="Image" height="200"></a></p>
 
 ### 5. Thumbnail With Link To Original Image And A caption
 
@@ -222,7 +222,7 @@ With attributes width=500, height=400 and a linkable caption to open it in new t
 
 ```
 
-> <figure class="embed-block" style="display:inline-block;"><a href="https://static.pexels.com/photos/2324/skyline-buildings-new-york-skyscrapers.jpg" target="_blank"><figcaption class="embed-caption">Skyscrapers</figcaption><img src="http://assets.barcroftmedia.com.s3-website-eu-west-1.amazonaws.com/assets/images/recent-images-11.jpg" height="200"  /></a></figure>
+> <figure class="embed-block" style="display:inline-block;"><a href="https://static.pexels.com/photos/2324/skyline-buildings-new-york-skyscrapers.jpg" target="\_blank"><figcaption class="embed-caption">Skyscrapers</figcaption><img src="http://assets.barcroftmedia.com.s3-website-eu-west-1.amazonaws.com/assets/images/recent-images-11.jpg" height="200"  /></a></figure>
 
 ### 6. Iframe
 
@@ -529,3 +529,24 @@ You can also have empty span. You can use this to display glyphicons.
 </p>
 ```
 > <p><span class="glyphicon glyphicon-download-alt"></span></p>
+
+### 13. RID link
+
+Takes an RID of an existing record and generates a resolvable link for that record. This is not part of commonMark specification. It will result in an [inline](#inline-vs-block) element. You have to follow the syntax completely (notice the newline in the closing tag).
+
+```md
+:::rid <RID> \n:::
+```
+
+**There must be a space before `\n:::`**.
+
+- **RID**: A valid RID to an existing record
+
+**Example**
+```html
+:::rid 1-3X0H \n:::
+
+# OUTPUT:
+<a href="/id/1-3X0H">1-3X0H</a>\n
+```
+> <a href="/id/1-3X0H">1-3X0H</a>\n

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -2176,6 +2176,30 @@
                 }
             }
         });
+
+        // Injects `a` tag with RID as the link
+        md.use(mdContainer, 'rid', {
+
+            /*
+             * Checks whetehr string matches format ":::rid <RID> \n:::"
+             */
+            validate: function (params) {
+                return params.trim().match(/rid(.*)$/i);
+            },
+
+            render: function (tokens, idx) {
+                var m = tokens[idx].info.trim().match(/rid(.*)$/i);
+
+                // opening tag
+                if (tokens[idx].nesting === 1) {
+                    return '<a href="/id/' + m[1].trim() +'">' + m[1].trim();
+                }
+                // the closing tag
+                else {
+                    return "</a>\n";
+                }
+            }
+        });
     };
 
     // Characters to replace Markdown special characters

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -197,12 +197,11 @@ exports.execute = function (options) {
                 // NOTE currently these are the only two use cases of this.
             });
 
-            it ("should support :::rid", function () {
-                testPrintMarkdown(
-                    ":::rid 1-HBO4 \n:::",
-                    '<a href="/id/1-HBO4">1-HBO4</a>\n',
-                    "invalid string"
-                );
+            it ("should support [[rid]]", function () {
+                expect(printMarkdown("[[1-HBO4]]")).toBe('<p><a href="/id/1-HBO4">1-HBO4</a></p>\n', "invalid rid template");
+                expect(printMarkdown("[[1-HBO4]]", {inline: true})).toBe('<a href="/id/1-HBO4">1-HBO4</a>', "invalid rid template");
+                expect(printMarkdown("[[1-HBO4]]()")).toBe('<p><a href="">[1-HBO4]</a></p>\n', "link md syntax should take precedence");
+
             });
 
             it ("should support superscript and subscript.", function () {

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -197,6 +197,14 @@ exports.execute = function (options) {
                 // NOTE currently these are the only two use cases of this.
             });
 
+            it ("should support :::rid", function () {
+                testPrintMarkdown(
+                    ":::rid 1-HBO4 \n:::",
+                    '<a href="/id/1-HBO4">1-HBO4</a>\n',
+                    "invalid string"
+                );
+            });
+
             it ("should support superscript and subscript.", function () {
                 expect(printMarkdown('H~2~0')).toBe('<p>H<sub>2</sub>0</p>\n', "invalid sub");
                 expect(printMarkdown('H~2~{.test}0')).toBe('<p>H<sub class="test">2</sub>0</p>\n', "invalid sub with attrs");


### PR DESCRIPTION
This PR adds a new markdown template that allows users to supply an RID that will create a template with a resolvable link to the record associated with that RID.