### PR TITLE
Use unlink instead of remove for batch association delete

### DIFF
--- a/js/errors.js
+++ b/js/errors.js
@@ -380,8 +380,19 @@
      * @constructor
      * @desc A malformed URI was passed to the API.
      */
-    function BatchUnlinkResponse(message, subMessage) {
+    function BatchUnlinkResponse(totalSuccess, totalFail, subMessage) {
+        var message = "";
+        if (totalSuccess > 0) {
+            message = totalSuccess + " record" + (totalSuccess > 1 ? "s" : "") + " successfully unlinked.";
+            if (totalFail > 0) message += " ";
+        }
+
+        if (totalFail > 0) {
+            message += totalFail + " record" + (totalFail > 1 ? "s" : "") + " could not be unlinked. Check the error details below to see more information.";
+        }
+
         this.message = message;
+        this.subMessage = subMessage;
         ERMrestError.call(this, '', module._errorStatus.BATCH_UNLINK, message, subMessage);
     }
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -2229,8 +2229,7 @@
                         k++;
                         recursiveDelete(referencePathObjs[k], catalogObj);
                     } else {
-                        var message = "";
-                        var deleteSubmessage = "";
+                        var deleteSubmessage = null;
                         var totalSuccess = 0;
                         var successTupleData = [];
                         if (successResponses.length > 0) {
@@ -2246,6 +2245,7 @@
                         var failedTupleData = [];
                         var errorsPresent = deleteErrors.length > 0;
                         if (errorsPresent) {
+                            deleteSubmessage = "";
                             deleteErrors.forEach(function (errPair, idx) {
                                 deleteSubmessage += errPair.error.data;
                                 if (idx < deleteErrors.length-1) deleteSubmessage += " \n";
@@ -2256,17 +2256,7 @@
                             });
                         }
 
-                        if (totalSuccess > 0) {
-                            message = totalSuccess + " record" + (totalSuccess > 1 ? "s" : "") + " successfully removed.";
-                            if (totalFail > 0) message += " ";
-                        }
-
-                        var err = new module.BatchUnlinkResponse(message);
-
-                        if (totalFail > 0) {
-                            message += totalFail + " record" + (totalFail > 1 ? "s" : "") + " could not be removed. Check the error details below to see more information.";
-                            err = new module.BatchUnlinkResponse(message, deleteSubmessage);
-                        }
+                        var err = new module.BatchUnlinkResponse(totalSuccess, totalFail, deleteSubmessage);
 
                         err.successTupleData = successTupleData;
                         err.failedTupleData = failedTupleData;

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -223,7 +223,7 @@
         INVALID_FILTER: "Invalid Filter",
         INVALID_INPUT: "Invalid Input",
         INVALID_URI: "Invalid URI",
-        BATCH_UNLINK: "Batch Remove Summary",
+        BATCH_UNLINK: "Batch Unlink Summary",
         NO_DATA_CHANGED: "No Data Changed",
         NO_CONNECTION_ERROR: "No Connection Error",
         INVALID_SORT: "Invalid Sort Criteria",

--- a/test/specs/reference/tests/11.delete.js
+++ b/test/specs/reference/tests/11.delete.js
@@ -123,7 +123,7 @@ exports.execute = function (options) {
                 //   - an array of "leaf_table" tuples
                 //   - a filtered reference representing a single row from the leaf table
                 filteredLeafReference.deleteBatchAssociationTuples(mainTuple, relatedLeafTuples).then(function (res) {
-                    expect(res.message).toBe("3 records successfully removed.")
+                    expect(res.message).toBe("3 records successfully unlinked.")
                     expect(res.successTupleData.length).toBe(3, "success count for batch delete is incorrect");
 
                     return relatedLeafReference.read(7);
@@ -289,8 +289,8 @@ exports.execute = function (options) {
                 // trying to delete rows (5, 55), (6, 66), (7, 77)
                 // user can only unlink (6, 66)
                 filteredLeafReferenceWAcls.deleteBatchAssociationTuples(mainTuple, relatedLeafTuples).then(function (res) {
-                    expect(res.status).toBe("Batch Remove Summary", "error status for batch delete is incorrect");
-                    expect(res.message).toBe("3 records could not be removed. Check the error details below to see more information.", "error message for batch delete is incorrect");
+                    expect(res.status).toBe("Batch Unlink Summary", "error status for batch delete is incorrect");
+                    expect(res.message).toBe("3 records could not be unlinked. Check the error details below to see more information.", "error message for batch delete is incorrect");
                     expect(res.subMessage).toBe("403 Forbidden\nThe requested delete access on one or more matching rows in table :delete_schema:association_table is forbidden.\n", "error sub message for batch delete is incorrect");
                     expect(res.successTupleData.length).toBe(0, "success count for batch delete is incorrect");
                     expect(res.failedTupleData.length).toBe(3, "failed count for batch delete is incorrect");
@@ -467,7 +467,7 @@ exports.execute = function (options) {
                 //   - an array of "leaf_table" tuples
                 //   - a filtered reference representing a single row from the leaf table
                 filteredLeafReference.deleteBatchAssociationTuples(mainTuple, relatedLeafTuples).then(function (res) {
-                    expect(res.message).toBe("81 records could not be removed. Check the error details below to see more information.")
+                    expect(res.message).toBe("81 records could not be unlinked. Check the error details below to see more information.")
                     expect(res.successTupleData.length).toBe(0, "success count for batch delete is incorrect");
 
                     done();
@@ -484,7 +484,7 @@ exports.execute = function (options) {
                 //   - an array of "leaf_table" tuples
                 //   - a filtered reference representing a single row from the leaf table
                 filteredLeafReference.deleteBatchAssociationTuples(mainTuple, relatedLeafTuples).then(function (res) {
-                    expect(res.message).toBe("1 record successfully removed. 79 records could not be removed. Check the error details below to see more information.")
+                    expect(res.message).toBe("1 record successfully unlinked. 79 records could not be unlinked. Check the error details below to see more information.")
                     expect(res.successTupleData.length).toBe(1, "success count for batch delete is incorrect");
 
                     return relatedLeafReference.read(100);
@@ -620,7 +620,7 @@ exports.execute = function (options) {
                 //   - an array of "leaf_table" tuples
                 //   - a filtered reference representing a single row from the leaf table
                 filteredLeafReference.deleteBatchAssociationTuples(mainTuple, relatedLeafTuples).then(function (res) {
-                    expect(res.message).toBe("82 records successfully removed.")
+                    expect(res.message).toBe("82 records successfully unlinked.")
                     expect(res.successTupleData.length).toBe(82, "success count for batch delete is incorrect");
 
                     return relatedLeafReference.read(100);


### PR DESCRIPTION
Change ermrestJS to use "unlink" instead of "remove" for the batch unlink association workflow. Updated test cases too.