### PR TITLE
added a class to the default download tag for assets

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -1966,7 +1966,7 @@ AssetPseudoColumn.prototype.formatPresentation = function(data, context, options
     }
 
     // otherwise return a download link
-    var template = "[{{{caption}}}]({{{url}}}){download .download}";
+    var template = "[{{{caption}}}]({{{url}}}){download .download .deriva-url-validate}";
     var url = data[this._baseCol.name];
     var caption = this.getMetadata(data, context, options).caption;
 

--- a/test/specs/column/tests/01.columns_list.js
+++ b/test/specs/column/tests/01.columns_list.js
@@ -358,7 +358,7 @@ exports.execute = function (options) {
                 '1000', '10001', 'filename', '1,242', 'md5', 'sha256',
                 '',
                 '<h2>filename</h2>\n',
-                '<a href="https://dev.isrd.isi.edu?uinit=1&amp;cid=test" download="" class="download">filename</a>',
+                '<a href="https://dev.isrd.isi.edu?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">filename</a>',
                 '4'
             ];
 

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -752,16 +752,16 @@ exports.execute = function (options) {
                         describe("if asset column has filenameColumn, ", function () {
                             it ("if its value is empty, use the url for caption.", function () {
                                 val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com", "col_filename": null}).value;
-                                expect(val).toEqual('<a href="https://example.com?uinit=1&amp;cid=test" download="" class="download">https://example.com</a>', "value missmatch.");
+                                expect(val).toEqual('<a href="https://example.com?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">https://example.com</a>', "value missmatch.");
                             });
 
                             it ("otherwise use the given caption.", function () {
                                 val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com", "col_filename": "filename"}).value;
-                                expect(val).toEqual('<a href="https://example.com?uinit=1&amp;cid=test" download="" class="download">filename</a>', "value missmatch.");
+                                expect(val).toEqual('<a href="https://example.com?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">filename</a>', "value missmatch.");
 
                                 val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com?query=1&v=1", "col_filename": "filename"}).value;
                                 //NOTE this is the output but it will be displayed correctly.
-                                expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1&amp;uinit=1&amp;cid=test" download="" class="download">filename</a>', "couldn't handle having query params in the url.");
+                                expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1&amp;uinit=1&amp;cid=test" download="" class="download deriva-url-validate">filename</a>', "couldn't handle having query params in the url.");
                             });
                         });
 
@@ -769,31 +769,31 @@ exports.execute = function (options) {
                             it ("if value matches the expected format, just return the filename.", function () {
                                 var hatracSampleURL = "/hatrac/Zf/ZfDsy20170915D/file-test.csv:2J7IIX63WQRUDIALUGYDKDO36A";
                                 val = assetRefCompactCols[8].formatPresentation({"col_asset_1": hatracSampleURL}).value;
-                                expect(val).toEqual('<a href="' + hatracSampleURL +'?uinit=1&amp;cid=test" download="" class="download">file-test.csv</a>', "value missmatch.");
+                                expect(val).toEqual('<a href="' + hatracSampleURL +'?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">file-test.csv</a>', "value missmatch.");
                             });
 
                             it ("in compact contexts, return the last part of url.", function () {
                                 var url = "http://example.com/folder/next/folder/image.png";
                                 val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "compact").value;
-                                expect(val).toEqual('<a href="' + url +'?uinit=1&amp;cid=test" download="" class="download">image.png</a>', "value missmatch for compact");
+                                expect(val).toEqual('<a href="' + url +'?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">image.png</a>', "value missmatch for compact");
 
                                 val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "compact/brief").value;
-                                expect(val).toEqual('<a href="' + url +'?uinit=1&amp;cid=test" download="" class="download">image.png</a>', "value missmatch for compact/brief");
+                                expect(val).toEqual('<a href="' + url +'?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">image.png</a>', "value missmatch for compact/brief");
                             });
 
                             it ("otherwise return the whole url.", function () {
                                 var url = "http://example.com/folder/next/folder/image.png";
                                 val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "detailed").value;
-                                expect(val).toEqual('<a href="' + url +'?uinit=1&amp;cid=test" download="" class="download">' + url + '</a>', "value missmatch for detailed");
+                                expect(val).toEqual('<a href="' + url +'?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">' + url + '</a>', "value missmatch for detailed");
 
                                 val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "https://example.com"}, "detailed").value;
-                                expect(val).toEqual('<a href="https://example.com?uinit=1&amp;cid=test" download="" class="download">https://example.com</a>', "value missmatch for unknown context");
+                                expect(val).toEqual('<a href="https://example.com?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">https://example.com</a>', "value missmatch for unknown context");
                             });
                         });
 
                         it ('if url has invalid characets in it and markdown cannot be parsed, it should return the produced markdown string.', function () {
                             val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "https://exam\nple.com"}, "detailed").value;
-                            expect(val).toEqual('[https://exam\nple.com](https://exam\nple.com?uinit=1&cid=test){download .download}', "value missmatch.");
+                            expect(val).toEqual('[https://exam\nple.com](https://exam\nple.com?uinit=1&cid=test){download .download .deriva-url-validate}', "value missmatch.");
                         });
                     });
                  });


### PR DESCRIPTION
Changes in this PR are made for [this issue](https://github.com/informatics-isi-edu/chaise/issues/1461) in chaise. This is so we have more control over which assets check the authorization status before downloading them for the user.