### PR TITLE
Fix issues with sorting all-outbound paths

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -8021,8 +8021,8 @@ This function is used to configure the module
 
 | Param | Type | Description |
 | --- | --- | --- |
-| http | <code>Object</code> | Angular $http service object |
-| q | <code>Object</code> | Angular $q service object |
+| http | <code>Object</code> | any http service (like Angular $http or axios) |
+| q | <code>Object</code> | Any promise library (like Angular $q or Q library) |
 
 <a name="ERMrest.getServer"></a>
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -34,7 +34,7 @@
      * feature anymore and will fallback to raw ermrest regular expression search.
      * Therefore it's highly recommended that you don't use this parameter and instead
      * modify the search-box source definition of the table.
-     * 
+     *
      * @param  {string} schemaName          Name of schema, can be null
      * @param  {string} tableName           Name of table
      * @param  {string} searchTerm          the search keyword
@@ -44,7 +44,7 @@
     module.createSearchPath = function (catalogId, schemaName, tableName, searchTerm, searchColumNames) {
         verify(typeof catalogId === "string" && catalogId.length > 0, "catalogId must be an string.");
         verify(typeof tableName === "string" && tableName.length > 0, "tableName must be an string.");
-        
+
         var hasSearch = (typeof searchTerm === "string" && searchTerm.trim().length > 0);
         var encode = module._fixedEncodeURIComponent;
 
@@ -56,7 +56,7 @@
                 compactPath += encode(schemaName) + ":";
             }
             compactPath += encode(tableName);
-            
+
             searchColumNames.forEach(function (col) {
                 parsedSearch.push(encode(col) + "::ciregexp::" + encode(searchTerm.trim()));
             });
@@ -73,7 +73,7 @@
         }
 
         return module.createPath(catalogId, schemaName, tableName, facets);
-        
+
     };
 
     /**
@@ -490,7 +490,6 @@
             var self = this;
             var rightJoinIndex = -1, i;
             var uri = "", alias, temp;
-            var lastPathPartAliasMapping = new PathPrefixAliasMapping();
 
             var getPathPartAliasMapping = function (index) {
                 if (index !== -1 && parsedPartsWithoutJoin[index].pathPrefixAliasMapping) {
@@ -501,18 +500,18 @@
 
             /**
              * As part of `jonsStr`, if the table instance is already defined and added
-             * to the aliases, we might not add any new instances and just refer to the 
+             * to the aliases, we might not add any new instances and just refer to the
              * previously defined instance. In this case, the `jonsStr` function will
              * change the alias property of pathPart to properly refer to the table instance.
-             * 
-             * But the alias names used for the last pathPart is specific and should not be 
+             *
+             * But the alias names used for the last pathPart is specific and should not be
              * changed. Therefore we're making sure if there's a sourcekey that is supposed
              * to use a shared instance, is using the forced alias name.
-             * 
+             *
              * Then the logic for generating new alias names will first look at the forced
              * aliases and if the sourcekey is part of forced aliases will not generate a new
              * one for it.
-             * @param {*} index 
+             * @param {*} index
              * @returns an object that represent forcedAliases
              * @ignore
              */
@@ -573,6 +572,23 @@
                     }, "");
                 }
             };
+
+            var projectedTable = null;
+            try {
+                projectedTable = self.catalogObject.schemas.findTable(self.tableName, self.schemaName);
+            } catch(exp) {
+                // fail silently
+            }
+            /**
+             * make sure the lastPathPartAliasMapping is defined
+             * NOTE: if the location doesn't have any facets, this object will
+             * be used. otherwise we will use the one generated based on facets
+             */
+            var lastPathPartAliasMapping = new PathPrefixAliasMapping(
+                self.pathParts.length > 0 ? getForcedAliases(self.pathParts.length-1) : null,
+                usedSourceObjects,
+                projectedTable
+            );
 
             // get the parsed one, and count the number of right joins
             // NOTE: we have to do this at first to find the facets with null

--- a/js/reference.js
+++ b/js/reference.js
@@ -4129,12 +4129,14 @@
             var hasSort = Array.isArray(this._location.sortObject) && (this._location.sortObject.length !== 0),
                 locationPath = this.location.path,
                 fkAliasPreix = module._parserAliases.FOREIGN_KEY_PREFIX,
+                allOutBoundUsedAliases = [],
                 _modifiedSortObject = [], // the sort object that is used for url creation (if location has sort).
