### PR TITLE
Introduce export fragment annotation

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -164,6 +164,7 @@ to use for ERMrest JavaScript agents.
             * [.uri](#ERMrest.Table+uri) : <code>string</code>
             * [.sourceDefinitions](#ERMrest.Table+sourceDefinitions) : <code>Object</code>
             * [.searchSourceDefinition](#ERMrest.Table+searchSourceDefinition) : <code>Array.&lt;Object&gt;</code> \| <code>false</code>
+                * [~_getSearchSourceDefinition()](#ERMrest.Table+searchSourceDefinition.._getSearchSourceDefinition)
             * [.pureBinaryForeignKeys](#ERMrest.Table+pureBinaryForeignKeys) : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
             * [._getRowDisplayKey(context)](#ERMrest.Table+_getRowDisplayKey)
             * [.getExportTemplates()](#ERMrest.Table+getExportTemplates) : <code>Array</code> \| <code>null</code>
@@ -1217,6 +1218,7 @@ check for table name existence
         * [.uri](#ERMrest.Table+uri) : <code>string</code>
         * [.sourceDefinitions](#ERMrest.Table+sourceDefinitions) : <code>Object</code>
         * [.searchSourceDefinition](#ERMrest.Table+searchSourceDefinition) : <code>Array.&lt;Object&gt;</code> \| <code>false</code>
+            * [~_getSearchSourceDefinition()](#ERMrest.Table+searchSourceDefinition.._getSearchSourceDefinition)
         * [.pureBinaryForeignKeys](#ERMrest.Table+pureBinaryForeignKeys) : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
         * [._getRowDisplayKey(context)](#ERMrest.Table+_getRowDisplayKey)
         * [.getExportTemplates()](#ERMrest.Table+getExportTemplates) : <code>Array</code> \| <code>null</code>
@@ -1374,6 +1376,13 @@ Returns an object with
 Returns an array of SourceObjectWrapper objects.
 
 **Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
+<a name="ERMrest.Table+searchSourceDefinition.._getSearchSourceDefinition"></a>
+
+##### searchSourceDefinition~\_getSearchSourceDefinition()
+search-box is either on the first level below the annotation,
+or parts of sources.
+
+**Kind**: inner method of [<code>searchSourceDefinition</code>](#ERMrest.Table+searchSourceDefinition)  
 <a name="ERMrest.Table+pureBinaryForeignKeys"></a>
 
 #### table.pureBinaryForeignKeys : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -772,13 +772,13 @@ This key can be used to define export templates that will be used for `ioboxd` s
 
 Supported JSON payload patterns:
 
-- `{` ... _context_ `:` `{` `"templates":` `[`_template_`]` `}` `,` ... `}`: An array of template objects to export.
+- `{` ... _context_ `:` `{` `"templates":` `[`_template_ `,` ... `]` `}` `,` ... `}`: An array of template objects to export.
 - `{` ... _context1_ `:` _context2_ ... `}`: Short-hand to allow _context1_ to use the same templates configured for _context2_.
 
 Supported _template_ patterns:
 - `{` ... `"displayname:"` _displayname_ ... `}`: The display name that will be used to populate the Chaise export drop-down for this _template_.
 - `{` ... `"type:"` _type_ ... `}` One of two keywords; _"FILE"_ or _"BAG"_, used to determine the container format for results.
-- `{`... `"outputs":` `[`_output_`]` ... `}`: An array of _output_ objects. If the template type is _"BAG"_ you MAY leave this attribute and not define it. In this case, the default `outputs` that the client generates will be used.
+- `{`... `"outputs":` `[`_output_`]` ... `}`: An array of _output_ objects.
 
 Supported _output_ patterns:
 - `{`... `"source:"` _sourceentry_ ... `}`: An object that contains parameters used to generate source data by querying ERMrest.
@@ -799,7 +799,7 @@ This annotation only applies to table but MAY be annotated at the schema level t
 
 #### Heurisistics
 
-If the annotation is missing from the table and the schema, client MAY apply a set of heuristics. Currently, chaise will apply some heursitscs only in `detailed` context (record app) which you can find more information about it [in here](export.md#how-ermrestjs-interperts-it).
+If the annotation is missing from the table, schema and catalog, client MAY apply a set of heuristics. Currently, chaise will apply some heursitscs only in `detailed` context (record app) which you can find more information about it [in here](export.md#default-bdbag-template).
 
 ### Tag: 2016 Export (_Deprecated_)
 

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -47,32 +47,33 @@ TBD changes to propose for ERMrest:
 Some annotations are supported on multiple types of model element, so
 here is a quick matrix to locate them.
 
-| Annotation                                                  | Catalog | Schema | Table | Column | Key | FKR | Summary                                       |
-|-------------------------------------------------------------|---------|--------|-------|--------|-----|-----|-----------------------------------------------|
-| [2015 Display](#tag-2015-display)                           | X       | X      | X     | X      | X   | -   | Display options                               |
-| [2015 Vocabulary](#tag-2015-vocabulary-deprecated) (_deprecated_) | -       | -      | X     | -      | -   | -   | Table as a vocabulary list                    |
-| [2016 Table Alternatives](#tag-2016-table-alternatives)     | -       | -      | X     | -      | _   | _   | Table abstracts another table                 |
-| [2016 Column Display](#tag-2016-column-display)             | -       | -      | -     | X      | -   | -   | Column-specific display options               |
-| [2017 Key Display](#tag-2017-key-display)                   | -       | -      | -     | -      | X   | -   | Key augmentation                              |
-| [2016 Foreign Key](#tag-2016-foreign-key)                   | -       | -      | -     | -      | -   | X   | Foreign key augmentation                      |
-| [2016 Generated](#tag-2016-generated)                       | -       | X      | X     | X      | -   | -   | Generated model element                       |
-| [2016 Ignore](#tag-2016-ignore-deprecated) (_deprecated_)   | -       | X      | X     | X      | -   | -   | Ignore model element                          |
-| [2016 Immutable](#tag-2016-immutable)                       | -       | X      | X     | X      | -   | -   | Immutable model element                       |
-| [2016 Non Deletable](#tag-2016-non-deletable)               | -       | X      | X     | -      | -   | -   | Non-deletable model element                   |
-| [2016 App Links](#tag-2016-app-links)                       | -       | X      | X     | -      | -   | -   | Intra-Chaise app links                        |
-| [2016 Table Display](#tag-2016-table-display)               | -       | -      | X     | -      | -   | -   | Table-specific display options                |
-| [2016 Visible Columns](#tag-2016-visible-columns)           | -       | -      | X     | -      | -   | -   | Column visibility and presentation order      |
-| [2016 Visible Foreign Keys](#tag-2016-visible-foreign-keys) | -       | -      | X     | -      | -   | -   | Foreign key visibility and presentation order |
-| [2019 Export](#tag-2019-export)                             | -       | X      | X     | -      | -   | -   | Describes export templates                    |
-| [2016 Export](#tag-2016-export-deprecated) (_deprecated_)   | -       | X      | X     | -      | -   | -   | Describes export templates                    |
-| [2017 Asset](#tag-2017-asset)                               | -       | -      | -     | X      | -   | -   | Describes assets                              |
-| [2018 Citation](#tag-2018-citation)                         | -       | -      | X     | -      | -   | -   | Describes citation                            |
-| [2018 Required](#tag-2018-required)                         | -       | -      | -     | X      | -   | -   | Required model column                         |
-| [2018 Indexing Preferences](#tag-2018-indexing-preferences) | -       | -      | X     | X      | -   | -   | Specify database indexing preferences         |
-| [2019 Chaise Config](#tag-2019-chaise-config)               | X       | -      | -     | -      | -   | -   | Properties to configure chaise app UX         |
-| [2019 Source Definitions](#tag-2019-source-definitions)     | -       | -      | X     | -      | -   | -   | Describe source definitions                   |
-| [2021 Google Dataset](#tag-2021-google-dataset)             | -       | -      | X     | -      | -   | -   | Describe metadata for rich results in Google Dataset |
-| [2021 Table Config](#tag-2021-table-config)                 | -       | -      | X     | -      | -   | -   | Describe Table Config                         |
+| Annotation                                                               | Catalog | Schema | Table | Column | Key | FKR | Summary                                                        |
+|--------------------------------------------------------------------------|---------|--------|-------|--------|-----|-----|----------------------------------------------------------------|
+| [2015 Display](#tag-2015-display)                                        | X       | X      | X     | X      | X   | -   | Display options                                                |
+| [2015 Vocabulary](#tag-2015-vocabulary-deprecated) (_deprecated_)        | -       | -      | X     | -      | -   | -   | Table as a vocabulary list                                     |
+| [2016 Table Alternatives](#tag-2016-table-alternatives)                  | -       | -      | X     | -      | _   | _   | Table abstracts another table                                  |
+| [2016 Column Display](#tag-2016-column-display)                          | -       | -      | -     | X      | -   | -   | Column-specific display options                                |
+| [2017 Key Display](#tag-2017-key-display)                                | -       | -      | -     | -      | X   | -   | Key augmentation                                               |
+| [2016 Foreign Key](#tag-2016-foreign-key)                                | -       | -      | -     | -      | -   | X   | Foreign key augmentation                                       |
+| [2016 Generated](#tag-2016-generated)                                    | -       | X      | X     | X      | -   | -   | Generated model element                                        |
+| [2016 Ignore](#tag-2016-ignore-deprecated) (_deprecated_)                | -       | X      | X     | X      | -   | -   | Ignore model element                                           |
+| [2016 Immutable](#tag-2016-immutable)                                    | -       | X      | X     | X      | -   | -   | Immutable model element                                        |
+| [2016 Non Deletable](#tag-2016-non-deletable)                            | -       | X      | X     | -      | -   | -   | Non-deletable model element                                    |
+| [2016 App Links](#tag-2016-app-links)                                    | -       | X      | X     | -      | -   | -   | Intra-Chaise app links                                         |
+| [2016 Table Display](#tag-2016-table-display)                            | -       | -      | X     | -      | -   | -   | Table-specific display options                                 |
+| [2016 Visible Columns](#tag-2016-visible-columns)                        | -       | -      | X     | -      | -   | -   | Column visibility and presentation order                       |
+| [2016 Visible Foreign Keys](#tag-2016-visible-foreign-keys)              | -       | -      | X     | -      | -   | -   | Foreign key visibility and presentation order                  |
+| [2019 Export](#tag-2019-export)                                          | X       | X      | X     | -      | -   | -   | Describes export templates                                     |
+| [2016 Export](#tag-2016-export-deprecated) (_deprecated_)                | X       | X      | X     | -      | -   | -   | Describes export templates                                     |
+| [2017 Asset](#tag-2017-asset)                                            | -       | -      | -     | X      | -   | -   | Describes assets                                               |
+| [2018 Citation](#tag-2018-citation)                                      | -       | -      | X     | -      | -   | -   | Describes citation                                             |
+| [2018 Required](#tag-2018-required)                                      | -       | -      | -     | X      | -   | -   | Required model column                                          |
+| [2018 Indexing Preferences](#tag-2018-indexing-preferences)              | -       | -      | X     | X      | -   | -   | Specify database indexing preferences                          |
+| [2019 Chaise Config](#tag-2019-chaise-config)                            | X       | -      | -     | -      | -   | -   | Properties to configure chaise app UX                          |
+| [2019 Source Definitions](#tag-2019-source-definitions)                  | -       | -      | X     | -      | -   | -   | Describe source definitions                                    |
+| [2021 Google Dataset](#tag-2021-google-dataset)                          | -       | -      | X     | -      | -   | -   | Describe metadata for rich results in Google Dataset           |
+| [2021 Table Config](#tag-2021-table-config)                              | -       | -      | X     | -      | -   | -   | Describe Table Config                                          |
+| [2021 Export Fragment Definitions](#tag-2021-export-fragment-definitions)| X       | X      | X     | -      | -   | -   | Describe export fragments that may be used in export anotation |
 
 For brevity, the annotation keys are listed above by their section
 name within this documentation. The actual key URI follows one of these formats:
@@ -1059,7 +1060,7 @@ Supported _columns_ patterns:
 - `true`: By setting the value of `"columns"` to `true`, chaise will provide the data for all the outbound foreign keys fo the table in templating environments.
 - _Any other values_ : In this case chaise will not provide any foreign key data in templating environments.
 
-## Tag: 2021 Google Dataset
+### Tag: 2021 Google Dataset
 `tag:isrd.isi.edu,2021:google-dataset`
 
 This key indicates the metadata that will be converted to valid and well-formed JSON-LD referencing a table. In terms of SEO, JSON-LD is implemented leveraging the Schema.org vocabulary, which is a unified structured data vocabulary for the web. [Google Dataset Search](https://datasetsearch.research.google.com/) discovers datasets when a valid JSON-LD of type [Dataset](https://www.schema.org/Dataset) is added to the HTML page.
@@ -1119,7 +1120,7 @@ The following is an example of this annotation. You can also find more informati
   }
 }
 ```
-## Tag: 2021 Table Config
+### Tag: 2021 Table Config
 `tag:isrd.isi.edu,2021:table-config`
 
 This key indicates that the annotated table has a specific configuration options that modify the behavior of the table when accessing the APIs.
@@ -1139,7 +1140,12 @@ Note:
 - "Stable key" is used to provide a more stable and presistent value for entity facets and used in combination of "save query" feature. In some cases the model might change and the facet definitions are optimized to be performant and not stable/persistence. In these circumstances you can define a "stable key" for the table and Chaise will store value of stable key instead.
 
 
-### Context Names
+### Tag: 2021 Export Fragment Definitions
+
+`tag:isrd.isi.edu,2021:export-fragment-definitions`
+
+By using this key you can define an object that can be referred to while writing export annotation. The value of this key MUST be an object, otherwise it will be ignored. Please refer to `[Export annotation document](export.md)` for more details.
+## Context Names
 
 List of _context_ names that are used in ERMrest:
 

--- a/docs/user-docs/export.md
+++ b/docs/user-docs/export.md
@@ -2,37 +2,167 @@
 
 Using the [export annotation](annotation.md#tag-2019-export) you can define export templates that will be used for `ioboxd` service integration with the client tools. For detailed information please refer to [the ioboxd documentation](https://github.com/informatics-isi-edu/ioboxd/blob/master/doc/integration.md).
 
+To make the process of writing export annotation simpler and modular, you can use [export fragment annotation](annotation.md#tag-2021-export-fragment-annotations). 
 
-## Structure
+
+## Export Template Structure
 
 The following is how ERMrestJS and Chaise leverage the different values defined in the export annotation:
 
 ```js
-"templates": [
-  {
-    "displayname": <chaise-display-name>, // name displayed in dropdown menu in the client
-    "type": <FILE or BAG>,
-    "outputs": [
-      {
-        "source": {
-          "api": <ermrest-query-type>, // entity, attribute, attribute-group
-          "path": <optional-ermrest-predicate> // used to represent more complex queries
-        },
-        destination: {
-          "name": <output-file-base-name>,
-          "type": <output-format-suffix>, // FILE supports csv, json; BAG supports csv, json, fetch(?), download(?)
-          "params": <not-sure> // conditionally optional
-        }
-      }, ...
-    ]
-  }
-]
+{
+  "templates": [
+    {
+      "displayname": <chaise-display-name>, // name displayed in dropdown menu in the client
+      "type": <FILE or BAG>, // whether we should call export module or send a direct request to ERMrest
+      "outputs": [
+        {
+          "source": {
+            "api": <ermrest-query-type>, // entity, attribute, attribute-group
+            "path": <optional-ermrest-predicate> // used to represent more complex queries
+          },
+          destination: {
+            "name": <output-file-base-name>,
+            "type": <output-format-suffix>, // FILE supports csv, json; BAG supports csv, json, fetch, download
+            "params": {} // conditionally optional
+          }
+        }, ...
+      ],
+      "transforms": [], // refer to export module for more details
+      "postprocessors": [], // refer to export module for more details
+      "public": <Boolean>, // refer to export module for more details
+      "bag_archiver": <string> // refer to export module for more details
+    }
+  ]
+}
 ```
 
-## How ERMrestJS Interperts It
+## How it works
+
+For processing export, we have to consult [export annotation](annotation.md#tag-2019-export) and [export fragment annotation](annotation.md#tag-2021-export-fragment-annotations). The following is how ERMrestJS looks at these two annotations:
+
+1. We start by creating a fragment object that can be used while writing export annotation. To do so, 
+
+    1.1. The following is the starting default object:
+      ```js
+      {
+        "$chaise_default_bdbag_template": {
+          "type": "BAG",
+          "displayname": "$chaise_default_bdbag_displayname",
+          "outputs": "$chaise_default_bdbag_outputs"
+        },
+        "$chaise_default_bdbag_displayname": "BDBag",
+        "$chaise_default_bdbag_outputs": <chaise-default-bdbag>
+      }
+      ```
+      > for more information about the chaise default BDBag, please navigate to [this section](#default-bdbag-template).
+
+    1.2. We look for the export fragment definitions annotation on catalog, if defined, we will merge the starting object with what's defined on catalog. This will allow you to override the default properties that we're adding. This step will continue for schema, as well as, table. 
+
+2. In this step, we will find the export templates that should be used. Given that this annotation is used for a specific table in a specific context, the following is how we find the proper definition:
+    - If the annotation is defined for the context on table, use it.
+    - Otherwise, if the annotation is defined for the context on schema, use it.
+    - Otherwise, if the annotation is defined for the context on catalog, use it.
+    - Otherwise, if chaise-config `disableDefaultExport` is not set to `true`, apply the following default annotation:
+      ```json
+      {
+        "tag:isrd.isi.edu,2019:export": {
+          "*": {
+            "templates": []
+          },
+          "detailed": {
+            "templates": { "fragment_key": "$chaise_default_bdbag_template"}
+          }
+        } 
+      }
+      ```
+
+3. Now that we have the export definition as well as fragments, we just need to make sure any usage of `fragment_key` is replace with the actual definition.
+
+<!-- TODO REQUIRES MORE INFO -->
+
+4. As the last step, to just ensure Chaise is not throwing a terminal error, we will validate the templates and ignore the ones that are problematic. The following are the checks that we're doing:
+  - Template is an array.
+  - Template has `displayname` and `type`.
+  - `type` value is either `FILE` or `BAG`.
+  - `outputs` is a non-empty array.
+  - Each output in the `outputs` array has `source` and `destination`.
+  - `source` has `api` property.
+  - `destination` has `type` property.
+
+### Examples
 
 
-This annotation only applies to a table, but MAY be annotated at the schema level to set a schema-wide default. If the annotation is missing on the table, we will get the export definition from the schema. If the annotation is missing from both schema and table, we are going to apply default heuristics for this annotation only in `detailed` context. This means if you navigate to a page with `detailed` context (record page in chaise) and you haven't defined any export annotation, we are going to use the default export template. The following is the content of the generated default export template:
+#### Example 1
+
+In this example, we want to add a new template to a table that uses the same default BDBag template, but with a customized post process. To do so, we just have to make sure we're using the predefined `fragment_key`:
+
+```js
+{
+  "tag:isrd.isi.edu,2019:export": {
+    "detailed": {
+      "templates": [
+        {
+          "displayname": "New template",
+          "type": "BAG",
+          "outputs": [
+            {"fragment_key": "$chaise_default_bdbag_template"}
+          ],
+          "postprocessors": [
+            // the custom post process goes here
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+#### Example 2
+Let's assume you want to create global templates that should be used on every table. To do so,
+
+- First define the templates as a fragment that can be used later. Since we want a global template, we would define this on catalog:
+    ```js
+    {
+      "tag:isrd.isi.edu,2021:export-fragment-definitions": {
+        "my_default_templates": [
+          // your templates go here
+        ]
+      }
+    }
+    ```
+
+- To make sure tables/schemas that don't have any annotation inject these templates, you can define a catalog-level export annotation like this:
+    ```js
+    {
+      "tag:isrd.isi.edu,2019:export": {
+        "*": {
+          "templates": [
+            {"fragment_key": "my_default_templates"}
+          ]
+        }
+      }
+    }
+    ```
+
+- For tables that already have this annotation, you can just inject this fragment in the list of templates:
+    ```js
+    {
+      "tag:isrd.isi.edu,2019:export": {
+        "*": {
+          "templates": [
+            {"fragment_key": "my_default_templates"},
+            // other templates that are defined for this specific table
+          ]
+        }
+      }
+    }
+    ```
+
+
+### Default BDBag template
+
+If export annotation is missing for `detailed` context, we will add a default BDBag template. This default template is also accessible through the export fragment definitions annotation as well. The following are the `outputs` of the generated default export template:
 
 - `csv` of `attributegroup` API request to the main table.
   - The projection list is created based on the `visible-columns` defined for the `export/detailed` context (or `detailed` if `export` context is not specified).
@@ -55,7 +185,7 @@ This annotation only applies to a table, but MAY be annotated at the schema leve
 > If the generated path for any of the `attributegroup` API requests is lengthy, we will use the `entity` API instead.
 
 
-### Default CSV option
+### Default CSV template
 
 Chaise will add a default CSV option to the presented list of export templates. This option will prompt a download for a `csv` file that uses `attributegroup` API of ERMrest. The projection list is created based on the `visible-columns` and depending on the app it will use different contexts.
 

--- a/js/export.js
+++ b/js/export.js
@@ -45,15 +45,8 @@ var ERMrest = (function(module) {
         }
 
         // in FILE, outputs must be properly defined
-        if (template.type === "FILE") {
-            if (!Array.isArray(template.outputs) || template.outputs.length === 0) {
-                errMessage("outputs must be an array when template type is FILE.");
-                return false;
-            }
-        } else if (template.outputs == null) {
-            return true; // it could be missing or null (in this case we should use the default outputs)
-        } else if (!Array.isArray(template.outputs) || template.outputs.length === 0) {
-            errMessage("if outputs is defined, it must be an array.");
+        if (!Array.isArray(template.outputs) || template.outputs.length === 0) {
+            errMessage("outputs must be a non-empty array.");
             return false;
         }
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -2588,23 +2588,29 @@
                 
                 // if it's an object, we have to see whether it's fragment or not
                 if (isObjectAndNotNull(obj)) {
+
                     if ("fragment_key" in obj) {
                         var fragmentKey = obj.fragment_key;
+
+                        // there was a cycle, so just set the variables and abort
                         if (fragmentKey in usedFragments) {
                             cycleKey = fragmentKey;
                             hasCycle = true;
                             return null;
                         }
 
-                        usedFragments[fragmentKey] = true;
-                        if (fragmentKey in exportFragments) {
-                            return _replaceFragments(exportFragments[fragmentKey], usedFragments);
-                        } else {
+                        // fragment_key is invalid
+                        if (!(fragmentKey in exportFragments)) {
                             module._log.warn("Export: the given fragment_key `" + fragmentKey + "` is not valid");
                             return null;
                         }
+
+                        // replace with actual definition
+                        usedFragments[fragmentKey] = true;
+                        return _replaceFragments(exportFragments[fragmentKey], usedFragments);
                     }
                     
+                    // run the function for each value
                     res = {};
                     for (var k in obj) {
                         res[k] = _replaceFragments(obj[k], usedFragments);

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -54,8 +54,10 @@
         DISPLAY: "tag:misd.isi.edu,2015:display",
         EXPORT: "tag:isrd.isi.edu,2016:export",
         EXPORT_CONTEXTED: "tag:isrd.isi.edu,2019:export",
+        EXPORT_FRAGMENT_DEFINITIONS: "tag:isrd.isi.edu,2021:export-fragment-definitions",
         FOREIGN_KEY: "tag:isrd.isi.edu,2016:foreign-key",
         GENERATED: "tag:isrd.isi.edu,2016:generated",
+        GOOGLE_DATASET_METADATA: "tag:isrd.isi.edu,2021:google-dataset",
         HIDDEN: "tag:misd.isi.edu,2015:hidden", //TODO deprecated and should be deleted.
         IGNORE: "tag:isrd.isi.edu,2016:ignore", //TODO should not be used in column and foreign key
         IMMUTABLE: "tag:isrd.isi.edu,2016:immutable",
@@ -67,8 +69,7 @@
         TABLE_CONFIG: "tag:isrd.isi.edu,2021:table-config",
         TABLE_DISPLAY: "tag:isrd.isi.edu,2016:table-display",
         VISIBLE_COLUMNS: "tag:isrd.isi.edu,2016:visible-columns",
-        VISIBLE_FOREIGN_KEYS: "tag:isrd.isi.edu,2016:visible-foreign-keys",
-        GOOGLE_DATASET_METADATA: "tag:isrd.isi.edu,2021:google-dataset"
+        VISIBLE_FOREIGN_KEYS: "tag:isrd.isi.edu,2016:visible-foreign-keys"
     });
 
     /**


### PR DESCRIPTION
This PR will do the changes described in #914. To summarize,

- The export annotation can now be defined on catalog.
- A new `export-fragment-definitions` annotation has been added that allows reuse of fragments in export annotation.
- The heuristic to add `outputs` to templates have been removed.

What's left:

- I implemented the general solution for fragment support. Instead of making assumption about the properties and types, I'm recursively traversing the whole export object and replacing the `{"fragment_key": <key>}` instances with the actual fragment definition and will continue to do so until there's no other instances of fragment usage. This works properly, but in the cases that we expect an array might be a bit confusing. For example if you define something like this:
  ```js
  "2019:export": {
    "templates": {"fragment_key": "temp1"}
  }
  ```
  Only works if the `temp1` is an array (since we expect `templates` to be an array). But if you write it like this:
  ```js
  "2019:export": {
    "templates": [{"fragment_key": "temp1"}]
  }
  ```
  works properly if `temp1` is just an object or array of objects. This is mainly because when I see an array, I'm recursively tranforming each item in the array and then flattening it. So if it's `[fargment1, template3]` and the `item1` is actually an array of `[template1, template2]`, the result will be `[template1, template2, template3]`.

- More documentation. I'm still not sure what is the best way to explain the fragment concept in annotation document. I added more info and example to the export document that we have, but I think I need to add more to annotation document.
- Fix broken test cases because of changes in the expected behavior.
- Add test cases 