### PR TITLE
support color_rgb_hex type

### DIFF
--- a/js/ag_reference.js
+++ b/js/ag_reference.js
@@ -562,7 +562,7 @@ AttributeGroupReference.prototype = {
             contextHeaderParams[key] = this.defaultLogInfo[key];
         }
 
-        if (isInteger(page_size)) {
+        if (Number.isInteger(page_size)) {
             contextHeaderParams.page_size = page_size;
         }
 
@@ -807,7 +807,7 @@ AttributeGroupTuple.prototype = {
             var data = this._data, hasNull, self = this;
             this._uniqueId = self._page.reference.shortestKey.reduce(function (res, c, index) {
                 hasNull = hasNull || data[c.name] == null;
-                return res + (index > 0 ? "_" : "") + c.formatvalue(data[c.name], self._page.reference._context);
+                return res + (index > 0 ? "_" : "") + data[c.name];
             }, "");
 
             //TODO should be evaluated for composite keys
@@ -844,7 +844,7 @@ AttributeGroupTuple.prototype = {
                 hasNull = hasNull || data[c.name] == null;
                 if (hasNull) return;
 
-                hasMarkdown = hasMarkdown || c.type.name === "markdown";
+                hasMarkdown = hasMarkdown || (module._HTMLColumnType.indexOf(c.type.name) != -1);
                 values.push(c.formatvalue(data[c.name], self._page.reference._context));
             });
 
@@ -1007,7 +1007,7 @@ AttributeGroupColumn.prototype = {
          * are aliases and not the actual column names in the table.
          *
          */
-        if (this.type.name === "markdown") {
+        if (module._HTMLColumnType.indexOf(this.type.name) != -1) {
             return {isHTML: true, value: module.renderMarkdown(formattedValue, true), unformatted: formattedValue};
         }
         return {isHTML: false, value: formattedValue, unformatted: formattedValue};

--- a/js/core.js
+++ b/js/core.js
@@ -2850,7 +2850,7 @@
                     "preformatConfig": hasPreformat ? annotation.pre_format : null,
                     "isMarkdownPattern": (typeof annotation.markdown_pattern === 'string'),
                     "isMarkdownType" : this.type.name === 'markdown',
-                    "isHTML": (typeof annotation.markdown_pattern === 'string') || this.type.name === 'markdown',
+                    "isHTML": (typeof annotation.markdown_pattern === 'string') || (module._HTMLColumnType.indexOf(this.type.name) != -1),
                     "markdownPattern": annotation.markdown_pattern,
                     "templateEngine": annotation.template_engine,
                     "columnOrder": columnOrder

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -103,6 +103,9 @@
         "json", "jsonb"
     ];
 
+    // column types that their value should be considered as HTML
+    module._HTMLColumnType = ["markdown", "color_rgb_hex"];
+
     // types we support for our plotly histogram graphs
     module._histogramSupportedTypes = [
         'int2', 'int4', 'int8', 'float', 'float4', 'float8', 'numeric',
@@ -290,7 +293,8 @@
         download: "download-alt",
         postLoad: "-chaise-post-load",
         hideInPrintMode: "hide-in-print",
-        showInPrintMode: "video-info-in-print"
+        showInPrintMode: "video-info-in-print",
+        colorPreview: "chaise-color-preview"
     });
 
     module._specialSourceDefinitions = Object.freeze({

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1721,6 +1721,16 @@
 
             if (options.returnArray) return arr;
             return arr.join(", ");
+        },
+
+        printColor: function (value, options) {
+            options = (typeof options === 'undefined') ? {} : options;
+
+            if (!isStringAndNotEmpty(value) || !(/^#[0-9a-fA-F]{6}$/i.test(value))) {
+                return '';
+            }
+
+            return value + ' :span: :/span:{.' + module._classNames.colorPreview + ' style=background-color:' + value +'}';
         }
     };
 
@@ -1764,6 +1774,9 @@
             case 'json':
             case 'jsonb':
                 data = utils.printJSON(data, options);
+                break;
+            case 'color_rgb_hex':
+                data = utils.printColor(data, options);
                 break;
             default: // includes 'text' and 'longtext' cases
                 data = type.baseType ? _formatValueByType(type.baseType, data, options) : utils.printText(data, options);
@@ -1907,10 +1920,10 @@
                               html = '<span class="' + module._classNames.showInPrintMode + '" style="visibility:hidden">' + videoText + "</span>";
                               iframeTagClasses.push(module._classNames.hideInPrintMode);
                             }
-                            
+
                             // add the iframe tag
                             html += iframeHTML;
-                            
+
                             // attach the iframe tag classes
                             if (iframeTagClasses.length > 0) {
                                 html += 'class="' + iframeTagClasses.join(" ") + '" ';

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1730,7 +1730,8 @@
                 return '';
             }
 
-            return value + ' :span: :/span:{.' + module._classNames.colorPreview + ' style=background-color:' + value +'}';
+            value = value.toUpperCase();
+            return ':span: :/span:{.' + module._classNames.colorPreview + ' style=background-color:' + value +'} ' + value;
         }
     };
 