-                sortMap = {}, // maps an alias to PseudoColumn, used for sorting
+                allOutBoundSortMap = {}, // maps an alias to PseudoColumn, used for sorting
                 sortObject,  // the sort that will be accessible by this._location.sortObject
                 sortColNames = {}, // to avoid adding duplciate columns
                 sortObjectNames = {}, // to avoid computing sortObject logic more than once
                 addSort,
+                hasFKSort = false,
                 sortCols,
                 col, i, j, k, l;
 
@@ -4161,9 +4163,7 @@
              *           - The sort column name must be the "foreignkey_alias:column_name".
              * */
             var processSortObject= function (self) {
-                var foreignKeys = self._table.foreignKeys,
-                    colName,
-                    fkIndex, fk, desc;
+                var colName, desc;
 
                 for (i = 0, k = 1; i < sortObject.length; i++) {
                     // find the column in ReferenceColumns
@@ -4191,21 +4191,23 @@
                     // use the sort columns instead of the actual column.
                     for (j = 0; j < sortCols.length; j++) {
                         if (col.isForeignKey || (col.isPathColumn && col.isUnique)) {
-                            if (useEntity) addSort = false;
+                            // TODO if the code asks for entity read,
+                            // we should make sure only include the ones that are needed
+                            // for sort, but currently we're just switching to attributegroup
+                            hasFKSort = true;
 
                             // the column must be part of outbounds, so we don't need to check for it
+                            // NOTE what about the backward compatibility code?
                             fkIndex = findAllOutBoundIndex(col.name);
-
-                            if (col.canUseScalarProjection) {
-                                // in this case the column itself is projected,
-                                // and sort can only be based on the column itself..
-                                // so we don't need sortMap and just need to
-                                // ensure the colName is referring to the proper fk
-                                colName = fkIndex;
-                            } else {
-                                colName = fkAliasPreix + (allOutBounds.length + k++);
-                                sortMap[colName] = [fkAliasPreix + (fkIndex+1), module._fixedEncodeURIComponent(sortCols[j].column.name)].join(":");
-                            }
+                            // create a new projection alias to be used for this sort column
+                            colName = fkAliasPreix + (allOutBounds.length + k++);
+                            // store the actual column name and foreignkey info for later
+                            // the alias used for the fk might be different from what we expect now
+                            // (because of the shared prefix code)
+                            allOutBoundSortMap[colName] = {
+                                fkIndex: fkIndex,
+                                colName: module._fixedEncodeURIComponent(sortCols[j].column.name)
+                            };
                         } else {
                             colName = sortCols[j].column.name;
                             if (colName in sortColNames) {
@@ -4277,7 +4279,7 @@
             var associatonRef = this.derivedAssociationReference;
             var associationTableAlias = module._parserAliases.ASSOCIATION_TABLE;
 
-            var isAttributeGroup = !useEntity;
+            var isAttributeGroup = hasFKSort || !useEntity;
             if (isAttributeGroup) {
                 isAttributeGroup = allOutBounds.length > 0 ||
                                    (getTCRS && this.canUseTCRS) ||
@@ -4344,6 +4346,8 @@
                 for (k = allOutBounds.length - 1; k >= 0; k--) {
                     allOutBound = allOutBounds[k];
                     pseudoPathRes = getPseudoPath(k, fkAliasPreix + (k+1));
+                    // capture the used aliases (used in sorting)
+                    allOutBoundUsedAliases[k] = pseudoPathRes.usedOutAlias;
 
                     // TODO could be improved by adding $M to the begining?
                     // if the result is just the alias, we don't need to add it at all
@@ -4353,7 +4357,7 @@
                     }
 
                     // entity mode: F2:array_d(F2:*),F1:array_d(F1:*)
-                    // scalar mode: F2:F2:col,F1:F1:col
+                    // scalar mode: F2:=F2:col,F1:=F1:col
                     if (allOutBound.isPathColumn && allOutBound.canUseScalarProjection) {
                         aggList.push(fkAliasPreix + (k+1) + ":=" + pseudoPathRes.usedOutAlias + ":" + module._fixedEncodeURIComponent(allOutBound.baseColumn.name));
                     } else {
@@ -4387,9 +4391,13 @@
 
                 addedCols = {};
                 for(k = 0; k < sortCols.length; k++) {
-                    if (sortCols[k] in sortMap) {
-                        // sort column has been created via PseudoColumn, so we should use a new alias
-                        sortColumn = module._fixedEncodeURIComponent(sortCols[k]) + ":=" + sortMap[sortCols[k]];
+                    if (sortCols[k] in allOutBoundSortMap) {
+                        var allOutBoundSortMapInfo = allOutBoundSortMap[sortCols[k]];
+                        // the sortCols[k] is an alias that we assigned before
+                        // this will be in format of: <new-alias>:=<fk-alias>:<col-name>
+                        // so for example: F10:=F1:name
+                        sortColumn = sortCols[k] + ":=" +
+                                     allOutBoundUsedAliases[allOutBoundSortMapInfo.fkIndex] + ":" + allOutBoundSortMapInfo.colName;
                     } else {
                         sortColumn = module._fixedEncodeURIComponent(sortCols[k]);
                     }

--- a/js/utils/pseudocolumn_helpers.js
+++ b/js/utils/pseudocolumn_helpers.js
@@ -2228,35 +2228,46 @@
 
     /**
      * This prototype is used for the shared prefix logic.
+     *
+     * @param {Object} forcedAliases        The aliases that must be used for the given sourcekeys
+     * @param {Object[]?} usedSourceObjects The source objects that are used in the url
+     *                                      (used for populating usedSourceKeys)
+     * @param {ERMrest.Table?} rootTable    The table that the source objects start from
+     *                                      (used for populating usedSourceKeys)
      * @ignore
      */
     function PathPrefixAliasMapping (forcedAliases, usedSourceObjects, rootTable) {
         /**
          * Aliases that already mapped to a join statement
          * <sourcekey> -> <alias>
+         * @type {Object
          */
         this.aliases = {};
 
         /**
          * sourcekeys that are used more than once and require alias
          * <sourcekey> -> value is not important
+         * @type {Object
          */
         this.usedSourceKeys = {};
 
         /**
          * The index of last added alias
+         * @type {number}
          */
         this.lastIndex = 0;
 
         /**
          * The aliases that must be used for the given sourcekeys
          * <sourcekey> -> <alias>
+         * @type {Object}
          */
         this.forcedAliases = {};
         if (isObjectAndNotNull(forcedAliases)) {
             this.forcedAliases = forcedAliases;
         }
 
+        // populate the this.usedSourceKeys based on the given objects
         this._populateUsedSourceKeys(usedSourceObjects, rootTable);
     }
 
@@ -2281,10 +2292,8 @@
          * "key1_i1" as part of usedSourcekeys even though adding alias for "key1_i1" is enough and
          * we don't need any for "key1".
          *
-         * @param {string[]} usedSourceKeys - an array of strings representing the sourcekeys that are used
-         *                             more than once and therefore should add alias.
-         * @param {Object[]} sources
-         * @param {ERMrest.Table} rootTable
+         * @param {Object[]} sources the source objects that are used in the url
+         * @param {ERMrest.Table} rootTable the table that the source objects start from
          * @private
          */
         _populateUsedSourceKeys: function (sources, rootTable) {

--- a/test/specs/reference/conf/reference_schema/data/sorted_table.json
+++ b/test/specs/reference/conf/reference_schema/data/sorted_table.json
@@ -1,8 +1,8 @@
-[{"id":9000,"name":"Hank","value":12, "row_order_col": 99},
-  {"id":9001,"name":"Harold","value":17, "row_order_col": 98},
-  {"id":9002,"name":"Heather","value":26, "row_order_col": 97},
-  {"id":9003,"name":"Henry","value":4, "row_order_col": 96},
-  {"id":9004,"name":"Helga","value":66, "row_order_col": 95},
-  {"id":9005,"name":"Harry","value":23, "row_order_col": 94},
-  {"id":9006,"name":"Ramona","value":1, "row_order_col": 93},
-  {"id":9007,"name":"Ralph","value":160, "row_order_col": 92}]
+[{"id":9000,"name":"Hank","value":12, "row_order_col": 99, "fk1_col_1": "1"},
+  {"id":9001,"name":"Harold","value":17, "row_order_col": 98, "fk1_col_1": "2"},
+  {"id":9002,"name":"Heather","value":26, "row_order_col": 97, "fk1_col_1": "3"},
+  {"id":9003,"name":"Henry","value":4, "row_order_col": 96, "fk1_col_1": "4"},
+  {"id":9004,"name":"Helga","value":66, "row_order_col": 95, "fk1_col_1": "5"},
+  {"id":9005,"name":"Harry","value":23, "row_order_col": 94, "fk1_col_1": "6"},
+  {"id":9006,"name":"Ramona","value":1, "row_order_col": 93, "fk1_col_1": "7"},
+  {"id":9007,"name":"Ralph","value":160, "row_order_col": 92, "fk1_col_1": "8"}]

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -776,8 +776,25 @@
                     ]
                 }
             ],
-            "entityCount": 0,
-            "foreign_keys": [],
+            "foreign_keys": [
+                {
+                    "names": [["reference_schema", "sorted_table_fk1"]],
+                    "foreign_key_columns": [
+                        {
+                            "schema_name": "reference_schema",
+                            "table_name": "sorted_table",
+                            "column_name": "fk1_col_1"
+                        }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "schema_name": "reference_schema",
+                            "table_name": "table_w_composite_key",
+                            "column_name": "id"
+                        }
+                    ]
+                }
+            ],
             "table_name": "sorted_table",
             "schema_name": "reference_schema",
             "column_definitions": [
@@ -811,6 +828,12 @@
                                 "column_order": ["name"]
                             }
                         }
+                    }
+                },
+                {
+                    "name": "fk1_col_1",
+                    "type": {
+                        "typename": "text"
                     }
                 }
             ],
@@ -1012,7 +1035,45 @@
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns" : {
-                    "*": ["id", ["reference_schema", "sorted_table_w_fk_fk1"], ["reference_schema", "sorted_table_w_fk_fk2"], ["reference_schema", "sorted_table_w_fk_fk3"]]
+                    "*": [
+                        "id",
+                        ["reference_schema", "sorted_table_w_fk_fk1"],
+                        ["reference_schema", "sorted_table_w_fk_fk3"],
+                        {
+                            "source": [
+                                {"outbound": ["reference_schema", "sorted_table_w_fk_fk3"]},
+                                "col. w. dot."
+                            ],
+                            "entity": false
+                        },
+                        {
+                            "source": [
+                                {"sourcekey": "path_to_main_sorted_table"},
+                                {"outbound": ["reference_schema", "sorted_table_fk1"]},
+                                "RID"
+                            ]
+                        },
+                        {
+                            "source": [
+                                {"sourcekey": "path_to_main_sorted_table"},
+                                {"outbound": ["reference_schema", "sorted_table_fk1"]},
+                                "id"
+                            ],
+                            "entity": false
+                        },
+                        {"sourcekey": "path_to_main_sorted_table"}
+                    ]
+                },
+                "tag:isrd.isi.edu,2019:source-definitions": {
+                    "sources": {
+                        "path_to_main_sorted_table": {
+                            "source": [
+                                {"outbound": ["reference_schema", "sorted_table_w_fk_fk2"]},
+                                "RID"
+                            ],
+                            "entity": true
+                        }
+                    }
                 }
             }
         },

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -1053,6 +1053,7 @@
                                 "RID"
                             ]
                         },
