### PR TITLE
COMPACT_ENTRY context

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -1736,7 +1736,7 @@ ForeignKeyPseudoColumn.prototype.filteredRef = function(data, linkedData) {
                     keyValues,
                     baseTable.schema.catalog,
                     {templateEngine: filterPatternTemplate}
-                )
+                );
 
                 if (displaynameMkdn != null && displaynameMkdn.trim() !== '') {
                     displayname = module.renderMarkdown(displaynameMkdn, true);

--- a/js/reference.js
+++ b/js/reference.js
@@ -2844,7 +2844,7 @@
 
             var context = this._context;
             isEntry = module._isEntryContext(context);
-            isCompactEntry = context.startsWith(module._contexts.COMPACT_ENTRY);
+            isCompactEntry = (typeof context === "string" && context.startsWith(module._contexts.COMPACT_ENTRY));
 
             // check if we should hide some columns or not.
             // NOTE: if the reference is actually an inbound related reference, we should hide the foreign key that created this link.

--- a/js/reference.js
+++ b/js/reference.js
@@ -1247,8 +1247,9 @@
                     }
 
                     var ref = new Reference(module.parse(uri), self._table.schema.catalog);
+                    ref = (response.data.length > 1 ? ref.contextualize.compactEntry : ref.contextualize.compact);
                     //  make a page of tuples of the results (unless error)
-                    var page = new Page(ref.contextualize.compactEntry, etag, response.data, false, false);
+                    var page = new Page(ref, etag, response.data, false, false);
 
                     //  resolve the promise, passing back the page
                     return defer.resolve({
@@ -1840,6 +1841,7 @@
                     }
 
                     var ref = new Reference(module.parse(uri), self._table.schema.catalog).contextualize.compactEntry;
+                    ref = (response.data.length > 1 ? ref.contextualize.compactEntry : ref.contextualize.compact);
                     var successfulPage = new Page(ref, etag, pageData, false, false);
                     var failedPage = null;
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -3306,12 +3306,6 @@
                         this._referenceColumns.splice(i, 1);
                         i--;
                     }
-
-                    // TODO: remove columns in COMPACT_ENTRY context:
-                    // if (context.startsWith(module._contexts.COMPACT_ENTRY) && (refCol.hasWaitFor || !refCol.isUnique || (refCol.hasPath && refCol.isUnique && refCol.foreignKeys.length > 1)) ) {
-                    //     this._referenceColumns.splice(i, 1);
-                    // }
-
                 }
             }
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -3062,7 +3062,13 @@
 
                             // in entry mode, pseudo-column, inbound fk, and key are not allowed
                             if (!(isEntry && (refCol.isPathColumn || refCol.isInboundForeignKey || refCol.isKey) )) {
-                                this._referenceColumns.push(refCol);
+                                // NOTE: should I check refCol.hasAggregate ?
+                                // check we are in entry/compact mode before excluding more columns
+                                if (context.startsWith(module._contexts.COMPACT_ENTRY) && (refCol.hasWaitFor || !refCol.isUnique || (refCol.hasPath && refCol.isUnique && refCol.foreignKeys.length > 1)) ) {
+                                    // don't add the pseudo column
+                                } else {
+                                    this._referenceColumns.push(refCol);
+                                }
                             }
                         }
 
@@ -3297,6 +3303,12 @@
                         this._referenceColumns.splice(i, 1);
                         i--;
                     }
+
+                    // TODO: remove columns in COMPACT_ENTRY context:
+                    // if (context.startsWith(module._contexts.COMPACT_ENTRY) && (refCol.hasWaitFor || !refCol.isUnique || (refCol.hasPath && refCol.isUnique && refCol.foreignKeys.length > 1)) ) {
+                    //     this._referenceColumns.splice(i, 1);
+                    // }
+
                 }
             }
 
