### PR TITLE
google dataset: return object if string is parsable

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,3 +16,4 @@ JavaScript Client Libraries (ERMrestJS)
    user-docs/pseudo-column-template.md
    user-docs/table-alternatives.md
    user-docs/export.md
+   user-docs/google-dataset.md

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -201,7 +201,7 @@ This annotation provides an override guidance for Chaise applications using a hi
 
 Note:
 - An explicit setting of `null` will turn *off* inheritence and restore default behavior for that modele element and any of its nested elements.
-- The name_style has to be derived separately for each field e.g. one can set `underline_space=true` at the schema-level and doesn't have to set this again.   
+- The name_style has to be derived separately for each field e.g. one can set `underline_space=true` at the schema-level and doesn't have to set this again.
 
 ### Tag: 2015 Vocabulary (_deprecated_)
 
@@ -660,7 +660,7 @@ See [Context Names](#context-names) section for the list of supported _context_ 
 Supported JSON _option_ payload patterns:
 
 - `"row_order":` `[` _sortkey_ ... `]`: The list of one or more _sortkey_ defines the preferred or default order to present rows from a table. The ordered list of sort keys starts with a primary sort and optionally continues with secondary, tertiary, etc. sort keys. The given _sortkey_ s will be used as is (_columnorder_ SHOULD not be applied recursivly to this).
-- `"page_size":` `_number_`: The default number of rows to be shown on a page.  
+- `"page_size":` `_number_`: The default number of rows to be shown on a page.
 - `"collapse_toc_panel":` `_boolean_`: Controls whether the table of contents panel is collapsed on page load (only supported in `detailed` context).
 - `"hide_column_headers":` `_boolean_`: Controls whether the column names headers and separators between column values are shown (only supported in `detailed` context).
 - `"page_markdown_pattern"`: _pagepattern_: Render the page by composing a markdown representation only when `page_markdown_pattern` is non-null.
@@ -838,7 +838,7 @@ Default heuristics:
 - `url_pattern` MUST be specified for browser upload. If it is not specified or if it produces a null value, the browser upload will be disabled.
 - Column MUST be `text` typed. Otherwise the asset annotation will be ignored.
 - In addition to native columns, the following properties are also available under the annotated column object and can be referred in the _pattern_ e.g. `{{{_URI.md5_hex}}}` where `URI` is the annotated column (notice the [underscore before the column name](mustache-templating.md#raw-values)).
-  - `md5_hex` for hex  
+  - `md5_hex` for hex
   - `md5_base64` for base64
   - `filename` for filename
   - `size` for size in bytes
@@ -1062,11 +1062,11 @@ In all remaining scenarios, the problematic attribute (attributes that don't fol
 
 You can use [this](https://search.google.com/test/rich-results) tool by Google to validate any JSON-LD yourself if needed, it accepts both a URL or a code snippet.
 
-Example of annotation:
+The following is an example of this annotation. You can also find more information in [here](google-dataset.md).
 
 ```json
 {
-  "tag:isrd.isi.edu,2021:google-dataset": {  
+  "tag:isrd.isi.edu,2021:google-dataset": {
     "detailed": {
       "dataset": {
         "@context": "http://schema.org",
@@ -1114,8 +1114,8 @@ Note:
 List of _context_ names that are used in ERMrest:
 
 - `"compact"`: Any compact, tabular presentation of data from multiple entities.
-  - `"compact/brief"`: A limited compact, tabular presentation of data from multiple entities to be shown under the `detailed` context. In this context, only a page of data will be shown with a link to the access the `compact` context for more detail (related entities section).  
-  - `"compact/brief/inline"`: A limited inline, compact, tabular presentation of data from multiple entities to be shown under the `detailed` context. In this context, only a page of data will be shown with a link to the access the `compact` context for more detail (inline related entities section).  
+  - `"compact/brief"`: A limited compact, tabular presentation of data from multiple entities to be shown under the `detailed` context. In this context, only a page of data will be shown with a link to the access the `compact` context for more detail (related entities section).
+  - `"compact/brief/inline"`: A limited inline, compact, tabular presentation of data from multiple entities to be shown under the `detailed` context. In this context, only a page of data will be shown with a link to the access the `compact` context for more detail (inline related entities section).
   - `"compact/select"`: A sub-context of `compact` that is used for selecting entities, e.g. when prompting the user for choosing a foreign key or facet value.
 - `"detailed"`: Any detailed read-only, entity-level presentation context.
 - `"entry"`: Any data-entry presentation context, i.e. when prompting the user for input column values.

--- a/docs/user-docs/google-dataset.md
+++ b/docs/user-docs/google-dataset.md
@@ -1,0 +1,135 @@
+# Google dataset annotation
+
+By using [google-dataset](annotation.md#tag-2021-google-dataset) annotation, you can define the metadata that will be converted to valid and well-formed JSON-LD referencing a table. In terms of SEO, JSON-LD is implemented leveraging the Schema.org vocabulary, which is a unified structured data vocabulary for the web. [Google Dataset Search](https://datasetsearch.research.google.com/) discovers datasets when a valid JSON-LD of type [Dataset](https://www.schema.org/Dataset) is added to the HTML page.
+
+The is how this annotation looks like:
+
+```javascript
+{
+  "tag:isrd.isi.edu,2021:google-dataset": {
+    "detailed": {
+      "dataset": {
+        // the JSON-LD defnition goes here
+      },
+      "template_engine": "handlebars"
+    }
+  }
+}
+```
+
+## Expected Fields
+
+Given that we expect a valid JSON-LD of Dataset, the following properties must be defined on top level:
+
+- `@context`: It is a schema for your data, not only defining the property datatypes but also the classes of json resources. Default applied if none exists is `http://schema.org`.
+- `@type`: Used to set the data type of a node or typed value. At the top level, only a value of `Dataset` is supported. Default applied if none exists is `Dataset`.
+
+To make sure the given JSON-LD is valid and honors the [Schema.org](https://schema.org/Dataset) specifications, ERMrestJS uses [this](https://github.com/informatics-isi-edu/ermrestjs/blob/master/js/utils/json_ld_schema.js) file which is a subset of Schema.org vocabulary. Based on this file `name` and `description` are the other top-level required properties. Therefore the following is the bare minimum acceptable JSON-LD defnition:
+
+```json
+{
+  "@type": "Dataset",
+  "context": "https://schema.org",
+  "name": "some name",
+  "description": "Some description that must be at least 50 characters."
+}
+```
+
+## Guidelines
+
+In this section, we will summarize some of the best practices or common ways of writing this annotation.
+
+> to make this document shorter and easier to read, we will only write the JSON-LD without the annotation tag and other properties. Also, all the templates are written based on `handlebars` template engine.
+
+1. All the properties support [pattern expansion](annotation.md#pattern-expansion). Apart from the main table data and all-outbound foreign keys, the pattern has access to a `$self` object that has the following properties:
+    - `rowName`: Row-name of the represented row.
+    - `uri.detailed`: a uri to the row in `detailed` context.
+
+    ```javascript
+    {
+      "@type": "Dataset",
+      "context": "https://schema.org",
+      "name": "Table: {{{$self.rowName}}}",
+      "description": "{{{Description}}}",
+      "url": "{{{$self.uri.detailed}}}"
+    }
+    ```
+
+2. If you want to make sure this annotation is only added for certain rows, you can write conditional logic for the `name` or `description` properties (given that these two are required). In the following example, we are making sure that the JSON-LD is only added for rows with `Consortium=cons1`:
+
+    ```javascript
+    {
+      "name": "{{#if (eq _Consortium \"cons1\" )}}{{{Title}}}{{/if}}",
+      ...
+    }
+    ```
+
+3. You can use [Google's documentation](https://developers.google.com/search/docs/advanced/structured-data/dataset#dataset) to find the recommended list of properties. In the following we summarized some of the key information in this document:
+    - `description` must be between **50** and **5000** characters and may also include Markdown syntax.
+    - Embedded images in `description` need to use absolute path URLs (instead of relative paths).
+    - `identifier` can be used to denote a DOI or a Compact Identifier. If the dataset has more than one identifier, given that we're using JSON (and it must be JSON parsable), you can define an array of identifiers.
+
+4. Any non-required JSON-LD properties can be an array. For instance, if you want to encode multiple `funder` you can do the following:
+   ```javascript
+   {
+     "funder": [
+       {
+         "@type": "Organization",
+         "name": "funder1"
+       },
+       {
+         "@type": "Organization",
+         "name": "funder2"
+       }
+     ],
+     ...
+   }
+   ```
+
+5. If the value of a property is the string representation of a JSON object, ERMrestJS will turn it into an object. This would allow us to write patterns that produce an object.
+
+    5.1. For example assume that we have an array column called "authors" which has a value of `["John", "Jessica"]`, then we could do
+
+    ```javascript
+    {
+      "creator": "{{#if authors}} [ {{#each _authors}} { \"@type\":\"Person\", \"name\":{{{this}}} } {{#unless @last}}, {{/unless}}{{/each}} ] {{/if}}",
+      ...
+    }
+    ```
+    which would return
+    ```javascript
+    {
+      "creator": [
+        {
+          "@type": "Person",
+          "name": "John"
+        },
+        {
+          "@type": "Person",
+          "name": "Jessica"
+        }
+      ]
+    }
+    ```
+
+    5.2. Or let's say we want to store the value of a property in a jsonb column called `funder_jsonb_col`, then we could simply use the formatted value of that column:
+
+    ```javascript
+    {
+      "funder": "{{{funder_jsonb_col}}}",
+      ...
+    }
+    ```
+    This only works because ERMrestJS returns the string representation of the raw value when you do `{{{funder_jsonb_col}}}`.
+
+    5.3. But in a case where this value is stored in a field of a jsonb column, you cannot just directly pass the value and you have to turn it into a string first. For this case assume that we have a `DataCatalog` jsonb column where it has `funder` and `creator` fields. The following is how you can use this column:
+    ```javascript
+    {
+      "funder": "{{#jsonStringify}}{{{_DataCatalog.funder}}}{{/jsonStringify}}",
+      "creator": "{{#jsonStringify}}{{{_DataCatalog.funder}}}{{/jsonStringify}}",
+      ...
+    }
+    ```
+    Notice that we had to use `_DataCatalog` to access the raw value, and also call `jsonStringify` to turn the `funder` raw object into a string.
+
+

--- a/docs/user-docs/mustache-templating.md
+++ b/docs/user-docs/mustache-templating.md
@@ -8,7 +8,7 @@ The most basic tag type is a simple variable. A {{{name}}} tag renders the value
 
 ### Usage
 
-* `{{{COLUMN_NAME}}}` : The triple curly braces will replace the column value as is.  
+* `{{{COLUMN_NAME}}}` : The triple curly braces will replace the column value as is.
 
 ### Raw Values
 
@@ -19,6 +19,8 @@ By default ermrestJS returns formatted values for a column. If you need to acces
 
 {{{_user}}}
 ```
+
+In case of `jsonb` columns, `{{{col}}}` will return the string representation of the value, while `{{{_col}}}` can be used to access the raw value of the column. This will allow you to access the fields in the jsonb value. For instance if the jsonb value is `{"name": 1234}`, then you can use `{{{_col.name}}}` to access the `name` field. While accessing the raw jsonb column, we don't allow you to access the "formatted" values and the returned value is the raw field value. In the example above, `{{{_col.name}}}` will return "1234" and not "1,234".
 
 ### Foreign Key Values
 
@@ -197,7 +199,7 @@ To make sure that you handle above case, wrap properties which can be null insid
 
 ### Using Pre-defined Attributes
 
-Ermrestjs now allows users to access some pre-defined variables in the template environment for ease. You need to make sure that you don't use these variables as column-names in your tables to avoid them being overridden in the environment.  
+Ermrestjs now allows users to access some pre-defined variables in the template environment for ease. You need to make sure that you don't use these variables as column-names in your tables to avoid them being overridden in the environment.
 
 One of those variable is `$moment`.
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -6074,7 +6074,7 @@
                         element,
                         templateVariables,
                         table.schema.catalog,
-                        { templateEngine: templateEngine }
+                        { templateEngine: templateEngine, allowObject: true }
                     ));
                 });
             }
@@ -6083,7 +6083,7 @@
                     metadataAnnotation[key],
                     templateVariables,
                     table.schema.catalog,
-                    { templateEngine: templateEngine }
+                    { templateEngine: templateEngine, allowObject: true }
                 );
             }
         });

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -3056,6 +3056,8 @@
      * acceptable options:
      * - templateEngine: "mustache" or "handlbars"
      * - avoidValidation: to avoid validation of the template
+     * - allowObject: if the returned string is a parsable object, return it as object
+     *                instead of string.
      *
      * @param  {string} template - template to be rendered
      * @param  {object} keyValues - formatted key value pairs needed for the template
@@ -3065,19 +3067,30 @@
      */
     module._renderTemplate = function (template, keyValues, catalog, options) {
 
-        var obj = {};
-
         if (typeof template !== 'string') return null;
 
         options = options || {};
 
+        var res, objRes;
         if (options.templateEngine === module.HANDLEBARS) {
             // render the template using Handlebars
-            return module.renderHandlebarsTemplate(template, keyValues, catalog, options);
+            res = module.renderHandlebarsTemplate(template, keyValues, catalog, options);
+        } else {
+            // render the template using Mustache
+            res = module._renderMustacheTemplate(template, keyValues, catalog, options);
         }
 
-        // render the template using Mustache
-        return module._renderMustacheTemplate(template, keyValues, catalog, options);
+        if (options.allowObject) {
+            try {
+                // if it can be parsed and is an object, return the object
+                var objRes = JSON.parse(res);
+                if (typeof objRes === "object") {
+                    return objRes;
+                }
+            } catch (exp) {}
+        }
+
+        return res;
     };
 
     /**

--- a/js/utils/json_ld_schema.js
+++ b/js/utils/json_ld_schema.js
@@ -1,21 +1,22 @@
 /**
  * This JSON was generated with the help of scripts/google_dataset/schema_org_sparql.py
- * Format : {
- * SchemaOrgClass: {
-        "properties": {
-           Prop1:{"types":[Type1, Type2, ...]}, 
-           Prop2: {"types":[Type1, Type2, ...]}, 
-           ...}
-       },
-       "requiredProperties": [Prop2,...],
-        "parent": SchemaOrgParentClass
-    }
-    Here parent is a class who properties are inherited by the child class SchemaOrgClass and can be used in the JSON-LD for SchemaOrgClass
-    This JSON consists of a subset of the original list of properties and types provided by schema.org
-    The original list and description of each property can be found by going to schema.org/SchemaOrgClass , for example schema.org/Dataset
-    The details of any property can be found by going to schema.org/Prop , for example schema.org/citation
-    */
-   
+ * Format :
+ * {
+ *   SchemaOrgClass: {
+ *      "properties": {
+ *         Prop1:{"types":[Type1, Type2, ...]},
+ *         Prop2: {"types":[Type1, Type2, ...]},
+ *         ...}
+ *     },
+ *     "requiredProperties": [Prop2,...],
+ *     "parent": SchemaOrgParentClass
+ *   }
+ * }
+ * Here `parent` is a class who properties are inherited by the child class SchemaOrgClass and can be used in the JSON-LD for SchemaOrgClass
+ * This JSON consists of a subset of the original list of properties and types provided by schema.org
+ * The original list and description of each property can be found by going to schema.org/SchemaOrgClass , for example schema.org/Dataset
+ * The details of any property can be found by going to schema.org/Prop , for example schema.org/citation
+ */
 module.jsonldSchemaPropObj = Object.freeze({
     "CreativeWork": {
         "properties": {

--- a/test/specs/json_ld/conf/google_metadata/data/google_metadata_w_handlebars.json
+++ b/test/specs/json_ld/conf/google_metadata/data/google_metadata_w_handlebars.json
@@ -12,7 +12,18 @@
   "luxurious": "true",
   "RID": "1Y2",
   "RCT": "2021-06-29 15:16:24",
-  "RMT": "2021-06-29 15:16:24"
+  "RMT": "2021-06-29 15:16:24",
+  "DataCatalog": {
+    "funder": {
+      "@type": "Organization",
+      "name": "Funder name",
+      "url": "https://www.example.com/"
+    }
+  },
+  "citation_jsonb": {
+    "@type": "CreativeWork",
+    "url": "https://citation.com"
+  }
 },
 {
   "id": "2004",

--- a/test/specs/json_ld/conf/google_metadata/schema.json
+++ b/test/specs/json_ld/conf/google_metadata/schema.json
@@ -50,6 +50,18 @@
                     "type": {
                         "typename": "text"
                     }
+                },
+                {
+                    "name": "DataCatalog",
+                    "type": {
+                        "typename": "jsonb"
+                    }
+                },
+                {
+                    "name": "citation_jsonb",
+                    "type": {
+                        "typename": "jsonb"
+                    }
                 }
             ],
             "annotations": {
@@ -78,7 +90,9 @@
                             "dateModified": "{{{RMT}}}",
                             "datePublished": "{{{RCT}}}",
                             "isAccessibleForFree": "{{{luxurious}}}",
-                            "url": "{{{$self.uri.detailed}}}"
+                            "url": "{{{$self.uri.detailed}}}",
+                            "funder": "{{#jsonStringify}}{{{_DataCatalog.funder}}}{{/jsonStringify}}",
+                            "citation": "{{{citation_jsonb}}}"
                         },
                         "template_engine": "handlebars"
                     }

--- a/test/specs/json_ld/resources/generated_json_ld.json
+++ b/test/specs/json_ld/resources/generated_json_ld.json
@@ -19,5 +19,14 @@
     "description": "NH Hotels has six resorts in the city of Munich. Very close to Munich Main Train Station -- the train being one of the most interesting choices of transport for travelling around Germany -- is the four-star NH München Deutscher Kaiser Hotel. In addition to the excellent quality of accommodation that it offers, the hotel is located close to Marienplatz, the monumental central square in the city, the Frauenkirche church, Stachus (Karlsplatz) and the Viktualienmarkt. Other places of interest to explore in Munich are the English garden, the spectacular Nymphenburg Palace and the German Museum, a museum of science and technology very much in keeping with the industrial spirit of the city. Do not forget to visit Munich at the end of September and beginning of October, the time for its most famous international festival: Oktoberfest! Beer, sausages, baked knuckles and other gastronomic specialities await you in a festive atmosphere on the grasslands of Theresienwiese. Not to be missed! And with NH Hotels you can choose the hotels in Munich which best suit your travel plans, with free WiFi and the possibility to bring your pets with you.",
     "dateModified": "2021-07-09 11:27:10",
     "datePublished": "2021-07-09 11:27:10",
-    "isAccessibleForFree": "true"
+    "isAccessibleForFree": "true",
+    "funder": {
+        "@type": "Organization",
+        "name": "Funder name",
+        "url": "https://www.example.com/"
+    },
+    "citation": {
+        "@type": "CreativeWork",
+        "url": "https://citation.com"
+    }
 }

--- a/test/specs/json_ld/tests/01.reference_google_dataset.js
+++ b/test/specs/json_ld/tests/01.reference_google_dataset.js
@@ -4,7 +4,7 @@ var utils = require('./../../../utils/utilities.js');
 exports.execute = function (options) {
 
     describe('For determining google_metadata annotation, ', function () {
-        
+
         var catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "google_metadata_schema",
             tableName = "google_metadata_w_handlebars";
@@ -75,8 +75,7 @@ exports.execute = function (options) {
 
 
                 var metadata = reference.googleDatasetMetadata.compute(tuple);
-                expect(metadata).toBeObject();
-                expect(JSON.stringify(metadata)).toBeJsonString();
+                expect(metadata).toBeDefined();
                 expect(metadata.url).toEqual(expectedVal.url);
                 // date formats come differently so standardize them
                 expectedVal.datePublished = new Date(utils.findEntity(options, schemaName, tableName, "id", "2003").RCT).getDate();


### PR DESCRIPTION
While writing google dataset annotation for GUDMAP we realized that we might want to store the value of some JSON-LD properties in database. In this case, all the properties related to the consortium will come from a foreign key relationship, and we don't want to hard code the values for each dataset and instead we want the consortium to have those values in database. 

With the currently deployed code, we then have to write each individual value of the property:

```json
{
    "funder":  {
       "@type": "Organization",
     "name": "{{{$fkey_RNASeq_Study_Consortium_fkey.values._DataCatalog.funder.name}}",
      "url": "{{{$fkey_RNASeq_Study_Consortium_fkey.values._DataCatalog.funder.url}}"
    },
    "publisher": {
        "@type": "Organization",
        "name": "{{{$fkey_RNASeq_Study_Consortium_fkey.values._DataCatalog.publisher.name}}}",
        "url": "{{{$fkey_RNASeq_Study_Consortium_fkey.values._DataCatalog.publisher.url}}}"
    }
}
```
Which as you can see it doesn't scale and causes too many repetition. Also if we want each of these attributes to be an array, then we cannot easily do this. So we decided to allow data-modelers to define objects in the template. 

We [talked about this this before](https://github.com/informatics-isi-edu/chaise/issues/1801#issuecomment-871599855) and at the time we were thinking about adding a signal to mark a property as object or not. But we realized that we don't really need this. As long as the value can be parsed as an object, we can treat it as object. 

This will of course limit the data-modelers as you cannot write an object parsable string and expect it to remain as string. But in case of this annotation, this limitation doesn't seem too important. We couldn't think of an example where you might actually want the string to be treated differently. 

That being said, we can later change the behavior if we realized that we don't want to limit data-modelers in this way.

With the changes in this PR, we can rewrite the annotation like this:

```json
{
    "funder":  "{{#jsonStringify}}{{{$fkey_RNASeq_Study_Consortium_fkey.values._DataCatalog.funder}}{{/jsonStringify}}",
    "publisher":  "{{#jsonStringify}}{{{$fkey_RNASeq_Study_Consortium_fkey.values._DataCatalog.publisher}}{{/jsonStringify}}",
}
```


P.S. As part of this PR I also added a documentation to have all the guidelines related to the google dataset annotation.