### PR TITLE
No reload timeout

### DIFF
--- a/js/http.js
+++ b/js/http.js
@@ -256,7 +256,7 @@
                                             _encountered401Error = false;
 
                                             _authorizationDefers.forEach(function(defer) {
-                                                deferred.resolve();
+                                                defer.resolve();
                                             });
                                         }
                                     }, function (response) {

--- a/js/http.js
+++ b/js/http.js
@@ -248,14 +248,17 @@
                                     // On success set the flag as false and resolve all the authorizationDefers
                                     // So that other calls which failed due to 401 or were trigerred after the 401
                                     // are reexecuted
-                                    module._http401Handler().then(function() {
+                                    // differentUser variable is a boolean variable that states whether the different user logged in after the 401 error was thrown
+                                    module._http401Handler().then(function(differentUser) {
+                                        // if not a different user, continue with retrying previous requests
+                                        // This should handle the case where 'differentUser' is undefined or null as well
+                                        if (!differentUser) {
+                                            _encountered401Error = false;
 
-                                        _encountered401Error = false;
-
-                                        _authorizationDefers.forEach(function(defer) {
-                                            defer.resolve();
-                                        });
-
+                                            _authorizationDefers.forEach(function(defer) {
+                                                deferred.resolve();
+                                            });
+                                        }
                                     }, function (response) {
                                         _encountered401Error = false;
                                         deferred.reject(response);


### PR DESCRIPTION
Changes to go with the PR opened in chaise. The changes here are to prevent a request from being resent to the server when a 401 occurs and the new user after logging in is not the same user that started the action.

This covers the case only for 401, with some models in RBK, a 409 error is instead returned which ignores this logic and returns to a function in `errors.js` in chaise.