@@ -4114,6 +4126,14 @@
          */
         get entryEdit() {
             return this._contextualize(module._contexts.EDIT);
+        },
+
+        /**
+         * The _entry/compact_ context of this reference.
+         * @type {ERMrest.Reference}
+         */
+        get compactEntry() {
+            return this._contextualize(module._contexts.COMPACT_ENTRY);
         },
 
         /**

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -57,6 +57,7 @@
         COMPACT: 'compact',
         COMPACT_BRIEF: 'compact/brief',
         COMPACT_BRIEF_INLINE: 'compact/brief/inline',
+        COMPACT_ENTRY: 'compact/entry', // post create/edit for multiple rows
         COMPACT_SELECT: 'compact/select',
         CREATE: 'entry/create',
         DETAILED: 'detailed',
@@ -78,10 +79,10 @@
         }
     });
 
-    module._contextArray = ["compact", "compact/brief", "compact/select", "entry/create", "detailed", "entry/edit", "entry", "filter", "*", "row_name", "compact/brief/inline"];
+    module._contextArray = ["compact", "compact/brief", "compact/entry", "compact/select", "entry/create", "detailed", "entry/edit", "entry", "filter", "*", "row_name", "compact/brief/inline"];
 
     module._entryContexts = [module._contexts.CREATE, module._contexts.EDIT, module._contexts.ENTRY];
-    module._compactContexts = [module._contexts.COMPACT, module._contexts.COMPACT_BRIEF, module._contexts.COMPACT_BRIEF_INLINE, module._contexts.COMPACT_SELECT];
+    module._compactContexts = [module._contexts.COMPACT, module._contexts.COMPACT_BRIEF, module._contexts.COMPACT_BRIEF_INLINE, module._contexts.COMPACT_SELECT, module._contexts.COMPACT_ENTRY];
 
     module._tableKinds = Object.freeze({
         TABLE: "table",

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -258,10 +258,6 @@ exports.execute = function (options) {
             });
 
             it ("in compact entry context, should ignore the pseudoColumns that are not supported.", function () {
-                mainRefCompactEntry.columns.forEach(function (col) {
-                    console.log(col._name);
-                });
-
                 expect(mainRefCompactEntry.columns.length).toBe(9, "length missmatch.");
 
                 checkReferenceColumns([{

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -152,7 +152,7 @@ exports.execute = function (options) {
             "isPathColumn", "isPathColumn", "isAsset", "", "isPathColumn", "isPathColumn"
         ];
 
-        var mainRef, mainRefDetailed, invalidRef, mainRefEntry,
+        var mainRef, mainRefDetailed, invalidRef, mainRefEntry, mainRefCompactEntry,
             detailedCols, detailedColsWTuple, mainTuple, mainPage;
 
         beforeAll(function (done) {
@@ -162,6 +162,7 @@ exports.execute = function (options) {
                 mainRefDetailed = response.contextualize.detailed;
                 detailedCols = mainRefDetailed.columns;
                 mainRefEntry = response.contextualize.entry;
+                mainRefCompactEntry = response.contextualize.compactEntry;
                 return options.ermRest.resolve(invalidEntityUri, {cid: "test"});
             }).then(function (response) {
                 invalidRef = response;
@@ -252,6 +253,28 @@ exports.execute = function (options) {
                     "ref": mainRefEntry,
                     "expected": [
                         "main_table_id_col", "col", ["pseudo_column_schema", "main_fk1"].join("_"), "asset"
+                    ]
+                }]);
+            });
+
+            it ("in compact entry context, should ignore the pseudoColumns that are not supported.", function () {
+                mainRefCompactEntry.columns.forEach(function (col) {
+                    console.log(col._name);
+                });
+
+                expect(mainRefCompactEntry.columns.length).toBe(9, "length missmatch.");
+
+                checkReferenceColumns([{
+                    "ref": mainRefCompactEntry,
+                    "expected": [
+                        "main_table_id_col",
+                        "col",
+                        ["pseudo_column_schema", "main_key1"].join("_"),
+                        ["pseudo_column_schema", "main_fk1"].join("_"),
+                        [{"outbound": ["pseudo_column_schema", "main_fk1"]}, "id"],
+                        "asset", "asset_filename",
+                        "$virtual-column-1",
+                        "$virtual-column-1-1"
                     ]
                 }]);
             });

--- a/test/specs/reference/tests/01.reference.js
+++ b/test/specs/reference/tests/01.reference.js
@@ -444,7 +444,8 @@ exports.execute = function (options) {
             var testCreate = function (ref, rows, expectedData, done) {
                 createReference.create(rows).then(function (response) {
                     var page = response.successful;
-                    expect(page.reference._context).toEqual("compact", "page reference is not in the correct context.");
+                    var context = (rows.length > 1 ? "compact/entry" : "compact");
+                    expect(page.reference._context).toEqual(context, "page reference is not in the correct context.");
                     expect(page._data.length).toBe(expectedData.length, "data length missmatch.");
                     expectedData.forEach(function (data, i) {
                         for (var k in data) {


### PR DESCRIPTION
New context added to the reference API in ermrestJS denoted as compact/entry. This context has a special case for removing columns that generate additional requests for more information.