### PR TITLE
add new parameter to skip 401 handling

### DIFF
--- a/test/specs/errors/tests/06.http_401_error.js
+++ b/test/specs/errors/tests/06.http_401_error.js
@@ -46,7 +46,7 @@ exports.execute = function (options) {
               .get("/ermrest/catalog/" + id)
               .reply(401, 'Unauthorized Error');
 
-            ermRest.setHttpUnauthorizedFn(function() {
+            ermRest.setHTTP401Handler(function() {
                 var defer = ermRest._q.defer();
 
                 nock(url, ops)
@@ -75,7 +75,7 @@ exports.execute = function (options) {
               .reply(401, 'Unauthorized Error')
               .persist();
 
-            ermRest.setHttpUnauthorizedFn(function() {
+            ermRest.setHTTP401Handler(function() {
                 var defer = ermRest._q.defer();
 
                 nock(url, ops)
@@ -86,7 +86,7 @@ exports.execute = function (options) {
                 return defer.promise;
             });
 
-            server.http.get(url + "ermrest/catalog/" + id, {allowUnauthorized: true}).then(function (response) {
+            server.http.get(url + "ermrest/catalog/" + id, {skipHTTP401Handling: true}).then(function (response) {
                 done.fail("didn't throw any errors");
             }, function(err) {
                 // since the error is coming directly from the http module, it won't be any of the ERMrestError objects
@@ -100,12 +100,12 @@ exports.execute = function (options) {
 
     afterEach(function() {
         nock.cleanAll();
-        ermRest.setHttpUnauthorizedFn(null);
+        ermRest.setHTTP401Handler(null);
     })
 
     afterAll(function() {
         enableNet();
-        ermRest.setHttpUnauthorizedFn(null);
+        ermRest.setHTTP401Handler(null);
     });
 
   });

--- a/test/specs/errors/tests/06.http_401_error.js
+++ b/test/specs/errors/tests/06.http_401_error.js
@@ -4,37 +4,38 @@ exports.execute = function (options) {
 
   describe('For determining http 401 error behaviour, ', function () {
 
-        var server, ermRest, url, ops = {allowUnmocked: true}, catalog, schema, table, id = "3423423";
+    var server, ermRest, url, ops = {allowUnmocked: true}, catalog, schema, table, id = "3423423";
 
-        var enableNet = function() {
-            nock.cleanAll();
-            nock.enableNetConnect();
-        };
+    var enableNet = function() {
+        nock.cleanAll();
+        nock.enableNetConnect();
+    };
 
-        beforeAll(function () {
-            server = options.server;
-            ermRest = options.ermRest;
-            catalog = options.catalog;
-            catalogId = options.catalogId;
+    beforeAll(function () {
+        server = options.server;
+        ermRest = options.ermRest;
+        catalog = options.catalog;
+        catalogId = options.catalogId;
 
-            url = options.url.replace('ermrest', '');
-        });
+        url = options.url.replace('ermrest', '');
+    });
 
-        describe('For determining http 401 error behaviour, ', function () {
+    describe('For determining http 401 error behaviour, ', function () {
         it("should have no httpUnauthorizedFn handler and make a Get Catalog call and receive an exception with error code 401", function (done) {
 
             nock(url, ops)
               .get("/ermrest/catalog/" + id)
               .reply(401, 'Service Unavailable');
 
-            server.catalogs.get(id).then(null, function(err) {
+            server.catalogs.get(id).then(function (response) {
+                done.fail("didn't throw any errors");
+            }, function(err) {
 
                 expect(err instanceof ermRest.UnauthorizedError).toBe(true);
                 expect(err instanceof ermRest.ERMrestError).toBe(true);
                 done();
-            }).catch(function() {
-                expect(false).toBe(true);
-                done();
+            }).catch(function(err) {
+                done.fail(err);
             });
         });
 
@@ -49,36 +50,63 @@ exports.execute = function (options) {
                 var defer = ermRest._q.defer();
 
                 nock(url, ops)
-                    .get("/ermrest/catalog/" + id + "?cid=null")
+                    .get("/ermrest/catalog/" + id)
                     .reply(404, 'Catalog Not Found');
 
                 defer.resolve();
                 return defer.promise;
             });
 
-            server.catalogs.get(id).then(null, function(err) {
+            server.catalogs.get(id).then(function (response) {
+                done.fail("didn't throw any errors");
+            }, function(err) {
                 expect(err instanceof ermRest.NotFoundError).toBe(true);
                 expect(err instanceof ermRest.ERMrestError).toBe(true);
                 done();
             }).catch(function(err) {
-                console.log(err);
-                expect(false).toBe(true);
-                done();
+                done.fail(err);
             });
 
         });
-      });
 
+        it ("should ignore the httpUnauthorizedFn if the allowUnauthorized is passed as config to the http function.", function (done) {
+            nock(url, ops)
+              .get("/ermrest/catalog/" + id)
+              .reply(401, 'Unauthorized Error')
+              .persist();
 
-        afterEach(function() {
-            nock.cleanAll();
-            ermRest.setHttpUnauthorizedFn(null);
-        })
+            ermRest.setHttpUnauthorizedFn(function() {
+                var defer = ermRest._q.defer();
 
-        afterAll(function() {
-            enableNet();
-            ermRest.setHttpUnauthorizedFn(null);
+                nock(url, ops)
+                    .get("/ermrest/catalog/" + id)
+                    .reply(404, 'Catalog Not Found');
+
+                defer.resolve();
+                return defer.promise;
+            });
+
+            server.http.get(url + "ermrest/catalog/" + id, {allowUnauthorized: true}).then(function (response) {
+                done.fail("didn't throw any errors");
+            }, function(err) {
+                // since the error is coming directly from the http module, it won't be any of the ERMrestError objects
+                expect(err.statusCode).toBe(401);
+                done();
+            }).catch(function(err) {
+                done.fail(err);
+            });
         });
-
     });
+
+    afterEach(function() {
+        nock.cleanAll();
+        ermRest.setHttpUnauthorizedFn(null);
+    })
+
+    afterAll(function() {
+        enableNet();
+        ermRest.setHttpUnauthorizedFn(null);
+    });
+
+  });
 };


### PR DESCRIPTION
A while ago I changed the [chaise `$http` usage to `ERMrest.http`](https://github.com/informatics-isi-edu/chaise/pull/1772). This [caused issues related to 401 handling](https://github.com/informatics-isi-edu/chaise/commit/194e6f76f8c1baf9b766cb8d83317b153a593cb8).

To summarize the issue, In `http.js` if a request throws 401, we're going to set a flag and any request after that won't be fired until chaise tells `http.js` that the user has logged in and can continue. This caused issues since after 401, chaise will send a request to webauthn in order to get the actual login link. 

In this PR, I fixed this by adding a new flag. If this flag is present, we're going to skip the 401 handling. So any chaise authen request should send this flag. But I'm still not sure about the following two:

1. What's the best name for this flag? I currently used `allowUnauthorized` to be aligned with the name that we have chosen for the 401 handling callback (`setHttpUnauthorizedFn`). But maybe `skipUnauthorized` would be a better name? 

2. While writing the test cases I realized that `ERMrest.http` is not wrapping the http errors in appropriate ermrestjs error objects. It will return the plain http response that we're getting from the server. It makes sense since the whole purpose of `http.js` was to be the same as Angularjs's `$http`. But this means that any where that we're using the `ERMrest.http`, in the catch-block, we have to call the `ERMrest.responseToError` function to repaint these http errors. And that's how we've done it in ermerestjs. However since now chaise is going to use the `ERMrest.http` directly, I don't think it would be appropriate for chaise to always call this function. Maybe by default I should call the `responseToError`? Although this won't work for all the cases because `ERMrest.responseToError`  has evolved and we're passing different parameters based on the context. So maybe it's fine that chaise has to call the `ERMrest.responseToError`?