### PR TITLE
User favorites table path added to 2021:table-config annotation

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -155,6 +155,7 @@ to use for ERMrest JavaScript agents.
             * [.referredBy](#ERMrest.Table+referredBy) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
             * [.comment](#ERMrest.Table+comment) : <code>string</code>
             * [._showSavedQuery](#ERMrest.Table+_showSavedQuery) : <code>boolean</code>
+            * [._favoritesPath](#ERMrest.Table+_favoritesPath) : <code>string</code>
             * [.kind](#ERMrest.Table+kind) : <code>string</code>
             * [.shortestKey](#ERMrest.Table+shortestKey)
             * [.displayKey](#ERMrest.Table+displayKey) : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
@@ -378,6 +379,7 @@ to use for ERMrest JavaScript agents.
         * [.canUseTRS](#ERMrest.Reference+canUseTRS) : <code>Boolean</code>
         * [.canUseTCRS](#ERMrest.Reference+canUseTCRS) : <code>Boolean</code>
         * [.display](#ERMrest.Reference+display) : <code>Object</code>
+        * [.favoritesPath](#ERMrest.Reference+favoritesPath)
         * [.related](#ERMrest.Reference+related) : [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
         * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
         * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
@@ -702,6 +704,7 @@ to use for ERMrest JavaScript agents.
         * [.canUseTRS](#ERMrest.Reference+canUseTRS) : <code>Boolean</code>
         * [.canUseTCRS](#ERMrest.Reference+canUseTCRS) : <code>Boolean</code>
         * [.display](#ERMrest.Reference+display) : <code>Object</code>
+        * [.favoritesPath](#ERMrest.Reference+favoritesPath)
         * [.related](#ERMrest.Reference+related) : [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
         * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
         * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
@@ -1188,6 +1191,7 @@ get table by table name
         * [.referredBy](#ERMrest.Table+referredBy) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
         * [.comment](#ERMrest.Table+comment) : <code>string</code>
         * [._showSavedQuery](#ERMrest.Table+_showSavedQuery) : <code>boolean</code>
+        * [._favoritesPath](#ERMrest.Table+_favoritesPath) : <code>string</code>
         * [.kind](#ERMrest.Table+kind) : <code>string</code>
         * [.shortestKey](#ERMrest.Table+shortestKey)
         * [.displayKey](#ERMrest.Table+displayKey) : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
@@ -1294,6 +1298,12 @@ Documentation for this table
 <a name="ERMrest.Table+_showSavedQuery"></a>
 
 #### table.\_showSavedQuery : <code>boolean</code>
+**Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+<a name="ERMrest.Table+_favoritesPath"></a>
+
+#### table.\_favoritesPath : <code>string</code>
+The path to the table where the favorite terms are stored
+
 **Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+kind"></a>
 
@@ -2932,6 +2942,7 @@ Constructor for a ParsedFilter.
     * [.canUseTRS](#ERMrest.Reference+canUseTRS) : <code>Boolean</code>
     * [.canUseTCRS](#ERMrest.Reference+canUseTCRS) : <code>Boolean</code>
     * [.display](#ERMrest.Reference+display) : <code>Object</code>
+    * [.favoritesPath](#ERMrest.Reference+favoritesPath)
     * [.related](#ERMrest.Reference+related) : [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
     * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
     * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
@@ -3243,6 +3254,18 @@ if ( displayType === 'table') {
   // Use modulePath to render the rows
 }
 ```
+
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+<a name="ERMrest.Reference+favoritesPath"></a>
+
+#### reference.favoritesPath
+The path to the table where the favorite terms are stored. Checks the
+2021:table-config annotation for `user_favorites.storage_table`. If
+present, returns a string in the form of:
+  "/ermrest/catalog/<catalog-id>/entity/<schema>:<table>".
+
+If the annotation was not properly defined or not defined at all, this
+will return null.
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+related"></a>
@@ -6634,6 +6657,7 @@ get PathColumn object by column name
     * [.canUseTRS](#ERMrest.Reference+canUseTRS) : <code>Boolean</code>
     * [.canUseTCRS](#ERMrest.Reference+canUseTCRS) : <code>Boolean</code>
     * [.display](#ERMrest.Reference+display) : <code>Object</code>
+    * [.favoritesPath](#ERMrest.Reference+favoritesPath)
     * [.related](#ERMrest.Reference+related) : [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
     * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
     * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
@@ -6945,6 +6969,18 @@ if ( displayType === 'table') {
   // Use modulePath to render the rows
 }
 ```
+
+**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
+<a name="ERMrest.Reference+favoritesPath"></a>
+
+#### reference.favoritesPath
+The path to the table where the favorite terms are stored. Checks the
+2021:table-config annotation for `user_favorites.storage_table`. If
+present, returns a string in the form of:
+  "/ermrest/catalog/<catalog-id>/entity/<schema>:<table>".
+
+If the annotation was not properly defined or not defined at all, this
+will return null.
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+related"></a>

--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -155,7 +155,7 @@ to use for ERMrest JavaScript agents.
             * [.referredBy](#ERMrest.Table+referredBy) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
             * [.comment](#ERMrest.Table+comment) : <code>string</code>
             * [._showSavedQuery](#ERMrest.Table+_showSavedQuery) : <code>boolean</code>
-            * [._favoritesPath](#ERMrest.Table+_favoritesPath) : <code>string</code>
+            * [.favoritesPath](#ERMrest.Table+favoritesPath) : <code>string</code>
             * [.kind](#ERMrest.Table+kind) : <code>string</code>
             * [.shortestKey](#ERMrest.Table+shortestKey)
             * [.displayKey](#ERMrest.Table+displayKey) : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
@@ -379,7 +379,6 @@ to use for ERMrest JavaScript agents.
         * [.canUseTRS](#ERMrest.Reference+canUseTRS) : <code>Boolean</code>
         * [.canUseTCRS](#ERMrest.Reference+canUseTCRS) : <code>Boolean</code>
         * [.display](#ERMrest.Reference+display) : <code>Object</code>
-        * [.favoritesPath](#ERMrest.Reference+favoritesPath)
         * [.related](#ERMrest.Reference+related) : [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
         * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
         * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
@@ -704,7 +703,6 @@ to use for ERMrest JavaScript agents.
         * [.canUseTRS](#ERMrest.Reference+canUseTRS) : <code>Boolean</code>
         * [.canUseTCRS](#ERMrest.Reference+canUseTCRS) : <code>Boolean</code>
         * [.display](#ERMrest.Reference+display) : <code>Object</code>
-        * [.favoritesPath](#ERMrest.Reference+favoritesPath)
         * [.related](#ERMrest.Reference+related) : [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
         * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
         * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
@@ -1191,7 +1189,7 @@ get table by table name
         * [.referredBy](#ERMrest.Table+referredBy) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
         * [.comment](#ERMrest.Table+comment) : <code>string</code>
         * [._showSavedQuery](#ERMrest.Table+_showSavedQuery) : <code>boolean</code>
-        * [._favoritesPath](#ERMrest.Table+_favoritesPath) : <code>string</code>
+        * [.favoritesPath](#ERMrest.Table+favoritesPath) : <code>string</code>
         * [.kind](#ERMrest.Table+kind) : <code>string</code>
         * [.shortestKey](#ERMrest.Table+shortestKey)
         * [.displayKey](#ERMrest.Table+displayKey) : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
@@ -1299,9 +1297,9 @@ Documentation for this table
 
 #### table.\_showSavedQuery : <code>boolean</code>
 **Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
-<a name="ERMrest.Table+_favoritesPath"></a>
+<a name="ERMrest.Table+favoritesPath"></a>
 
-#### table.\_favoritesPath : <code>string</code>
+#### table.favoritesPath : <code>string</code>
 The path to the table where the favorite terms are stored
 
 **Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
@@ -2942,7 +2940,6 @@ Constructor for a ParsedFilter.
     * [.canUseTRS](#ERMrest.Reference+canUseTRS) : <code>Boolean</code>
     * [.canUseTCRS](#ERMrest.Reference+canUseTCRS) : <code>Boolean</code>
     * [.display](#ERMrest.Reference+display) : <code>Object</code>
-    * [.favoritesPath](#ERMrest.Reference+favoritesPath)
     * [.related](#ERMrest.Reference+related) : [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
     * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
     * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
@@ -3254,18 +3251,6 @@ if ( displayType === 'table') {
   // Use modulePath to render the rows
 }
 ```
-
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
-<a name="ERMrest.Reference+favoritesPath"></a>
-
-#### reference.favoritesPath
-The path to the table where the favorite terms are stored. Checks the
-2021:table-config annotation for `user_favorites.storage_table`. If
-present, returns a string in the form of:
-  "/ermrest/catalog/<catalog-id>/entity/<schema>:<table>".
-
-If the annotation was not properly defined or not defined at all, this
-will return null.
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+related"></a>
@@ -6657,7 +6642,6 @@ get PathColumn object by column name
     * [.canUseTRS](#ERMrest.Reference+canUseTRS) : <code>Boolean</code>
     * [.canUseTCRS](#ERMrest.Reference+canUseTCRS) : <code>Boolean</code>
     * [.display](#ERMrest.Reference+display) : <code>Object</code>
-    * [.favoritesPath](#ERMrest.Reference+favoritesPath)
     * [.related](#ERMrest.Reference+related) : [<code>Array.&lt;Reference&gt;</code>](#ERMrest.Reference)
     * [.unfilteredReference](#ERMrest.Reference+unfilteredReference) : [<code>Reference</code>](#ERMrest.Reference)
     * [.appLink](#ERMrest.Reference+appLink) : <code>String</code>
@@ -6969,18 +6953,6 @@ if ( displayType === 'table') {
   // Use modulePath to render the rows
 }
 ```
-
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
-<a name="ERMrest.Reference+favoritesPath"></a>
-
-#### reference.favoritesPath
-The path to the table where the favorite terms are stored. Checks the
-2021:table-config annotation for `user_favorites.storage_table`. If
-present, returns a string in the form of:
-  "/ermrest/catalog/<catalog-id>/entity/<schema>:<table>".
-
-If the annotation was not properly defined or not defined at all, this
-will return null.
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+related"></a>

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -50,13 +50,13 @@ here is a quick matrix to locate them.
 | Annotation                                                  | Catalog | Schema | Table | Column | Key | FKR | Summary                                       |
 |-------------------------------------------------------------|---------|--------|-------|--------|-----|-----|-----------------------------------------------|
 | [2015 Display](#tag-2015-display)                           | X       | X      | X     | X      | X   | -   | Display options                               |
-| [2015 Vocabulary](#tag-2015-vocabulary-deprecated) (_deprecated_)                     | -       | -      | X     | -      | -   | -   | Table as a vocabulary list                    |
+| [2015 Vocabulary](#tag-2015-vocabulary-deprecated) (_deprecated_) | -       | -      | X     | -      | -   | -   | Table as a vocabulary list                    |
 | [2016 Table Alternatives](#tag-2016-table-alternatives)     | -       | -      | X     | -      | _   | _   | Table abstracts another table                 |
 | [2016 Column Display](#tag-2016-column-display)             | -       | -      | -     | X      | -   | -   | Column-specific display options               |
 | [2017 Key Display](#tag-2017-key-display)                   | -       | -      | -     | -      | X   | -   | Key augmentation                              |
 | [2016 Foreign Key](#tag-2016-foreign-key)                   | -       | -      | -     | -      | -   | X   | Foreign key augmentation                      |
 | [2016 Generated](#tag-2016-generated)                       | -       | X      | X     | X      | -   | -   | Generated model element                       |
-| [2016 Ignore](#tag-2016-ignore-deprecated) (_deprecated_)              | -       | X      | X     | X      | -   | -   | Ignore model element                          |
+| [2016 Ignore](#tag-2016-ignore-deprecated) (_deprecated_)   | -       | X      | X     | X      | -   | -   | Ignore model element                          |
 | [2016 Immutable](#tag-2016-immutable)                       | -       | X      | X     | X      | -   | -   | Immutable model element                       |
 | [2016 Non Deletable](#tag-2016-non-deletable)               | -       | X      | X     | -      | -   | -   | Non-deletable model element                   |
 | [2016 App Links](#tag-2016-app-links)                       | -       | X      | X     | -      | -   | -   | Intra-Chaise app links                        |
@@ -64,18 +64,19 @@ here is a quick matrix to locate them.
 | [2016 Visible Columns](#tag-2016-visible-columns)           | -       | -      | X     | -      | -   | -   | Column visibility and presentation order      |
 | [2016 Visible Foreign Keys](#tag-2016-visible-foreign-keys) | -       | -      | X     | -      | -   | -   | Foreign key visibility and presentation order |
 | [2019 Export](#tag-2019-export)                             | -       | X      | X     | -      | -   | -   | Describes export templates                    |
-| [2016 Export](#tag-2016-export-deprecated) (_deprecated_)              | -       | X      | X     | -      | -   | -   | Describes export templates                    |
+| [2016 Export](#tag-2016-export-deprecated) (_deprecated_)   | -       | X      | X     | -      | -   | -   | Describes export templates                    |
 | [2017 Asset](#tag-2017-asset)                               | -       | -      | -     | X      | -   | -   | Describes assets                              |
 | [2018 Citation](#tag-2018-citation)                         | -       | -      | X     | -      | -   | -   | Describes citation                            |
 | [2018 Required](#tag-2018-required)                         | -       | -      | -     | X      | -   | -   | Required model column                         |
 | [2018 Indexing Preferences](#tag-2018-indexing-preferences) | -       | -      | X     | X      | -   | -   | Specify database indexing preferences         |
 | [2019 Chaise Config](#tag-2019-chaise-config)               | X       | -      | -     | -      | -   | -   | Properties to configure chaise app UX         |
 | [2019 Source Definitions](#tag-2019-source-definitions)     | -       | -      | X     | -      | -   | -   | Describe source definitions                   |
-| [2021 Google Dataset](#tag-2021-google-dataset)     | -       | -      | X     | -      | -   | -   | Describe metadata for rich results in Google Dataset                   |
+| [2021 Google Dataset](#tag-2021-google-dataset)             | -       | -      | X     | -      | -   | -   | Describe metadata for rich results in Google Dataset |
+| [2021 Table Config](#tag-2021-table-config)                 | -       | -      | X     | -      | -   | -   | Describe Table Config                         |
 
 For brevity, the annotation keys are listed above by their section
 name within this documentation. The actual key URI follows one of these formats:
-- `tag:misd.isi.edu,` _date_ `:` _key_ 
+- `tag:misd.isi.edu,` _date_ `:` _key_
 - `tag:isrd.isi.edu,` _date_ `:` _key_
 
 Where the _key_ part is lower-cased with hyphens replacing whitespace. For example, the `2015 Display` annotation key URI is actually `tag:misd.isi.edu,2015:display`, and `2017 Key Display` is `tag:isrd.isi.edu,2017:key-display`.
@@ -443,11 +444,11 @@ Configuration attributes (optional):
   ```json
   [
     {
-      "num_occurrences": true, 
+      "num_occurrences": true,
       "descending": true
     },
     {
-      "column": "<the scalar facet column name>", 
+      "column": "<the scalar facet column name>",
       "descending": false
     }
   ]
@@ -670,11 +671,11 @@ Supported JSON _option_ payload patterns:
         - `table`: the parent table name `{{{$page.parent.table}}}`.
         - `schema`: the parent schema name `{{{$page.parent.schema}}}`.
 - `"row_markdown_pattern":` _rowpattern_: Render the row by composing a markdown representation only when `row_markdown_pattern` is non-null.
-  - Expand _rowpattern_ to obtain a markdown representation of each row via [Pattern Expansion](#pattern-expansion). 
+  - Expand _rowpattern_ to obtain a markdown representation of each row via [Pattern Expansion](#pattern-expansion).
   - The pattern has access to column values **after** any processing implied by [2016 Column Display](#column-display).
   - If used in any context other than `row_name`, the pattern also has access to a `$self` object that has the following attributes:
     - `rowName`: Row-name of the represented row.
-    - `uri.detailed`: a uri to the row in `detailed` context. 
+    - `uri.detailed`: a uri to the row in `detailed` context.
 - `"separator_markdown":` _separator_: Insert _separator_ markdown text between each expanded _rowpattern_ when presenting row sets. (Default new-line `"\n"`.)
   - Ignore if `"row_markdown_pattern"` is not also configured.
 - `"prefix_markdown":` _prefix_: Insert _prefix_ markdown before the first _rowpattern_ expansion when presenting row sets. (Default empty string `""`.)
@@ -825,7 +826,7 @@ A new asset location may be specified via a pattern to induce a prospective asse
 Supported JSON payload patterns:
 
 - `{`... `"url_pattern": ` _pattern_ ...`}`: A desired upload location can be derived by [Pattern Expansion](#pattern-expansion) on _pattern_. This attribute is required for browser upload and if it is not specified the client will not provide the browser upload feature. See implementation notes below.
-- `{`... `"browser_upload": ` `false` ... `}`: If `url_pattern` is availale and valid browser upload feature will be enabled. If you want to force disabling this feature set it to `false`.
+- `{`... `"browser_upload": ` `false` ... `}`: If `url_pattern` is available and valid browser upload feature will be enabled. If you want to force disabling this feature set it to `false`.
 - `{`... `"filename_column": ` _column_ ...`}`: The _column_ stores the filename of the asset.
 - `{`... `"byte_count_column": ` _column_ ...`}`: The _column_ stores the file size in bytes of the asset. It SHOULD be an integer typed column.
 - `{`... `"md5": ` _column_ | `true` ...`}`: If _column_, then the _column_ stores the checksum generated by the 'md5' cryptographic hash function. It MUST be ASCII/UTF-8 hexadecimal encoded. If `true`, then the client SHOULD generate a 'md5' checksum and communicate it to the asset storage service according to its protocol.
@@ -876,7 +877,7 @@ Supported _waitForList_ pattern:
 Default heuristics:
 -  Apart from the main table data, all-outbound foreignkeys, and listed psuedo-columns in the `wait_for`, the pattern has access to a `$self` object that has the following attributes:
   - `rowName`: Row-name of the represented row.
-  - `uri.detailed`: a uri to the row in `detailed` context. 
+  - `uri.detailed`: a uri to the row in `detailed` context.
 - `journal_pattern`, `year_pattern`, and `url_pattern` MUST be specified for citation. If any of the 3 are not specified or if one of them produces a null value, citation will be disabled.
 - If any of the other values are not present or produce a null value, it is up to the client to decide how to display the citation.
 
@@ -1043,12 +1044,12 @@ Supported JSON payload pattern:
 Supported _jsonld_ payload pattern:
 
 
-- JSON-LD keywords: 
+- JSON-LD keywords:
     - `@context`: It is a schema for your data, not only defining the property datatypes but also the classes of json resources. Default applied if none exists is `http://schema.org`.
-    - `@type`: Used to set the data type of a node or typed value. At the top level, only a value of `Dataset` is supported. Default applied if none exists is `Dataset`. 
+    - `@type`: Used to set the data type of a node or typed value. At the top level, only a value of `Dataset` is supported. Default applied if none exists is `Dataset`.
 - Schema.org volabulary: The supported attributes and types are [here](https://github.com/informatics-isi-edu/ermrestjs/blob/master/js/utils/json_ld_schema.js). This is a subset of the original vocabulary provided by schema.org. All the properties support [pattern expansion](#pattern-expansion) and the `template_engine` property should be defined outside the `dataset` definition. Apart from the main table data and all-outbound foreignkeys the pattern has access to a `$self` object that has the following attributes:
   - `rowName`: Row-name of the represented row.
-  - `uri.detailed`: a uri to the row in `detailed` context. 
+  - `uri.detailed`: a uri to the row in `detailed` context.
 
 
 After generating the JSON-LD based on the given specifications, the client will validate it. If the generated JSON-LD has any of the following issues, the given JSON-LD will be completely invalidated and ignored:
@@ -1056,7 +1057,7 @@ After generating the JSON-LD based on the given specifications, the client will 
  - Incorrect value of `@type` (Must be `Dataset`.)
  - Missing or empty value of mandatory attribute `name`
  - Missing or empty value of mandatory attribute `description`
-    
+
 In all remaining scenarios, the problematic attribute (attributes that don't follow the expected structure or type) will simply be ignored and the reason for that will be logged in the browser console.
 
 You can use [this](https://search.google.com/test/rich-results) tool by Google to validate any JSON-LD yourself if needed, it accepts both a URL or a code snippet.
@@ -1068,8 +1069,8 @@ Example of annotation:
   "tag:isrd.isi.edu,2021:google-dataset": {  
     "detailed": {
       "dataset": {
-        "@context": "http://schema.org", 
-        "@type": "Dataset", 
+        "@context": "http://schema.org",
+        "@type": "Dataset",
         "name": "{{{title}}}",
         "description": "{{{summary}}}",
         "url": "{{{$self.uri.detailed}}}",
@@ -1087,7 +1088,19 @@ Example of annotation:
     }
   }
 }
-``` 
+```
+## Tag: 2021 Table Config
+`tag:isrd.isi.edu,2021:table-config`
+
+This key indicates that the annotated table has a specific configuration options that modify the behavior of the table when accessing the APIs.
+
+Supported JSON payload patterns:
+- `{`... `"user_favorites":` `{` _favoritesentry_ `}`:  Defines the user favorites configuration based on  _favoritesentry_. Attributes that this JSON document can have are:
+  - `"storage_table":` `{` _storageconfig_ `}`: An object containing the names of model elements for creating the ermrest path for creation and deletion. Teh _storageconfig_ has the following properties.
+    - `catalog`: Required. String value of the catalog id
+    - `schema`: Required. String value of the schema name
+    - `table`: Required. String value of the table name
+
 ### Context Names
 
 List of _context_ names that are used in ERMrest:

--- a/js/core.js
+++ b/js/core.js
@@ -1059,13 +1059,17 @@
          * @desc The path to the table where the favorite terms are stored
          * @type {string}
          */
-        this._favoritesPath = null;
+        this.favoritesPath = null;
         if (this.annotations.contains(module._annotations.TABLE_CONFIG)) {
             var userFavorites = this.annotations.get(module._annotations.TABLE_CONFIG).content.user_favorites;
-            console.log(userFavorites);
-            if (userFavorites && userFavorites.storage_table) {
+            // make sure user_favorites is defined
+            // make sure storage table is an object
+            if (userFavorites && typeof userFavorites.storage_table == "object") {
                 var favoritesTable = userFavorites.storage_table;
-                this._favoritesPath = "/ermrest/catalog/" + favoritesTable.catalog + "/entity/" + favoritesTable.schema + ":" + favoritesTable.table;
+                // make sure each key is present and the value is a non empty string
+                if (isStringAndNotEmpty(favoritesTable.catalog) && isStringAndNotEmpty(favoritesTable.schema) && isStringAndNotEmpty(favoritesTable.table)) {
+                    this.favoritesPath = "/ermrest/catalog/" + favoritesTable.catalog + "/entity/" + favoritesTable.schema + ":" + favoritesTable.table;
+                }
             }
         }
 

--- a/js/core.js
+++ b/js/core.js
@@ -1056,6 +1056,20 @@
         this._showSavedQuery = _getHierarchicalDisplayAnnotationValue(this, "show_saved_query");
 
         /**
+         * @desc The path to the table where the favorite terms are stored
+         * @type {string}
+         */
+        this._favoritesPath = null;
+        if (this.annotations.contains(module._annotations.TABLE_CONFIG)) {
+            var userFavorites = this.annotations.get(module._annotations.TABLE_CONFIG).content.user_favorites;
+            console.log(userFavorites);
+            if (userFavorites && userFavorites.storage_table) {
+                var favoritesTable = userFavorites.storage_table;
+                this._favoritesPath = "/ermrest/catalog/" + favoritesTable.catalog + "/entity/" + favoritesTable.schema + ":" + favoritesTable.table;
+            }
+        }
+
+        /**
          * @desc The type of this table
          * @type {string}
          */
@@ -1414,7 +1428,7 @@
                     module._log.info(message + ": " + " `sourcekey` didn't exist.");
                     return false;
                 }
-            
+
                 // if the key is special
                 if (Object.keys(module._specialSourceDefinitions).indexOf(key) !== -1) {
                     module._log.info(message + ": " + " `sourcekey` cannot be any of the special keys.");
@@ -1438,9 +1452,9 @@
                     // if it has prefix, we have to make sure the prefix is processed beforehand
                     hasPrefix = typeof sourceDef === "object" && Array.isArray(sourceDef.source) &&
                                 sourceDef.source.length > 1 && ("sourcekey" in sourceDef.source[0]);
-                    
+
                     if (hasPrefix) {
-                        // NOTE limitation because of other parts of the code which we might want 
+                        // NOTE limitation because of other parts of the code which we might want
                         //      to allow later
                         if (sourceDef.source.length < 3) {
                             module._log.info(message + ": " + "sourcekey (path prefix) can only be used when there's a path after it.");
@@ -1459,7 +1473,7 @@
                         }
                     }
 
-                    // NOTE we're passing the list of processed sources 
+                    // NOTE we're passing the list of processed sources
                     //      because some of them might have prefix and need that
                     pSource = new SourceObjectWrapper(sourceDef, self, consNames, false, res.sources);
                 } catch (exp) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -2016,6 +2016,24 @@
         },
 
         /**
+         * The path to the table where the favorite terms are stored. Checks the
+         * 2021:table-config annotation for `user_favorites.storage_table`. If
+         * present, returns a string in the form of:
+         *   "/ermrest/catalog/<catalog-id>/entity/<schema>:<table>".
+         *
+         * If the annotation was not properly defined or not defined at all, this
+         * will return null.
+         */
+        get favoritesPath () {
+            if (this._favoritesPath === undefined) {
+                console.log(this.table)
+                this._favoritesPath = this.table._favoritesPath;
+            }
+
+            return this._favoritesPath;
+        },
+
+        /**
          * The "related" references. Relationships are defined by foreign key
          * references between {@link ERMrest.Table}s. Those references can be
          * considered "outbound" where the table has FKRs to other entities or
@@ -3613,13 +3631,13 @@
                         filter[module._facetFilterTypes.CHOICE] = [tuple.data[col.name]];
                         filters.push(filter);
                     });
-                    
+
                     facets = {"and": filters};
                 }
 
                 // the facets are basd on the value of shortest key of current table
                 newRef._location.facets = facets;
-                
+
             }
 
             return newRef;
@@ -3852,10 +3870,10 @@
                     }
 
                     return _sourceColumnHelpers.parseAllOutBoundNodes(
-                        allOutBounds[l].sourceObjectNodes, 
+                        allOutBounds[l].sourceObjectNodes,
                         allOutBounds[l].lastForeignKeyNode,
-                        sourcekey, 
-                        pathPrefixAliasMapping, 
+                        sourcekey,
+                        pathPrefixAliasMapping,
                         outAlias,
                         mainTableAlias
                     );

--- a/js/reference.js
+++ b/js/reference.js
@@ -2016,24 +2016,6 @@
         },
 
         /**
-         * The path to the table where the favorite terms are stored. Checks the
-         * 2021:table-config annotation for `user_favorites.storage_table`. If
-         * present, returns a string in the form of:
-         *   "/ermrest/catalog/<catalog-id>/entity/<schema>:<table>".
-         *
-         * If the annotation was not properly defined or not defined at all, this
-         * will return null.
-         */
-        get favoritesPath () {
-            if (this._favoritesPath === undefined) {
-                console.log(this.table)
-                this._favoritesPath = this.table._favoritesPath;
-            }
-
-            return this._favoritesPath;
-        },
-
-        /**
          * The "related" references. Relationships are defined by foreign key
          * references between {@link ERMrest.Table}s. Those references can be
          * considered "outbound" where the table has FKRs to other entities or

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -64,6 +64,7 @@
         REQUIRED: "tag:isrd.isi.edu,2018:required",
         SOURCE_DEFINITIONS: "tag:isrd.isi.edu,2019:source-definitions",
         TABLE_ALTERNATIVES: "tag:isrd.isi.edu,2016:table-alternatives",
+        TABLE_CONFIG: "tag:isrd.isi.edu,2021:table-config",
         TABLE_DISPLAY: "tag:isrd.isi.edu,2016:table-display",
         VISIBLE_COLUMNS: "tag:isrd.isi.edu,2016:visible-columns",
         VISIBLE_FOREIGN_KEYS: "tag:isrd.isi.edu,2016:visible-foreign-keys",

--- a/test/specs/annotation/conf/table_config.conf.json
+++ b/test/specs/annotation/conf/table_config.conf.json
@@ -1,0 +1,12 @@
+{
+    "catalog": {},
+    "schema": {
+        "name": "table_config",
+        "createNew": true,
+        "path": "test/specs/annotation/conf/table_config/schema.json"
+    },
+    "tables": {
+        "createNew": true
+    },
+    "entities": {}
+}

--- a/test/specs/annotation/conf/table_config/schema.json
+++ b/test/specs/annotation/conf/table_config/schema.json
@@ -1,0 +1,108 @@
+{
+    "schema_name": "table_config",
+    "tables": {
+        "favorites_path": {
+            "comment": "Table with table-config annotation to save favorites",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id"
+                    ]
+                }
+            ],
+            "foreign_keys": [],
+            "table_name": "favorites_path",
+            "schema_name": "table_config",
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "int"
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2021:table-config": {
+                    "user_favorites": {
+                        "storage_table": {
+                            "catalog": 1,
+                            "schema": "table_config",
+                            "table": "my_favorites"
+                        }
+                    }
+                }
+            }
+        },
+        "no_annotation": {
+            "comment": "Table with NO table-config annotation for testing defaults",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id"
+                    ]
+                }
+            ],
+            "foreign_keys": [],
+            "table_name": "no_annotation",
+            "schema_name": "table_config",
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "int"
+                    }
+                }
+            ],
+            "annotations": {}
+        },
+        "favorites_null": {
+            "comment": "Table with an improperly configured table-config annotation for the user_favorites property",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id"
+                    ]
+                }
+            ],
+            "foreign_keys": [],
+            "table_name": "favorites_null",
+            "schema_name": "table_config",
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "int"
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2021:table-config": {
+                    "user_favorites": {}
+                }
+            }
+        }
+    },
+    "table_names": [
+        "favorites_path",
+        "no_annotation",
+        "favorites_null"
+    ],
+    "comment": null,
+    "annotations": {
+        "tag:misd.isi.edu,2015:display": {
+            "show_saved_query": false
+        }
+    }
+}

--- a/test/specs/annotation/conf/table_config/schema.json
+++ b/test/specs/annotation/conf/table_config/schema.json
@@ -100,9 +100,5 @@
         "favorites_null"
     ],
     "comment": null,
-    "annotations": {
-        "tag:misd.isi.edu,2015:display": {
-            "show_saved_query": false
-        }
-    }
+    "annotations": {}
 }

--- a/test/specs/annotation/conf/table_config/schema.json
+++ b/test/specs/annotation/conf/table_config/schema.json
@@ -29,7 +29,7 @@
                 "tag:isrd.isi.edu,2021:table-config": {
                     "user_favorites": {
                         "storage_table": {
-                            "catalog": 1,
+                            "catalog": "1",
                             "schema": "table_config",
                             "table": "my_favorites"
                         }

--- a/test/specs/annotation/tests/10.table_config.js
+++ b/test/specs/annotation/tests/10.table_config.js
@@ -23,7 +23,7 @@ exports.execute = function (options) {
                 reference = response;
                 expect(reference).toEqual(jasmine.any(Object));
 
-                expect(reference.favoritesPath).toBe("/ermrest/catalog/1/entity/table_config:my_favorites", "table-config annotation not set properly on table favorites_path");
+                expect(reference.table.favoritesPath).toBe("/ermrest/catalog/1/entity/table_config:my_favorites", "table-config annotation not set properly on table favorites_path");
 
                 done();
             }, function (err) {
@@ -37,7 +37,7 @@ exports.execute = function (options) {
                 referenceNoTableAnnotation = response;
                 expect(referenceNoTableAnnotation).toEqual(jasmine.any(Object));
 
-                expect(referenceNoTableAnnotation.favoritesPath).toBe(null, "default value for favoritesPath not set properly");
+                expect(referenceNoTableAnnotation.table.favoritesPath).toBe(null, "default value for favoritesPath not set properly");
 
                 done();
             }, function (err) {
@@ -51,7 +51,7 @@ exports.execute = function (options) {
                 referenceMisconfiguredAnnotation = response;
                 expect(referenceMisconfiguredAnnotation).toEqual(jasmine.any(Object));
 
-                expect(referenceMisconfiguredAnnotation.favoritesPath).toBe(null, "misconfigured annotation did not set the value to the default");
+                expect(referenceMisconfiguredAnnotation.table.favoritesPath).toBe(null, "misconfigured annotation did not set the value to the default");
 
                 done();
             }, function (err) {

--- a/test/specs/annotation/tests/10.table_config.js
+++ b/test/specs/annotation/tests/10.table_config.js
@@ -1,0 +1,65 @@
+exports.execute = function (options) {
+
+    describe("testing user_favorites property of table-config annotation,", function () {
+
+        var catalog_id = process.env.DEFAULT_CATALOG,
+            schemaName = "table_config",
+            tableName = "favorites_path",
+            tableNameNoAnnotation = "no_annotation",
+            tableNameMisconfiguredAnnotation = "favorites_null";
+
+        var tableUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"  + tableName,
+            tableNoAnnotationUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"  + tableNameNoAnnotation,
+            tableMisconfiguredAnnotationUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"  + tableNameMisconfiguredAnnotation;
+
+        var reference, referenceNoTableAnnotation, referenceMisconfiguredAnnotation;
+
+        // configuration:
+        //   - annotation properly defined on favorites_path
+        //   - annotation not defined on favorites_no_anno
+        //   - annoation defined improperly on favorites_null
+        it("reference should have favoritesPath set to the favorites table defined in the table-config annotation on the table", function (done) {
+            options.ermRest.resolve(tableUri, {cid: "test"}).then(function (response) {
+                reference = response;
+                expect(reference).toEqual(jasmine.any(Object));
+
+                expect(reference.favoritesPath).toBe("/ermrest/catalog/1/entity/table_config:my_favorites", "table-config annotation not set properly on table favorites_path");
+
+                done();
+            }, function (err) {
+                console.dir(err);
+                done.fail();
+            });
+        });
+
+        it("reference should have favoritesPath set to null with no table-config annotation on the table", function (done) {
+            options.ermRest.resolve(tableNoAnnotationUri, {cid: "test"}).then(function (response) {
+                referenceNoTableAnnotation = response;
+                expect(referenceNoTableAnnotation).toEqual(jasmine.any(Object));
+
+                expect(referenceNoTableAnnotation.favoritesPath).toBe(null, "default value for favoritesPath not set properly");
+
+                done();
+            }, function (err) {
+                console.dir(err);
+                done.fail();
+            });
+        });
+
+        it("reference should have favoritesPath set to null when the table-config annotation is improperly defined on the table", function (done) {
+            options.ermRest.resolve(tableMisconfiguredAnnotationUri, {cid: "test"}).then(function (response) {
+                referenceMisconfiguredAnnotation = response;
+                expect(referenceMisconfiguredAnnotation).toEqual(jasmine.any(Object));
+
+                expect(referenceMisconfiguredAnnotation.favoritesPath).toBe(null, "misconfigured annotation did not set the value to the default");
+
+                done();
+            }, function (err) {
+                console.dir(err);
+                done.fail();
+            });
+        });
+
+    });
+
+};


### PR DESCRIPTION
Changes to support `user_favorites.storage_table` property of the table-config annotation. `reference.favoritesPath` will return the ermrest path to the table that favorites are stored in for the current table. If the `storage_table` property of `user_favorites` is not defined, `reference.favoritesPath` will return null.

Test cases added to test the default value (`null`), a properly defined annotation, and an annotation with no storage table defined. I could add another test case for having table-config annotation defined but no `user_favorites` but I figured testing the case when `storage_table` is missing would imply the same thing.

_pending annotation.md changes_