### PR TITLE
Add data source api

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -385,6 +385,7 @@ to use for ERMrest JavaScript agents.
         * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
         * [.table](#ERMrest.ReferenceColumn+table) : [<code>Table</code>](#ERMrest.Table)
         * [.name](#ERMrest.ReferenceColumn+name) : <code>string</code>
+        * [.dataSource](#ERMrest.ReferenceColumn+dataSource)
         * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>object</code>
         * [.type](#ERMrest.ReferenceColumn+type) : [<code>Type</code>](#ERMrest.Type)
         * [.nullok](#ERMrest.ReferenceColumn+nullok) : <code>Boolean</code>
@@ -3801,6 +3802,7 @@ count aggregate representation
     * [.isPseudo](#ERMrest.ReferenceColumn+isPseudo) : <code>boolean</code>
     * [.table](#ERMrest.ReferenceColumn+table) : [<code>Table</code>](#ERMrest.Table)
     * [.name](#ERMrest.ReferenceColumn+name) : <code>string</code>
+    * [.dataSource](#ERMrest.ReferenceColumn+dataSource)
     * [.displayname](#ERMrest.ReferenceColumn+displayname) : <code>object</code>
     * [.type](#ERMrest.ReferenceColumn+type) : [<code>Type</code>](#ERMrest.Type)
     * [.nullok](#ERMrest.ReferenceColumn+nullok) : <code>Boolean</code>
@@ -3848,6 +3850,13 @@ indicates that this object represents a Column.
 name of the column.
 
 **Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+<a name="ERMrest.ReferenceColumn+dataSource"></a>
+
+#### referenceColumn.dataSource
+the source path from the main reference to this column
+
+**Kind**: instance property of [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)  
+**Type{object}**:   
 <a name="ERMrest.ReferenceColumn+displayname"></a>
 
 #### referenceColumn.displayname : <code>object</code>

--- a/js/column.js
+++ b/js/column.js
@@ -150,6 +150,23 @@ ReferenceColumn.prototype = {
     },
 
     /**
+     * the source path from the main reference to this column
+     * @type{Object}
+     */
+    get dataSource() {
+        if (this._dataSource === undefined) {
+            if (this.sourceObject && this.sourceObject.source) {
+                this._dataSource = this.sourceObject.source;
+            } else if (this._simple) {
+                this._dataSource = this._baseCols[0].name;
+            } else {
+                this._dataSource = null;
+            }
+        }
+        return this._dataSource;
+    },
+
+    /**
      * @type {object}
      * @desc name of the column.
      */
@@ -1938,6 +1955,23 @@ Object.defineProperty(ForeignKeyPseudoColumn.prototype, "display", {
         return this._display_cached;
     }
 });
+Object.defineProperty(ForeignKeyPseudoColumn.prototype, "dataSource", {
+    get: function () {
+        if (this._dataSource === undefined) {
+            if (this.sourceObject && this.sourceObject.source) {
+                this._dataSource = this.sourceObject.source;
+            } else if (this.table.shortestKey.length === 1){
+                this._dataSource = [
+                    {"outbound": this.foreignKey.constraint_names[0]},
+                    this.table.shortestKey[0].name
+                ];
+            } else {
+                this._dataSource = null;
+            }
+        }
+        return this._dataSource;
+    }
+});
 
 /**
  * @memberof ERMrest
@@ -2594,6 +2628,20 @@ Object.defineProperty(InboundForeignKeyPseudoColumn.prototype, "default", {
 Object.defineProperty(InboundForeignKeyPseudoColumn.prototype, "nullok", {
     get: function () {
         throw new Error("can not use this type of column in entry mode.");
+    }
+});
+Object.defineProperty(InboundForeignKeyPseudoColumn.prototype, "dataSource", {
+    get: function () {
+        if (this._dataSource === undefined) {
+            if (this.sourceObject && this.sourceObject.source) {
+                this._dataSource = this.sourceObject.source;
+            } else if (this.reference.dataSource){
+                this._dataSource = this.reference.dataSource;
+            } else {
+                this._dataSource = null;
+            }
+        }
+        return this._dataSource;
     }
 });
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -3216,6 +3216,8 @@
          *      0.1 origFKR: the foreign key that created this related reference (used in chaise for autofill)
          *      0.2 parentDisplayname: the displayname of parent
          *          - logic: foriengkey's to_name or this.displayname
+         *      0.3 mainTuple: the tuple used to generate the related references (might be undefined)
+         *      0.4 dataSource: the source path from the main to the related table (might be undefined)
          *
          * 1. If it's pure and binary association. (current reference: T1) <-F1-(A)-F2-> (T2)
          *      1.1 displayname: F2.to_name or T2.displayname
@@ -3240,7 +3242,7 @@
          * @return {ERMrest.Reference}  a reference which is related to current reference with the given fkr
          */
         _generateRelatedReference: function (fkr, tuple, checkForAssociation, sourceObject) {
-            var j, col, uri, source;
+            var j, col, uri, filterSource = [], dataSource = [];
 
             var useFaceting = (typeof tuple === 'object');
 
@@ -3278,7 +3280,10 @@
                 newRef.parentDisplayname = this.displayname;
             }
 
+            dataSource.push({"inbound": fkr.constraint_names[0]});
+
             var fkrTable = fkr.colset.columns[0].table;
+
             if (checkForAssociation && fkrTable.isPureBinaryAssociation) { // Association Table
 
                 // find the other foreignkey
@@ -3305,10 +3310,11 @@
                     newRef._location = module.parse(this._location.compactUri + "/" + fkr.toString() + "/" + otherFK.toString(true));
                 }
 
-                // build source
-                source = [
-                    {"inbound": otherFK.constraint_names[0]}
-                ];
+                // build the filter source
+                filterSource.push({"inbound": otherFK.constraint_names[0]});
+
+                // buld the data source
+                dataSource.push({"outbound": otherFK.constraint_names[0]});
 
                 // additional values for sorting related references
                 newRef._related_key_column_positions = fkr.key.colset._getColumnPositions();
@@ -3335,8 +3341,6 @@
                 if (!useFaceting) {
                     newRef._location = module.parse(this._location.compactUri + "/" + fkr.toString());
                 }
-                // build source
-                source = [];
 
                 // additional values for sorting related references
                 newRef._related_key_column_positions = fkr.key.colset._getColumnPositions();
@@ -3352,9 +3356,15 @@
                 };
             }
 
-            source.push({"outbound": fkr.constraint_names[0]});
-            // TODO should we do something with the source?
-            // it could be use for generating the name and stuff...
+            // attach the dataSource
+            if (sourceObject && sourceObject.source) {
+                newRef.dataSource = sourceObject.source;
+            } else if (newRef._table.shortestKey.length === 1) {
+                newRef.dataSource = dataSource.concat(newRef._table.shortestKey[0].name);
+            }
+
+            // complete the path
+            filterSource.push({"outbound": fkr.constraint_names[0]});
 
             if (useFaceting) {
                 var table = newRef._table;
@@ -3368,7 +3378,7 @@
                 var filters = [], filter;
                 fkr.key.table.shortestKey.forEach(function (col) {
                     filter = {
-                        source: source.concat(col.name)
+                        source: filterSource.concat(col.name)
                     };
                     filter[module._facetFilterTypes.CHOICE] = [tuple.data[col.name]];
                     filters.push(filter);

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -535,7 +535,10 @@
     };
 
     /**
-    * @param {ERMrest.Table}
+    * @param {ERMrest.Table|ERMrest.Column|ERMrest.ForeignKeyRef} obj either table object, or an object that has `.table`
+    * @param {String} context the context string
+    * @param {String} annotKey the annotation key that you want the annotation value for
+    * @param {Boolean} isTable if the first parameter is table, you should pass `true` for this parameter
     */
     module._getHierarchicalDisplayAnnotationValue = function (obj, context, annotKey, isTable) {
         var hierarichy = [obj], table, annot, value = -1;

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -71,6 +71,33 @@ exports.execute = function (options) {
             "id_2": "3"
         };
 
+        // NOTE relies on the heuristics
+        // needs to be adjusted if we change the heuristics
+        var expectedDataSources = [
+            "id",
+            [{"outbound": ["columns_schema", "outbound_fk_1"]}, "RID"],
+            [{"outbound": ["columns_schema", "outbound_fk_2"]}, "RID"],
+            [{"outbound": ["columns_schema", "outbound_fk_3"]}, "RID"],
+            [{"outbound": ["columns_schema", "outbound_fk_4"]}, "RID"],
+            "col_3",
+            "col_4",
+            "col 5",
+            "col_6",
+            "col_7",
+            "columns_schema_outbound_fk_7",
+            "columns_schema_handlebars_col",
+            "RID",
+            "RCT",
+            "RMT",
+            "RCB",
+            "RMB",
+            [{"outbound": ["columns_schema", "outbound_fk_5"]}, "RID"],
+            [{"outbound": ["columns_schema", "outbound_fk_6"]}, "RID"],
+            [{"outbound": ["columns_schema", "outbound_fk_8"]}, "RID"],
+            [{"outbound": ["columns_schema", "outbound_fk_7"]}, "RID"],
+            [{"outbound": ["columns_schema", "outbound_fk_9"]}, "RID"]
+        ];
+
 
         var reference, compactRef, entryCreateRef, entryEditRef, compactSelectRef, compactBriefRef, compactColumns;
         var assetRef, assetRefCompactCols, assetRefEntryCols, detailedRef, detailedColumns, diffColTypeColumns;
@@ -230,6 +257,15 @@ exports.execute = function (options) {
                 }
             });
         });
+
+
+        describe("dataSource, ", function () {
+            it ("should return the correct value for all the different column types.", function () {
+                compactColumns.forEach(function (col, index) {
+                    expect(col.dataSource).toEqual(expectedDataSources[index], "missmatch for index=" + index);
+                });
+            });
+        })
 
         describe('.name, ', function () {
             it('for pseudoColumns, should return a unique and deterministic string.', function () {

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -671,6 +671,106 @@ exports.execute = function (options) {
                 });
             });
 
+            describe("dataSource, ", function () {
+                var detailedColumnDataSources = [
+                    "main_table_id_col", //0
+                    "col", //1
+                    "main_table_id_col", //2
+                    [{"outbound": ["pseudo_column_schema", "main_fk1"]}, "id"], //3
+                    [{"outbound": ["pseudo_column_schema", "main_fk1"]}, "id"], //4
+                    [
+                        {"outbound": ["pseudo_column_schema", "main_fk1"]},
+                        {"outbound": ["pseudo_column_schema", "outbound_1_fk1"]},
+                        "id"
+                    ], //5
+                    [
+                        {"outbound": ["pseudo_column_schema", "main_fk1"]},
+                        {"outbound": ["pseudo_column_schema", "outbound_1_fk1"]},
+                        "id"
+                    ], //6
+                    [{"inbound": ["pseudo_column_schema", "inbound_1_fk1"]}, "id"], //7
+                    [
+                        {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                        {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                        "id"
+                    ], //8
+                    [
+                        {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                        {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                        {"outbound": ["pseudo_column_schema", "inbound_2_fk1"]},
+                        "id"
+                    ], //9
+                    [
+                        {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]}, "id"
+                    ], //10
+                    [
+                        {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                        {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                        "id"
+                    ], //11
+                    [
+                        {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                        {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                        {"outbound": ["pseudo_column_schema", "inbound_2_fk1"]},
+                        "id"
+                    ], //12
+                    [
+                        {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]}, "id"
+                    ], //13
+                    "col", //14
+                    [
+                        {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                        {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                        "id"
+                    ], //15
+                    [
+                        { "inbound": [ "pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                        { "outbound": [ "pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                        "id"
+                    ], //16
+                    [
+                        { "inbound": [ "pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                        { "outbound": [ "pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                        "id"
+                    ], //17
+                    [
+                        {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                        {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                        "id"
+                    ], //18
+                    [
+                        {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                        {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                        "RID"
+                    ], //19
+                    [
+                        {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                        {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                        "timestamp_col"
+                    ], //20
+                    [
+                        {"inbound": ["pseudo_column_schema", "inbound_4_long_table_name_fk"]}, "foreign key column name to main"
+                    ], //21
+                    "asset", //22
+                    "asset_filename", //23
+                    [
+                        {"outbound": ["pseudo_column_schema", "main_fk2"]},
+                        {"inbound": ["pseudo_column_schema", "outbound_2_inbound_1_fk1"]},
+                        "id"
+                    ], //24
+                    [
+                        {"outbound": ["pseudo_column_schema", "main_fk2"]},
+                        {"outbound": ["pseudo_column_schema", "outbound_2_fk1"]},
+                        "id"
+                    ] //25
+                ];
+                it ("should return the data source of the pseudo-column.", function () {
+                    detailedColsWTuple.forEach(function (col, index) {
+                        expect(col.dataSource).toEqual(detailedColumnDataSources[index], "missmatch for index=" + index);
+                    });
+                });
+            })
+
             describe("sortable, ", function () {
                 describe("if it's unique (one-to-one) path should apply the same logic as foreignkey. ", function () {
                     it ("use the column_order defined on last foreignkey.", function () {

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -468,6 +468,9 @@
                     }]
                 },
                 {
+                    "names": [
+                        ["reference_schema", "association_table_with_system_col_fk_fk2"]
+                    ],
                     "comment": "fk to inbound_related_reference_table",
                     "foreign_key_columns": [{
                         "schema_name": "reference_schema",
@@ -481,6 +484,9 @@
                     }]
                 },
                 {
+                    "names": [
+                        ["reference_schema", "association_table_with_system_col_fk_fk3"]
+                    ],
                     "foreign_key_columns": [{
                         "schema_name": "reference_schema",
                         "table_name": "association_table_with_system_col_fk",
@@ -493,6 +499,9 @@
                     }]
                 },
                 {
+                    "names": [
+                        ["reference_schema", "association_table_with_system_col_fk_fk4"]
+                    ],
                     "foreign_key_columns": [{
                         "schema_name": "reference_schema",
                         "table_name": "association_table_with_system_col_fk",

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -199,6 +199,35 @@ exports.execute = function(options) {
                 expect(related[3].origFKR.toString()).toBe('(id)=(reference_schema:association%20table%20with%20id:id%20from%20ref%20table)');
             });
 
+            it ('.dataSource should have the correct value', function () {
+                var expectedDataSources = [
+                    [{"inbound": ["reference_schema", "fromname_fk_inbound_related_to_reference"]}, "RID"],
+                    [{"inbound": ["reference_schema", "fk_inbound_related_to_reference"]}, "id"],
+                    [
+                        {"inbound": ["reference_schema", "toname_fk_association_related_to_reference"]},
+                        {"outbound": ["reference_schema", "association_table_with_toname_id_from_inbound_related_table1"]},
+                        "RID"
+                    ],
+                    [
+                        {"inbound": ["reference_schema", "id_fk_association_related_to_reference"]},
+                        {"outbound": ["reference_schema", "fk_to_inbound_related_reference_table"]},
+                        "id"
+                    ],
+                    [
+                        {"inbound": ["reference_schema", "system_col_fk_asscoation_related_to_reference"]},
+                        {"outbound": ["reference_schema", "association_table_with_system_col_fk_fk2"]},
+                        "RID"
+                    ],
+                    [
+                        {"inbound": ["reference_schema", "extra_fk_association_related_to_reference"]},
+                        "RID"
+                    ]
+                ];
+                related.forEach(function (rel, i) {
+                    expect(related[i].dataSource).toEqual(expectedDataSources[i], "missmatch for index=" + i);
+                })
+            })
+
             describe('for inbound foreign keys, ', function() {
                 it('should have the correct catalog, schema, and table.', function() {
                     expect(related[0]._location.catalog).toBe(catalog_id.toString());


### PR DESCRIPTION
This PR will add `.dataSource` to all different types of `ReferenceColumn` as well as the related `Reference`s. 

It can be used to determine the path from the main reference to the given column/related reference.

```js
// assuming we have a reference object

var columnDataSource = ref.columns[i].dataSource;

var relatedDataSource = ref.related[i].dataSource;

````

This has been added since in the changes that @jrchudy  is working on, we want to pass this attribute to the logs. 