### PR TITLE
Export changes

### DIFF
--- a/docs/user-docs/export.md
+++ b/docs/user-docs/export.md
@@ -35,7 +35,7 @@ This annotation only applies to table but MAY be annotated at the schema level t
 
 - `csv` of `attributegroup` API request to the main table. The projection list is created based on the `visible-columns` defined for `export` context (or `detailed` if `export` annotation is not defined).
 
-- `csv` of `attributegroup` API for all the other related entities. The projection list includes all the visible columns of the table (based on `export` or `detailed` context), plus the foreign key value of the main entity. This request will be grouped by the value of table's key and foreign key value.
+- `csv` of `attributegroup` API for all the other related entities (using the `context` or `detailed` context in `visible-foreign-keys` annotation). The projection list includes all the visible columns of the table (based on `export` or `detailed` context), plus the foreign key value of the main entity. This request will be grouped by the value of table's key and foreign key value.
 
 - `fetch` all visible assets of the main entity (in `export` or `detailed` context) that have `byte_count_column`, `filename_column`, and `md5` (or `sha256`) in the asset annotation.
 

--- a/docs/user-docs/export.md
+++ b/docs/user-docs/export.md
@@ -31,14 +31,25 @@ The following is how ERMrestJS and Chaise leverage the different values defined 
 
 ## How ERMrestJS Interperts It
 
-This annotation only applies to table but MAY be annotated at the schema level to set a schema-wide default. If the annotation is missing on the table, we will get the export definition from the schema. If the annotation is missing from both schema and table, we are going to apply default heuristics for this annotation in detailed context. This means if you navigate to a page with `detailed` context (record page in chaise) and you haven't defined any export annotation, we are going to use the default export template. The following is the content of the generated default export template:
 
-- `csv` of `attributegroup` API request to the main table. The projection list is created based on the `visible-columns` defined for `export` context (or `detailed` if `export` annotation is not defined).
+This annotation only applies to a table, but MAY be annotated at the schema level to set a schema-wide default. If the annotation is missing on the table, we will get the export definition from the schema. If the annotation is missing from both schema and table, we are going to apply default heuristics for this annotation only in `detailed` context. This means if you navigate to a page with `detailed` context (record page in chaise) and you haven't defined any export annotation, we are going to use the default export template. The following is the content of the generated default export template:
 
-- `csv` of `attributegroup` API for all the other related entities (using the `context` or `detailed` context in `visible-foreign-keys` annotation). The projection list includes all the visible columns of the table (based on `export` or `detailed` context), plus the foreign key value of the main entity. This request will be grouped by the value of table's key and foreign key value.
+- `csv` of `attributegroup` API request to the main table.
+  - The projection list is created based on the `visible-columns` defined for the `export` context (or `detailed` if `export` annotation is not specified).
 
-- `fetch` all visible assets of the main entity (in `export` or `detailed` context). The `destination.name` is generated using the `assets/<column name>` pattern, where `<column name>` is the name of your asset column.
 
-- `fetch` all visible assets of the related entities (in `export` or `detailed` context). The `destination.name` is generated using the `assets/<table displayname>/<column name>` pattern, where `<table displayname>` is the displayname of the related table, and `<column name>` is the name of your asset column.
+- `csv` of `attributegroup` API for all the other related entities.
+  - The List of related entities is populated using the `export` (or `detailed`) context in `visible-foreign-keys` annotation.
+  - The projection list includes all the visible columns of the related table based on `export` (or `detailed`) context.
+  - The foreign key column of the main entity is added to the projection list, so we don't lose the relationship of the related entity.
+  - This request is grouped by the value of table's key and foreign key value.
+
+
+- `fetch` all visible assets of the main entity in `export` (or `detailed`) context.
+   - The `destination.name` is generated using the `assets/<column name>` pattern, where `<column name>` is the name of your asset column.
+
+
+- `fetch` all visible assets of the related entities in `export` (or `detailed` ) context.
+  - The `destination.name` is generated using the `assets/<table displayname>/<column name>` pattern, where `<table displayname>` is the displayname of the related table, and `<column name>` is the name of your asset column.
 
 > If the generated path for any of the `attributegroup` API requests is lengthy, we will use the `entity` API instead.

--- a/docs/user-docs/export.md
+++ b/docs/user-docs/export.md
@@ -37,8 +37,8 @@ This annotation only applies to table but MAY be annotated at the schema level t
 
 - `csv` of `attributegroup` API for all the other related entities (using the `context` or `detailed` context in `visible-foreign-keys` annotation). The projection list includes all the visible columns of the table (based on `export` or `detailed` context), plus the foreign key value of the main entity. This request will be grouped by the value of table's key and foreign key value.
 
-- `fetch` all visible assets of the main entity (in `export` or `detailed` context) that have `byte_count_column`, `filename_column`, and `md5` (or `sha256`) in the asset annotation.
+- `fetch` all visible assets of the main entity (in `export` or `detailed` context). The `destination.name` is generated using the `assets/<column name>` pattern, where `<column name>` is the name of your asset column.
 
