### PR TITLE
add systemColumnDisplayEntry and change case for *Detailed and *Compact

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,7 +33,7 @@ This document is a summary of code changes in Chaise. This is the vocabulary use
 # 09/31/19
 
   - [Added] RID markdown tag to generate resolvable link for a record given the RID value: [[RID]]
-  - [Added] SystemColumnsDisplayCompact and SystemColumnsDisplayDetailed chaise-config properties support.
+  - [Added] systemColumnsDisplayCompact and systemColumnsDisplayDetailed chaise-config properties support.
   - [Changed] asset presentation heuristics:
     - Added external origin information
     - Added support for external-link behavior


### PR DESCRIPTION
This PR is paired with [changes in chaise](https://github.com/informatics-isi-edu/chaise/pull/1994). This is to verify that the function preivously written for `compact` and `detailed` properly applies to `entry` context as well.