### PR TITLE
Asset column order

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -2599,7 +2599,7 @@ AssetPseudoColumn.prototype._determineSortable = function () {
         this._sortColumns_cached = [{column: this.filenameColumn}];
         this._sortable = true;
     }
-}
+};
 
 /**
  * Returns the template_engine defined in the annotation

--- a/js/column.js
+++ b/js/column.js
@@ -2585,7 +2585,6 @@ AssetPseudoColumn.prototype.formatPresentation = function(data, context, templat
  * if
  *  - the filename_column is defined and valid
  *  - column_order is not defined on the column-display
- *  - markdown_pattern is not defined on the column-display or source definition.
  * This has been done to ensure the sorted column is the same as displayed value.
  * In most default cases, all the conditions will met.
  */
@@ -2595,9 +2594,8 @@ AssetPseudoColumn.prototype._determineSortable = function () {
     // if column_order is missing and it doesn't have any makrdown_pattern and
     // filename is defined, use the filename column.
     var columnOrder = this.display.columnOrder;
-    if (this.filenameColumn && (columnOrder == undefined || columnOrder.length === 0) &&
-        !(this.display.sourceMarkdownPattern || this._baseCol.getDisplay(this._context).isMarkdownPattern)) {
-
+    if (this.filenameColumn && (columnOrder == undefined || columnOrder.length === 0)) {
+        this._sortColumns_cached = [];
         this._sortColumns_cached = [{column: this.filenameColumn}];
         this._sortable = true;
     }

--- a/js/column.js
+++ b/js/column.js
@@ -2579,12 +2579,25 @@ AssetPseudoColumn.prototype.formatPresentation = function(data, context, templat
     return {isHTML: true, value: module.renderMarkdown(unformatted, true), unformatted: unformatted};
 };
 
+/**
+ * @private
+ * Modify the default column_order heuristics for the asset, by using the filename
+ * if
+ *  - the filename_column is defined and valid
+ *  - column_order is not defined on the column-display
+ *  - markdown_pattern is not defined on the column-display or source definition.
+ * This has been done to ensure the sorted column is the same as displayed value.
+ * In most default cases, all the conditions will met.
+ */
 AssetPseudoColumn.prototype._determineSortable = function () {
     AssetPseudoColumn.super._determineSortable.call(this);
 
-    // if column_order is missing and filename is defined, use it
+    // if column_order is missing and it doesn't have any makrdown_pattern and
+    // filename is defined, use the filename column.
     var columnOrder = this.display.columnOrder;
-    if (this.filenameColumn && (columnOrder == undefined || columnOrder.length === 0)) {
+    if (this.filenameColumn && (columnOrder == undefined || columnOrder.length === 0) &&
+        !(this.display.sourceMarkdownPattern || this._baseCol.getDisplay(this._context).isMarkdownPattern)) {
+
         this._sortColumns_cached = [{column: this.filenameColumn}];
         this._sortable = true;
     }

--- a/js/column.js
+++ b/js/column.js
@@ -2579,6 +2579,17 @@ AssetPseudoColumn.prototype.formatPresentation = function(data, context, templat
     return {isHTML: true, value: module.renderMarkdown(unformatted, true), unformatted: unformatted};
 };
 
+AssetPseudoColumn.prototype._determineSortable = function () {
+    AssetPseudoColumn.super._determineSortable.call(this);
+
+    // if column_order is missing and filename is defined, use it
+    var columnOrder = this.display.columnOrder;
+    if (this.filenameColumn && (columnOrder == undefined || columnOrder.length === 0)) {
+        this._sortColumns_cached = [{column: this.filenameColumn}];
+        this._sortable = true;
+    }
+}
+
 /**
  * Returns the template_engine defined in the annotation
  * @member {ERMrest.Refernece} template_engine

--- a/test/specs/column/conf/columns_schema/data/table_w_asset.json
+++ b/test/specs/column/conf/columns_schema/data/table_w_asset.json
@@ -10,5 +10,7 @@
     "col_asset_1": null,
     "col_asset_2": "https://dev.isrd.isi.edu",
     "col_asset_3": "https://dev.isrd.isi.edu",
-    "col_asset_4": 4
+    "col_asset_4": "https://dev.isrd.isi.edu",
+    "col_asset_4_filename": "filename4",
+    "col_asset_5": 4
 }]

--- a/test/specs/column/conf/columns_schema/schema.json
+++ b/test/specs/column/conf/columns_schema/schema.json
@@ -977,7 +977,10 @@
                         },
                         "tag:isrd.isi.edu,2016:column-display" : {
                             "*" : {
-                                "markdown_pattern" : "## {{col_filename}}"
+                                "markdown_pattern" : "## {{col_filename}}",
+                                "column_order": [
+                                    "col_asset_2", "col_filename"
+                                ]
                             }
                         }
                     }

--- a/test/specs/column/conf/columns_schema/schema.json
+++ b/test/specs/column/conf/columns_schema/schema.json
@@ -1005,17 +1005,41 @@
                 },
                 {
                     "name": "col_asset_4",
+                    "comment":"column with asset annotation",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2017:asset": {
+                            "url_pattern": "/hatrac/{{col_asset_4}}",
+                            "filename_column": "col_asset_4_filename"
+                        },
+                        "tag:isrd.isi.edu,2016:column-display" : {
+                            "*" : {
+                                "markdown_pattern" : "{{col_asset_4_filename}}"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "col_asset_4_filename",
+                    "comment": "",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col_asset_5",
                     "comment": "column with asset annotation",
                     "type": {
                         "typename": "int4"
                     },
                     "annotations": {
                         "tag:isrd.isi.edu,2017:asset": {
-                            "url_pattern": "/hatrac/{{col_asset_4}}"
+                            "url_pattern": "/hatrac/{{col_asset_5}}"
                         }
                     }
                 }
-
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns": {

--- a/test/specs/column/tests/01.columns_list.js
+++ b/test/specs/column/tests/01.columns_list.js
@@ -171,7 +171,7 @@ exports.execute = function (options) {
         ];
 
         var assetEntryExpectedValue = [
-            '1', '1', '1000', '10001', null, 'https://dev.isrd.isi.edu', 'https://dev.isrd.isi.edu', 4
+            '1', '1', '1000', '10001', null, 'https://dev.isrd.isi.edu', 'https://dev.isrd.isi.edu', 'https://dev.isrd.isi.edu', 4
         ];
 
         var compactRefExpectedLinkedValue, assetCompactExpectedValue, tableWSlashData;
@@ -267,9 +267,11 @@ exports.execute = function (options) {
          *  6: col_md5
          *  7: col_sha256
          *  8: col_asset_1 *AssetPseudoColumn* disabeld (no url_pattern)
-         *  9: col_asset_2 *AssetPseudoColumn* (asset with invalid options) has column-display
+         *  9: col_asset_2 *AssetPseudoColumn* (asset with invalid options) has column-display (markdown and order)
          *  10: col_asset_3 *AssetPseudoColumn* (asset with valid options)
-         *  11: col_asset_4 (asset with type not text)
+         *  11: col_asset_4 *AssetPseudoColumn* (asset with url_pattern and filename) has column-display (markdown)
+         *  12: col_asset_4_filename
+         *  13: col_asset_5 (asset with type not text)
          *
          *  ref.columns for entry (no context present):
          *  0: id
@@ -280,6 +282,7 @@ exports.execute = function (options) {
          *  5: col_asset_2 *AssetPseudoColumn*
          *  6: col_asset_3 *AssetPseudoColumn*
          *  7: col_asset_4
+         *  8: col_asset_5
          *
          *
          *  contexts that are used:
@@ -368,6 +371,7 @@ exports.execute = function (options) {
                 '',
                 '<h2>filename</h2>\n',
                 '<a href="https://dev.isrd.isi.edu?uinit=1&amp;cid=test" download="" class="download-alt asset-permission">filename</a>',
+                'filename4',
                 '4'
             ];
 
@@ -698,20 +702,21 @@ exports.execute = function (options) {
                 });
 
                 describe('for asset columns,', function () {
-                    describe('filname, byte, md5, and sha256 columns', function() {
+                    describe('filename, byte, md5, and sha256 columns', function() {
                         it('should be ignored in edit context.', function() {
                             checkReferenceColumns([{
                                 ref: assetRefEntry,
                                 expected: [
                                     "id",
                                     ["columns_schema", "table_w_asset_fk_to_outbound"].join("_"),
-                                    "col_1", "col_2", "col_asset_1", "col_asset_2", "col_asset_3", "col_asset_4"
+                                    "col_1", "col_2",
+                                    "col_asset_1", "col_asset_2", "col_asset_3", "col_asset_4", "col_asset_5"
                                 ]
                             }]);
                         });
 
                         it('should not be ignored in other contexts.', function() {
-                            expect(assetRefCompactCols.length).toBe(17);
+                            expect(assetRefCompactCols.length).toBe(19);
                             expect(assetRefCompactCols[4].name).toBe("col_filename");
                             expect(assetRefCompactCols[4].isPseudo).toBe(false);
                             expect(assetRefCompactCols[5].name).toBe("col_byte");
@@ -734,10 +739,10 @@ exports.execute = function (options) {
                     });
 
                     it("if column type is not `text`, should ignore the asset annotation.", function() {
-                      expect(assetRefCompactCols[11].name).toBe("col_asset_4", "invalid name for compact");
-                      expect(assetRefCompactCols[11].isPseudo).toBe(false, "invalid isPseudo for compact");
-                      expect(assetRefEntry.columns[7].name).toBe("col_asset_4", "invalid name for entry");
-                      expect(assetRefEntry.columns[7].isPseudo).toBe(false, "invalid isPseudo for entry");
+                      expect(assetRefCompactCols[13].name).toBe("col_asset_5", "invalid name for compact");
+                      expect(assetRefCompactCols[13].isPseudo).toBe(false, "invalid isPseudo for compact");
+                      expect(assetRefEntry.columns[8].name).toBe("col_asset_5", "invalid name for entry");
+                      expect(assetRefEntry.columns[8].isPseudo).toBe(false, "invalid isPseudo for entry");
                     });
 
                     it('if columns has been used as the keyReferenceColumn, should ignore the asset annotation.', function () {

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -969,6 +969,33 @@ exports.execute = function (options) {
                 });
             });
 
+            describe("for assets, ", function () {
+                it ("should return the defined column_order on the column.", function () {
+                    // 9
+                    expect(assetRefCompactCols[9].sortable).toBe(true, "sortable missmatch, index=9.");
+                    expect(assetRefCompactCols[9]._sortColumns.length).toBe(2, "sort column length missmatch, index=9.");
+                    expect(assetRefCompactCols[9]._sortColumns.map(function (col) {
+                        return col.column.name
+                    })).toEqual(['col_asset_2', 'col_filename'], "sort columns missmatch.");
+                });
+
+                it ("otherwise if filename column is defined should return it", function () {
+                    expect(assetRefCompactCols[10].sortable).toBe(true, "sortable missmatch, index=9.");
+                    expect(assetRefCompactCols[10]._sortColumns.length).toBe(1, "sort column length missmatch, index=9.");
+                    expect(assetRefCompactCols[10]._sortColumns.map(function (col) {
+                        return col.column.name
+                    })).toEqual(['col_filename'], "sort columns missmatch.");
+                });
+
+                it ("otherwise should return the url column.", function () {
+                    expect(assetRefCompactCols[8].sortable).toBe(true, "sortable missmatch, index=9.");
+                    expect(assetRefCompactCols[8]._sortColumns.length).toBe(1, "sort column length missmatch, index=9.");
+                    expect(assetRefCompactCols[8]._sortColumns.map(function (col) {
+                        return col.column.name
+                    })).toEqual(['col_asset_1'], "sort columns missmatch.");
+                });
+            });
+
             describe('for other columns, ', function () {
                 it('when `column_order:false` annotation is defined in column, should return false.', function () {
                     // col_3

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -155,7 +155,7 @@ exports.execute = function (options) {
                     expect(compactColumns[i].isPseudo).toBe(true, "problem with Outbound FKs, index=" + i);
                 }
 
-                for (i = 9; i < 11; i++) {
+                for (i = 9; i < 12; i++) {
                     expect(assetRefCompactCols[i].isPseudo).toBe(true, "problem with Asset index=" + i);
                 }
 
@@ -201,7 +201,7 @@ exports.execute = function (options) {
 
         describe('.isAsset, ', function () {
             it ('for PseudoColumns that are asset should return true.', function () {
-                for (var i = 8; i < 11; i++) {
+                for (var i = 8; i < 12; i++) {
                     expect(assetRefCompactCols[i].isAsset).toBe(true, "invalid isAsset for index="+ i);
                 }
             });
@@ -252,7 +252,7 @@ exports.execute = function (options) {
                     expect(compactColumns[i].table.name).toBe(tableName);
                 }
 
-                for (var i = 8; i < 11; i++) {
+                for (var i = 8; i < 12; i++) {
                     expect(assetRefCompactCols[i].table.name).toBe(tableWithAsset);
                 }
             });
@@ -365,7 +365,7 @@ exports.execute = function (options) {
                 for (var i = 17; i < 22; i++) {
                     expect(compactColumns[i].type.name).toBe("markdown");
                 }
-                for (var i = 9; i < 11; i++) {
+                for (var i = 9; i < 12; i++) {
                     expect(assetRefCompactCols[i].type.name).toBe('markdown');
                 }
 
@@ -971,7 +971,6 @@ exports.execute = function (options) {
 
             describe("for assets, ", function () {
                 it ("should return the defined column_order on the column.", function () {
-                    // 9
                     expect(assetRefCompactCols[9].sortable).toBe(true, "sortable missmatch, index=9.");
                     expect(assetRefCompactCols[9]._sortColumns.length).toBe(2, "sort column length missmatch, index=9.");
                     expect(assetRefCompactCols[9]._sortColumns.map(function (col) {
@@ -979,8 +978,16 @@ exports.execute = function (options) {
                     })).toEqual(['col_asset_2', 'col_filename'], "sort columns missmatch.");
                 });
 
+                it ("otherwise if markdown_pattern is defined, should not modify the column_order and return url column.", function () {
+                    expect(assetRefCompactCols[11].sortable).toBe(true, "sortable missmatch, index=11.");
+                    expect(assetRefCompactCols[11]._sortColumns.length).toBe(1, "sort column length missmatch, index=9.");
+                    expect(assetRefCompactCols[11]._sortColumns.map(function (col) {
+                        return col.column.name
+                    })).toEqual(['col_asset_4'], "sort columns missmatch.");
+                });
+
                 it ("otherwise if filename column is defined should return it", function () {
-                    expect(assetRefCompactCols[10].sortable).toBe(true, "sortable missmatch, index=9.");
+                    expect(assetRefCompactCols[10].sortable).toBe(true, "sortable missmatch, index=10.");
                     expect(assetRefCompactCols[10]._sortColumns.length).toBe(1, "sort column length missmatch, index=9.");
                     expect(assetRefCompactCols[10]._sortColumns.map(function (col) {
                         return col.column.name
@@ -988,7 +995,7 @@ exports.execute = function (options) {
                 });
 
                 it ("otherwise should return the url column.", function () {
-                    expect(assetRefCompactCols[8].sortable).toBe(true, "sortable missmatch, index=9.");
+                    expect(assetRefCompactCols[8].sortable).toBe(true, "sortable missmatch, index=8.");
                     expect(assetRefCompactCols[8]._sortColumns.length).toBe(1, "sort column length missmatch, index=9.");
                     expect(assetRefCompactCols[8]._sortColumns.map(function (col) {
                         return col.column.name

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -975,31 +975,29 @@ exports.execute = function (options) {
                     expect(assetRefCompactCols[9]._sortColumns.length).toBe(2, "sort column length missmatch, index=9.");
                     expect(assetRefCompactCols[9]._sortColumns.map(function (col) {
                         return col.column.name
-                    })).toEqual(['col_asset_2', 'col_filename'], "sort columns missmatch.");
-                });
-
-                it ("otherwise if markdown_pattern is defined, should not modify the column_order and return url column.", function () {
-                    expect(assetRefCompactCols[11].sortable).toBe(true, "sortable missmatch, index=11.");
-                    expect(assetRefCompactCols[11]._sortColumns.length).toBe(1, "sort column length missmatch, index=9.");
-                    expect(assetRefCompactCols[11]._sortColumns.map(function (col) {
-                        return col.column.name
-                    })).toEqual(['col_asset_4'], "sort columns missmatch.");
+                    })).toEqual(['col_asset_2', 'col_filename'], "sort columns missmatch, index=9.");
                 });
 
                 it ("otherwise if filename column is defined should return it", function () {
                     expect(assetRefCompactCols[10].sortable).toBe(true, "sortable missmatch, index=10.");
-                    expect(assetRefCompactCols[10]._sortColumns.length).toBe(1, "sort column length missmatch, index=9.");
+                    expect(assetRefCompactCols[10]._sortColumns.length).toBe(1, "sort column length missmatch, index=10.");
                     expect(assetRefCompactCols[10]._sortColumns.map(function (col) {
                         return col.column.name
-                    })).toEqual(['col_filename'], "sort columns missmatch.");
+                    })).toEqual(['col_filename'], "sort columns missmatch, index=10.");
+
+                    expect(assetRefCompactCols[11].sortable).toBe(true, "sortable missmatch, index=11.");
+                    expect(assetRefCompactCols[11]._sortColumns.length).toBe(1, "sort column length missmatch, index=11.");
+                    expect(assetRefCompactCols[11]._sortColumns.map(function (col) {
+                        return col.column.name
+                    })).toEqual(['col_asset_4_filename'], "sort columns missmatch, index=11.");
                 });
 
                 it ("otherwise should return the url column.", function () {
                     expect(assetRefCompactCols[8].sortable).toBe(true, "sortable missmatch, index=8.");
-                    expect(assetRefCompactCols[8]._sortColumns.length).toBe(1, "sort column length missmatch, index=9.");
+                    expect(assetRefCompactCols[8]._sortColumns.length).toBe(1, "sort column length missmatch, index=8.");
                     expect(assetRefCompactCols[8]._sortColumns.map(function (col) {
                         return col.column.name
-                    })).toEqual(['col_asset_1'], "sort columns missmatch.");
+                    })).toEqual(['col_asset_1'], "sort columns missmatch, index=8.");
                 });
             });
 


### PR DESCRIPTION
**Description**
This PR will change the default sort of asset columns to be based on the filename column, if:

- `column_order` is not already defined on the column (the order is not already customized by annotation)
- `filename_column` is specified on the asset annotation.

**Side note**
We went back and forth on what should be the conditions for adding this default. Our initial goal was to make sure what's displayed is the same as what's sorted. So we looked at the presentation logic. The following is how we derive the displayed value for an asset column (first applicable rule):

1. The `display.markdown_pattern` on source syntax.
2. The `markdown_pattern` on `column-display` annotation.
3. Create a download button where the caption is either:
   3.1. If `filename_column` defined in the asset annotation and its value is not null.
   3.2. If it's a hatrac url: the extracted filename from the url. 
   3.3. Last part of the url (whatever comes after the last `/`).

And to make sure we're actually checking for the "3.1" case, I added checks to ensure 1 and 2 are not met. But after testing it, we decided to drop those checks. We're designing this for the "default" case so there's no need for the extra `markdown_pattern` check. This heuristic should work almost all the times, and If this heuristics doesn't work (because of a customized markdown-pattern) data-modelers can simply modify the `column_order` annotation 

issue: #871 
P.S. It's a simple change so code review won't be necessary. I mainly created this PR for documentation purposes.
