### PR TITLE
Modify log headers

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -67,7 +67,7 @@ to use for ERMrest JavaScript agents.
         * [.cid](#ERMrest.Server+cid) : <code>string</code>
         * [.pid](#ERMrest.Server+pid) : <code>string</code>
         * [.catalogs](#ERMrest.Server+catalogs) : [<code>Catalogs</code>](#ERMrest.Catalogs)
-        * [.logHeaders(headers, location)](#ERMrest.Server+logHeaders)
+        * [.logClientAction(headers)](#ERMrest.Server+logClientAction)
     * [.Catalogs](#ERMrest.Catalogs)
         * [new Catalogs(server)](#new_ERMrest.Catalogs_new)
         * [.length()](#ERMrest.Catalogs+length) ⇒ <code>Number</code>
@@ -78,7 +78,7 @@ to use for ERMrest JavaScript agents.
         * [.id](#ERMrest.Catalog+id) : <code>string</code>
         * [.schemas](#ERMrest.Catalog+schemas) : [<code>Schemas</code>](#ERMrest.Schemas)
         * [.chaiseConfig](#ERMrest.Catalog+chaiseConfig) ⇒ <code>Object</code>
-        * [.currentSnaptime()](#ERMrest.Catalog+currentSnaptime) ⇒ <code>Promise</code>
+        * [.currentSnaptime(contextHeaderParams)](#ERMrest.Catalog+currentSnaptime) ⇒ <code>Promise</code>
         * [.constraintByNamePair(pair, subject)](#ERMrest.Catalog+constraintByNamePair) ⇒ <code>Object</code> \| <code>null</code>
         * [.getTable(tableName, schemaName)](#ERMrest.Catalog+getTable) ⇒ [<code>Table</code>](#ERMrest.Table)
     * [.Schemas](#ERMrest.Schemas)
@@ -698,7 +698,7 @@ to use for ERMrest JavaScript agents.
     * [.cid](#ERMrest.Server+cid) : <code>string</code>
     * [.pid](#ERMrest.Server+pid) : <code>string</code>
     * [.catalogs](#ERMrest.Server+catalogs) : [<code>Catalogs</code>](#ERMrest.Catalogs)
-    * [.logHeaders(headers, location)](#ERMrest.Server+logHeaders)
+    * [.logClientAction(headers)](#ERMrest.Server+logClientAction)
 
 <a name="new_ERMrest.Server_new"></a>
 
@@ -737,17 +737,16 @@ page-id: shows the id of the page that this server is being used for
 
 #### server.catalogs : [<code>Catalogs</code>](#ERMrest.Catalogs)
 **Kind**: instance property of [<code>Server</code>](#ERMrest.Server)  
-<a name="ERMrest.Server+logHeaders"></a>
+<a name="ERMrest.Server+logClientAction"></a>
 
-#### server.logHeaders(headers, location)
-should be used to log information on the server to different log locations
+#### server.logClientAction(headers)
+should be used to log client action information on the server
 
 **Kind**: instance method of [<code>Server</code>](#ERMrest.Server)  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | headers | <code>Object</code> | the headers to be logged, should include action |
-| location | <code>String</code> | the path for logging (terminal_error || client_action) |
 
 <a name="ERMrest.Catalogs"></a>
 
@@ -804,7 +803,7 @@ Get a catalog by id. This call does catalog introspection.
     * [.id](#ERMrest.Catalog+id) : <code>string</code>
     * [.schemas](#ERMrest.Catalog+schemas) : [<code>Schemas</code>](#ERMrest.Schemas)
     * [.chaiseConfig](#ERMrest.Catalog+chaiseConfig) ⇒ <code>Object</code>
-    * [.currentSnaptime()](#ERMrest.Catalog+currentSnaptime) ⇒ <code>Promise</code>
+    * [.currentSnaptime(contextHeaderParams)](#ERMrest.Catalog+currentSnaptime) ⇒ <code>Promise</code>
     * [.constraintByNamePair(pair, subject)](#ERMrest.Catalog+constraintByNamePair) ⇒ <code>Object</code> \| <code>null</code>
     * [.getTable(tableName, schemaName)](#ERMrest.Catalog+getTable) ⇒ [<code>Table</code>](#ERMrest.Table)
 
@@ -836,13 +835,18 @@ The catalog identifier.
 **Returns**: <code>Object</code> - the chaise config object from the catalog annotation  
 <a name="ERMrest.Catalog+currentSnaptime"></a>
 
-#### catalog.currentSnaptime() ⇒ <code>Promise</code>
+#### catalog.currentSnaptime(contextHeaderParams) ⇒ <code>Promise</code>
 This will return the snapshot from the catalog request instead of schema,
 because it will return the snapshot based on the model changes.
 
 **Kind**: instance method of [<code>Catalog</code>](#ERMrest.Catalog)  
 **Returns**: <code>Promise</code> - a promise that returns json object or snaptime if resolved or
      [ERMrestError](#ERMrest.ERMrestError) if rejected  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| contextHeaderParams | <code>Object</code> | properties to log under the dcctx header |
+
 <a name="ERMrest.Catalog+constraintByNamePair"></a>
 
 #### catalog.constraintByNamePair(pair, subject) ⇒ <code>Object</code> \| <code>null</code>

--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -745,7 +745,7 @@ should be used to log information on the server to different log locations
 | Param | Type | Description |
 | --- | --- | --- |
 | headers | <code>Object</code> | the headers to be logged, should include action |
-| location | <code>String</code> | the path for logging (terminal_error || button_action) |
+| location | <code>String</code> | the path for logging (terminal_error || client_action) |
 
 <a name="ERMrest.Catalogs"></a>
 

--- a/js/core.js
+++ b/js/core.js
@@ -145,7 +145,6 @@
          */
         this.http = module._wrap_http(module._http);
         this.http.contextHeaderParams = contextHeaderParams;
-        this.http.contextHeaderParams.cid = this.http.contextHeaderParams.cid;
 
         /**
          * context-id: shows the id of app that this server is being used for

--- a/js/core.js
+++ b/js/core.js
@@ -317,13 +317,23 @@
          * @return {Promise} a promise that returns json object or snaptime if resolved or
          *      {@link ERMrest.ERMrestError} if rejected
          */
-        currentSnaptime: function (action) {
+        currentSnaptime: function (header) {
             var self = this, defer = module._q.defer(), headers = {};
-            headers[module.contextHeaderName] = {
-                action: action || "model/snaptime",
-                catalog: self.id
+
+            if (header) {
+                headers[module.contextHeaderName] = header;
+            } else {
+                headers[module.contextHeaderName] = {
+                    action: "model/snaptime",
+                    catalog: self.id
+                };
+            }
+
+            var config = {
+                headers: headers
             };
-            this.server.http.get(this._uri, {headers: headers}).then(function (response) {
+
+            this.server.http.get(this._uri, config).then(function (response) {
                 defer.resolve(response.data.snaptime);
             }, function (error) {
                 defer.reject(error);

--- a/js/core.js
+++ b/js/core.js
@@ -173,8 +173,16 @@
         this.logHeaders = function (contextHeaderParams, location) {
             var defer = module._q.defer();
 
+            if (!contextHeaderParams || (contextHeaderParams === Object(contextHeaderParams) && !Array.isArray(contextHeaderParams))) {
+                // maybe throw an error?
+                // NOTE: currently only called by a function in chaise that always sends the object { action: "" || undefined }
+            }
+
+            var headers = {};
+            headers[module.contextHeaderName] = contextHeaderParams;
+
             var config = {
-                headers: this._generateContextHeader(contextHeaderParams)
+                headers: headers
             };
 
             this.http.head(this.uri + "/" + location, config).then(function () {

--- a/js/core.js
+++ b/js/core.js
@@ -168,15 +168,16 @@
         /**
          * should be used to log information on the server to different log locations
          * @param {Object} headers - the headers to be logged, should include action
-         * @param {String} location - the path for logging (terminal_error || button_action)
+         * @param {String} location - the path for logging (terminal_error || client_action)
          **/
-        this.logHeaders = function (actionHeader, location) {
+        this.logHeaders = function (contextHeaderParams, location) {
             var defer = module._q.defer();
 
-            var headers = {};
-            headers[module.contextHeaderName] = actionHeader;
+            var config = {
+                headers: this._generateContextHeader(contextHeaderParams)
+            };
 
-            this.http.head(this.uri + "/" + location, {headers: headers}).then(function () {
+            this.http.head(this.uri + "/" + location, config).then(function () {
                 defer.resolve();
             }, function (error) {
                 defer.reject(error);

--- a/js/core.js
+++ b/js/core.js
@@ -171,7 +171,8 @@
         this.logClientAction = function (contextHeaderParams) {
             var defer = module._q.defer();
 
-            if (!contextHeaderParams || (contextHeaderParams === Object(contextHeaderParams) && !Array.isArray(contextHeaderParams))) {
+            // make sure contextHeaderParams is an object and NOT an array
+            if (!contextHeaderParams || (contextHeaderParams === Object(contextHeaderParams) && Array.isArray(contextHeaderParams))) {
                 var error = new module.InvalidInputError("Context header params were not passed");
                 // Errors for client action logging should not force a terminal error
                 return defer.reject(error), defer.promise;

--- a/js/core.js
+++ b/js/core.js
@@ -174,7 +174,7 @@
             if (!contextHeaderParams || (contextHeaderParams === Object(contextHeaderParams) && !Array.isArray(contextHeaderParams))) {
                 var error = new module.InvalidInputError("Context header params were not passed");
                 // Errors for client action logging should not force a terminal error
-                defer.resolve(error);
+                return defer.reject(error), defer.promise;
             }
 
             var headers = {};
@@ -187,7 +187,7 @@
             this.http.head(this.uri + "/client_action", config).then(function () {
                 defer.resolve();
             }, function (error) {
-                defer.resolve(error);
+                defer.reject(error);
             });
 
             return defer.promise;

--- a/js/http.js
+++ b/js/http.js
@@ -126,6 +126,7 @@
         function wrap(method, fn, scope) {
             scope = scope || window;
             var cfg_idx = _method_to_config_idx[method];
+            var startTime = Date.now();
             return function() {
                 var args;
 
@@ -170,6 +171,7 @@
                   *
                   **/
                 if (typeof config.headers[module.contextHeaderName] === 'object') {
+                    config.headers[module.contextHeaderName].elapsed_s = Date.now() - startTime;
                     // encode and make sure it's not very lengthy
                     config.headers[module.contextHeaderName] = module._certifyContextHeader(config.headers[module.contextHeaderName]);
                 }


### PR DESCRIPTION
Modified the log headers function to take an object as a parameter instead of a string representing the action. 

I left a NOTE in the code to mark where I was uncertain what should be done to handle missing parameters.