### PR TITLE
Fix for max-width style with fullscreen button

### DIFF
--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1942,10 +1942,10 @@
                                         // min/max width needs to be applied to the wrapper of the caption and fullscreen button for consistent button placement
                                         // check for min-width style
                                         var minWidthIdx = attr[1].indexOf("min-width");
-                                        if (minWidthIdx >= 0) {
+                                        if (minWidthIdx != -1) {
                                             endStyleIdx = attr[1].indexOf(";", minWidthIdx);
                                             // get the min-width `key: value` pair
-                                            if (endStyleIdx) {
+                                            if (endStyleIdx != -1) {
                                                 subStrStyle = attr[1].substring(minWidthIdx, endStyleIdx);
                                             } else {
                                                 // if no `;` after min-width, assume end of string
@@ -1956,11 +1956,10 @@
 
                                         // check for max-width style
                                         var maxWidthIdx = attr[1].indexOf("max-width");
-
-                                        if (maxWidthIdx >= 0) {
+                                        if (maxWidthIdx != -1) {
                                             endStyleIdx = attr[1].indexOf(";", maxWidthIdx);
                                             // get the max-width `key: value` pair
-                                            if (endStyleIdx) {
+                                            if (endStyleIdx != -1) {
                                                 subStrStyle = attr[1].substring(maxWidthIdx, endStyleIdx);
                                             } else {
                                                 // if no `;` after max-width, assume end of string

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1937,12 +1937,13 @@
                                             frameWidth = attr[1];
                                         }
 
+                                        var endStyleIdx;
                                         // handles `style="some: style;"` case from template
                                         // min/max width needs to be applied to the wrapper of the caption and fullscreen button for consistent button placement
                                         // check for min-width style
                                         var minWidthIdx = attr[1].indexOf("min-width");
                                         if (minWidthIdx >= 0) {
-                                            var endStyleIdx = attr[1].indexOf(";", minWidthIdx);
+                                            endStyleIdx = attr[1].indexOf(";", minWidthIdx);
                                             // get the min-width `key: value` pair
                                             widthStyles.push(attr[1].substring(minWidthIdx, endStyleIdx));
                                         }
@@ -1950,7 +1951,7 @@
                                         // check for max-width style
                                         var maxWidthIdx = attr[1].indexOf("max-width");
                                         if (maxWidthIdx >= 0) {
-                                            var endStyleIdx = attr[1].indexOf(";", maxWidthIdx);
+                                            endStyleIdx = attr[1].indexOf(";", maxWidthIdx);
                                             // get the max-width `key: value` pair
                                             widthStyles.push(attr[1].substring(maxWidthIdx, endStyleIdx));
                                         }

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1885,7 +1885,7 @@
                         if (attrs[0].children[0].type == "link_open") {
                             var iframeHTML = "<iframe", openingLink = attrs[0].children[0];
                             var captionLink, captionTarget= "", posTop = true, captionClass = "", captionStyle = "", figureClass = "", figureStyle = "",
-                                iframeSrc = "", frameWidth = "", fullscreenTarget = "";
+                                iframeSrc = "", frameWidth = "", widthStyles = "", fullscreenTarget = "";
                             var isYTlink = false, videoURL = "", iframeClasses = [];
 
                             // Add all attributes to the iframe
@@ -1938,6 +1938,19 @@
                                         }
 
                                         // handles `style="some: style;"` case from template
+                                        // min/max width needs to be applied to the wrapper of the caption and fullscreen button for consistent button placement
+                                        // check for min-width style
+                                        var minWidthIdx = attr[1].indexOf("min-width");
+                                        if (minWidthIdx >= 0) {
+                                            widthStyles += attr[1].substring(minWidthIdx, attr[1].indexOf(";", minWidthIdx)+1);
+                                        }
+
+                                        // check for max-width style
+                                        var maxWidthIdx = attr[1].indexOf("max-width");
+                                        if (maxWidthIdx >= 0) {
+                                            widthStyles += (minWidthIdx >= 0 ? " " : "") + attr[1].substring(maxWidthIdx, attr[1].indexOf(";", maxWidthIdx)+1);
+                                        }
+
                                         iframeHTML += " " + attr[0] + '="' + attr[1] + '"';
                                         break;
                                 }
@@ -1989,7 +2002,8 @@
                             // Checks for a width being defined. If it's defined and not a number, assume it has `px` or `%` appended already and use as is.
                             // If width is defined and is a number, assume it's in pixels and append `px`.
                             // If no width, use "100%"
-                            var contentsWidth = 'style="width: ' + (frameWidth ? (frameWidth + (isNaN(parseInt(frameWidth)) ? "" : "px")) : "100%")+ ';"';
+                            // if min/max width are defined for the iframe, apply here as well
+                            var contentsWidth = 'style="width: ' + (frameWidth ? (frameWidth + (isNaN(parseInt(frameWidth)) ? "" : "px")) : "100%") + ';' + (widthStyles ? " " + widthStyles : "" ) + '"';
 
                             // fullscreen button html that is attached to the top right corner of the iframe
                             var buttonHtml = '<div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="' + iframeSrc + '"' + fullscreenTarget + '><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div>';

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1937,7 +1937,7 @@
                                             frameWidth = attr[1];
                                         }
 
-                                        var endStyleIdx;
+                                        var endStyleIdx, subStrStyle;
                                         // handles `style="some: style;"` case from template
                                         // min/max width needs to be applied to the wrapper of the caption and fullscreen button for consistent button placement
                                         // check for min-width style
@@ -1945,15 +1945,28 @@
                                         if (minWidthIdx >= 0) {
                                             endStyleIdx = attr[1].indexOf(";", minWidthIdx);
                                             // get the min-width `key: value` pair
-                                            widthStyles.push(attr[1].substring(minWidthIdx, endStyleIdx));
+                                            if (endStyleIdx) {
+                                                subStrStyle = attr[1].substring(minWidthIdx, endStyleIdx);
+                                            } else {
+                                                // if no `;` after min-width, assume end of string
+                                                subStrStyle = attr[1].substring(minWidthIdx);
+                                            }
+                                            widthStyles.push(subStrStyle);
                                         }
 
                                         // check for max-width style
                                         var maxWidthIdx = attr[1].indexOf("max-width");
+
                                         if (maxWidthIdx >= 0) {
                                             endStyleIdx = attr[1].indexOf(";", maxWidthIdx);
                                             // get the max-width `key: value` pair
-                                            widthStyles.push(attr[1].substring(maxWidthIdx, endStyleIdx));
+                                            if (endStyleIdx) {
+                                                subStrStyle = attr[1].substring(maxWidthIdx, endStyleIdx);
+                                            } else {
+                                                // if no `;` after max-width, assume end of string
+                                                subStrStyle = attr[1].substring(maxWidthIdx);
+                                            }
+                                            widthStyles.push(subStrStyle);
                                         }
 
                                         iframeHTML += " " + attr[0] + '="' + attr[1] + '"';

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -113,7 +113,7 @@ exports.execute = function (options) {
             });
 
             it ("should support :::iframe.", function () {
-                // 01: Check for iframe ith height and width
+                // 01: Check for iframe with height and width
                 expect(printMarkdown('::: iframe [Chaise](https://dev.isrd.isi.edu/chaise/search){width=800 height=300} \n:::'))
                     .toBe('<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 800px;"><figcaption class="embed-caption">Chaise</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/search"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/search" width="800" height="300"></iframe></figure>', "case 01");
 
@@ -137,6 +137,10 @@ exports.execute = function (options) {
                 var iframeHTML = '<figure class="embed-block -chaise-post-load"><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/search"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div><iframe src="https://dev.isrd.isi.edu/chaise/search"></iframe><figcaption class="embed-caption cclass" style="font-weight:500;">CAPTION</figcaption></figure>';
                 expect(printMarkdown(iframeMarkdown)).toBe(iframeHTML, "case 05");
 
+                // 05.1: Check for iframe tag with min/max width applied to the iframe and the container for the caption and fullscreen button
+                var iframeMarkdown = '::: iframe [CAPTION](https://dev.isrd.isi.edu/chaise/search){style="min-width:400px; max-width:900px;"} \n:::';
+                var iframeHTML = '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;min-width:400px;max-width:900px"><figcaption class="embed-caption">CAPTION</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/search"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/search" style="min-width:400px; max-width:900px;"></iframe></figure>';
+                expect(printMarkdown(iframeMarkdown)).toBe(iframeHTML, "case 05.1");
 
                 // 06: Check for iframe tag with a caption at the bottom with figure-style and caption-class
                 var iframeMarkdown = '::: iframe [CAPTION](https://dev.isrd.isi.edu/chaise/search){pos="bottom" caption-class="cclass" figure-style="font-weight:500;"} \n:::';


### PR DESCRIPTION
This change parses out the min/max width styles to apply to the caption and fullscreen button wrapper (container).