### PR TITLE
Add hideRowCount api to reference.display

### DIFF
--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -98,6 +98,7 @@ Supported JSON payload patterns:
 - `{`... `"show_null":` `{` _context_ `:` _nshow_ `,` ... `}`: How to display NULL data values.
 - `{`... `"show_key_link":` `{` _context_ `:` _keylink_ `,` ... `}`: Whether default display of keys (sel link) should include link to the row.
 - `{`... `"show_foreign_key_link":` `{` _context_ `:` _fklink_ `,` ... `}`: Whether default display of foreign keys should include link to the row.
+- `{`... `"hide_row_count":` `{` _context_ `:` _rowcount_ `,` ... `}`: Whether we should display the total row count. Since the request to fetch total row count is expensive, you can use this to signal to client to skip the request (and therefore do not display it to users.)
 
 Supported JSON _ccomment_ patterns:
 
@@ -139,6 +140,11 @@ Supported JSON _keylink_ patterns:
 
 - `true`: Present the key (self link) values with a link to the referred row.
 - `false`: Present the key (self link) values without adding extra links.
+
+Supported JSON _rowcount_ patterns:
+
+- `true`: Don't display the total row count.
+- `false`: Display the total row count to users.
 
 Supported JSON _context_ patterns:
 - See [Context Names](#context-names) section for the list of supported JSON _context_ patterns.

--- a/js/reference.js
+++ b/js/reference.js
@@ -2167,6 +2167,10 @@
                     annotation = module._getRecursiveAnnotationValue(this._context, this._table.annotations.get(module._annotations.TABLE_DISPLAY).content);
                 }
 
+                // get the hide_row_count from display annotation
+                var hideRowCount = module._getHierarchicalDisplayAnnotationValue(this._table, this._context, "hide_row_count", true);
+                this._display.hideRowCount = (typeof hideRowCount == "boolean") ? hideRowCount : false;
+
                 // If annotation is defined then parse it
                 if (annotation) {
 

--- a/test/specs/annotation/conf/table_display/schema.json
+++ b/test/specs/annotation/conf/table_display/schema.json
@@ -658,6 +658,12 @@
             }
         ],
         "annotations": {
+            "tag:misd.isi.edu,2015:display": {
+              "hide_row_count": {
+                  "compact": false,
+                  "compact/select": true
+              }
+            },
             "tag:isrd.isi.edu,2016:table-display": {
                 "compact": {
                     "collapse_toc_panel": true,
@@ -667,5 +673,13 @@
         }
     }
   },
-  "schema_name": "schema_table_display"
+  "schema_name": "schema_table_display",
+  "annotations": {
+      "tag:misd.isi.edu,2015:display": {
+          "hide_row_count": {
+              "compact": true,
+              "compact/select": false
+          }
+      }
+  }
 }

--- a/test/specs/annotation/tests/03.table_display.js
+++ b/test/specs/annotation/tests/03.table_display.js
@@ -2,7 +2,7 @@ var utils = require('./../../../utils/utilities.js');
 
 exports.execute = function (options) {
 
-    describe("2016:table-display annotation test", function () {
+    describe("Reference display related APIs", function () {
 
         var catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "schema_table_display",
@@ -636,13 +636,57 @@ exports.execute = function (options) {
             it ('should be able to access options in annotation.', function (done) {
                 options.ermRest.resolve(tableCompactOptionsEntityUri, {cid: "test"}).then(function (ref) {
                     var ref = ref.contextualize.compact
-                    expect(ref.display.collapseToc).toBeTruthy("Collapse ToC option is not defined");
-                    expect(ref.display.hideColumnHeaders).toBeTruthy("Hide Column Headers option is not defined");
+                    expect(ref.display.collapseToc).toBeTruthy("Collapse ToC compact missmatch");
+                    expect(ref.display.hideColumnHeaders).toBeTruthy("Hide Column Headers compact missmatch");
+
+                    // other contexts should return false values
+                    ref = ref.contextualize.detailed;
+                    expect(ref.display.collapseToc).toBeFalsy("Collapse ToC detailed missmatch");
+                    expect(ref.display.hideColumnHeaders).toBeFalsy("Hide Column Headers detailed missmatch");
+
                     done();
                 }).catch(function (err) {
                     done.fail(err);
                 });
             });
         });
+
+        describe("display.hideTotalCount", function () {
+            var refWithHideRowCountAnnot, refWithoutHideRowCountAnnot;
+
+            it ("should get it from display annotation on table", function (done) {
+                options.ermRest.resolve(tableCompactOptionsEntityUri, {cid: "test"}).then(function (ref) {
+                    refWithHideRowCountAnnot = ref;
+
+                    expect(ref.contextualize.compact.display.hideRowCount).toBeFalsy("hide Row Count compact missmatch");
+                    expect(ref.contextualize.compactSelect.display.hideRowCount).toBeTruthy("hide Row Count compact/select missmatch");
+                    
+                    done();
+                }).catch(function (err) {
+                    done.fail(err);
+                });
+            });
+
+            it ("otherwise should get it from display annotation on schema", function (done) {
+                options.ermRest.resolve(table1EntityUri, {cid: "test"}).then(function (ref) {
+                    refWithoutHideRowCountAnnot = ref;
+
+                    expect(ref.contextualize.compact.display.hideRowCount).toBeTruthy("hide Row Count compact missmatch");
+                    expect(ref.contextualize.compactSelect.display.hideRowCount).toBeFalsy("hide Row Count compact/select missmatch");
+
+                    done();
+                }).catch(function (err) {
+                    done.fail(err);
+                });
+            });
+
+            it ("should return false if not defined for the context", function () {
+                // both are not defined for detailed
+                expect(refWithHideRowCountAnnot.contextualize.detailed.display.hideRowCount).toBeFalsy("missmatch for first reference");
+                expect(refWithoutHideRowCountAnnot.contextualize.detailed.display.hideRowCount).toBeFalsy("missmatch for second reference");
+            });
+        });
+        
     });
+    
 };


### PR DESCRIPTION
As title suggests, this PR will add `Reference.display.hideRowCount` based on what we decided in #883 issue.

It's a very simple change and I created this PR just for announcement. 