--- a/test/ermrest_config.json
+++ b/test/ermrest_config.json
@@ -38,6 +38,7 @@
       "text": { "aliases": [ "character varying" ] },
       "longtext": null,
       "markdown": null,
+      "color_rgb_hex": null,
       "gene_sequence": null,
       "timestamp": { "aliases": ["timestamp without time zone"] },
       "timestamptz": { "aliases": [ "timestamptz", "timestamp with time zone" ] },

--- a/test/specs/ag_reference/tests/01.ag_reference.js
+++ b/test/specs/ag_reference/tests/01.ag_reference.js
@@ -558,8 +558,8 @@ exports.execute = function (options) {
                         });
 
                         describe("uniqueId, ", function () {
-                            it ("should return an string based on shortest key values.", function () {
-                                expect(tuples[0].uniqueId).toBe("**test2**_YES");
+                            it ("should return an string based on raw values of shortest key.", function () {
+                                expect(tuples[0].uniqueId).toBe("**test2**_true");
                             });
 
                             it ("should return null if any of the key columns are null.", function (done) {

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -125,6 +125,10 @@
                     "type": { "typename": "serial4" }
                 },
                 {
+                    "name": "table_1_color_rgb_hex",
+                    "type": { "typename": "color_rgb_hex" }
+                },
+                {
                     "name": "table_1_text_array",
                     "type": {
                         "is_array": true,

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -326,7 +326,7 @@ exports.execute = function(options) {
                         testFormatvalue('table_1_color_rgb_hex', null, '', 'empty value');
                         testFormatvalue('table_1_color_rgb_hex', '00ff00', '', 'invalid value 1');
                         testFormatvalue('table_1_color_rgb_hex', '#00kj00', '', 'invalid value 2');
-                        testFormatvalue('table_1_color_rgb_hex', '#00ff00', '#00ff00 :span: :/span:{.chaise-color-preview style=background-color:#00ff00}', 'valid value');
+                        testFormatvalue('table_1_color_rgb_hex', '#00ff00', ':span: :/span:{.chaise-color-preview style=background-color:#00FF00} #00FF00', 'valid value');
                     });
                 });
 

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -321,6 +321,15 @@ exports.execute = function(options) {
                     });
                 });
 
+                describe('should call printColor() to format,', function () {
+                    it('color_rgb_hex columns correctly.', function () {
+                        testFormatvalue('table_1_color_rgb_hex', null, '', 'empty value');
+                        testFormatvalue('table_1_color_rgb_hex', '00ff00', '', 'invalid value 1');
+                        testFormatvalue('table_1_color_rgb_hex', '#00kj00', '', 'invalid value 2');
+                        testFormatvalue('table_1_color_rgb_hex', '#00ff00', '#00ff00 :span: :/span:{.chaise-color-preview style=background-color:#00ff00}', 'valid value');
+                    });
+                });
+
                 describe('should handle array columns.', function () {
                     var cases = [
                         {

--- a/test/specs/reference/conf/reference_schema/data/reference_values.json
+++ b/test/specs/reference/conf/reference_schema/data/reference_values.json
@@ -1,7 +1,53 @@
-[{"id":4000, "some_markdown": "**date is :**", "name":"Hank", "url": "https://www.google.com", "some_gene_sequence": "GATCGATCGCGTATT", "video_col": "http://techslides.com/demos/sample-videos/small.mp4", "catalog_snapshot": "schema:table"},
- {"id":4001, "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)", "name":"Harold","some_invisible_column": "Junior", "fk_col": 1},
- {"id":4002, "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)", "url": "https://www.google.com", "fk_col": 2},
- {"id":4003, "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)", "some_invisible_column": "Freshmen", "fk_col": 3},
- {"id":4004, "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)", "name": "weird & HTML < ", "fk_col": 4},
- {"id":4005, "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)", "name": "<a href='javascript:alert();'></a>", "some_invisible_column": "Senior", "fk_col": 5},
- {"id":4006, "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)", "name": "<script>alert();</script>", "some_gene_sequence": "GATCGATCGCGTATT", "some_invisible_column": "Sophomore", "fk_col": 6}]
+[{
+        "id": 4000,
+        "some_markdown": "**date is :**",
+        "name": "Hank",
+        "url": "https://www.google.com",
+        "some_gene_sequence": "GATCGATCGCGTATT",
+        "video_col": "http://techslides.com/demos/sample-videos/small.mp4",
+        "catalog_snapshot": "schema:table",
+        "color_rgb_hex_col": "#00ff00"
+    },
+    {
+        "id": 4001,
+        "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)",
+        "name": "Harold",
+        "some_invisible_column": "Junior",
+        "fk_col": 1,
+        "color_rgb_hex_col": "#0000ff"
+    },
+    {
+        "id": 4002,
+        "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)",
+        "url": "https://www.google.com",
+        "fk_col": 2,
+        "color_rgb_hex_col": "#ff3411"
+    },
+    {
+        "id": 4003,
+        "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)",
+        "some_invisible_column": "Freshmen",
+        "fk_col": 3
+    },
+    {
+        "id": 4004,
+        "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)",
+        "name": "weird & HTML < ",
+        "fk_col": 4
+    },
+    {
+        "id": 4005,
+        "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)",
+        "name": "<a href='javascript:alert();'></a>",
+        "some_invisible_column": "Senior",
+        "fk_col": 5
+    },
+    {
+        "id": 4006,
+        "some_markdown": "**This is some markdown** with some `code` and a [link](http://www.example.com)",
+        "name": "<script>alert();</script>",
+        "some_gene_sequence": "GATCGATCGCGTATT",
+        "some_invisible_column": "Sophomore",
+        "fk_col": 6
+    }
+]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -1474,6 +1474,10 @@
                           }
                       }
                   }
+              },
+              {
+                  "name": "color_rgb_hex_col",
+                  "type": {"typename": "color_rgb_hex"}
               }
             ],
             "annotations": {
@@ -1483,7 +1487,7 @@
                       "iframe","some_markdown", "some_markdown_with_pattern",
                       "some_gene_sequence", "column_using_invisble_column",
                       "video_col", "fkeys_col", "catalog_snapshot",
-                      "moment_col", "encodefacet_col"
+                      "moment_col", "encodefacet_col", "color_rgb_hex_col"
                   ]
                 }
             }

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -73,7 +73,7 @@ exports.execute = function (options) {
                                         '<p>'+catalog_id+': '+catalog_id+'/schema:table</p>\n',
                                         expectedMomentValue,
                                         '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABnYF14BfeL7oA</p>\n',
-                                        '<p>#00ff00 <span class="chaise-color-preview" background-color="#00ff00"> </span></p>\n'
+                                        '<p><span class="chaise-color-preview" background-color="#00FF00"> </span> #00FF00</p>\n'
                                          ],
                     "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true, false, true, true, true, true]
                     },
