### PR TITLE
Check asset origin

### DIFF
--- a/docs/user-docs/markdown-formatting.md
+++ b/docs/user-docs/markdown-formatting.md
@@ -149,14 +149,14 @@ Example 1:
 
 Example 2:
 ```html
-[Jquery Download](https://code.jquery.com/jquery-3.1.0.js){download .download .deriva-url-validate}
+[Jquery Download](https://code.jquery.com/jquery-3.1.0.js){download .download .asset-permission}
 
 # OUTPUT:
 <p>
-	<a href="https://code.jquery.com/jquery-3.1.0.js" download="" class="download deriva-url-validate">Jquery Download</a>
+	<a href="https://code.jquery.com/jquery-3.1.0.js" download="" class="download asset-permission">Jquery Download</a>
 </p>
 ```
-> <p><a href="https://code.jquery.com/jquery-3.1.0.js" download="" class="download deriva-url-validate">Jquery Download</a></p>
+> <p><a href="https://code.jquery.com/jquery-3.1.0.js" download="" class="download asset-permission">Jquery Download</a></p>
 
 **NOTE:** please stick to the above formats only to generate a download link.
 

--- a/js/column.js
+++ b/js/column.js
@@ -2163,7 +2163,7 @@ AssetPseudoColumn.prototype.getMetadata = function (data, context, options) {
     var self = this;
 
     var result = {
-        url: "", caption: "", filename: "", byteCount: "", md5: "", sha256: "", origin: ""
+        url: "", caption: "", filename: "", byteCount: "", md5: "", sha256: "", sameOrigin: false, hostInformation: ""
     };
 
     // if null, return null value
@@ -2184,6 +2184,22 @@ AssetPseudoColumn.prototype.getMetadata = function (data, context, options) {
         urlCaption = true;
     }
 
+    // see if link contains absolute paths that start with https:// or http://
+    var protocolRegexp = new RegExp('^(?:[a-z]+:)?//', 'i');
+    var temp = caption.split("/");
+
+    // assume same origin because most paths should be relative
+    var sameOrigin = true;
+    if (protocolRegexp.test(caption)) {
+        var assetOrigin = temp[0] + "//" + temp[2];
+        var currentOrigin = this.table.schema.catalog.server.uri;
+        // check if currentOrigin contains the
+        sameOrigin = (currentOrigin.indexOf(assetOrigin) == 0);
+    } // else, path is relative, so same origin
+
+    result.sameOrigin = sameOrigin;
+
+
     // if we're using the url as caption
     if (urlCaption) {
         // if caption matches the expected format, just show the file name
@@ -2193,17 +2209,13 @@ AssetPseudoColumn.prototype.getMetadata = function (data, context, options) {
         }
         // otherwise return the last part of url
         else {
-            // in detailed, we want to show the origin
+            // in detailed, we want to show the host information
             if (typeof context === "string" && context === module._contexts.DETAILED) {
 
                 // only match absolute paths that start with https:// or http://
-                // so when we split by /, the third element will be the origin
-                var r = new RegExp('^(?:[a-z]+:)?//', 'i');
-                if (r.test(caption)) {
-                     var temp = caption.split("/");
-                     if (temp.length > 0 && temp.length >= 3) {
-                         result.origin = temp[2];
-                     }
+                if (protocolRegexp.test(caption) && temp.length >= 3) {
+                    // so when we split by /, the third element will be the host information
+                    result.hostInformation = temp[2];
                 }
             }
 
@@ -2243,7 +2255,7 @@ AssetPseudoColumn.prototype.getMetadata = function (data, context, options) {
  * 3. otherwise if column-display is defined, use it.
  * 4. otherwise if value is null, return null.
  * 5. otherwise use getMetadata to genarate caption and origin and return a download button.
- * 
+ *
  * @param {Object} data the raw data of the table
  * @param {String} context the app context
  * @param {Object} options include `formattedValues`
@@ -2277,26 +2289,33 @@ AssetPseudoColumn.prototype.formatPresentation = function(data, context, options
         return nullValue;
     }
 
-    // otherwise return a download link
-    var template = "[{{{caption}}}]({{{url}}}){download .download .deriva-url-validate}";
-    var url = data[this._baseCol.name];
+    // var currentOrigin = server.url.origin
     var metadata = this.getMetadata(data, context, options);
-    var caption = metadata.caption, origin = metadata.origin;
+    var caption = metadata.caption,
+        hostInfo = metadata.hostInformation,
+        sameOrigin = metadata.sameOrigin;
 
-    // add the uinit=1 query params
-    url += ( url.indexOf("?") !== -1 ? "&": "?") + "uinit=1";
+    // otherwise return a download link
+    var template = "[{{{caption}}}]({{{url}}}){download .download" + (sameOrigin ? " .asset-permission" : "") + "}";
+    var url = data[this._baseCol.name];
 
-    // add cid query param
-    var cid = this.table.schema.catalog.server.cid;
-    if (cid) url += "&cid=" + cid;
+    // only add query parameters if same origin
+    if (sameOrigin) {
+        // add the uinit=1 query params
+        url += ( url.indexOf("?") !== -1 ? "&": "?") + "uinit=1";
+
+        // add cid query param
+        var cid = this.table.schema.catalog.server.cid;
+        if (cid) url += "&cid=" + cid;
+    }
 
     var keyValues = {
         "caption": caption,
         "url": url,
-        "origin": origin
+        "hostInfo": hostInfo // NOTE: this is actually just the host
     };
-    if (origin) {
-        template += ":span:(source: {{{origin}}}):/span:{.asset-source-description}";
+    if (hostInfo) {
+        template += ":span:(source: {{{hostInfo}}}):/span:{.asset-source-description}";
     }
     var unformatted = module._renderTemplate(template, keyValues, this.table.schema.catalog);
     return {isHTML: true, value: module._formatUtils.printMarkdown(unformatted, {inline:true}), unformatted: unformatted};

--- a/js/column.js
+++ b/js/column.js
@@ -2312,7 +2312,7 @@ AssetPseudoColumn.prototype.formatPresentation = function(data, context, options
     var keyValues = {
         "caption": caption,
         "url": url,
-        "hostInfo": hostInfo // NOTE: this is actually just the host
+        "hostInfo": hostInfo
     };
     if (hostInfo) {
         template += ":span:(source: {{{hostInfo}}}):/span:{.asset-source-description}";

--- a/js/column.js
+++ b/js/column.js
@@ -2185,15 +2185,15 @@ AssetPseudoColumn.prototype.getMetadata = function (data, context, options) {
     }
 
     // see if link contains absolute paths that start with https:// or http://
-    var protocolRegexp = new RegExp('^(?:[a-z]+:)?//', 'i');
-    var temp = caption.split("/");
+    var hasProtocol = new RegExp('^(?:[a-z]+:)?//', 'i').test(result.url);
+    var urlParts = result.url.split("/");
 
     // assume same origin because most paths should be relative
     var sameOrigin = true;
-    if (protocolRegexp.test(caption)) {
-        var assetOrigin = temp[0] + "//" + temp[2];
+    if (hasProtocol) {
+        var assetOrigin = urlParts[0] + "//" + urlParts[2];
         var currentOrigin = this.table.schema.catalog.server.uri;
-        // check if currentOrigin contains the
+        // check if currentOrigin contains the assetOrigin
         sameOrigin = (currentOrigin.indexOf(assetOrigin) == 0);
     } // else, path is relative, so same origin
 
@@ -2213,9 +2213,9 @@ AssetPseudoColumn.prototype.getMetadata = function (data, context, options) {
             if (typeof context === "string" && context === module._contexts.DETAILED) {
 
                 // only match absolute paths that start with https:// or http://
-                if (protocolRegexp.test(caption) && temp.length >= 3) {
+                if (hasProtocol && urlParts.length >= 3) {
                     // so when we split by /, the third element will be the host information
-                    result.hostInformation = temp[2];
+                    result.hostInformation = urlParts[2];
                 }
             }
 

--- a/js/http.js
+++ b/js/http.js
@@ -188,7 +188,9 @@
                     },
                     function(response) {
                         response.status = response.status || response.statusCode;
-                        if ((_retriable_error_codes.indexOf(response.status) != -1) && count < max_retries) {
+                        // if retry flag is set, skip on -1 and 0
+                        var skipRetry = config.skipRetryBrowserError && (response.status == -1 || response.status == 0);
+                        if ((_retriable_error_codes.indexOf(response.status) != -1) && count < max_retries && !skipRetry) {
                             count += 1;
                             setTimeout(function() {
                                 module._onHttpAuthFlowFn().then(function() {

--- a/test/specs/column/tests/01.columns_list.js
+++ b/test/specs/column/tests/01.columns_list.js
@@ -361,7 +361,7 @@ exports.execute = function (options) {
                 '1000', '10001', 'filename', '1,242', 'md5', 'sha256',
                 '',
                 '<h2>filename</h2>\n',
-                '<a href="https://dev.isrd.isi.edu?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">filename</a>',
+                '<a href="https://dev.isrd.isi.edu?uinit=1&amp;cid=test" download="" class="download asset-permission">filename</a>',
                 '4'
             ];
 

--- a/test/specs/column/tests/01.columns_list.js
+++ b/test/specs/column/tests/01.columns_list.js
@@ -355,13 +355,19 @@ exports.execute = function (options) {
                 '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_composite_key/RID=' + findRID("table_w_composite_key", "id", "4") + '">4001 , 4002</a>',
                 ''
             ];
+            var html = "";
+            if (process.env.TRAVIS) {
+                html = '<a href="https://dev.isrd.isi.edu" download="" class="download external-link">filename</a>'
+            } else {
+                html = '<a href="https://dev.isrd.isi.edu?uinit=1&amp;cid=test" download="" class="download asset-permission">filename</a>'
+            }
             assetCompactExpectedValue = [
                 '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_asset/id=1">1</a>',
                 '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/RID=' + findRID("columns_table", "id", "1") + '">1</a>',
                 '1000', '10001', 'filename', '1,242', 'md5', 'sha256',
                 '',
                 '<h2>filename</h2>\n',
-                '<a href="https://dev.isrd.isi.edu?uinit=1&amp;cid=test" download="" class="download asset-permission">filename</a>',
+                html,
                 '4'
             ];
 

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -749,11 +749,11 @@ exports.execute = function (options) {
 
                     it ("otherwise, if asset column has filenameColumn and it's value is not empty, should use it for caption.", function () {
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com", "col_filename": "filename"}).value;
-                        expect(val).toEqual('<a href="https://example.com?uinit=1&amp;cid=test" download="" class="download asset-permission">filename</a>', "value missmatch.");
+                        expect(val).toEqual('<a href="https://example.com" download="" class="download">filename</a>', "value missmatch.");
 
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com?query=1&v=1", "col_filename": "filename"}).value;
                         //NOTE this is the output but it will be displayed correctly.
-                        expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1&amp;uinit=1&amp;cid=test" download="" class="download asset-permission">filename</a>', "couldn't handle having query params in the url.");
+                        expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1" download="" class="download">filename</a>', "couldn't handle having query params in the url.");
                     });
 
                     it ("otherwise, if url matches the expected hatrac format, return the filename.", function () {

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -749,11 +749,11 @@ exports.execute = function (options) {
 
                     it ("otherwise, if asset column has filenameColumn and it's value is not empty, should use it for caption.", function () {
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com", "col_filename": "filename"}).value;
-                        expect(val).toEqual('<a href="https://example.com" download="" class="download">filename</a>', "value missmatch.");
+                        expect(val).toEqual('<a href="https://example.com" download="" class="download external-link">filename</a>', "value missmatch.");
 
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com?query=1&v=1", "col_filename": "filename"}).value;
                         //NOTE this is the output but it will be displayed correctly.
-                        expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1" download="" class="download">filename</a>', "couldn't handle having query params in the url.");
+                        expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1" download="" class="download external-link">filename</a>', "couldn't handle having query params in the url.");
                     });
 
                     it ("otherwise, if url matches the expected hatrac format, return the filename.", function () {
@@ -770,20 +770,20 @@ exports.execute = function (options) {
                     it ("otherwise, if context is detailed and url is absolute, use last part of url as caption and add origin beside the button.", function () {
                         var url = "http://example.com/folder/next/folder/image.png";
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "detailed").value;
-                        expect(val).toEqual('<a href="' + url +'" download="" class="download">image.png</a><span class="asset-source-description">(source: example.com)</span>', "value missmatch for detailed");
+                        expect(val).toEqual('<a href="' + url +'" download="" class="download external-link">image.png</a><span class="asset-source-description">(source: example.com)</span>', "value missmatch for detailed");
                     });
 
                     it ("otherwise, use the last part of url without any origin information.", function () {
                         // has filenameColumn but its value is null
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com/asset.png", "col_filename": null}).value;
-                        expect(val).toEqual('<a href="https://example.com/asset.png" download="" class="download">asset.png</a>', "value missmatch.");
+                        expect(val).toEqual('<a href="https://example.com/asset.png" download="" class="download external-link">asset.png</a>', "value missmatch.");
 
                         var url = "http://example.com/folder/next/folder/image.png";
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "compact").value;
-                        expect(val).toEqual('<a href="' + url +'" download="" class="download">image.png</a>', "value missmatch for compact");
+                        expect(val).toEqual('<a href="' + url +'" download="" class="download external-link">image.png</a>', "value missmatch for compact");
 
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "compact/brief").value;
-                        expect(val).toEqual('<a href="' + url +'" download="" class="download">image.png</a>', "value missmatch for compact/brief");
+                        expect(val).toEqual('<a href="' + url +'" download="" class="download external-link">image.png</a>', "value missmatch for compact/brief");
 
                         // detailed but relative url
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "go/to/file.png"}, "detailed").value;
@@ -793,7 +793,7 @@ exports.execute = function (options) {
 
                     it ("if url has invalid characeters in it and markdown cannot be parsed, it should return the produced markdown string.", function () {
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "https://exam\nple.com/file.png"}).value;
-                        expect(val).toEqual('[file.png](https://exam\nple.com/file.png){download .download}', "value missmatch.");
+                        expect(val).toEqual('[file.png](https://exam\nple.com/file.png){download .download .external-link}', "value missmatch.");
                     });
                  });
 
@@ -1055,6 +1055,14 @@ exports.execute = function (options) {
                         testMetadata(assetRefEntryCols[4], {col_asset_1: "http://example.com/folder/next/folder/image.png"}, "detailed", "non-hatrac entry file", "image.png", "example.com", false);
 
                         testMetadata(assetRefEntryCols[4], {col_asset_1: "next/folder/image.png"}, "non-hatrac entry file", "detailed", "image.png", "", true);
+                    });
+
+                    it("if url is absolute and from the same origin, host information should not be returned.", function () {
+                        testMetadata(assetRefEntryCols[4], {col_asset_1: options.url + "/folder/next/folder/image.png"}, "detailed", "absolute, same host, non-hatrac entry file", "image.png", null, true);
+                    });
+
+                    it("if url is absolute and NOT from the same origin, and hatrac is in the path, host information should be returned.", function () {
+                        testMetadata(assetRefEntryCols[4], {col_asset_1: "http://example.com/hatrac/next/folder/image.png"}, "detailed", "absolute, different host, hatrac name included in entry file", "image.png", "example.com", false);
                     });
                 });
             });

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -749,16 +749,16 @@ exports.execute = function (options) {
 
                     it ("otherwise, if asset column has filenameColumn and it's value is not empty, should use it for caption.", function () {
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com", "col_filename": "filename"}).value;
-                        expect(val).toEqual('<a href="https://example.com?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">filename</a>', "value missmatch.");
+                        expect(val).toEqual('<a href="https://example.com?uinit=1&amp;cid=test" download="" class="download asset-permission">filename</a>', "value missmatch.");
 
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com?query=1&v=1", "col_filename": "filename"}).value;
                         //NOTE this is the output but it will be displayed correctly.
-                        expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1&amp;uinit=1&amp;cid=test" download="" class="download deriva-url-validate">filename</a>', "couldn't handle having query params in the url.");
+                        expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1&amp;uinit=1&amp;cid=test" download="" class="download asset-permission">filename</a>', "couldn't handle having query params in the url.");
                     });
 
                     it ("otherwise, if url matches the expected hatrac format, return the filename.", function () {
                         var hatracSampleURL = "/hatrac/Zf/ZfDsy20170915D/file-test.csv:2J7IIX63WQRUDIALUGYDKDO36A";
-                        var expectedValue = '<a href="' + hatracSampleURL +'?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">file-test.csv</a>';
+                        var expectedValue = '<a href="' + hatracSampleURL +'?uinit=1&amp;cid=test" download="" class="download asset-permission">file-test.csv</a>';
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": hatracSampleURL}).value;
                         expect(val).toEqual(expectedValue, "value missmatch.");
 
@@ -770,30 +770,30 @@ exports.execute = function (options) {
                     it ("otherwise, if context is detailed and url is absolute, use last part of url as caption and add origin beside the button.", function () {
                         var url = "http://example.com/folder/next/folder/image.png";
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "detailed").value;
-                        expect(val).toEqual('<a href="' + url +'?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">image.png</a><span class="asset-source-description">(source: example.com)</span>', "value missmatch for detailed");
+                        expect(val).toEqual('<a href="' + url +'" download="" class="download">image.png</a><span class="asset-source-description">(source: example.com)</span>', "value missmatch for detailed");
                     });
 
                     it ("otherwise, use the last part of url without any origin information.", function () {
                         // has filenameColumn but its value is null
                         val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com/asset.png", "col_filename": null}).value;
-                        expect(val).toEqual('<a href="https://example.com/asset.png?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">asset.png</a>', "value missmatch.");
+                        expect(val).toEqual('<a href="https://example.com/asset.png" download="" class="download">asset.png</a>', "value missmatch.");
 
                         var url = "http://example.com/folder/next/folder/image.png";
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "compact").value;
-                        expect(val).toEqual('<a href="' + url +'?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">image.png</a>', "value missmatch for compact");
+                        expect(val).toEqual('<a href="' + url +'" download="" class="download">image.png</a>', "value missmatch for compact");
 
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "compact/brief").value;
-                        expect(val).toEqual('<a href="' + url +'?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">image.png</a>', "value missmatch for compact/brief");
+                        expect(val).toEqual('<a href="' + url +'" download="" class="download">image.png</a>', "value missmatch for compact/brief");
 
                         // detailed but relative url
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "go/to/file.png"}, "detailed").value;
-                        expect(val).toEqual('<a href="go/to/file.png?uinit=1&amp;cid=test" download="" class="download deriva-url-validate">file.png</a>', "value missmatch for detailed context");
+                        expect(val).toEqual('<a href="go/to/file.png?uinit=1&amp;cid=test" download="" class="download asset-permission">file.png</a>', "value missmatch for detailed context");
                     });
 
 
                     it ("if url has invalid characeters in it and markdown cannot be parsed, it should return the produced markdown string.", function () {
                         val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "https://exam\nple.com/file.png"}).value;
-                        expect(val).toEqual('[file.png](https://exam\nple.com/file.png?uinit=1&cid=test){download .download .deriva-url-validate}', "value missmatch.");
+                        expect(val).toEqual('[file.png](https://exam\nple.com/file.png){download .download}', "value missmatch.");
                     });
                  });
 
@@ -985,7 +985,7 @@ exports.execute = function (options) {
             });
 
             describe(".getMetadata", function () {
-                var testMetadata = function (col, data, context, message, expectedCaption, expectedOrigin, expectedFilename, expectedByte, expectedMd5, expectedSha256) {
+                var testMetadata = function (col, data, context, message, expectedCaption, expectedHostInformation, expectedSameOrigin, expectedFilename, expectedByte, expectedMd5, expectedSha256) {
                     var m = col.getMetadata(data, context);
                     if (expectedCaption != null) {
                         expect(m.caption).toBe(expectedCaption, "caption missmatch for " + message);
@@ -1007,8 +1007,12 @@ exports.execute = function (options) {
                         expect(m.sha256).toBe(expectedSha256, "sha256 missmatch for " + message);
                     }
 
-                    if (expectedOrigin != null) {
-                        expect(m.origin).toBe(expectedOrigin, "origin missmatch for " + message);
+                    if (expectedHostInformation != null) {
+                        expect(m.hostInformation).toBe(expectedHostInformation, "origin missmatch for " + message);
+                    }
+
+                    if (expectedSameOrigin != null) {
+                        expect(m.sameOrigin).toBe(expectedSameOrigin, "origin missmatch for " + message);
                     }
                 };
 
@@ -1021,36 +1025,36 @@ exports.execute = function (options) {
                 };
 
                 it ("should return empty values if the asset is null.", function () {
-                    testMetadata(assetRefCompactCols[9], {}, null, "empty asset index=9.", "", "", "", "", "", "");
+                    testMetadata(assetRefCompactCols[9], {}, null, "empty asset index=9.", "", "", false, "", "", "", "");
 
-                    testMetadata(assetRefCompactCols[10], {}, null, "empty asset index=10.", "", "", "", "", "", "");
+                    testMetadata(assetRefCompactCols[10], {}, null, "empty asset index=10.", "", "", false, "", "", "", "");
                 });
 
                 describe("regarding byteCount, md5, sha256.", function () {
                     it ("if annotation has metadata columns, should return their values.", function () {
-                        testMetadata(assetRefCompactCols[10], assetMetadataTestData, null, "empty asset index=10.", null, null, "filenamevalue.png",12400000, "md5value", "sha256value");
+                        testMetadata(assetRefCompactCols[10], assetMetadataTestData, null, "empty asset index=10.", null, null, null, "filenamevalue.png",12400000, "md5value", "sha256value");
                     });
 
                     it ("otherwise should return empty string.", function () {
-                        testMetadata(assetRefCompactCols[9], {"col_asset_2": "/hatrac/testurl"}, null, "empty asset index=10.", null, null, "", "", "", "");
+                        testMetadata(assetRefCompactCols[9], {"col_asset_2": "/hatrac/testurl"}, null, "empty asset index=10.", null, null, null, "", "", "", "");
                     });
                 });
 
-                describe("regarding caption and origin, ", function () {
-                    it ("if asset column has filename column and its value is not empty, should return it as caption. origin should be empty.", function () {
-                        testMetadata(assetRefCompactCols[10], assetMetadataTestData, null, "asset with filename value", "filenamevalue.png", "");
+                describe("regarding caption, hostInformation, and sameOrigin ", function () {
+                    it ("if asset column has filename column and its value is not empty, should return it as caption. hostInformation should be empty. sameOrigin should be false.", function () {
+                        testMetadata(assetRefCompactCols[10], assetMetadataTestData, null, "asset with filename value", "filenamevalue.png", "", true);
                     });
 
-                    it ("otherwise, if the url value matches the format, should extract the filename. origin should be empty.", function () {
-                        testMetadata(assetRefCompactCols[8], {col_asset_1: "/hatrac/Zf/ZfDsy20170915D/file-test.csv:2J7IIX63WQRUDIALUGYDKDO36A"}, null, "hatrac file", "file-test.csv", "");
+                    it ("otherwise, if the url value matches the format, should extract the filename. hostInformation should be empty. sameOrigin should be true.", function () {
+                        testMetadata(assetRefCompactCols[8], {col_asset_1: "/hatrac/Zf/ZfDsy20170915D/file-test.csv:2J7IIX63WQRUDIALUGYDKDO36A"}, null, "hatrac file", "file-test.csv", "", true);
                     });
 
-                    it ("otherwise, should return the last part of url. origin in detailed if url is absolute should be valid.", function () {
-                        testMetadata(assetRefCompactCols[8], {col_asset_1: "http://example.com/folder/next/folder/image.png"}, "compact", "non-hatrac compact file", "image.png", "");
+                    it ("otherwise, should return the last part of url. hostInformation in detailed if url is absolute should be valid.", function () {
+                        testMetadata(assetRefCompactCols[8], {col_asset_1: "http://example.com/folder/next/folder/image.png"}, "compact", "non-hatrac compact file", "image.png", "", false);
 
-                        testMetadata(assetRefEntryCols[4], {col_asset_1: "http://example.com/folder/next/folder/image.png"}, "detailed", "non-hatrac entry file", "image.png", "example.com");
+                        testMetadata(assetRefEntryCols[4], {col_asset_1: "http://example.com/folder/next/folder/image.png"}, "detailed", "non-hatrac entry file", "image.png", "example.com", false);
 
-                        testMetadata(assetRefEntryCols[4], {col_asset_1: "next/folder/image.png"}, "non-hatrac entry file", "detailed", "image.png", "");
+                        testMetadata(assetRefEntryCols[4], {col_asset_1: "next/folder/image.png"}, "non-hatrac entry file", "detailed", "image.png", "", true);
                     });
                 });
             });


### PR DESCRIPTION
The following changes were made:
 - change `deriva-url-validate` to `asset-permission`
 - conditionally add `asset-permission` to asset pseudo column default display heuristic if same origin
 - apply the same condition to adding `uinit` and `cid` query parameters
 - Added a new option that the http wrapper will check for to skip the retry logic for specific cases (when error code 0 or -1 is returned)

