### PR TITLE
modify catalogs.get function

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -72,7 +72,7 @@ to use for ERMrest JavaScript agents.
         * [new Catalogs(server)](#new_ERMrest.Catalogs_new)
         * [.length()](#ERMrest.Catalogs+length) ⇒ <code>Number</code>
         * [.names()](#ERMrest.Catalogs+names) ⇒ <code>Array</code>
-        * [.get(id)](#ERMrest.Catalogs+get) ⇒ <code>Promise</code>
+        * [.get(id, dontFetchSchema)](#ERMrest.Catalogs+get) ⇒ <code>Promise</code>
     * [.Catalog](#ERMrest.Catalog)
         * [new Catalog(server, id)](#new_ERMrest.Catalog_new)
         * [.id](#ERMrest.Catalog+id) : <code>string</code>
@@ -782,7 +782,7 @@ should be used to log client action information on the server
     * [new Catalogs(server)](#new_ERMrest.Catalogs_new)
     * [.length()](#ERMrest.Catalogs+length) ⇒ <code>Number</code>
     * [.names()](#ERMrest.Catalogs+names) ⇒ <code>Array</code>
-    * [.get(id)](#ERMrest.Catalogs+get) ⇒ <code>Promise</code>
+    * [.get(id, dontFetchSchema)](#ERMrest.Catalogs+get) ⇒ <code>Promise</code>
 
 <a name="new_ERMrest.Catalogs_new"></a>
 
@@ -806,7 +806,7 @@ Constructor for the Catalogs.
 **Returns**: <code>Array</code> - Returns an array of names of catalogs.  
 <a name="ERMrest.Catalogs+get"></a>
 
-#### catalogs.get(id) ⇒ <code>Promise</code>
+#### catalogs.get(id, dontFetchSchema) ⇒ <code>Promise</code>
 Get a catalog by id. This call does catalog introspection.
 
 **Kind**: instance method of [<code>Catalogs</code>](#ERMrest.Catalogs)  
@@ -817,6 +817,7 @@ Get a catalog by id. This call does catalog introspection.
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>string</code> | Catalog ID. |
+| dontFetchSchema | <code>Boolean</code> | whether we should fetch the schemas |
 
 <a name="ERMrest.Catalog"></a>
 

--- a/js/setup/node.js
+++ b/js/setup/node.js
@@ -79,11 +79,19 @@ if (typeof module === 'object' && module.exports && typeof require === 'function
      * after a 20ms timeout to allow it to load
      */
     var loadScript = function (url, callback) {
+      // ermrestjsBuildVersion variable is added in the makefile by the pre-generate-files-for-build command
+      url += "?v=" + ermrestjsBuildVersion;
+
+      // already injected
+      if (document.querySelector('script[src="' + url + '"]')) {
+          if (typeof callback !== "undefined") callback();
+          return;
+      }
+
       /* Load script from url and calls callback once it's loaded */
       var scriptTag = document.createElement('script');
       scriptTag.setAttribute("type", "text/javascript");
-      // ermrestjsBuildVersion variable is added in the makefile by the pre-generate-files-for-build command
-      scriptTag.setAttribute("src", url + "?v=" + ermrestjsBuildVersion);
+      scriptTag.setAttribute("src", url);
       if (typeof callback !== "undefined") {
         if (scriptTag.readyState) {
           /* For old versions of IE */


### PR DESCRIPTION
In chaise, the config app only needs the catalog and doesn't need to send the heavy schema request. So I added a new option to `Catalogs.get` that can be used to signal that we only want the catalog.

I also had to make sure for the normal case of wanting catalog and its schemas we're not sending another extra catalog request. So I had to cache the catalog response and also add a boolean to signal whether the schema has been fetched.

I also added a simple check in `node.js` to ignore the dependencies that are already injected in the HTML.

This PR is part of [chaise#1936](https://github.com/informatics-isi-edu/chaise/issues/1936), and other incremental changes will be added later as part of other PRs.