### PR TITLE
Error handling improvements

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -330,6 +330,8 @@ to use for ERMrest JavaScript agents.
         * [new InvalidSortCriteria(message, path)](#new_ERMrest.InvalidSortCriteria_new)
     * [.InvalidPageCriteria](#ERMrest.InvalidPageCriteria)
         * [new InvalidPageCriteria(message, path)](#new_ERMrest.InvalidPageCriteria_new)
+    * [.InvalidServerResponse](#ERMrest.InvalidServerResponse)
+        * [new InvalidServerResponse(uri, data, logAction)](#new_ERMrest.InvalidServerResponse_new)
     * [.ParsedFilter](#ERMrest.ParsedFilter)
         * [new ParsedFilter(type)](#new_ERMrest.ParsedFilter_new)
         * [.setFilters(filters)](#ERMrest.ParsedFilter+setFilters)
@@ -2814,6 +2816,22 @@ Invalid page conditions
 | --- | --- | --- |
 | message | <code>string</code> | error message |
 | path | <code>string</code> | path for redirectLink |
+
+<a name="ERMrest.InvalidServerResponse"></a>
+
+### ERMrest.InvalidServerResponse
+**Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
+<a name="new_ERMrest.InvalidServerResponse_new"></a>
+
+#### new InvalidServerResponse(uri, data, logAction)
+Invalid server response
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| uri | <code>string</code> | error message |
+| data | <code>object</code> | the returned data |
+| logAction | <code>string</code> | the log action of the request |
 
 <a name="ERMrest.ParsedFilter"></a>
 

--- a/js/errors.js
+++ b/js/errors.js
@@ -207,7 +207,8 @@
      */
     function InternalServerError(status, message) {
         status = isStringAndNotEmpty(status) ? status : module._errorStatus.INTERNAL_SERVER_ERROR;
-        ERMrestError.call(this, module._HTTPErrorCodes.INTERNAL_SERVER_ERROR, status, message);
+        // use the message as subMessage and add a generic message instead
+        ERMrestError.call(this, module._HTTPErrorCodes.INTERNAL_SERVER_ERROR, status, module._errorMessage.INTERNAL_SERVER_ERROR, message);
     }
 
     InternalServerError.prototype = Object.create(ERMrestError.prototype);

--- a/js/errors.js
+++ b/js/errors.js
@@ -22,6 +22,7 @@
     module.DuplicateConflictError = DuplicateConflictError;
     module.InvalidSortCriteria = InvalidSortCriteria;
     module.InvalidPageCriteria = InvalidPageCriteria;
+    module.InvalidServerResponse = InvalidServerResponse;
 
     /**
      * @memberof ERMrest
@@ -440,6 +441,26 @@
 
     InvalidPageCriteria.prototype = Object.create(ERMrestError.prototype);
     InvalidPageCriteria.prototype.constructor = InvalidPageCriteria;
+
+    /**
+     * @memberof ERMrest
+     * @param {string} uri error message
+     * @param {object} data the returned data
+     * @param {string} logAction the log action of the request
+     * @constructor
+     * @desc Invalid server response
+     */
+     function InvalidServerResponse(uri, data, logAction) {
+        var message = "Request URI: " + uri + "\n";
+        message += "Request action: " + logAction + "\n";
+        message += "returned data:\n" + data;
+        ERMrestError.call(this, '', module._errorStatus.INVALID_SERVER_RESPONSE, message);
+    }
+
+    InvalidServerResponse.prototype = Object.create(ERMrestError.prototype);
+    InvalidServerResponse.prototype.constructor = InvalidServerResponse;
+
+
     /**
      * Log the error object to the given ermrest location.
      * It will generate a put request to the /terminal_error with the correct headers.
@@ -447,16 +468,19 @@
      * @param  {object} err             the error object
      * @param  {string} ermrestLocation the ermrest location
      */
-    module.logError = function (err, ermrestLocation) {
+    module.logError = function (err, ermrestLocation, contextHeaderParams) {
         var defer = module._q.defer();
         var http = module._wrap_http(module._http);
 
+        if (!contextHeaderParams || typeof contextHeaderParams != "object") {
+            contextHeaderParams = {};
+        }
+        contextHeaderParams.e = 1;
+        contextHeaderParams.name = err.constructor.name;
+        contextHeaderParams.message = err.message;
+
         var headers = {};
-        headers[module.contextHeaderName] = {
-            e: 1,
-            name: err.constructor.name,
-            message: err.message
-        };
+        headers[module.contextHeaderName] = contextHeaderParams;
 
         // this http request will fail but will still log the message.
         http.put(ermrestLocation + "/terminal_error", {}, {headers: headers}).then(function () {

--- a/js/http.js
+++ b/js/http.js
@@ -214,7 +214,7 @@
                             // Ermrest never produces HTML errors, so this was produced by the server itself
                             if (response.headers()['content-type'] && response.headers()['content-type'].indexOf("html") > -1) {
                                 response.status = response.statusCode = _http_status_codes.internal_server_error;
-                                response.data = "An unexpected error has occurred. Please report this problem to your system administrators.";
+                                // keep response.data the way it is, so client can provide more info to users
                             } else {
                                 response.status = response.statusCode = _http_status_codes.no_content;
                             }
@@ -280,7 +280,7 @@
                             // Ermrest never produces HTML errors, so this was produced by the server itself
                             if (response.headers()['content-type'] && response.headers()['content-type'].indexOf("html") > -1) {
                                 response.status = response.statusCode = _http_status_codes.internal_server_error;
-                                response.data = "An unexpected error has occurred. Please report this problem to your system administrators.";
+                                // keep response.data the way it is, so client can provide more info to users
                             }
 
                             module.onload().then(function() {

--- a/js/reference.js
+++ b/js/reference.js
@@ -1402,6 +1402,10 @@
                     headers: this._generateContextHeader(contextHeaderParams, limit)
                 };
                 this._server.http.get(uri, config).then(function (response) {
+                    if (!Array.isArray(response.data)) {
+                        throw new InvalidServerResponse(uri, response.data, action);                    
+                    }
+
                     var etag = response.headers().etag;
 
                     var hasPrevious, hasNext = false;

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -227,7 +227,8 @@
     module._errorMessage = Object.freeze({
         INVALID_FACET: "Given encoded string for facets is not valid.",
         INVALID_CUSTOM_FACET: "Given encoded string for cfacets is not valid.",
-        INVALID_FACET_OR_FILTER: "Given filter or facet is not valid."
+        INVALID_FACET_OR_FILTER: "Given filter or facet is not valid.",
+        INTERNAL_SERVER_ERROR: "An unexpected error has occurred. Please report this problem to your system administrators."
     });
 
     module._facetingErrors = Object.freeze({

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -220,7 +220,8 @@
         NO_DATA_CHANGED: "No Data Changed",
         NO_CONNECTION_ERROR: "No Connection Error",
         INVALID_SORT: "Invalid Sort Criteria",
-        INVALID_PAGE: "Invalid Page Criteria"
+        INVALID_PAGE: "Invalid Page Criteria",
+        INVALID_SERVER_RESPONSE: "Invalid Server Response"
     });
 
     module._errorMessage = Object.freeze({

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1379,6 +1379,9 @@
      */
     module.responseToError = function (response, reference, actionFlag) {
         var status = response.status || response.statusCode;
+        if (response instanceof module.ERMrestError) {
+            return response;
+        }
         switch(status) {
             case -1:
                 return new module.NoConnectionError(response.data);

--- a/test/specs/errors/tests/08.http_content_error.js
+++ b/test/specs/errors/tests/08.http_content_error.js
@@ -18,8 +18,6 @@ exports.execute = function (options) {
                 + '</body>'
             + '</html>';
 
-        var terminalErrorMessage = "An unexpected error has occurred. Please report this problem to your system administrators.";
-
         beforeAll(function () {
             server = options.server;
             catalog = options.catalog;
@@ -35,7 +33,7 @@ exports.execute = function (options) {
 
             server.catalogs.get(id).then(null, function(err) {
                 expect(err.code).toBe(500);
-                expect(err.message).toBe(terminalErrorMessage);
+                expect(err.message).toBe(htmlResponseMessage);
                 done();
             }).catch(function() {
                 expect(false).toBe(true);

--- a/test/specs/errors/tests/08.http_content_error.js
+++ b/test/specs/errors/tests/08.http_content_error.js
@@ -17,6 +17,9 @@ exports.execute = function (options) {
                     + '<p>The requested URL /t.html was not found on this server.</p>'
                 + '</body>'
             + '</html>';
+        
+        var internalServerErrorMessage = "An unexpected error has occurred. ";
+        internalServerErrorMessage += "Please report this problem to your system administrators."
 
         beforeAll(function () {
             server = options.server;
@@ -33,7 +36,8 @@ exports.execute = function (options) {
 
             server.catalogs.get(id).then(null, function(err) {
                 expect(err.code).toBe(500);
-                expect(err.message).toBe(htmlResponseMessage);
+                expect(err.message).toBe(internalServerErrorMessage, "message missmatch");
+                expect(err.subMessage).toBe(htmlResponseMessage, "subMessage missmatch");
                 done();
             }).catch(function() {
                 expect(false).toBe(true);


### PR DESCRIPTION
This PR includes multiple changes to error handling and logging:

- [Based on user reports](https://github.com/informatics-isi-edu/rbk-project/issues/731), we found an odd case where the server is not returning an array in response. this change will make sure we're properly catching this error so we can track it.
- Modify `logError` so Chaise can pass `cid`, `wid`, `pid` that will be logged with the error.
- Preserver the `response.data` when the given response is HTML. Chaise will display this in the "show details" section for the error.