-- `fetch` all visible assets of the related entities (in `export` or `detailed` context) that have `byte_count_column`, `filename_column`, and `md5` (or `sha256`) in the asset annotation.
+- `fetch` all visible assets of the related entities (in `export` or `detailed` context). The `destination.name` is generated using the `assets/<table displayname>/<column name>` pattern, where `<table displayname>` is the displayname of the related table, and `<column name>` is the name of your asset column.
 
 > If the generated path for any of the `attributegroup` API requests is lengthy, we will use the `entity` API instead.

--- a/js/export.js
+++ b/js/export.js
@@ -532,7 +532,7 @@ var ERMrest = (function(module) {
 
     /**
      * Given a column will return the appropriate output object for asset.
-     * It will return null if annotation is not complete or column is not an asset.
+     * It will return null if column is not an asset.
      * @private
      * @param  {ERMrest.Column} col the column object
      * @param  {String} destinationPath the string that will be prepended to destination path
@@ -546,14 +546,10 @@ var ERMrest = (function(module) {
         var sanitize = module._sanitizeFilename,
             encode = module._fixedEncodeURIComponent;
 
-        // required attributes
+        // attributes
         var attributes = {
             byteCountColumn: "length",
-            filenameColumn: "filename"
-        };
-
-        // at least one of these must be available
-        var checksum = {
+            filenameColumn: "filename",
             md5: "md5",
             sha256: "sha256"
         };
@@ -561,21 +557,11 @@ var ERMrest = (function(module) {
         // add the url
         path.push("url:=" + encode(col.name));
 
-        // add the required attributes
+        // add the attributes (ignore the ones that are not defined)
         for (key in attributes) {
-            if (col[key] == null) return null;
+            if (col[key] == null) continue;
             path.push(attributes[key] + ":=" + encode(col[key].name));
         }
-
-        // at least one checksum must be available
-        var hasChecksum = false;
-        for (key in checksum) {
-            if (col[key] == null) continue;
-            hasChecksum = true;
-            path.push(checksum[key] + ":=" + encode(col[key].name));
-        }
-
-        if (!hasChecksum) return null;
 
         return {
             destination: {

--- a/js/reference.js
+++ b/js/reference.js
@@ -2291,8 +2291,18 @@
                      });
                  }
 
-                 // related entities
-                 self.related.forEach(processRelatedReference);
+                 // related entities (use the export context otherwise detailed)
+                 var hasRelatedExport = false;
+                 if (self.table.annotations.contains(module._annotations.VISIBLE_FOREIGN_KEYS)) {
+                     var exportRelated = module._getRecursiveAnnotationValue(module._contexts.EXPORT, self.table.annotations.get(module._annotations.VISIBLE_FOREIGN_KEYS).content, true);
+                     hasRelatedExport = exportRelated !== -1 && Array.isArray(exportRelated);
+                 }
+
+                 // if export context is defined in visible-foreign-keys, use it, otherwise fallback to detailed
+                 var exportRefForRelated = hasRelatedExport ? self.contextualize.export : (self._context === module._contexts.DETAILED ? self : self.contextualize.detailed);
+                 if (exportRefForRelated.table.name === self.table.name) {
+                     exportRefForRelated.related.forEach(processRelatedReference);
+                 }
 
                  self._defaultExportTemplate = {
                      displayname: "BAG",

--- a/test/specs/export/conf/export_schema_annot_schema/schema.json
+++ b/test/specs/export/conf/export_schema_annot_schema/schema.json
@@ -321,7 +321,7 @@
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-foreign-keys": {
-                    "*": [
+                    "detailed": [
                         ["export_schema_annot_schema", "f1_fk_1"],
                         ["export_schema_annot_schema", "no_export_annot_f2_assoc_fk_1"],
                         {

--- a/test/specs/export/conf/export_table_annot_schema/schema.json
+++ b/test/specs/export/conf/export_table_annot_schema/schema.json
@@ -527,7 +527,7 @@
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-foreign-keys": {
-                    "*": [
+                    "export": [
                         ["export_table_annot_schema", "f1_fk_1"],
                         ["export_table_annot_schema", "no_export_annot_f2_assoc_fk_1"],
                         {

--- a/test/specs/export/tests/01.export.js
+++ b/test/specs/export/tests/01.export.js
@@ -58,6 +58,36 @@ exports.execute = function (options) {
                 },
                 {
                     destination: {
+                        name: "assets/asset_5",
+                        type: "fetch"
+                    },
+                    source: {
+                        api: "attribute",
+                        path: "!(asset_5::null::)/url:=asset_5"
+                    }
+                },
+                {
+                    destination: {
+                        name: "assets/asset_4",
+                        type: "fetch"
+                    },
+                    source: {
+                        api: "attribute",
+                        path: "!(asset_4::null::)/url:=asset_4"
+                    }
+                },
+                {
+                    destination: {
+                        name: "assets/asset_3",
+                        type: "fetch"
+                    },
+                    source: {
+                        api: "attribute",
+                        path: "!(asset_3::null::)/url:=asset_3,filename:=asset_3_filename"
+                    }
+                },
+                {
+                    destination: {
                         name: "assets/asset_2",
                         type: "fetch"
                     },


### PR DESCRIPTION
This PR changes the default export heuristics to:

- Use the `export` context for getting the list of related entities (Instead of using `detailed` all the times). 

- Remove the check for the extra asset columns. The export service can now handle `fetch` by just passing the URL, so it's safe to do so in the heuristics. 