### PR TITLE
Improvements regarding dynamic ACL support

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1825,25 +1825,6 @@
             return this._pureBinaryForeignKeys_cached;
         },
 
-
-        get supportRightsSummary() {
-            if (this._supportRightsSummary === undefined) {
-                var rightKey = module._ERMrestFeatures.TABLE_RIGHTS_SUMMARY;
-                var feature = this.schema.catalog.features[rightKey] === true;
-                this._supportRightsSummary = feature && this.columns.has("RID");
-            }
-            return this._supportRightsSummary;
-        },
-
-        get supportColumnRightsSummary() {
-            if (this._supportColumnRightsSummary === undefined) {
-                var rightKey = module._ERMrestFeatures.TABLE_COL_RIGHTS_SUMMARY;
-                var feature = this.schema.catalog.features[rightKey] === true;
-                this._supportColumnRightsSummary = feature && this.columns.has("RID");
-            }
-            return this._supportColumnRightsSummary;
-        },
-
         _computePureBinaryAssociation: function () {
             var isSystemCol = function (col) {
                 return module._systemColumns.indexOf(col.name) !== -1;

--- a/js/reference.js
+++ b/js/reference.js
@@ -1177,7 +1177,7 @@
             if (this._canUseTRS === undefined) {
                 var rightKey = module._ERMrestFeatures.TABLE_RIGHTS_SUMMARY;
                 this._canUseTRS = (this.table.schema.catalog.features[rightKey] === true) && 
-                                  this.table.rights[module._ERMrestACLs.UPDATE] == null || this.table.rights[module._ERMrestACLs.DELETE] == null && 
+                                  (this.table.rights[module._ERMrestACLs.UPDATE] == null || this.table.rights[module._ERMrestACLs.DELETE] == null) && 
                                   this.table.columns.has("RID") && 
                                   (this.canUpdate || this.canDelete);
             }
@@ -5089,7 +5089,7 @@
         this._data = data || {};
         this._linkedData = (typeof linkedData === "object") ? linkedData : {};
         this._rightsSummary = (typeof rightsSummary === "object") ? rightsSummary : {};
-        this._associationRightsSummary = (typeof rightsSummary === "object") ? associationRightsSummary : {};
+        this._associationRightsSummary = (typeof associationRightsSummary === "object") ? associationRightsSummary : {};
     }
 
     Tuple.prototype = {

--- a/js/reference.js
+++ b/js/reference.js
@@ -3859,6 +3859,8 @@
          * @param {Boolean} getTCRS whether we should fetch the table-level and column-level row acls (if table supports it)
          * @param {Boolean} getUnlinkTRS whether we should fetch the acls of association
          *                  table. Use this only if the association is based on facet syntax
+         * 
+         * TODO we might want to add an option to only do TCRS or TRS without the foreignkeys for later
          * @type {Object}
          */
          _getReadPath: function(useEntity, getTRS, getTCRS, getUnlinkTRS) {
@@ -4683,7 +4685,7 @@
                         if (tcrs in data[i]) {
                             this._rightsSummary.push(data[i][tcrs]);
                         }
-                        if (trs in data[i]) {
+                        else if (trs in data[i]) {
                             this._rightsSummary.push(data[i][trs]);
                         }
                     }

--- a/test/specs/column/tests/05.active_list.js
+++ b/test/specs/column/tests/05.active_list.js
@@ -232,6 +232,8 @@ exports.execute = function (options) {
         });
 
         describe("Reference._getReadPath in case of attributegroup", function () {
+            // NOTE since we're using static ACLs here, the readPath should not have trs/tcrs
+            
             it ("should add the allOutBounds.", function () {
                 // the order of defined foreignkeys might change in the schema, and
                 // therefore the order of .fkeys that we get from sourceDefinitions might change.
@@ -254,7 +256,7 @@ exports.execute = function (options) {
                 "F1:=left(fk1_col1,fk1_col2)=(active_list_schema:outbound1:outbound1_id1,outbound1_id2)/$M/" +
                 "main_id;M:=array_d(M:*),F11:=array_d(F11:*),F10:=array_d(F10:*),F9:=array_d(F9:*)," +
                 "F8:=array_d(F8:*),F7:=array_d(F7:*),F6:=array_d(F6:*),F5:=array_d(F5:*)," +
-                "F4:=array_d(F4:*),F3:=array_d(F3:*),F2:=array_d(F2:*),F1:=array_d(F1:*),tcrs:=tcrs(M:RID)@sort(main_id)";
+                "F4:=array_d(F4:*),F3:=array_d(F3:*),F2:=array_d(F2:*),F1:=array_d(F1:*)@sort(main_id)";
 
                 var expectedPath1 = "M:=active_list_schema:main/" +
                 "F11:=left(fk4_col1)=(active_list_schema:outbound3:outbound3_id)/$M/" +
@@ -269,8 +271,8 @@ exports.execute = function (options) {
                 expect([expectedPath1, expectedPath2]).toContain(mainRefCompact.readPath);
             });
 
-            it ("should only add the tcrs if there are no outbound foreignkeys.", function () {
-                expect(mainEmptFkRefCompact.readPath).toEqual("M:=active_list_schema:main_empty_fkeys/main_empty_fkeys_id;M:=array_d(M:*),tcrs:=tcrs(M:RID)@sort(main_empty_fkeys_id)");
+            it ("should fall back to entity no outbound foreignkeys.", function () {
+                expect(mainEmptFkRefCompact.readPath).toEqual("M:=active_list_schema:main_empty_fkeys@sort(main_empty_fkeys_id)");
             });
         });
 

--- a/test/specs/reference/tests/06_1.permissions_acls.js
+++ b/test/specs/reference/tests/06_1.permissions_acls.js
@@ -588,7 +588,7 @@ exports.execute = (options) => {
 
         describe("regarding dynamic ACLs, ", function () {
 
-            describe ("when delete is only allowed for certain rows", function () {
+            describe ("when delete is only allowed for certain rows, ", function () {
                 var reference;
 
                 beforeAll((done) => {
@@ -619,8 +619,22 @@ exports.execute = (options) => {
                     }, (response) => reference = response, restrictedUserCookie);
                 });
 
-                it ("should Tuple should return proper canDelete values", function (done) {
+                it ("Tuple should should return static ACLs by default", function (done) {
                     reference.read(3).then(function (page) {
+                        expect(page.length).toBe(3, "page length missmatch");
+
+                        expect(page.tuples.map(function (t) {
+                            return t.canDelete;
+                        })).toEqual([true, true, true], "canDelete missmatch");
+
+                        done();
+                    }).catch(function (err) {
+                        done.fail(err);
+                    });
+                });
+
+                it ("Tuple should should return proper canDelete values when asked to use TRS", function (done) {
+                    reference.read(3, null, false, false, true).then(function (page) {
                         expect(page.length).toBe(3, "page length missmatch");
 
                         expect(page.tuples.map(function (t) {
@@ -654,7 +668,7 @@ exports.execute = (options) => {
                 });
             });
 
-            describe("when delete is only allowed for certain rows in related entities", function () {
+            describe("when delete is only allowed for certain rows in related entities, ", function () {
                 var reference;
 
                 beforeAll((done) => {
@@ -708,7 +722,7 @@ exports.execute = (options) => {
 
                         expect(reference.related.length).toBe(1, "related length missmatch");
 
-                        return reference.related[0].read(2, null, false, false, true);
+                        return reference.related[0].read(2, null, false, false, false, false, true);
                     }).then(function (page) {
                         expect(page.length).toBe(2, "page length missmatch");
 
@@ -754,7 +768,7 @@ exports.execute = (options) => {
                 });
             });
 
-            describe ("when update is only allowed for certain rows", function () {
+            describe ("when update is only allowed for certain rows, ", function () {
                 var reference;
 
                 beforeAll((done) => {
@@ -785,8 +799,21 @@ exports.execute = (options) => {
                     }, (response) => reference = response, restrictedUserCookie);
                 });
 
-                it ("Tuple should return proper canUpdate values", function (done) {
+                it ("Tuple should return static ACLs by default", function (done) {
                     reference.read(3).then(function (page) {
+                        expect(page.length).toBe(3, "path length missmatch");
+                        expect(page.tuples.map(function (t) {
+                            return t.canUpdate;
+                        })).toEqual([true, true, true], "canUpdate missmatch");
+
+                        done();
+                    }).catch(function (err) {
+                        done.fail(err);
+                    });
+                });
+
+                it ("Tuple should return proper canUpdate values when asked to use TRS", function (done) {
+                    reference.read(3, {}, false, false, true).then(function (page) {
                         expect(page.length).toBe(3, "page length missmatch");
 
                         expect(page.tuples.map(function (t) {
@@ -820,7 +847,7 @@ exports.execute = (options) => {
                 });
             });
 
-            describe ("when update is only allowed for certain columns,", function () {
+            xdescribe ("when update is only allowed for certain columns, ", function () {
                 var reference, tuples;
 
                 beforeAll((done) => {
@@ -1066,7 +1093,7 @@ exports.execute = (options) => {
                         }
                     });
                 });
-            });
+            }).pend("tcrs support removed because of performance issues and requires rework");
 
         });
 

--- a/test/specs/reference/tests/06_1.permissions_acls.js
+++ b/test/specs/reference/tests/06_1.permissions_acls.js
@@ -449,14 +449,14 @@ exports.execute = (options) => {
                                                 "name": {
                                                     "acls": {
                                                         "insert" : [],
-                                                        "select": [],
+                                                        "select": ["*"],
                                                         "update": []
                                                     }
                                                 },
                                                 "term": {
                                                     "acls": {
                                                         "insert" : [],
-                                                        "select": [],
+                                                        "select": ["*"],
                                                         "update": []
                                                     }
                                                 }
@@ -564,14 +564,14 @@ exports.execute = (options) => {
                                             "name": {
                                                 "acls": {
                                                     "insert" : [],
-                                                    "select": [],
+                                                    "select": ["*"],
                                                     "update": []
                                                 }
                                             },
                                             "term": {
                                                 "acls": {
                                                     "insert" : [],
-                                                    "select": [],
+                                                    "select": ["*"],
                                                     "update": []
                                                 }
                                             }
@@ -722,7 +722,7 @@ exports.execute = (options) => {
 
                         expect(reference.related.length).toBe(1, "related length missmatch");
 
-                        return reference.related[0].read(2, null, false, false, false, false, true);
+                        return reference.related[0].read(2, null, false, false, true, false, true);
                     }).then(function (page) {
                         expect(page.length).toBe(2, "page length missmatch");
 

--- a/test/specs/reference/tests/06_1.permissions_acls.js
+++ b/test/specs/reference/tests/06_1.permissions_acls.js
@@ -847,7 +847,7 @@ exports.execute = (options) => {
                 });
             });
 
-            xdescribe ("when update is only allowed for certain columns, ", function () {
+            describe ("when update is only allowed for certain columns, ", function () {
                 var reference, tuples;
 
                 beforeAll((done) => {
@@ -979,8 +979,9 @@ exports.execute = (options) => {
                     }, (response) => reference = response.contextualize.entryEdit, restrictedUserCookie);
                 });
 
-                it ("Tuple should return proper canUpdate based on table and column level acls, ", function (done) {
-                    reference.read(3).then(function (page) {
+                it ("Tuple should return proper canUpdate based on table and column level acls when using TCRS, ", function (done) {
+                    // NOTE passing the getTCRS=true option
+                    reference.read(3, null, false, false, false, true).then(function (page) {
                         expect(page.length).toBe(3, "page length missmatch");
 
                         tuples = page.tuples;
@@ -1093,7 +1094,7 @@ exports.execute = (options) => {
                         }
                     });
                 });
-            }).pend("tcrs support removed because of performance issues and requires rework");
+            })
 
         });
 


### PR DESCRIPTION
This PR is part of requires changes to resolve [this issue in chaise](https://github.com/informatics-isi-edu/chaise/issues/2092). In summary:

- Modified the `read` function so client has to specifically ask for `trs` or `tcrs`. This allows Chaise to ask for `trs`/`tcrs` on only requests that need it without affecting other requests.
- Modified the check for using `trs`/`tcrs` to be under `Reference` API. This allows to properly add other checks other than making sure ermrest and table can support it. The added checks are:
   - Make sure table doesn't have static permissions.
   - Make sure annotation doesn't mark the table as non-deletable non-updatable (if that is the case, we don't need to get the row-level ACLs as annotation completely has disabled those features)