### PR TITLE
add $self to row_markdown_pattern and citation

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -4924,7 +4924,7 @@
 
             if (!self._data || !self._data.length) return null;
 
-            var i, value, pattern, values = [], keyValues;
+            var i, j, value, pattern, values = [], keyValues;
             var display = ref.display;
 
             // markdown_pattern in the source object
@@ -4996,6 +4996,8 @@
 
                     // make sure we have the formatted key values
                     keyValues = self.tuples[i].templateVariables.values;
+
+                    keyValues.$self = self.tuples[i].selfTemplateVariable;
 
                     // render template
                     value = module._renderTemplate(ref.display._rowMarkdownPattern, keyValues, ref.table.schema.catalog, { templateEngine: ref.display.templateEngine});
@@ -5699,6 +5701,26 @@
         },
 
         /**
+         * Should be used for populating $self for this tuple in templating environments
+         * It will have,
+         * - rowName
+         * - uri
+         * @type {Object}
+         */
+        get selfTemplateVariable() {
+            if (this._selfTemplateVariable === undefined) {
+                var $self = {};
+                for (j in this.templateVariables) {
+                    if (this.templateVariables.hasOwnProperty(j) && j != "values") {
+                        $self[j] = this.templateVariables[j];
+                    }
+                }
+                this._selfTemplateVariable = $self;
+            }
+            return this._selfTemplateVariable;
+        },
+
+        /**
          * If the Tuple is derived from an association related table,
          * this function will return a reference to the corresponding
          * entity of this tuple's association table.
@@ -5860,6 +5882,8 @@
             if (!templateVariables) {
                 templateVariables = tuple.templateVariables.values;
             }
+
+            templateVariables.$self = tuple.selfTemplateVariable;
 
             var citation = {};
             // author, title, id set to null if not defined

--- a/test/specs/annotation/conf/citation/schema.json
+++ b/test/specs/annotation/conf/citation/schema.json
@@ -62,7 +62,7 @@
                     "author_pattern":  "{{#$fkeys.citation_schema.citation_w_mustache_author_fkey}}{{{values.first_name}}} {{{values.last_name}}}{{/$fkeys.citation_schema.citation_w_mustache_author_fkey}}",
                     "title_pattern":   "{{#title}}{{{title}}}{{/title}}{{^title}}No title{{/title}}",
                     "year_pattern":    "2018",
-                    "url_pattern":     "https://dev.isrd.isi.edu/chaise/record/#{{{$catalog.snapshot}}}/citation_schema:citation_w_mustache/id={{{id}}}",
+                    "url_pattern":     "{{{$self.uri.detailed}}}",
                     "id_pattern":      "{{{id}}}"
                 }
             }
@@ -124,12 +124,17 @@
             "annotations": {
                 "tag:isrd.isi.edu,2018:citation": {
                     "template_engine": "handlebars",
-                    "journal_pattern": "{{journal}}",
-                    "author_pattern":  "{{#with $fkeys.citation_schema.citation_w_handlebars_author_fkey}}{{values.first_name}} {{values.last_name}}{{/with}}",
-                    "title_pattern":   "{{#if title}}{{title}}{{else}}No title{{/if}}",
+                    "journal_pattern": "{{{journal}}}",
+                    "author_pattern":  "{{#with $fkeys.citation_schema.citation_w_handlebars_author_fkey}}{{{values.first_name}}} {{values.last_name}}{{/with}}",
+                    "title_pattern":   "{{#if title}}{{{title}}}{{else}}No title{{/if}}",
                     "year_pattern":    "{{formatDate RCT 'YYYY'}}",
-                    "url_pattern":     "https://dev.isrd.isi.edu/chaise/record/#{{$catalog.snapshot}}/citation_schema:citation_w_handlebars/id={{id}}",
-                    "id_pattern":      "{{id}}"
+                    "url_pattern":     "{{{$self.uri.detailed}}}",
+                    "id_pattern":      "{{{$self.rowName}}}"
+                },
+                "tag:isrd.isi.edu,2016:table-display": {
+                    "row_name": {
+                        "row_markdown_pattern": "{{{id}}}"
+                    }
                 }
             }
         },
@@ -372,7 +377,7 @@
                     "author_pattern":  "{{{author}}}",
                     "title_pattern":   "{{#if title}}{{title}}{{else}}No title{{/if}}",
                     "year_pattern":    "{{formatDate RCT 'YYYY'}}",
-                    "url_pattern":     "https://dev.isrd.isi.edu/chaise/record/#{{$catalog.snapshot}}/citation_schema:citation_w_handlebars/id={{id}}",
+                    "url_pattern":     "{{{$self.uri.detailed}}}",
                     "id_pattern":      "{{id}}",
                     "wait_for": ["citation_journal_field"]
                 },
@@ -419,7 +424,7 @@
                     "author_pattern":  "{{#each citation_authors}}{{{this.rowName}}}{{/each}}",
                     "title_pattern":   "{{#if title}}{{title}}{{else}}No title{{/if}}",
                     "year_pattern":    "{{formatDate RCT 'YYYY'}}",
-                    "url_pattern":     "https://dev.isrd.isi.edu/chaise/record/#{{$catalog.snapshot}}/citation_schema:citation_w_handlebars/id={{id}}",
+                    "url_pattern":     "{{{$self.uri.detailed}}}",
                     "id_pattern":      "{{id}}",
                     "wait_for": ["citation_authors"]
                 },

--- a/test/specs/annotation/conf/table_display/data/table_w_rowname_self.json
+++ b/test/specs/annotation/conf/table_display/data/table_w_rowname_self.json
@@ -1,0 +1,1 @@
+[{"id": 1,"text_col": "value"}]

--- a/test/specs/annotation/conf/table_display/schema.json
+++ b/test/specs/annotation/conf/table_display/schema.json
@@ -437,8 +437,11 @@
             "prefix_markdown": "ignored prefix",
             "page_size": 5
           },
+          "row_name": {
+            "row_markdown_pattern": "{{{title}}}"
+          },
           "detailed" : {
-            "row_markdown_pattern": ":::iframe [{{title}}{{#$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}(with {{{rowName}}} from catalog {{{$catalog.snapshot}}}){{/$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}](https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id={{_id}}) \n:::",
+            "row_markdown_pattern": ":::iframe [{{{$self.rowName}}}{{#$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}(with {{{rowName}}} from catalog {{{$catalog.snapshot}}}){{/$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}]({{{$self.uri.detailed}}}) \n:::",
             "prefix_markdown": "## Movie titles \n\n",
             "page_size": 10
           }

--- a/test/specs/annotation/tests/03.table_display.js
+++ b/test/specs/annotation/tests/03.table_display.js
@@ -442,7 +442,7 @@ exports.execute = function (options) {
                 expect(display.type).toEqual('markdown');
             });
 
-            var markdownPattern = ":::iframe [{{title}}{{#$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}(with {{{rowName}}} from catalog {{{$catalog.snapshot}}}){{/$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}](https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id={{_id}}) \n:::";
+            var markdownPattern = ":::iframe [{{{$self.rowName}}}{{#$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}(with {{{rowName}}} from catalog {{{$catalog.snapshot}}}){{/$fkeys.schema_table_display.table_w_t_disp_annot_w_mp_fkey}}]({{{$self.uri.detailed}}}) \n:::";
             it("reference.display._rowMarkdownPattern should be '" + markdownPattern + "' ", function() {
                 expect(reference.display._rowMarkdownPattern).toEqual(markdownPattern);
             });
@@ -474,19 +474,34 @@ exports.execute = function (options) {
                     done.fail(err);
                 });
             });
-
-            var content = '<h2>Movie titles</h2>\n' +
-            '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;"><figcaption class="embed-caption">Hamlet(with <strong>William Shakespeare</strong> from catalog '+catalog_id+')</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20001"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20001"></iframe></figure>' +
-            '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;"><figcaption class="embed-caption">The Adventures of Huckleberry Finn(with <strong>Mark Twain</strong> from catalog '+catalog_id+')</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20002"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20002"></iframe></figure>' +
-            '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;"><figcaption class="embed-caption">Alice in Wonderland(with <strong>Lewis Carroll</strong> from catalog '+catalog_id+')</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20003"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20003"></iframe></figure>' +
-            '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;"><figcaption class="embed-caption">Pride and Prejudice(with <strong>Jane Austen</strong> from catalog '+catalog_id+')</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20004"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20004"></iframe></figure>' +
-            '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;"><figcaption class="embed-caption">Great Expectations</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20005"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20005"></iframe></figure>' +
-            '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;"><figcaption class="embed-caption">David Copperfield</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20006"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20006"></iframe></figure>' +
-            '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;"><figcaption class="embed-caption">Emma</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20007"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20007"></iframe></figure>' +
-            '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;"><figcaption class="embed-caption">As You Like It</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20008"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20008"></iframe></figure>' +
-            '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;"><figcaption class="embed-caption">The Adventures of Tom Sawyer</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20009"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20009"></iframe></figure>' +
-            '<figure class="embed-block -chaise-post-load"><div class="figcaption-wrapper" style="width: 100%;"><figcaption class="embed-caption">Through the Looking Glass</figcaption><div class="iframe-btn-container"><a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20010"><span class="glyphicon glyphicon-fullscreen"></span> Full screen</a></div></div><iframe src="https://dev.isrd.isi.edu/chaise/record-two/1/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/id=20010"></iframe></figure>';
             it('page.content should return HTML for all tuples using row_markdown_pattern and prefix_markdown and separator_markdown', function() {
+                var rowContent = function (id, caption) {
+                    var ridVal = findRID(tableName7, id);
+                    var iframeURL = 'https://dev.isrd.isi.edu/chaise/record/schema_table_display:table_w_table_display_annotation_w_markdown_pattern/RID=' + ridVal;
+                    return '<figure class="embed-block -chaise-post-load">' + 
+                                '<div class="figcaption-wrapper" style="width: 100%;">' + 
+                                    '<figcaption class="embed-caption">' + caption + '</figcaption>' + 
+                                    '<div class="iframe-btn-container">' + 
+                                        '<a class="chaise-btn chaise-btn-secondary chaise-btn-iframe" href="' + iframeURL + '">' +
+                                            '<span class="glyphicon glyphicon-fullscreen"></span> Full screen' + 
+                                        '</a>' + 
+                                    '</div>' + 
+                                '</div>' + 
+                                '<iframe src="' + iframeURL + '"></iframe>' + 
+                            '</figure>';
+                }
+                var content = '<h2>Movie titles</h2>\n';
+                content += rowContent('20001', 'Hamlet(with <strong>William Shakespeare</strong> from catalog '+catalog_id+')');
+                content += rowContent('20002', 'The Adventures of Huckleberry Finn(with <strong>Mark Twain</strong> from catalog '+catalog_id+')');
+                content += rowContent('20003', 'Alice in Wonderland(with <strong>Lewis Carroll</strong> from catalog '+catalog_id+')');
+                content += rowContent('20004', 'Pride and Prejudice(with <strong>Jane Austen</strong> from catalog '+catalog_id+')');
+                content += rowContent('20005', 'Great Expectations');
+                content += rowContent('20006', 'David Copperfield');
+                content += rowContent('20007', 'Emma');
+                content += rowContent('20008', 'As You Like It');
+                content += rowContent('20009', 'The Adventures of Tom Sawyer');
+                content += rowContent('20010', 'Through the Looking Glass');
+
                 expect(page.content).toEqual(content);
             });
 

--- a/test/specs/annotation/tests/05.citation.js
+++ b/test/specs/annotation/tests/05.citation.js
@@ -54,6 +54,14 @@ exports.execute = function (options) {
             return url;
         };
 
+        // you should use this function only after options.entities value is populated
+        // (in any of jasmine blocks)
+        var findRID = function (currTable, keyName, keyValue) {
+            return options.entities[schemaName][currTable].filter(function (e) {
+                return e[keyName] == keyValue;
+            })[0].RID;
+        };
+
         beforeAll(function() {
             options.ermRest.appLinkFn(appLinkFn);
         });
@@ -85,7 +93,7 @@ exports.execute = function (options) {
                 expect(citation.author).toBe("John Doe", "Author does not match for tuple[0]");
                 expect(citation.title).toBe("The First Data Row", "Title does not match for tuple[0]");
                 expect(citation.year).toBe("2018", "Year does not match for tuple[0]");
-                expect(citation.url).toBe("https://dev.isrd.isi.edu/chaise/record/#" + catalog_id + "/citation_schema:citation_w_mustache/id=1", "Url does not match for tuple[0]");
+                expect(citation.url).toBe("https://dev.isrd.isi.edu/chaise/record/citation_schema:citation_w_mustache/RID=" + findRID("citation_w_mustache", "id", "1"), "Url does not match for tuple[0]");
                 expect(citation.id).toBe("1", "Id does not match for tuple[0]");
 
                 done();
@@ -101,7 +109,7 @@ exports.execute = function (options) {
                 expect(citation.author).toBe("John Doe", "Author does not match for tuple[1]");
                 expect(citation.title).toBe("No title", "Title does not match for tuple[1]");
                 expect(citation.year).toBe("2018", "Year does not match for tuple[1]");
-                expect(citation.url).toBe("https://dev.isrd.isi.edu/chaise/record/#" + catalog_id + "/citation_schema:citation_w_mustache/id=2", "Url does not match for tuple[1]");
+                expect(citation.url).toBe("https://dev.isrd.isi.edu/chaise/record/citation_schema:citation_w_mustache/RID=" + findRID("citation_w_mustache", "id", "2"), "Url does not match for tuple[0]");
                 expect(citation.id).toBe("2", "Id does not match for tuple[1]");
 
                 done();
@@ -146,7 +154,7 @@ exports.execute = function (options) {
                 expect(citation.author).toBe("John Doe", "Author does not match for tuple[0]");
                 expect(citation.title).toBe("The First Data Row", "Title does not match for tuple[0]");
                 expect(citation.year).toBe(year, "Year does not match for tuple[0]");
-                expect(citation.url).toBe("https://dev.isrd.isi.edu/chaise/record/#" + catalog_id + "/citation_schema:citation_w_handlebars/id=1", "Url does not match for tuple[0]");
+                expect(citation.url).toBe("https://dev.isrd.isi.edu/chaise/record/citation_schema:citation_w_handlebars/RID=" + findRID("citation_w_handlebars", "id", "1"), "Url does not match for tuple[0]");
                 expect(citation.id).toBe("1", "Id does not match for tuple[0]");
 
                 done();
@@ -165,7 +173,7 @@ exports.execute = function (options) {
                 expect(citation.author).toBe("John Doe", "Author does not match for tuple[1]");
                 expect(citation.title).toBe("No title", "Title does not match for tuple[1]");
                 expect(citation.year).toBe(year, "Year does not match for tuple[1]");
-                expect(citation.url).toBe("https://dev.isrd.isi.edu/chaise/record/#" + catalog_id + "/citation_schema:citation_w_handlebars/id=2", "Url does not match for tuple[1]");
+                expect(citation.url).toBe("https://dev.isrd.isi.edu/chaise/record/citation_schema:citation_w_handlebars/RID=" + findRID("citation_w_handlebars", "id", "2"), "Url does not match for tuple[1]");
                 expect(citation.id).toBe("2", "Id does not match for tuple[1]");
 
                 done();
@@ -220,7 +228,7 @@ exports.execute = function (options) {
                     expect(computedCitation.author).toBe("Record author", "Author missmatch");
                     expect(computedCitation.title).toBe("Record title", "Title missmatch");
                     expect(computedCitation.year).toBe(year, "Year missmatch");
-                    expect(computedCitation.url).toBe("https://dev.isrd.isi.edu/chaise/record/#" + catalog_id + "/citation_schema:citation_w_handlebars/id=1", "Url missmatch");
+                    expect(computedCitation.url).toBe("https://dev.isrd.isi.edu/chaise/record/citation_schema:citation_w_waitfor/RID=" + findRID("citation_w_waitfor", "id", "1"), "Url missmatch");
                     expect(computedCitation.id).toBe("1", "id missmatch");
                     done();
                 });


### PR DESCRIPTION
Currently `$self` is only used in visible-columns markdown_pattern to access the current visible-column. With this change, we're allowing the usage of `$self` in  `row_markdown_pattern` of `table-display`, as well as `citation`.


`$self`will have the following structure:

```json
{
  "rowName": "",
  "uri": {
    "detailed": ""
  }
}
```

We should eventually also change the `$page` that is used in `page_markdown_pattern` to `$self` for consistency. We decided to not include that change for now since that might break some deployments that are using it.


The change is simple, and I created this PR just for documentation.