### PR TITLE
clear asset metadata columns if asset is null

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -1547,23 +1547,33 @@
                             // If a column is an asset column then set values for
                             // dependent properties like filename, bytes_count_column, md5 and sha
                             if (column.isAsset) {
+                                var isNull = newData[column.name] === null ? true : false;
+
                                 // If column has a filename column then add it to the projections
                                 if (column.filenameColumn) {
+                                    // If asset url is null then set filename also null
+                                    if (isNull) newData[column.filenameColumn.name] = null;
                                     addProjection(column.filenameColumn.name);
                                 }
 
                                 // If column has a bytecount column thenadd it to the projections
                                 if (column.byteCountColumn) {
+                                    // If asset url is null then set filename also null
+                                    if (isNull) newData[column.byteCountColumn.name] = null;
                                     addProjection(column.byteCountColumn.name);
                                 }
 
                                 // If column has a md5 column then add it to the projections
                                 if (column.md5 && typeof column.md5 === 'object') {
+                                    // If asset url is null then set filename also null
+                                    if (isNull) newData[column.md5.name] = null;
                                     addProjection(column.md5.name);
                                 }
 
                                 // If column has a sha256 column then add it to the projections
                                 if (column.sha256 && typeof column.sha256 === 'object') {
+                                    // If asset url is null then set filename also null
+                                    if (isNull) newData[column.sha256.name] = null;
                                     addProjection(column.sha256.name);
                                 }
 
@@ -1619,34 +1629,25 @@
                             // If a column is an asset column then set values for
                             // dependent properties like filename, bytes_count_column, md5 and sha
                             if (column.isAsset) {
-                                var isNull = newData[column.name] === null ? true : false;
                                 /* Populate all values in row depending on column from current asset */
 
                                 // If column has a filename column then populate its value
                                 if (column.filenameColumn) {
-                                    // If asset url is null then set filename also null
-                                    if (isNull) newData[column.filenameColumn.name] = null;
                                     addSubmissionData(i, column.filenameColumn.name);
                                 }
 
                                 // If column has a bytecount column then populate its value
                                 if (column.byteCountColumn) {
-                                    // If asset url is null then set filename also null
-                                    if (isNull) newData[column.byteCountColumn.name] = null;
                                     addSubmissionData(i, column.byteCountColumn.name);
                                 }
 
                                 // If column has a md5 column then populate its value
                                 if (column.md5 && typeof column.md5 === 'object') {
-                                    // If asset url is null then set filename also null
-                                    if (isNull) newData[column.md5.name] = null;
                                     addSubmissionData(i, column.md5.name);
                                 }
 
                                 // If column has a sha256 column then populate its value
                                 if (column.sha256 && typeof column.sha256 === 'object') {
-                                    // If asset url is null then set filename also null
-                                    if (isNull) newData[column.sha256.name] = null;
                                     addSubmissionData(i, column.sha256.name);
                                 }
 

--- a/test/specs/upload/conf/upload/schema.json
+++ b/test/specs/upload/conf/upload/schema.json
@@ -189,7 +189,7 @@
                     "comment": null,
                     "name": "file1_name",
                     "default": null,
-                    "nullok": false,
+                    "nullok": true,
                     "type": {
                         "typename": "text"
                     },
@@ -206,7 +206,7 @@
                     "comment": "asset/reference",
                     "name": "file1_uri",
                     "default": null,
-                    "nullok": false,
+                    "nullok": true,
                     "type": {
                         "typename": "text"
                     },

--- a/test/specs/upload/tests/03.update_w_upload.js
+++ b/test/specs/upload/tests/03.update_w_upload.js
@@ -192,6 +192,45 @@ exports.execute = function (options) {
                 });
             });
 
+            it ("clearing the asset column value should clear the metadata columns as well.", function (done) {
+                var tuples, tuple, updateData = {},
+                    baseUrl = options.url.replace("/ermrest", "");
+
+                reference.read(1).then(function(response) {
+                    tuples = response.tuples;
+                    tuple = tuples[0];
+
+                    updateData = {
+                        file1_uri: null
+                    }
+                    var data = tuple.data;
+
+                    for (var key in updateData) {
+                        data[key] = updateData[key];
+                    }
+
+                    return reference.update(tuples);
+                }).then(function (response) {
+                    response = response.successful;
+                    expect(response._data.length).toBe(1, "Update data set that was returned is not the right length");
+
+                    utils.checkPageValues(response._data, tuples, sortBy);
+
+                    // verify that reading the reference again returns the updated row
+                    return reference.read(1);
+                }).then(function (response) {
+                    var pageData = response._data[0];
+                    expect(pageData.file1_uri).toBe(null, "Entity file1 uri is not null.");
+                    expect(pageData.file1_bytes).toBe(null, "Entity file1 bytes is not null.");
+                    expect(pageData.file1_MD5).toBe(null, "Entity file1 md5 does is not null.");
+                    expect(pageData.file1_name).toBe(null, "Entity file1 name does is not null.");
+                    done();
+                }).catch(function (error) {
+                    console.dir(error);
+                    done.fail();
+                });
+            });
+
             afterAll(function(done) {
                 // remove the files from the chaise folder
                 for (var j=0; j<files.length; j++) {


### PR DESCRIPTION
It seems like the code to handle this was already there but in the wrong place. I just had to move it and add test cases for it.

The code was first creating `columnProjections` based on the changed values. And in the cases that an asset column is changed, it wouldn't create column projection for the meta data columns.

Then the code would go based on the values and if the asset was null, it was fixing the value of `newData` and was calling `addSubmissionData`. But the `addSubmissionData` function first is making sure the column is added to  `columnProjections` which in this case it wasn't. 