@@ -96,7 +96,7 @@ exports.execute = function (options) {
                                 '',
                                 expectedMomentValue,
                                 '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYEYBdeAX3h68gA</p>\n',
-                                '<p>#0000ff <span class="chaise-color-preview" background-color="#0000ff"> </span></p>\n'
+                                '<p><span class="chaise-color-preview" background-color="#0000FF"> </span> #0000FF</p>\n'
                             ],
                 "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, false, true, true, true]
                 },
@@ -119,7 +119,7 @@ exports.execute = function (options) {
                                 '',
                                 expectedMomentValue,
                                 '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYCYBdeAX3h68gA</p>\n',
-                                '<p>#ff3411 <span class="chaise-color-preview" background-color="#ff3411"> </span></p>\n'
+                                '<p><span class="chaise-color-preview" background-color="#FF3411"> </span> #FF3411</p>\n'
                                 ],
                 "isHTML" : [false, false, false, true, true, true, false, true, false, true, false, true, true, false, true, true, true]
                 },

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -72,9 +72,10 @@ exports.execute = function (options) {
                                         '', // This value is set later by setLinkRID()
                                         '<p>'+catalog_id+': '+catalog_id+'/schema:table</p>\n',
                                         expectedMomentValue,
-                                        '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABnYF14BfeL7oA</p>\n'
+                                        '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABnYF14BfeL7oA</p>\n',
+                                        '<p>#00ff00 <span class="chaise-color-preview" background-color="#00ff00"> </span></p>\n'
                                          ],