+                        {"sourcekey": "path_to_main_sorted_table"},
                         {
                             "source": [
                                 {"sourcekey": "path_to_main_sorted_table"},
@@ -1060,8 +1061,7 @@
                                 "id"
                             ],
                             "entity": false
-                        },
-                        {"sourcekey": "path_to_main_sorted_table"}
+                        }
                     ]
                 },
                 "tag:isrd.isi.edu,2019:source-definitions": {

--- a/test/specs/reference/tests/03.reference_sort.js
+++ b/test/specs/reference/tests/03.reference_sort.js
@@ -9,8 +9,8 @@ exports.execute = function (options) {
 
         var outboundTableVisColNames = [
             'id', 'AmU5Bnpob57TlHBvLFLu8w', 'eYcW4ExSOlwtjNUvpNrZbA',
-            'DpOPZjKrep4VR09840YwRA', 'KSK3d0VUL0g8N4P1SZzDZw', '8tw62El12BT87wkFsN__1Q',
-            'HYUMN3Ihd6vR-0YnlIWR7Q'
+            'DpOPZjKrep4VR09840YwRA', 'KSK3d0VUL0g8N4P1SZzDZw',
+            '8tw62El12BT87wkFsN__1Q', 'HYUMN3Ihd6vR-0YnlIWR7Q',
         ];
 
         var multipleEntityUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":" + tableName;
@@ -187,12 +187,11 @@ exports.execute = function (options) {
                 colName;
             var readPathPrefix = [
                 "M:=reference_schema:sorted_table_w_fk/",
-                "F6:=left(fk2_col_1)=(reference_schema:sorted_table:id)/$M/",
-                "left(fk2_col_1)=(reference_schema:sorted_table:id)/F5:=left(fk1_col_1)=(reference_schema:table_w_composite_key:id)/$M/",
-                "left(fk2_col_1)=(reference_schema:sorted_table:id)/F4:=left(fk1_col_1)=(reference_schema:table_w_composite_key:id)/$M/",
+                "M_P1:=left(fk2_col_1)=(reference_schema:sorted_table:id)/F6:=left(fk1_col_1)=(reference_schema:table_w_composite_key:id)/$M/",
+                "$M_P1/F4:=left(fk1_col_1)=(reference_schema:table_w_composite_key:id)/$M/",
                 "F3:=left(fk3_col_1)=(reference_schema:table_w_composite_key:id)/$M/",
                 "F2:=left(fk3_col_1)=(reference_schema:table_w_composite_key:id)/$M/",
-                "F1:=left(fk1_col_1,fk1_col_2)=(reference_schema:table_w_composite_key:id_1,id_2)/$M/",
+                "F1:=left(fk1_col_1,fk1_col_2)=(reference_schema:table_w_composite_key:id_1,id_2)/$M/"
             ].join("");
 
             beforeAll(function(done) {
@@ -239,7 +238,7 @@ exports.execute = function (options) {
                         done,
                         [
                             readPathPrefix,
-                            "F7:=F6:row_order_col,F8:=F6:id,RID;M:=array_d(M:*),F6:=array_d(F6:*),F5:=F5:id,F4:=array_d(F4:*),F3:=F3:col.%20w.%20dot.,F2:=array_d(F2:*),F1:=array_d(F1:*)@sort(F7::desc::,F8,RID)"
+                            "F7:=M_P1:row_order_col,F8:=M_P1:id,RID;M:=array_d(M:*),F6:=F6:id,F5:=array_d(M_P1:*),F4:=array_d(F4:*),F3:=F3:col.%20w.%20dot.,F2:=array_d(F2:*),F1:=array_d(F1:*)@sort(F7::desc::,F8,RID)"
                         ].join("")
                     );
                 });
@@ -257,7 +256,7 @@ exports.execute = function (options) {
                         done,
                         [
                             readPathPrefix,
-                            "F7:=F3:col.%20w.%20dot.,RID;M:=array_d(M:*),F6:=array_d(F6:*),F5:=F5:id,F4:=array_d(F4:*),F3:=F3:col.%20w.%20dot.,F2:=array_d(F2:*),F1:=array_d(F1:*)@sort(F7,RID)"
+                            "F7:=F3:col.%20w.%20dot.,RID;M:=array_d(M:*),F6:=F6:id,F5:=array_d(M_P1:*),F4:=array_d(F4:*),F3:=F3:col.%20w.%20dot.,F2:=array_d(F2:*),F1:=array_d(F1:*)@sort(F7,RID)"
                         ].join("")
                     );
                 });
@@ -276,7 +275,7 @@ exports.execute = function (options) {
                             done,
                             [
                                 readPathPrefix,
-                                "F7:=F5:id,RID;M:=array_d(M:*),F6:=array_d(F6:*),F5:=F5:id,F4:=array_d(F4:*),F3:=F3:col.%20w.%20dot.,F2:=array_d(F2:*),F1:=array_d(F1:*)@sort(F7::desc::,RID)"
+                                "F7:=F6:id,RID;M:=array_d(M:*),F6:=F6:id,F5:=array_d(M_P1:*),F4:=array_d(F4:*),F3:=F3:col.%20w.%20dot.,F2:=array_d(F2:*),F1:=array_d(F1:*)@sort(F7::desc::,RID)"
                             ].join("")
                         );
                     });


### PR DESCRIPTION
This PR will ensure we're using proper aliases while sorting all-outbound paths.

When I modified the `Reference.readPath` to not ask for the whole row of data in scalar all-outbounds, I [broke the sort functionality](https://github.com/informatics-isi-edu/chaise/issues/2167) and didn't properly test the changes. This PR will fix the sort functionality and also adds more test cases.

Also, the code assumed that the all-outbound path table instances are using aliases in the `F#` format. While this is generally the case, the alias name might be different when the path with prefix syntax is deployed. With these changes, the code is now using the actual alias instead of assuming the format.