### PR TITLE
Filter in source (phase 2)

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -487,6 +487,7 @@ to use for ERMrest JavaScript agents.
         * [.isEntityMode](#ERMrest.PseudoColumn+isEntityMode) : <code>boolean</code>
         * [.isUnique](#ERMrest.PseudoColumn+isUnique) : <code>boolean</code>
         * [.hasAggregate](#ERMrest.PseudoColumn+hasAggregate) : <code>boolean</code>
+        * [.isFiltered](#ERMrest.PseudoColumn+isFiltered) : <code>boolean</code>
         * [.comment](#ERMrest.PseudoColumn+comment) : <code>Object</code>
         * [.commentDisplay](#ERMrest.PseudoColumn+commentDisplay) : <code>Object</code>
         * [.displayname](#ERMrest.PseudoColumn+displayname) : <code>Object</code>
@@ -531,6 +532,7 @@ to use for ERMrest JavaScript agents.
         * [.foreignKey](#ERMrest.InboundForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
         * [.isPseudo](#ERMrest.InboundForeignKeyPseudoColumn+isPseudo) : <code>boolean</code>
         * [.isInboundForeignKey](#ERMrest.InboundForeignKeyPseudoColumn+isInboundForeignKey) : <code>boolean</code>
+        * [.isFiltered](#ERMrest.InboundForeignKeyPseudoColumn+isFiltered) : <code>boolean</code>
     * [.FacetColumn](#ERMrest.FacetColumn)
         * [new FacetColumn(reference, index, facetObject, filters)](#new_ERMrest.FacetColumn_new)
         * [._column](#ERMrest.FacetColumn+_column) : [<code>Column</code>](#ERMrest.Column)
@@ -4535,6 +4537,7 @@ it will append "-<integer>" to it.
     * [.isEntityMode](#ERMrest.PseudoColumn+isEntityMode) : <code>boolean</code>
     * [.isUnique](#ERMrest.PseudoColumn+isUnique) : <code>boolean</code>
     * [.hasAggregate](#ERMrest.PseudoColumn+hasAggregate) : <code>boolean</code>
+    * [.isFiltered](#ERMrest.PseudoColumn+isFiltered) : <code>boolean</code>
     * [.comment](#ERMrest.PseudoColumn+comment) : <code>Object</code>
     * [.commentDisplay](#ERMrest.PseudoColumn+commentDisplay) : <code>Object</code>
     * [.displayname](#ERMrest.PseudoColumn+displayname) : <code>Object</code>
@@ -4591,6 +4594,12 @@ If the pseudoColumn is referring to a unique row (the path is one to one)
 
 #### pseudoColumn.hasAggregate : <code>boolean</code>
 If aggregate function is defined on the column.
+
+**Kind**: instance property of [<code>PseudoColumn</code>](#ERMrest.PseudoColumn)  
+<a name="ERMrest.PseudoColumn+isFiltered"></a>
+
+#### pseudoColumn.isFiltered : <code>boolean</code>
+If the pseudoColumn has filter in its path
 
 **Kind**: instance property of [<code>PseudoColumn</code>](#ERMrest.PseudoColumn)  
 <a name="ERMrest.PseudoColumn+comment"></a>
@@ -5021,6 +5030,7 @@ Format the presentation value corresponding to this asset definition.
     * [.foreignKey](#ERMrest.InboundForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
     * [.isPseudo](#ERMrest.InboundForeignKeyPseudoColumn+isPseudo) : <code>boolean</code>
     * [.isInboundForeignKey](#ERMrest.InboundForeignKeyPseudoColumn+isInboundForeignKey) : <code>boolean</code>
+    * [.isFiltered](#ERMrest.InboundForeignKeyPseudoColumn+isFiltered) : <code>boolean</code>
 
 <a name="new_ERMrest.InboundForeignKeyPseudoColumn_new"></a>
 
@@ -5028,6 +5038,9 @@ Format the presentation value corresponding to this asset definition.
 Constructor for InboundForeignKeyPseudoColumn. This class is a wrapper for [ForeignKeyRef](#ERMrest.ForeignKeyRef).
 This is a bit different than the [ForeignKeyPseudoColumn](#ERMrest.ForeignKeyPseudoColumn), as that was for foreign keys
 of current table. This wrapper is for inbound foreignkeys. It is actually warpping the whole reference (table).
+
+Note: The sourceObjectWrapper might include filters and therefore the relatedReference
+      might not be a simple path from main to related table and it could have filters.
 
 This class extends the [ReferenceColumn](#ERMrest.ReferenceColumn)
 
@@ -5065,6 +5078,12 @@ indicates that this object represents a PseudoColumn.
 
 #### inboundForeignKeyPseudoColumn.isInboundForeignKey : <code>boolean</code>
 Indicates that this ReferenceColumn is an inbound foreign key.
+
+**Kind**: instance property of [<code>InboundForeignKeyPseudoColumn</code>](#ERMrest.InboundForeignKeyPseudoColumn)  
+<a name="ERMrest.InboundForeignKeyPseudoColumn+isFiltered"></a>
+
+#### inboundForeignKeyPseudoColumn.isFiltered : <code>boolean</code>
+Indicates that this related table has filters in its path
 
 **Kind**: instance property of [<code>InboundForeignKeyPseudoColumn</code>](#ERMrest.InboundForeignKeyPseudoColumn)  
 <a name="ERMrest.FacetColumn"></a>

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -262,10 +262,10 @@ using a hierarchical scoping mode:
 `tag:isrd.isi.edu,2016:immutable`
 
 This key indicates that the values for a given model element may not be mutated
-(changed) once set. 
+(changed) once set.
 
 This key is allowed on any number of columns, tables, and schemas. If a schema is marked as immutable, all the tables in that schema will also inherit this setting. To avoid this on a table, you can define the immutable annotation and use the special `false` value (The same is true about tables and columns).
- 
+
 
 ### Tag: 2016 Generated
 
@@ -352,12 +352,12 @@ Supported _columnentry_ patterns:
 Supported _sourceentry_ pattern:
 - _columnname_: : A string literal. _columnname_ identifies a constituent column of the table.
 
-- An array of _path element_ that ends with a _columnname_ that will be projected. 
-  
+- An array of _path element_ that ends with a _columnname_ that will be projected.
+
   - `[` _path element_  `,`  _columnname_`]`
-  
+
   Each anterior _path element_ MAY use one of the following sub-document structures:
-  
+
   - `{ "sourcekey":` _sourcekey prefix_ `}`
     - Only acceptable as the first element. Please refer to [Data source with reusable prefix](facet-json-structure.md#data-source-with-reusable-prefix) for more information.
     - _sourcekey prefix_ is a string literal that refers to any of the defined sources in [`source-definitions` annotations](annotation.md#tag-2019-source-definitions)
@@ -368,23 +368,20 @@ Supported _sourceentry_ pattern:
     - _fkeyname_ is the given name of the foreign key which is usually in the following format: `[` _schema name_ `,` _constraint name_ `]`
 
   - `{ "and": [` _filter_ `,` ... `], "negate": ` _negate_ `}`
-    - Currently only limited to `filter` context of visible-columns annotation.
     - A logical conjunction of multiple _filter_ clauses is applied to the query to constrain matching rows.
 	- The logical result is negated only if _negate_ is `true`.
 	- Each _filter_ clause may be a terminal filter element, conjunction, or disjunction.
-  
+
   - `{ "or": [` _filter_ `,` ... `], "negate": ` _negate_ `}`
-    - Currently only limited to `filter` context of visible-columns annotation.
     - A logical disjunction of multiple _filter_ clauses is applied to the query to constrain matching rows.
 	  - The logical result is negated only if _negate_ is `true`.
 	  - Each _filter_ clause may be a terminal filter element, conjunction, or disjunction.
-  
+
   - `{ "filter":` _column_ `, "operand_pattern":` _value_ `, "operator":` _operator_ `, "negate":` _negate_ `}`
-    - Currently only limited to `filter` context of visible-columns annotation.
     - An individual filter _path element_ is applied to the query or individual _filter_ clauses participate in a conjunction or disjunction.
-    
+
     - The filter constrains a named _column_ in the current context table.
-    
+
     - The _operator_ specifies the constraint operator via one of the valid operator names in the ERMrest REST API, which are
 
         | operator  | meaning |
@@ -402,7 +399,7 @@ Supported _sourceentry_ pattern:
       > If `operator` is missing, we will use `=` by default.
 
     - The _value_ specifies the constant operand for a binary constraint operator and must be computed to a non-empty value. Pattern expansion MAY be used to access [the pre-defined values in templating envorinment](mustache-templating.md#using-pre-defined-attributes).
-    
+
     - The logical result of the constraint is negated only if _negate_ is `true`.
 
 
@@ -735,14 +732,14 @@ Supported _fkeylist_ patterns:
      - `wait_for`: List of pseudo-column [`sourcekey`](#tag-2019-source-definitions)s that used in `markdown_pattern`. You should list all the all-outbound, aggregates, and entity sets that you are using.
 - `{ "sourcekey": ` _sourcekey_ `}`: Defines a pseudo-column based on the given _sourcekey_.
 
-Supported _sourceentry_ pattern in here:
+Supported _sourceentry_ patterns:
 
-- An array of _path element_ that ends with a _columnname_ that will be projected. 
-  
+- An array of _path element_ that ends with a _columnname_ that will be projected.
+
   - `[` _path element_  `,`  _columnname_`]`
-  
+
   Each anterior _path element_ MAY use one of the following sub-document structures:
-  
+
   - `{ "sourcekey":` _sourcekey prefix_ `}`
     - Only acceptable as the first element. Please refer to [Data source with reusable prefix](facet-json-structure.md#data-source-with-reusable-prefix) for more information.
     - _sourcekey prefix_ is a string literal that refers to any of the defined sources in [`source-definitions` annotations](annotation.md#tag-2019-source-definitions)
@@ -752,7 +749,42 @@ Supported _sourceentry_ pattern in here:
     - _direction_ can either be `"inbound"`, or `"outbound"`.
     - _fkeyname_ is the given name of the foreign key which is usually in the following format: `[` _schema name_ `,` _constraint name_ `]`
 
-Supported _sourcekey_ pattern in here:
+  - `{ "and": [` _filter_ `,` ... `], "negate": ` _negate_ `}`
+    - A logical conjunction of multiple _filter_ clauses is applied to the query to constrain matching rows.
+  	- The logical result is negated only if _negate_ is `true`.
+	  - Each _filter_ clause may be a terminal filter element, conjunction, or disjunction.
+
+  - `{ "or": [` _filter_ `,` ... `], "negate": ` _negate_ `}`
+    - A logical disjunction of multiple _filter_ clauses is applied to the query to constrain matching rows.
+	  - The logical result is negated only if _negate_ is `true`.
+	  - Each _filter_ clause may be a terminal filter element, conjunction, or disjunction.
+
+  - `{ "filter":` _column_ `, "operand_pattern":` _value_ `, "operator":` _operator_ `, "negate":` _negate_ `}`
+    - An individual filter _path element_ is applied to the query or individual _filter_ clauses participate in a conjunction or disjunction.
+
+    - The filter constrains a named _column_ in the current context table.
+
+    - The _operator_ specifies the constraint operator via one of the valid operator names in the ERMrest REST API, which are
+
+        | operator  | meaning |
+        |-----------|---------|
+        | `::null::`| column is `null`     |
+        | `=`      | column equals value |
+        | `::lt::` | column less than value |
+        | `::leq::` | column less than or equal to value |
+        | `::gt::` | column greater than value |
+        | `::geq::` | column greater than or equal to value |
+        | `::regexp::` | column matches regular expression value |
+        | `::ciregexp::` | column matches regular expression value case-insensitively |
+        | `::ts::` | column matches text-search query value |
+
+      > If `operator` is missing, we will use `=` by default.
+
+    - The _value_ specifies the constant operand for a binary constraint operator and must be computed to a non-empty value. Pattern expansion MAY be used to access [the pre-defined values in templating envorinment](mustache-templating.md#using-pre-defined-attributes).
+
+    - The logical result of the constraint is negated only if _negate_ is `true`.
+
+Supported _sourcekey_ patterns:
   - A string literal that refers to any of the defined sources in [`source-definitions` annotations](#tag-2019-source-definitions).
 
 
@@ -1006,12 +1038,12 @@ Supported _sourcekey_ pattern:
 
 Supported _sourceentry_ pattern:
   - _columnname_: : A string literal. _columnname_ identifies a constituent column of the table.
-  - An array of _path element_ that ends with a _columnname_ that will be projected. 
-    
+  - An array of _path element_ that ends with a _columnname_ that will be projected.
+
     - `[` _path element_  `,`  _columnname_`]`
-    
+
     Each anterior _path element_ MAY use one of the following sub-document structures:
-    
+
     - `{ "sourcekey":` _sourcekey prefix_ `}`
       - Only acceptable as the first element. Please refer to [Data source with reusable prefix](facet-json-structure.md#data-source-with-reusable-prefix) for more information.
       - _sourcekey prefix_ is a string literal that refers to any of the defined sources in [`source-definitions` annotations](#tag-2019-source-definitions)
@@ -1026,13 +1058,13 @@ Supported _sourceentry_ pattern:
       - A logical conjunction of multiple _filter_ clauses is applied to the query to constrain matching rows.
   	- The logical result is negated only if _negate_ is `true`.
   	- Each _filter_ clause may be a terminal filter element, conjunction, or disjunction.
-  
+
     - `{ "or": [` _filter_ `,` ... `], "negate": ` _negate_ `}`
       - Currently only limited to `filter` context of visible-columns annotation.
       - A logical disjunction of multiple _filter_ clauses is applied to the query to constrain matching rows.
 	  - The logical result is negated only if _negate_ is `true`.
 	  - Each _filter_ clause may be a terminal filter element, conjunction, or disjunction.
-  
+
     - `{ "filter":` _column_ `, "operand_pattern":` _value_ `, "operator":` _operator_ `, "negate":` _negate_ `}`
       - Currently only limited to `filter` context of visible-columns annotation.
       - An individual filter _path element_ is applied to the query or individual _filter_ clauses participate in a conjunction or disjunction.

--- a/docs/user-docs/facet-json-structure.md
+++ b/docs/user-docs/facet-json-structure.md
@@ -12,7 +12,7 @@ The overall structure of filters is as follows. Each facet term combines a data 
 <TERM>:     { <logical-operator>: <TERMSET> }
             or
             { "source": <data-source>, <constraint(s)>, <extra-attribute(s)> }
-            or 
+            or
             { "sourcekey": <source-key>, <constraint(s)>, <extra-attribute(s)> }
 ```
 
@@ -45,12 +45,12 @@ Therefore the following are acceptable ways of defining data source:
   {"source": "column"}
   {"source": ["column"]}
   ```
-- An array of _path element_ that ends with a _columnname_ that will be projected and filtered. 
-  
+- An array of _path element_ that ends with a _columnname_ that will be projected and filtered.
+
   - `[` _path element_  `,`  _columnname_`]`
-  
+
   Each anterior element MAY use one of the following sub-document structures:
-  
+
   - `{ "sourcekey":` _sourcekey prefix_ `}`
     - Only acceptable as the first element. Please refer to [Data source with reusable prefix](#data-source-with-reusable-prefix) for more information.
     - _sourcekey prefix_ is a string literal that refers to any of the defined sources in [`source-definitions` annotations](annotation.md#tag-2019-source-definitions)
@@ -61,23 +61,20 @@ Therefore the following are acceptable ways of defining data source:
     - _fkeyname_ is the given name of the foreign key which is usually in the following format: `[` _schema name_ `,` _constraint name_ `]`
 
   - `{ "and": [` _filter_ `,` ... `], "negate": ` _negate_ `}`
-    - Currently only limited to `filter` context of visible-columns annotation.
     - A logical conjunction of multiple _filter_ clauses is applied to the query to constrain matching rows.
 	- The logical result is negated only if _negate_ is `true`.
 	- Each _filter_ clause may be a terminal filter element, conjunction, or disjunction.
-  
+
   - `{ "or": [` _filter_ `,` ... `], "negate": ` _negate_ `}`
-    - Currently only limited to `filter` context of visible-columns annotation.
     - A logical disjunction of multiple _filter_ clauses is applied to the query to constrain matching rows.
 	  - The logical result is negated only if _negate_ is `true`.
 	  - Each _filter_ clause may be a terminal filter element, conjunction, or disjunction.
-  
+
   - `{ "filter":` _column_ `, "operand_pattern":` _value_ `, "operator":` _operator_ `, "negate":` _negate_ `}`
-    - Currently only limited to `filter` context of visible-columns annotation.
     - An individual filter _path element_ is applied to the query or individual _filter_ clauses participate in a conjunction or disjunction.
-    
+
     - The filter constrains a named _column_ in the current context table.
-    
+
     - The _operator_ specifies the constraint operator via one of the valid operator names in the ERMrest REST API, which are
 
         | operator  | meaning |
@@ -95,9 +92,9 @@ Therefore the following are acceptable ways of defining data source:
       > If `operator` is missing, we will use `=` by default.
 
     - The _value_ specifies the constant operand for a binary constraint operator and must be computed to a non-empty value. Pattern expansion MAY be used to access [the pre-defined values in templating envorinment](mustache-templating.md#using-pre-defined-attributes).
-    
+
     - The logical result of the constraint is negated only if _negate_ is `true`.
-  
+
 
   The following are some examples of defining data source:
   ```
@@ -109,8 +106,8 @@ Therefore the following are acceptable ways of defining data source:
 
  In some cases, the defined foreign key paths for different columns/facets might be sharing the same prefix. In those cases, reusing the prefix allows sharing certain joined table instances rather than introducing more "copies" as each facet is activated which in turn will increase the performance.
 
- To do this, you would have to use [`2019:source-definitions`](annotation.md#tag-2019-source-definitions) annotation and define the shared prefix. Then you can use `sourcekey` to refer to this shared prefix in the data source. 
- 
+ To do this, you would have to use [`2019:source-definitions`](annotation.md#tag-2019-source-definitions) annotation and define the shared prefix. Then you can use `sourcekey` to refer to this shared prefix in the data source.
+
  - When using a prefix, the prefix's last column and all the other extra attributes on it will be ignored for the purpose of prefix.
 - You can use recursive prefixes. If we detect a circular dependency, we're going to invalidate the given definition.
 - While using prefix, you MUST add extra foreign key paths to the relationship. The following is not an acceptable source:
@@ -122,7 +119,7 @@ Therefore the following are acceptable ways of defining data source:
 
  For example, assume the following is the ERD of table:
 
-![erd_01](https://raw.githubusercontent.com/informatics-isi-edu/ermrestjs/master/docs/resources/facet-json-structure-path-prefix-erd-01.png) 
+![erd_01](https://raw.githubusercontent.com/informatics-isi-edu/ermrestjs/master/docs/resources/facet-json-structure-path-prefix-erd-01.png)
 
 And the following is source-definition and visible-columns annotation:
 

--- a/js/column.js
+++ b/js/column.js
@@ -40,7 +40,7 @@ module._createPseudoColumn = function (reference, sourceObjectWrapper, mainTuple
 
 
     // has aggregate
-    if (sourceObjectWrapper.hasAggregate || sourceObjectWrapper.isUniqueFiltered) {
+    if (sourceObjectWrapper.hasAggregate) {
         return generalPseudo();
     }
 
@@ -798,6 +798,12 @@ function PseudoColumn (reference, column, sourceObjectWrapper, name, mainTuple) 
      * @type {boolean}
      */
     this.hasAggregate = this.sourceObjectWrapper.hasAggregate;
+
+    /**
+     * If the pseudoColumn has filter in its path
+     * @type {boolean}
+     */
+    this.isFiltered = this.sourceObjectWrapper.isFiltered;
 
     this.baseColumn = column;
 
@@ -2615,6 +2621,9 @@ Object.defineProperty(AssetPseudoColumn.prototype, "filenameExtFilter", {
  * This is a bit different than the {@link ERMrest.ForeignKeyPseudoColumn}, as that was for foreign keys
  * of current table. This wrapper is for inbound foreignkeys. It is actually warpping the whole reference (table).
  *
+ * Note: The sourceObjectWrapper might include filters and therefore the relatedReference
+ *       might not be a simple path from main to related table and it could have filters.
+ *
  * This class extends the {@link ERMrest.ReferenceColumn}
  */
 function InboundForeignKeyPseudoColumn (reference, relatedReference, sourceObjectWrapper, name) {
@@ -2654,6 +2663,12 @@ function InboundForeignKeyPseudoColumn (reference, relatedReference, sourceObjec
      * @desc Indicates that this ReferenceColumn is an inbound foreign key.
      */
     this.isInboundForeignKey = true;
+
+    /**
+     * @type {boolean}
+     * @desc Indicates that this related table has filters in its path
+     */
+    this.isFiltered = isObjectAndNotNull(sourceObjectWrapper) && sourceObjectWrapper.isFiltered;
 
     this.isUnique = false;
 

--- a/js/column.js
+++ b/js/column.js
@@ -39,8 +39,12 @@ module._createPseudoColumn = function (reference, sourceObjectWrapper, mainTuple
 
 
 
-    // has aggregate
-    if (sourceObjectWrapper.hasAggregate) {
+    // has aggregate or filter
+    // TODO FILTER_IN_SOURCE later this should be more specific so we can
+    //      categorize some of them as simple inbound, or p&b.
+    //      currently we don't want to allow "add" feature so it's easier if
+    //      we just mark them as general pseudo-column
+    if (sourceObjectWrapper.hasAggregate || sourceObjectWrapper.isFiltered) {
         return generalPseudo();
     }
 

--- a/js/core.js
+++ b/js/core.js
@@ -3834,7 +3834,8 @@
                                 wrapper = new SourceObjectWrapper(orders[i], this._table, module._constraintNames);
                             } catch (exp) {
                                 // we might want to show a better error message later.
-                                wrapper = null;
+                                logErr(true, exp.message, i);
+                                invalid = true;
                             }
                         } else {
                             var def = definitions.sources[orders[i].sourcekey];
@@ -3848,7 +3849,8 @@
                         // 2. no inbound
                         // 3. not entity mode
                         // 4. has aggregate
-                        invalid = logErr(!wrapper || !wrapper.hasPath, wm.INVALID_FK, i) ||
+                        invalid = invalid ||
+                                  logErr(!wrapper || !wrapper.hasPath, wm.INVALID_FK, i) ||
                                   logErr(!wrapper.hasInbound, wm.INVALID_FK_NO_INBOUND, i) ||
                                   logErr(!wrapper.isEntityMode, wm.SCALAR_NOT_ALLOWED) ||
                                   logErr(wrapper.hasAggregate, wm.AGG_NOT_ALLOWED);
@@ -3861,6 +3863,7 @@
                     if (!invalid) {
                         addToList({isPath: true, sourceObjectWrapper: wrapper, name: wrapper.name});
                     }
+                    invalid = false;
                 }
             }
             this._contextualize_cached[context] = result;

--- a/js/core.js
+++ b/js/core.js
@@ -3851,8 +3851,7 @@
                         invalid = logErr(!wrapper || !wrapper.hasPath, wm.INVALID_FK, i) ||
                                   logErr(!wrapper.hasInbound, wm.INVALID_FK_NO_INBOUND, i) ||
                                   logErr(!wrapper.isEntityMode, wm.SCALAR_NOT_ALLOWED) ||
-                                  logErr(wrapper.hasAggregate, wm.AGG_NOT_ALLOWED) ||
-                                  logErr(wrapper.isFiltered, wm.FILTER_NOT_ALLOWED);
+                                  logErr(wrapper.hasAggregate, wm.AGG_NOT_ALLOWED);
 
                     } else {
                         invalid = true;

--- a/js/reference.js
+++ b/js/reference.js
@@ -3199,7 +3199,6 @@
                         ignore = logCol((wrapper.name in consideredColumns), wm.DUPLICATE_PC, i) ||
                                  (wrapper.hasPath && !wrapper.hasInbound && wrapper.foreignKeyPathLength == 1 && hideFKR(wrapper.firstForeignKeyNode.nodeObject)) ||
                                  (!wrapper.hasPath && hideColumn(wrapper.column)) ||
-                                 logCol(wrapper.isFiltered, wm.FILTER_NOT_ALLOWED) ||
                                  logCol(wrapper.sourceObject.self_link === true && !wrapper.column.isUniqueNotNull, wm.INVALID_SELF_LINK, i) ||
                                  logCol((!wrapper.hasAggregate && wrapper.hasInbound && !wrapper.isEntityMode), wm.MULTI_SCALAR_NEED_AGG, i) ||
                                  logCol((!wrapper.hasAggregate && wrapper.hasInbound && wrapper.isEntityMode && context !== module._contexts.DETAILED && context.indexOf(module._contexts.EXPORT) == -1), wm.MULTI_ENT_NEED_AGG, i) ||

--- a/js/reference.js
+++ b/js/reference.js
@@ -3203,6 +3203,7 @@
                                  logCol((!wrapper.hasAggregate && wrapper.hasInbound && !wrapper.isEntityMode), wm.MULTI_SCALAR_NEED_AGG, i) ||
                                  logCol((!wrapper.hasAggregate && wrapper.hasInbound && wrapper.isEntityMode && context !== module._contexts.DETAILED && context.indexOf(module._contexts.EXPORT) == -1), wm.MULTI_ENT_NEED_AGG, i) ||
                                  logCol(wrapper.hasAggregate && wrapper.isEntryMode, wm.NO_AGG_IN_ENTRY, i) ||
+                                 logCol(wrapper.isUniqueFiltered, wm.FILTER_NO_PATH_NOT_ALLOWED) ||
                                  logCol(isEntry && wrapper.hasPath && (wrapper.hasInbound || wrapper.isFiltered || wrapper.foreignKeyPathLength > 1), wm.NO_PATH_IN_ENTRY, i);
 
                         // avoid duplciates and hide the column

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -292,7 +292,8 @@
         INVALID_COLUMN_DEF: "column definiton must be an array, object, or string.",
         INVALID_COLUMN_IN_SOURCE_PATH: "end column in the path is not valid (not available in the end table)",
         NO_INBOUND_IN_NON_DETAILED: "inline table is not valid in this context.",
-        FILTER_NOT_ALLOWED: "filter in source is only supported in `filter` context of visible-columns"
+        FILTER_NOT_ALLOWED: "filter in source is only supported in `filter` context of visible-columns",
+        FILTER_NO_PATH_NOT_ALLOWED: "filter in source is not supported with local columns or all-outbound paths."
     });
 
     module._permissionMessages = Object.freeze({

--- a/js/utils/pseudocolumn_helpers.js
+++ b/js/utils/pseudocolumn_helpers.js
@@ -1078,19 +1078,14 @@
 
             // TODO FILTER_IN_SOURCE better name...
             /**
-             * I would have to create a new column type that allows this,
-             * then depending on whether its fk or not then I would have to do something
-             * else ...
-             * the request should be something like the aggregate ..
-             * so it's more or less like aggregate, right?
-             * LETS IGNORE THIS FOR NOW, right?
-             * _createPseudoColumn should also then change to create generalPseudo for these
-             *
+             * these type of columns would be very similiar to aggregate columns.
+             * but it requires more changes in both chaise and ermrestjs
+             * (most probably a new column type or at least more api to fetch their values is needed)
+             * (in chaise we would have to add a new type of secondary requests to active list)
+             * (not sure if these type of pseudo-columns are even useful or not)
+             * so for now we're not going to allow these type of pseudo-columns in visible-columns
              */
-            // self.isUniqueFiltered = !self.hasAggregate && self.isFiltered && (!hasPath || !hasInbound);
-            if (self.isFiltered && !self.hasAggregate && (!hasPath || !hasInbound)) {
-                return returnError(wm.FILTER_NO_PATH_NOT_ALLOWED);
-            }
+            self.isUniqueFiltered = !self.hasAggregate && self.isFiltered && (!hasPath || !hasInbound);
 
             // attach last fk
             if (lastForeignKeyNode != null) {

--- a/js/utils/pseudocolumn_helpers.js
+++ b/js/utils/pseudocolumn_helpers.js
@@ -390,10 +390,22 @@
             };
         };
 
+        var shortenAndOr = function (node) {
+            return function (k) {
+                if (!Array.isArray(node[k])) return;
+
+                node[k].forEach(function (el) {
+                    ["and", "or"].forEach(shortenAndOr(el));
+                    ["filter", "operand_pattern", "operator", "negate"].forEach(shorten(el));
+                });
+            };
+        };
+
         if (!_sourceColumnHelpers._sourceHasNodes(source)) return res;
 
-        // TODO FILTER_IN_SOURCE and and or should recursively do this
         for (var i = 0; i < res.length; i++) {
+            ["and", "or"].forEach(shortenAndOr(res[i]));
+
             ["alias", "sourcekey", "inbound", "outbound", "filter", "operand_pattern", "operator", "negate"].forEach(shorten(res[i]));
         }
         return res;
@@ -1806,7 +1818,6 @@
          *      - if same size, sort based on string representation.
          * @param {*} a
          * @param {*} b
-         * @returns
          */
         _sortFilterInSource: function (a, b) {
             var srcProps = module._sourceProperties,
@@ -1823,10 +1834,10 @@
                 var tempA = helpers._stringifyFilterInSource(a),
                     tempB = helpers._stringifyFilterInSource(b);
                 if (tempA == tempB) {
-                    return 0
+                    return 0;
                 }
                 return tempA > tempB ? 1 : -1;
-            }
+            };
 
             // ------- only one has negate (the one with negative comes second) -------- //
             if (aHasNegate && !bHasNegate) {

--- a/test/specs/annotation/conf/source_definitions/schema.json
+++ b/test/specs/annotation/conf/source_definitions/schema.json
@@ -275,7 +275,7 @@
                       },
                       "fk1_col_entity_w_filter_invalid_1": {
                           "source": [
-                              {"outbound": ["source_definitions_schema", "main_fk1"]}, 
+                              {"outbound": ["source_definitions_schema", "main_fk1"]},
                               {"filter": "invalid_col", "negate": true, "operand_pattern": "1"},
                               "RID"
                           ],
@@ -283,7 +283,7 @@
                       },
                       "fk1_col_entity_w_filter_invalid_2": {
                           "source": [
-                              {"outbound": ["source_definitions_schema", "main_fk1"]}, 
+                              {"outbound": ["source_definitions_schema", "main_fk1"]},
                               {"filter": "RID", "operator": "some_unknown_operator", "operand_pattern": "1"},
                               "RID"
                           ],
@@ -291,7 +291,7 @@
                       },
                       "fk1_col_entity_w_filter_invalid_3": {
                           "source": [
-                              {"outbound": ["source_definitions_schema", "main_fk1"]}, 
+                              {"outbound": ["source_definitions_schema", "main_fk1"]},
                               {"filter": "RID", "operator": "::null::", "operand_pattern": "1"},
                               "RID"
                           ],
@@ -299,7 +299,7 @@
                       },
                       "fk1_col_entity_w_filter_invalid_4": {
                           "source": [
-                              {"outbound": ["source_definitions_schema", "main_fk1"]}, 
+                              {"outbound": ["source_definitions_schema", "main_fk1"]},
                               {"filter": "RID", "operator": "::lt::"},
                               "RID"
                           ],
@@ -307,7 +307,7 @@
                       },
                       "fk1_col_entity_w_filter_invalid_5": {
                           "source": [
-                              {"outbound": ["source_definitions_schema", "main_fk1"]}, 
+                              {"outbound": ["source_definitions_schema", "main_fk1"]},
                               {"filter": "RID", "operand_pattern": "{{{invalid_column}}}"},
                               "RID"
                           ],
@@ -322,7 +322,7 @@
                       "fk1_col_entity_w_filter_1": {
                           "source": [
                               {"filter": "id", "operator": "::gt::", "operand_pattern": "1"},
-                              {"outbound": ["source_definitions_schema", "main_fk1"]}, 
+                              {"outbound": ["source_definitions_schema", "main_fk1"]},
                               "RID"
                           ],
                           "entity": true
@@ -330,7 +330,7 @@
                       "fk1_col_entity_w_filter_2": {
                           "source": [
                               {"filter": "RID", "negate": true, "operand_pattern": "1"},
-                              {"outbound": ["source_definitions_schema", "main_fk1"]}, 
+                              {"outbound": ["source_definitions_schema", "main_fk1"]},
                               "RID"
                           ],
                           "entity": true
@@ -355,7 +355,7 @@
                                       }
                                   ]
                               },
-                              {"outbound": ["source_definitions_schema", "main_fk1"]}, 
+                              {"outbound": ["source_definitions_schema", "main_fk1"]},
                               "RID"
                           ],
                           "entity": true
@@ -381,7 +381,33 @@
                                       }
                                   ]
                               },
-                              {"outbound": ["source_definitions_schema", "main_fk1"]}, 
+                              {"outbound": ["source_definitions_schema", "main_fk1"]},
+                              "RID"
+                          ],
+                          "entity": true
+                      },
+                      "fk1_col_entity_w_filter_3_third_name": {
+                          "comment": "same as above with diff order of filters and just added for testing hashname logic",
+                          "source": [
+                              {
+                                  "or": [
+                                      {"operand_pattern": "some val", "operator": "::ts::", "filter": "col"},
+                                      {
+                                          "or": [
+                                              {"operator": "::null::", "filter": "id"},
+                                              {"operator": "::null::", "filter": "RMB"}
+                                          ],
+                                          "negate": true
+                                      },
+                                      {
+                                        "and": [
+                                            {"filter": "col w space", "negate": true, "operator": "::null::"},
+                                            {"operand_pattern": "{{{$moment.year}}}", "filter": "id"}
+                                        ]
+                                    }
+                                  ]
+                              },
+                              {"outbound": ["source_definitions_schema", "main_fk1"]},
                               "RID"
                           ],
                           "entity": true

--- a/test/specs/annotation/tests/07.source_definitions.js
+++ b/test/specs/annotation/tests/07.source_definitions.js
@@ -371,7 +371,7 @@ exports.execute = function (options) {
                             isFiltered: true
                         },
                         "fk1_col_entity_w_filter_3": {
-                            name: "MHj4HzaOa23u--ySNclwJA",
+                            name: "csGT5JMaMLp77iWXs6mWgQ",
                             columnName: "RID",
                             isHash: true,
                             hasPath: true,
@@ -381,7 +381,17 @@ exports.execute = function (options) {
                             isFiltered: true
                         },
                         "fk1_col_entity_w_filter_3_second_name": {
-                            name: "MHj4HzaOa23u--ySNclwJA",
+                            name: "csGT5JMaMLp77iWXs6mWgQ",
+                            columnName: "RID",
+                            isHash: true,
+                            hasPath: true,
+                            hasInbound: false,
+                            isEntityMode: true,
+                            foreignKeyPathLength: 1,
+                            isFiltered: true
+                        },
+                        "fk1_col_entity_w_filter_3_third_name": {
+                            name: "csGT5JMaMLp77iWXs6mWgQ",
                             columnName: "RID",
                             isHash: true,
                             hasPath: true,
@@ -480,7 +490,7 @@ exports.execute = function (options) {
                         "5uyQhvQzuNEIo1OAhJuHzg": ["col_w_filter"],
                         "Wcv9DsKtYwVpGSMAnSlCvw": ["fk1_col_entity_w_filter_1"],
                         "agJ6hGYbIa1FzQwScpQcoA": ["fk1_col_entity_w_filter_2"],
-                        "MHj4HzaOa23u--ySNclwJA": ["fk1_col_entity_w_filter_3", "fk1_col_entity_w_filter_3_second_name"],
+                        "csGT5JMaMLp77iWXs6mWgQ": ["fk1_col_entity_w_filter_3", "fk1_col_entity_w_filter_3_second_name", "fk1_col_entity_w_filter_3_third_name"],
                         "zfchwF3DOkHZ_PDPQhu4VA": ["path_to_outbound2_outbound1_w_filter_1"],
                         "cbQKEIV_BqzKdUvA1OQiyA": ["path_to_outbound2_outbound1_w_filter_2"],
                         "XnjW7-cTPW1vu71_89uYCg": ["path_to_outbound2_outbound1_w_filter_2_diff_col"],

--- a/test/specs/column/conf/pseudo_column_schema/schema.json
+++ b/test/specs/column/conf/pseudo_column_schema/schema.json
@@ -258,6 +258,18 @@
                                 "id"
                             ],
                             "aggregate": "array"
+                        },
+                        {
+                            "source": [
+                                {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                                {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                                {"or": [
+                                    {"filter": "RCT", "operand_pattern": "{{{$moment.year}}}-{{{$moment.month}}}-{{{$moment.day}}}", "operator": "::gt::"},
+                                    {"filter": "RID", "operator": "::null::", "negate": true}
+                                ]},
+                                "id"
+                            ],
+                            "aggregate": "array"
                         }
                     ],
                     "entry": "detailed",

--- a/test/specs/faceting/tests/01.faceting.js
+++ b/test/specs/faceting/tests/01.faceting.js
@@ -681,20 +681,19 @@ exports.execute = function (options) {
                 });
 
                 describe("should be able to handle sources with filter", function () {
-                    // TODO this requires a change in code...
-                    // I HAVE TO MAKE SURE THE HASH STAYS THE SAME BASED ON ALL THESE DIFFERENT PROPERTIES
-                    // THERE IS NO GUARANTEE THAT JSON.STRINGIFY JUST KEEPS THE ORDER
                     it ("when the facet exists in the annotation, should merge", function (done) {
                         facetObj = {
                             "and": [
                                 {
                                     "source": [
-                                        // {"filter": "id", "operand_pattern": "-1", "operator": "::gt::"},
                                         {"outbound": ["faceting_schema", "main_fk3"]},
-                                        {"and": [
-                                            {"filter": "date_col", "operand_pattern": "{{{$moment.year}}}-{{{$moment.month}}}-{{{$moment.day}}}", "operator": "::gt::"},
-                                            {"filter": "path_prefix_o1_col", "operand_pattern": "some_non_used_value"}
-                                        ], "negate": true},
+                                        {
+                                            "negate": true,
+                                            "and": [
+                                                {"operand_pattern": "some_non_used_value", "filter": "path_prefix_o1_col"},
+                                                {"operator": "::gt::", "filter": "date_col", "operand_pattern": "{{{$moment.year}}}-{{{$moment.month}}}-{{{$moment.day}}}"},
+                                            ]
+                                        },
                                         "path_prefix_o1_col"
                                     ],
                                     "choices": ["1"]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -206,6 +206,46 @@
                                 "RID"
                             ],
                             "comment": "recursive path prefix"
+                        },
+                        {
+                            "source": [
+                                {"or": [
+                                    {"filter": "RCT", "operator": "::null::"},
+                                    {"filter": "RID", "operator": "::null::"}
+                                ]},
+                                {"inbound": ["reference_schema", "fk_inbound_related_to_reference"]},
+                                {"filter": "id", "operand_pattern": "-1", "negate": true},
+                                "id"
+                            ],
+                            "markdown_name": "inbound related with filter"
+                        },
+                        {
+                            "source": [
+                                {"filter": "RID", "negate": true, "operand_pattern": "-1"},
+                                {"inbound": ["reference_schema", "id_fk_association_related_to_reference"]},
+                                {"outbound": ["reference_schema", "fk_to_inbound_related_reference_table"]},
+                                {"or": [
+                                    {"filter": "RCT", "operator": "::null::"},
+                                    {"filter": "RID", "operator": "::null::"}
+                                ]},
+                                "id"
+                            ],
+                            "markdown_name": "associative related with filter"
+                        },
+                        {
+                            "source": [
+                                {"filter": "RCT", "negate": true, "operand_pattern": "{{{$moment.year}}}-{{{$moment.month}}}-{{{$moment.day}}}", "operator": "::lt::"},
+                                {"inbound": ["reference_schema","fromname_fk_inbound_related_to_reference"]},
+                                {"inbound":["reference_schema","fk_to_inbound_related_reference_table"]},
+                                {"filter": "RID", "negate": true, "operand_pattern": "-1"},
+                                {"outbound":["reference_schema","id_fk_association_related_to_reference"]},
+                                {"or": [
+                                    {"filter": "RCT", "operator": "::null::"},
+                                    {"filter": "RID", "operator": "::null::"}
+                                ]},
+                                "RID"
+                            ],
+                            "markdown_name": "free form related with filter"
                         }
                     ]
                 },

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -65,10 +65,16 @@ exports.execute = function(options) {
             });
         }
 
-        function checkRelated (ref, schema, table, facet) {
+        function checkRelated (ref, schema, table, facet, ermrestCompactPath) {
             expect(ref.table.schema.name).toBe(schema, "schema missmatch.");
             expect(ref.table.name).toBe(table, "table missmatch.");
-            expect(JSON.stringify(ref.location.facets.decoded)).toEqual(JSON.stringify(facet), "facet missmatch.");
+            if (facet) {
+                expect(ref.location.facets.decoded).toEqual(jasmine.objectContaining(facet), "facet missmatch.");
+            }
+
+            if (ermrestCompactPath) {
+                expect(ref.location.ermrestCompactPath).toEqual(ermrestCompactPath);
+            }
         };
 
         function checkUri (index, expectedTable, expectedFacets) {
@@ -153,7 +159,7 @@ exports.execute = function(options) {
                 describe("regarding column objects defining path.", function () {
 
                     it ('should ignore the invalid (invalid, no path, non-entity, has aggregate, all-outbound) objects.', function () {
-                        expect(pathRelatedWithTuple.length).toBe(6);
+                        expect(pathRelatedWithTuple.length).toBe(9);
                     });
 
                     it ('should create the reference by using facet syntax (starting from related table with facet on shortestkey of main table.).', function () {
@@ -211,6 +217,49 @@ exports.execute = function(options) {
                                 {"inbound": ["reference_schema", "reference_table_fk1"]},
                                 "RID"
                             ], "choices":[utils.findEntityRID(options, schemaName, tableName, "id", "9003")]}]}
+                        );
+                    });
+
+                    it ("should be able to support inbound related with filter", function () {
+                        // we cannot guarantee the order of properties so we cannot check the facet object
+                        checkRelated(
+                            pathRelatedWithTuple[6], "reference_schema", "inbound_related_reference_table", null,
+                            [
+                                "M:=reference_schema:inbound_related_reference_table",
+                                "!(id=-1)/(fk_to_reference%20with%20space)=(reference_schema:reference_table:id)/(RCT::null::;RID::null::)",
+                                "RID=" + utils.findEntityRID(options, schemaName, tableName, "id", "9003"),
+                                "$M"
+                            ].join("/")
+                        );
+
+                    });
+
+                    it ("should be able to support pure & binary related with filter", function () {
+                        // we cannot guarantee the order of properties so we cannot check the facet object
+                        checkRelated(
+                            pathRelatedWithTuple[7], "reference_schema", "inbound_related_reference_table", null,
+                            [
+                                "M:=reference_schema:inbound_related_reference_table",
+                                "(RCT::null::;RID::null::)/(id)=(reference_schema:association%20table%20with%20id:id_from_inbound_related_table)",
+                                "(id%20from%20ref%20table)=(reference_schema:reference_table:id)/!(RID=-1)",
+                                "RID=" + utils.findEntityRID(options, schemaName, tableName, "id", "9003"),
+                                "$M"
+                            ].join("/")
+                        );
+                    });
+
+                    it ("should be able to support free-form related with filter", function () {
+                        // we cannot guarantee the order of properties so we cannot check the facet object
+                        checkRelated(
+                            pathRelatedWithTuple[8], "reference_schema", "reference_table", null,
+                            [
+                                "M:=reference_schema:reference_table",
+                                "(RCT::null::;RID::null::)/(id)=(reference_schema:association%20table%20with%20id:id%20from%20ref%20table)",
+                                "!(RID=-1)/(id_from_inbound_related_table)=(reference_schema:inbound_related_reference_table:id)",
+                                "(fk_to_reference_with_fromname)=(reference_schema:reference_table:id)/!(RCT::lt::2022-1-1)",
+                                "RID=" + utils.findEntityRID(options, schemaName, tableName, "id", "9003"),
+                                "$M"
+                            ].join("/")
                         );
                     });
                 });
@@ -292,10 +341,26 @@ exports.execute = function(options) {
                             {"key": "path_to_outbound1_inbound1_outbound1"},
                             {"i": ["reference_schema", "reference_outbound1_inbound1_outbound1_inbound1_fk1"]},
                             "RID"
-                        ]
+                        ],
+                        [
+                            {"or": [
+                                {"f": "RCT", "opr": "::null::"},
+                                {"f": "RID", "opr": "::null::"}
+                            ]},
+                            {"i": ["reference_schema", "fk_inbound_related_to_reference"]},
+                            {"f": "id", "opd": "-1", "n": true},
+                            "id"
+                        ], false, false
                     ];
                     pathRelatedWithTuple.forEach(function (rel, i) {
-                        expect(rel.compressedDataSource).toEqual(expectedCompressedDataSources[i], "missmatch for index=" + i);
+                        var expVal = expectedCompressedDataSources[i];
+                        if (!expVal) {
+                            // we cannot easily test the expected value, so just make sure it's not throwing any errors.
+                            expect(rel.compressedDataSource).toBeDefined("missmatch for index=" + i);
+                        }
+                        else {
+                            expect(rel.compressedDataSource).toEqual(expVal, "missmatch for index=" + i);
+                        }
                     });
                 });
             });


### PR DESCRIPTION
This PR will make modifications to filter in source feature based on #685's phase 1.5 and phase 2. The changes are:

- Improve pseudo-column hash logic regarding filters to sort the `and`/`or` filters before generating the hash to ensure the order of filters doesn't matter in `and`/`or`.
- Allow filter in source in columns and related references
- Disallow filter in all-outbound or local columns