-                    "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true, false, true, true, true]
+                    "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true, false, true, true, true, true]
                     },
             "test2": {
                 "rowValue" :["id=4001, name=Harold,some_invisible_column= Junior"],
@@ -94,9 +95,10 @@ exports.execute = function (options) {
                                 '',  // This value is set later by setLinkRID()
                                 '',
                                 expectedMomentValue,
-                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYEYBdeAX3h68gA</p>\n'
+                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYEYBdeAX3h68gA</p>\n',
+                                '<p>#0000ff <span class="chaise-color-preview" background-color="#0000ff"> </span></p>\n'
                             ],
-                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, false, true, true]
+                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, false, true, true, true]
                 },
             "test3": {
                 "rowValue" : ["id=4002, url= https://www.google.com, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
@@ -116,9 +118,10 @@ exports.execute = function (options) {
                                 '', // This value is set later by setLinkRID()
                                 '',
                                 expectedMomentValue,
-                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYCYBdeAX3h68gA</p>\n'
+                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYCYBdeAX3h68gA</p>\n',
+                                '<p>#ff3411 <span class="chaise-color-preview" background-color="#ff3411"> </span></p>\n'
                                 ],
-                "isHTML" : [false, false, false, true, true, true, false, true, false, true, false, true, true, false, true, true]
+                "isHTML" : [false, false, false, true, true, true, false, true, false, true, false, true, true, false, true, true, true]
                 },
             "test4": {
                 "rowValue" : ["id=4003 ,some_invisible_column= Freshmen"],
@@ -138,9 +141,10 @@ exports.execute = function (options) {
                                 '', // This value is set later by setLinkRID()
                                 '',
                                 expectedMomentValue,
-                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYGYBdeAX3h68gA</p>\n'
+                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYGYBdeAX3h68gA</p>\n',
+                                ''
                                 ],
-                "isHTML" : [false, false, false, true, true, true, false, true, false, true, true, true, true, false, true, true]
+                "isHTML" : [false, false, false, true, true, true, false, true, false, true, true, true, true, false, true, true, false]
                 },
             "test5": {
                 "rowValue" :  ["id=4004, name= weird & HTML < "],
@@ -160,9 +164,10 @@ exports.execute = function (options) {
                                 '', // This value is set later by setLinkRID()
                                 '',
                                 expectedMomentValue,
-                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABleYF14BfebnkA</p>\n'
+                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABleYF14BfebnkA</p>\n',
+                                ''
                                 ],
-                "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true, true, false, true, true]
+                "isHTML" : [false, true, true, true, true, true, true, true, true, true, false, true, true, false, true, true, false]
                 },
             "test6": {
                 "rowValue" : ["id=4005, name= <a href='javascript:alert();'></a>, some_invisible_column= Senior"],
@@ -182,9 +187,10 @@ exports.execute = function (options) {
                                 '', // This value is set later by setLinkRID()
                                 '',
                                 expectedMomentValue,
-                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYFYBdeAX3h68gA</p>\n'
+                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYFYBdeAX3h68gA</p>\n',
+                                ''
                                 ],
-                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, false, true, true]
+                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, false, true, true, false]
                 },
             "test7": {
                 "rowValue" : ["id=4006, name= <script>alert();</script>, some_gene_sequence= GATCGATCGCGTATT, some_invisible_column= Sophomore"],
@@ -204,9 +210,10 @@ exports.execute = function (options) {
                                 '', // This value is set later by setLinkRID()
                                 '',
                                 expectedMomentValue,
-                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYDYBdeAX3h68gA</p>\n'
+                                '<p>/*::facets::N4IghgdgJiBcAEBteoDOB7ArgJwMYFM54QBLGAGmNwAt0SDUjEAWABlYDYBdeAX3h68gA</p>\n',
+                                ''
                                 ],
-                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, false, true, true]
+                "isHTML" : [false, true, true, true, true, true, true, true, true, true, true, true, true, false, true, true, false]
             }
         };
 
