### PR TITLE
improve domain_filter support and modify cfacets syntax to support it

### DIFF
--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -476,7 +476,7 @@ Supported JSON payload patterns:
 - `{` ... `"to_comment_display":` _comment_display_ ... `}`: The display mode for the tooltip. Set to `inline` to show it as text or `tooltip` to show as a hover tooltip.
     - Currently the `comment_display` is only supported for foreign key relationships in detailed context when they are part of `visible-columns` or `visible-foreign-keys`.
 - `{` ... `"display": {` _context_`:` _option_ ...`}` ... `}`: Apply each _option_ to the presentation of referenced content for any number of _context_ names.
-- `{` ... `"domain_filter_pattern":` _pattern_ ...`}`: The _pattern_ yields a _filter_ via [Pattern Expansion](#pattern-expansion). The _filter_ is a URL substring using the ERMrest filter language, which can be applied to the referenced table. The defined _filter_ will be appended directly to the reference uri and therefore must be properly url encoded (chaise WILL NOT apply additional url encoding).
+- `{` ... `"domain_filter":` _domainfilter_ ...`}`: The domain filter that will be used while selecting a value for this particular foreign key in the entry contexts. This attribute can be used to limit the available options to the user.
 
 Supported _comment_ syntax:
 
@@ -497,6 +497,43 @@ Supported _columnorder_key_ syntax:
 - `{ "column":` _columnname_ `}`: If omitted, the `"descending"` field defaults to `false` as per above.
 - _columnname_: A bare _columnname_ is a short-hand for `{ "column":` _columnname_ `}`. _columnname_ can be the name of any columns from the table that the foreign key is referring to.
 
+Supported _domainfilter_ syntax:
+- `{ "ermrest_path_pattern":` _pathpattern_ `}`: The _pathpattern_ yields a _filter_ via [Pattern Expansion](#pattern-expansion). With this syntax, the applied filter will be hidden from the user.
+- `{ "ermrest_path_pattern":` _pathpattern_ `, "display_markdown_pattern":` _displaypattern_ `}`: The _pathpattern_ yields a _filter_ via [Pattern Expansion](#pattern-expansion). _displaypattern_ will provide the visual presentation of the filter which will be computed by performing [Pattern Expansion](#pattern-expansion) to obtain a markdown-formatted text value which MAY be rendered using a markdown-aware renderer.
+
+Supported _filter_ syntax:
+
+- The _filter_ is a URL substring using the ERMrest filter language,
+which can be applied to the referenced table.
+The defined _filter_ will be appended directly to the reference uri
+and therefore must be properly url encoded
+ (chaise WILL NOT apply additional url encoding).
+
+- The leading and trailing slash that you might have defined
+in your path will be stripped off and ignored.
+
+- All _column_ names and _value_
+literals MUST be URL-escaped to protect any special characters. All
+_column_ names MUST match columns in the referenced table.
+
+- Since chaise will directly append the given _filter_ in the request for getting the values to the ERMrest request URI, you are free to use any ERMrest-supported [path filters](https://docs.derivacloud.org/ermrest/api-doc/data/naming.html#path-filters) or [entity links](https://docs.derivacloud.org/ermrest/api-doc/data/naming.html#entity-links) as long as the projected table stays the same.
+- The following is a summary of supported path filters in ERMrest:
+    - Grouping: `(` _filter_ `)`
+    - Disjunction: _filter_ `;` _filter_
+    - Conjunction: _filter_ `&` _filter_
+    - Negation: `!` _filter_
+    - Unary predicates: _column_ `::null::`
+    - Binary predicates: _column_ _op_ _value_
+      - Equality: `=`
+      - Inequality: `::gt::`, `::lt::`, `::geq::`, `::leq::`
+      - Regular expressions: `::regexp::`, `::ciregexp::`
+
+- If you're using entity links,
+  - Don't use use `T#` (where `#` is a number, e.g. T0, T1), `F#` (where `#` is a number, e.g. F0, F1), and `M` aliases. These are internally used by ERMrestJS.
+
+  - You can use `M` alias for referring to the referenced table.
+
+
 Set-naming heuristics (use first applicable rule):
 
 1. A set of "related entities" make foreign key reference to a presentation context:
@@ -515,34 +552,6 @@ Foreign key sorting heuristics (use first applicable rule):
 4. Otherwise, disable sort for psuedo-column.
 
 The first applicable rule MAY cause sorting to be disabled. Consider that determination final and do not continue to search subsequent rules.
-
-Domain value presentation heuristics:
-
-1. If _pattern_ expands to _filter_ and forms a valid filter string, present filtered results as domain values.
-    - With _filter_ `F`, the effective domain query would be `GET /ermrest/catalog/N/entity/S:T/F` or equivalent.
-	- The _filter_ SHOULD be validated according to the syntax summary below.
-	- If a server response suggests the filter is invalid, an application SHOULD retry as if the _pattern_ is not present.
-2. If _filter_ is not a valid filter string, proceed as if _pattern_ is not present.
-3. If _pattern_ is not present, present unfiltered results.
-
-Supported _filter_ language is the subset of ERMrest query path syntax
-allowed in a single path element:
-
-- Grouping: `(` _filter_ `)`
-- Disjunction: _filter_ `;` _filter_
-- Conjunction: _filter_ `&` _filter_
-- Negation: `!` _filter_
-- Unary predicates: _column_ `::null::`
-- Binary predicates: _column_ _op_ _value_
-  - Equality: `=`
-  - Inequality: `::gt::`, `::lt::`, `::geq::`, `::leq::`
-  - Regular expressions: `::regexp::`, `::ciregexp::`
-
-Notably, _filters_ MUST NOT contain the path divider `/` nor any other
-reserved syntax not summarized above. All _column_ names and _value_
-literals MUST be URL-escaped to protect any special characters. All
-_column_ names MUST match columns in the referenced table and MUST NOT
-be qualified with table instance aliases.
 
 ### Tag: 2016 Column Display
 

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -476,6 +476,7 @@ Supported JSON payload patterns:
 - `{` ... `"to_comment_display":` _comment_display_ ... `}`: The display mode for the tooltip. Set to `inline` to show it as text or `tooltip` to show as a hover tooltip.
     - Currently the `comment_display` is only supported for foreign key relationships in detailed context when they are part of `visible-columns` or `visible-foreign-keys`.
 - `{` ... `"display": {` _context_`:` _option_ ...`}` ... `}`: Apply each _option_ to the presentation of referenced content for any number of _context_ names.
+- `{` ... `"domain_filter_pattern":` _pathpattern_ ...`}` (_deprecated_): The _pathpattern_ yields a _filter_ via [Pattern Expansion](#pattern-expansion). This syntax has been deprecated in favor of the next syntax (`domainfilter`). The new syntax allows you to provide the visual presentation of the filter.
 - `{` ... `"domain_filter":` _domainfilter_ ...`}`: The domain filter that will be used while selecting a value for this particular foreign key in the entry contexts. This attribute can be used to limit the available options to the user.
 
 Supported _comment_ syntax:
@@ -503,36 +504,29 @@ Supported _domainfilter_ syntax:
 
 Supported _filter_ syntax:
 
-- The _filter_ is a URL substring using the ERMrest filter language,
-which can be applied to the referenced table.
-The defined _filter_ will be appended directly to the reference uri
-and therefore must be properly url encoded
- (chaise WILL NOT apply additional url encoding).
+- The _filter_ is a URL substring that can be applied to the referenced table.
+The defined _filter_ will be appended directly to the reference URI sent to ERMrest. Therefore,
+  - must be properly URL encoded (chaise WILL NOT apply additional URL encoding);
+  - supports any ERMrest-supported [path filters](https://docs.derivacloud.org/ermrest/api-doc/data/naming.html#path-filters) (simple predicate filters, e.g., `col=value`) or [entity links](https://docs.derivacloud.org/ermrest/api-doc/data/naming.html#entity-links) (join with other tables) as long as the projected table stays the same.
+
+    - If using entity links,
+      - cannot use `T#` (where `#` is a number, e.g., T0, T1), `F#` (where `#` is a number, e.g., F0, F1), and `M` aliases. ERMrestJS internally use these aliases.
+
+      - use `M` alias for referring to the referenced table.
+
+    - The following is a summary of supported path filters in ERMrest:
+        - Grouping: `(` _filter_ `)`
+        - Disjunction: _filter_ `;` _filter_
+        - Conjunction: _filter_ `&` _filter_
+        - Negation: `!` _filter_
+        - Unary predicates: _column_ `::null::`
+        - Binary predicates: _column_ _op_ _value_
+          - Equality: `=`
+          - Inequality: `::gt::`, `::lt::`, `::geq::`, `::leq::`
+          - Regular expressions: `::regexp::`, `::ciregexp::`
 
 - The leading and trailing slash that you might have defined
-in your path will be stripped off and ignored.
-
-- All _column_ names and _value_
-literals MUST be URL-escaped to protect any special characters. All
-_column_ names MUST match columns in the referenced table.
-
-- Since chaise will directly append the given _filter_ in the request for getting the values to the ERMrest request URI, you are free to use any ERMrest-supported [path filters](https://docs.derivacloud.org/ermrest/api-doc/data/naming.html#path-filters) or [entity links](https://docs.derivacloud.org/ermrest/api-doc/data/naming.html#entity-links) as long as the projected table stays the same.
-- The following is a summary of supported path filters in ERMrest:
-    - Grouping: `(` _filter_ `)`
-    - Disjunction: _filter_ `;` _filter_
-    - Conjunction: _filter_ `&` _filter_
-    - Negation: `!` _filter_
-    - Unary predicates: _column_ `::null::`
-    - Binary predicates: _column_ _op_ _value_
-      - Equality: `=`
-      - Inequality: `::gt::`, `::lt::`, `::geq::`, `::leq::`
-      - Regular expressions: `::regexp::`, `::ciregexp::`
-
-- If you're using entity links,
-  - Don't use use `T#` (where `#` is a number, e.g. T0, T1), `F#` (where `#` is a number, e.g. F0, F1), and `M` aliases. These are internally used by ERMrestJS.
-
-  - You can use `M` alias for referring to the referenced table.
-
+in _filter_ value will be stripped off and ignored.
 
 Set-naming heuristics (use first applicable rule):
 

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -476,7 +476,7 @@ Supported JSON payload patterns:
 - `{` ... `"to_comment_display":` _comment_display_ ... `}`: The display mode for the tooltip. Set to `inline` to show it as text or `tooltip` to show as a hover tooltip.
     - Currently the `comment_display` is only supported for foreign key relationships in detailed context when they are part of `visible-columns` or `visible-foreign-keys`.
 - `{` ... `"display": {` _context_`:` _option_ ...`}` ... `}`: Apply each _option_ to the presentation of referenced content for any number of _context_ names.
-- `{` ... `"domain_filter_pattern":` _pathpattern_ ...`}` (_deprecated_): The _pathpattern_ yields a _filter_ via [Pattern Expansion](#pattern-expansion). This syntax has been deprecated in favor of the next syntax (`domainfilter`). The new syntax allows you to provide the visual presentation of the filter.
+- `{` ... `"domain_filter_pattern":` _pathpattern_ ...`}` (_deprecated_): The _pathpattern_ yields a _filter_ via [Pattern Expansion](#pattern-expansion). The domain filter will be used while selecting a value for this particular foreign key in the entry contexts. This syntax has been deprecated in favor of the next syntax (`domain_filter`). The new syntax allows you to provide the visual presentation of the filter.
 - `{` ... `"domain_filter":` _domainfilter_ ...`}`: The domain filter that will be used while selecting a value for this particular foreign key in the entry contexts. This attribute can be used to limit the available options to the user.
 
 Supported _comment_ syntax:

--- a/js/column.js
+++ b/js/column.js
@@ -1724,13 +1724,8 @@ ForeignKeyPseudoColumn.prototype.filteredRef = function(data, linkedData) {
         keyValues = module._getFormattedKeyValues(baseTable, self._context, data, linkedData);
         content = self.foreignKey.annotations.get(module._annotations.FOREIGN_KEY).content;
 
-        // backward compatibility
-        if (typeof content.domain_filter_pattern === "string") {
-            filterPattern = content.domain_filter_pattern;
-            filterPatternTemplate = content.template_engine;
-
         // make sure the annotation is properly defined
-        } else if (isObjectAndNotNull(content.domain_filter) && isStringAndNotEmpty(content.domain_filter.ermrest_path_pattern)) {
+        if (isObjectAndNotNull(content.domain_filter) && isStringAndNotEmpty(content.domain_filter.ermrest_path_pattern)) {
             filterPattern = content.domain_filter.ermrest_path_pattern;
             filterPatternTemplate = content.domain_filter.template_engine;
 
@@ -1747,6 +1742,11 @@ ForeignKeyPseudoColumn.prototype.filteredRef = function(data, linkedData) {
                     displayname = module.renderMarkdown(displaynameMkdn, true);
                 }
             }
+        }
+        // backward compatibility
+        else if (typeof content.domain_filter_pattern === "string") {
+            filterPattern = content.domain_filter_pattern;
+            filterPatternTemplate = content.template_engine;
         }
 
         // process the filter pattern

--- a/js/parser.js
+++ b/js/parser.js
@@ -1750,9 +1750,9 @@
     }
     /**
      * An object that will have the follwoing attributes:
-     *  - displayname: "a markdown displayname",
      *  - facets: "the facet object"
      *  - ermrest_path: "ermrest path string"
+     *  - displayname: {value: "the value", isHTML: boolean} (optional)
      *
      *
      * @param       {String|Object} str Can be blob or json (object).
@@ -1788,7 +1788,7 @@
         }
 
         var obj = this.decoded;
-        if (!obj.hasOwnProperty("displayname") || (!obj.hasOwnProperty("facets") && !obj.hasOwnProperty("ermrest_path"))) {
+        if ((!obj.hasOwnProperty("facets") && !obj.hasOwnProperty("ermrest_path"))) {
             throw error;
         }
 
@@ -1808,9 +1808,26 @@
             this.ermrestPath = module.trimSlashes(obj.ermrest_path);
         }
 
-        /**
-         * The name that should be used to represent the facet value
-         * @type {string}
-         */
-        this.displayname = obj.displayname;
+        this.removable = true;
+        if (typeof obj.removable === "boolean") {
+            /**
+             * Whether user can remove the facet or not
+             * @type {string}
+             */
+            this.removable = obj.removable;
+        }
+
+        if (isStringAndNotEmpty(obj.displayname)) {
+            /**
+             * The name that should be used to represent the facet value (optional)
+             * @type {Object}
+             */
+            this.displayname = {
+                value: obj.displayname,
+                unformatted: obj.displayname,
+                isHTML: false
+            };
+        } else if (isObjectAndNotNull(obj.displayname) && ("value" in obj.displayname)) {
+            this.displayname = obj.displayname;
+        }
     }

--- a/test/specs/column/conf/columns_schema/schema.json
+++ b/test/specs/column/conf/columns_schema/schema.json
@@ -1192,7 +1192,9 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "position_type_col=fixed"
+                            "domain_filter": {
+                                "ermrest_path_pattern": "position_type_col=fixed"
+                            }
                         }
                     },
                     "referenced_columns": [
@@ -1215,7 +1217,10 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "position_type_col={{{_position_text_col}}}"
+                            "domain_filter": {
+                                "ermrest_path_pattern": "position_type_col={{{_position_text_col}}}",
+                                "display_markdown_pattern": "**position_type_col**: {{{_position_text_col}}}"
+                            }
                         }
                     },
                     "referenced_columns": [
@@ -1238,7 +1243,10 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "fk2={{{_fk1}}}&position_col={{{_position_text_col}}}"
+                            "domain_filter": {
+                                "ermrest_path_pattern": "fk2={{{_fk1}}}&position_col={{{_position_text_col}}}",
+                                "display_markdown_pattern": "**fk2**: {{{_fk1}}} and **position_col**:{{{_position_text_col}}}"
+                            }
                         }
                     },
                     "referenced_columns": [
@@ -1261,7 +1269,10 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "fk2={{{$fkeys.columns_schema.fk_position_predefined.values._int_value}}}&position_col={{{$fkeys.columns_schema.fk_position_user_defined.values._int_value}}}&id={{{_fk1}}}"
+                            "domain_filter": {
+                                "ermrest_path_pattern": "fk2={{{$fkeys.columns_schema.fk_position_predefined.values._int_value}}}&position_col={{{$fkeys.columns_schema.fk_position_user_defined.values._int_value}}}&id={{{_fk1}}}",
+                                "display_markdown_pattern": "**fk2**: {{{$fkeys.columns_schema.fk_position_predefined.values._int_value}}} and **position_col**:{{{$fkeys.columns_schema.fk_position_user_defined.values._int_value}}}"
+                            }
                         }
                     },
                     "referenced_columns": [
@@ -1333,7 +1344,7 @@
                     }
                 },
                 {
-                    "column": "used in a foreignkey that its domain_filter_pattern is using other foreignKey data",
+                    "column": "used in a foreignkey that its domain_filter is using other foreignKey data",
                     "name": "fkeys_fk_col",
                     "type": {
                         "typename": "int4"

--- a/test/specs/parser/tests/01.parser.js
+++ b/test/specs/parser/tests/01.parser.js
@@ -921,7 +921,13 @@ exports.execute = function(options) {
                 expect(loc.customFacets.encoded).toEqual(blob, "blob missmatch");
                 expect(loc.uri).toEqual(uri, "uri missmatch.");
                 expect(loc.ermrestPath).toEqual(ermrestPath, "ermrestCompactUri missmatch");
-                expect(loc.customFacets.displayname).toEqual(cfacets.displayname, "displayname missmatch");
+                if (typeof cfacets.displayname === "string") {
+                    expect(loc.customFacets.displayname.value).toEqual(cfacets.displayname, "displayname missmatch");
+                    expect(loc.customFacets.displayname.isHTML).toEqual(false, "isHTML missmatch");
+                } else {
+                    expect(loc.customFacets.displayname.value).toEqual(cfacets.displayname.value, "displayname missmatch");
+                    expect(loc.customFacets.displayname.isHTML).toEqual(cfacets.displayname.isHTML, "isHTML missmatch");
+                }
             };
 
             describe("getter, ", function () {
@@ -934,14 +940,6 @@ exports.execute = function(options) {
                     it ("when uri has an invalid cfacests blob, parser should throw an error.", function () {
                         expect(function () {
                             options.ermRest.parse(baseUri + "/*::cfacets::invalidblob");
-                        }).toThrow(customFacetError);
-                    });
-
-                    it ("when uri has a valid cfacets blob but `displayname` is missing, parser should throw an error.", function () {
-                        // {"ermrest_path": "id=2"}
-                        blob = "N4IgpgTgthYM4BcD6AHAhggFiAXCAlgCYC8ATCAL5A";
-                        expect(function () {
-                            options.ermRest.parse(baseUri + "/*::cfacets::" + blob);
                         }).toThrow(customFacetError);
                     });
 
@@ -966,11 +964,12 @@ exports.execute = function(options) {
                     });
 
                     it ("should handle passing only ermrest_path.", function () {
-                        blob = "N4IgJglgzgDgNgQwJ4DsEFsCmIBcIBuCcArtgDQiYBO6VmUALgPowIMAWuIEYAvAEwgAvkA";
+                        // {"displayname": {"value": "<strong>value</strong>", "isHTML": true}, "ermrest_path": "id=2"}
+                        blob = "N4IgJglgzgDgNgQwJ4DsEFsCmIBcoBuCcArtjiADxQAuATgPYoDmAfISZhQPQ0PMsgANCGgAJACoBZADK46pAL7DMtdLUw0A+jATUAFrhFgAvACYQCoA";
                         testCustomFacets(
                             baseUri + "/*::cfacets::" + blob,
                             blob,
-                            {"displayname": "value", "ermrest_path": "id=2"},
+                            {"displayname": {"value": "<strong>value</strong>", "isHTML": true}, "ermrest_path": "id=2"},
                             "M:=parse_schema:parse_table/id=2"
                         );
                     });


### PR DESCRIPTION
This PR will implement the changes described [in here](https://github.com/informatics-isi-edu/ermrestjs/issues/491#issuecomment-659758133). To summarize, 


- Changed the implementation of "domain filter" support to incorporate the new syntax (by using cfacets.)
- Modified the `displayname` property of `customFacets` to be aligned with the rest of ermrestjs and support HTML as well.
- Modified the existing `customFacets` and `filteredRef` test cases based on the changes.


Issue: #491