@@ -317,7 +324,7 @@ exports.execute = function (options) {
                     // get the RID value that was set on options.entities[schema_name][table_name]
                     setLinkRID(key);
 
-                    expect(tuples[tupleIndex].values.length).toBe(16);
+                    expect(tuples[tupleIndex].values.length).toBe(17);
                 });
 
                 var columnNames = [

--- a/test/specs/reference/tests/12.reference_values_edit.js
+++ b/test/specs/reference/tests/12.reference_values_edit.js
@@ -121,10 +121,10 @@ exports.execute = function (options) {
          */
         var testTupleValidity = function(tupleIndex, expectedValues) {
 
-            it("should return 15 values for a tuple", function() {
+            it("should return 17 values for a tuple", function() {
                 var values = tuples[tupleIndex].values;
 
-                expect(values.length).toBe(16);
+                expect(values.length).toBe(17);
             });
 
             checkValueAndIsHTML("id", tupleIndex, 0, expectedValues);
@@ -142,6 +142,7 @@ exports.execute = function (options) {
             checkValueAndIsHTML("catalog_snapshot", tupleIndex, 13, expectedValues);
             checkValueAndIsHTML("moment_col", tupleIndex, 14, expectedValues);
             checkValueAndIsHTML("encodefacet_col", tupleIndex, 15, expectedValues);
+            checkValueAndIsHTML("color_rgb_hex_col", tupleIndex, 16, expectedValues);
 
         };
 
@@ -153,31 +154,31 @@ exports.execute = function (options) {
             var testObjects ={
                 "test1": {
                         "rowValue" : ["id=4000, some_markdown= **date is :**, name=Hank, url= https://www.google.com, some_gene_sequence= GATCGATCGCGTATT, video_col= http://techslides.com/demos/sample-videos/small.mp4, catalog_snapshot=schema:table" ],
-                        "expectedValue": ["4000", "Hank", "https://www.google.com", null, null, null, null, '**date is :**', '**Name is :**', "GATCGATCGCGTATT",null, "http://techslides.com/demos/sample-videos/small.mp4", null, "schema:table", null, null]
+                        "expectedValue": ["4000", "Hank", "https://www.google.com", null, null, null, null, '**date is :**', '**Name is :**', "GATCGATCGCGTATT",null, "http://techslides.com/demos/sample-videos/small.mp4", null, "schema:table", null, null, "#00ff00"]
                         },
                 "test2": {
                         "rowValue" : ["id=4001, name=Harold,some_invisible_column= Junior, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-                        "expectedValue" : ["4001", "Harold", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null, null]
+                        "expectedValue" : ["4001", "Harold", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null, null, "#0000ff"]
                         },
                 "test3": {
                         "rowValue" : ["id=4002, url= https://www.google.com, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-                        "expectedValue" : ["4002", null, "https://www.google.com", null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null, null]
+                        "expectedValue" : ["4002", null, "https://www.google.com", null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null, null, "#ff3411"]
                         },
                 "test4": {
                         "rowValue" : ["id=4003 ,some_invisible_column= Freshmen, video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-                        "expectedValue" :["4003", null, null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**',null, null, null, null, null, null, null]
+                        "expectedValue" :["4003", null, null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**',null, null, null, null, null, null, null, null]
                         },
                 "test5": {
                         "rowValue" :["id=4004, name= weird & HTML < , video_col= http://techslides.com/demos/sample-videos/small.mp4"],
-                        "expectedValue" :["4004", "weird & HTML < ", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null, null]
+                        "expectedValue" :["4004", "weird & HTML < ", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null, null, null]
                         },
                 "test6": {
                         "rowValue": ["id=4005, name= <a href='javascript:alert();'></a>, some_invisible_column= Senior, video_col= http://techslides.com//small.mp4"],
-                        "expectedValue": ["4005", "<a href='javascript:alert();'></a>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null, null]
+                        "expectedValue": ["4005", "<a href='javascript:alert();'></a>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', null, null, null, null, null, null, null, null]
                         },
                 "test7": {
                         "rowValue" :["id=4006, name= <script>alert();</script>, some_gene_sequence= GATCGATCGCGTATT, some_invisible_column= Sophomore, video_col= http://techs.com/sample/small.mp4"],
-                        "expectedValue": ["4006", "<script>alert();</script>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', "GATCGATCGCGTATT", null, null, null, null, null, null]
+                        "expectedValue": ["4006", "<script>alert();</script>", null, null, null, null, null, '**This is some markdown** with some `code` and a [link](http://www.example.com)', '**Name is :**', "GATCGATCGCGTATT", null, null, null, null, null, null, null]
                         }
                 }
             var i =0;


### PR DESCRIPTION
This PR will add the proper support for `color_rgb_hex`. In edit mode, we will continue sending the raw value to Chaise, so no extra code is needed for that. In read-only mode, we want to display both the raw value as well as the color. So the formatted value would be a markdown in the format of 

```
<color> :span: :/span:{.chaise-color-preview background-color:<color>}
```

By utilizing markdown here, this column can be used in `markdown_pattern` annotations. I had to modify different APIs to make sure the `color_rgb_hex` formatted value is treated as a markdown and therefore the `formatPresentation` functions should call `renderMakrdown` on it.