### PR TITLE
Always use shortestkey for self_link (key pseudo-column)

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -2142,7 +2142,7 @@ KeyPseudoColumn.prototype.formatPresentation = function(data, context, templateV
     }
     if (this.display.sourceMarkdownPattern) {
         var keyValues = {}, selfTemplateVariables = {
-            "$self": module._getRowTemplateVariables(this.table, context, data, null, this.key)
+            "$self": module._getRowTemplateVariables(this.table, context, data, null)
         };
         Object.assign(keyValues, templateVariables, selfTemplateVariables);
         return module.processMarkdownPattern(
@@ -3028,7 +3028,7 @@ FacetColumn.prototype = {
     /**
      * uncontextualized {@link ERMrest.Reference} that has all the joins specified
      * in the source with all the filters of other FacetColumns in the reference.
-     * 
+     *
      * The returned reference will be in the following format:
      * <main-table>/<facets of main table except current facet>/<path to current facet>
      *
@@ -3039,7 +3039,7 @@ FacetColumn.prototype = {
      * Then the source reference for R3 will be the following:
      * T:=S:T/(fk1)/term=1/$T/(fk2)/term2/$T/M:=(fk3)
      * As you can see it has all the filters of the main table + join to current table.
-     * 
+     *
      * Notes:
      * - This function used to reverse the path from the current facet to each of the
      *   other facets in the main reference. Since this was very inefficient, we decided
@@ -3048,7 +3048,7 @@ FacetColumn.prototype = {
      *   therefore might have filters or reused table instances (shared path). That's why
      *   we're ensuring to pass the whole facetObjectWrapper to parser, so it can properly
      *   parse it.
-     * 
+     *
      *
      * @type {ERMrest.Reference}
      */
@@ -3116,7 +3116,7 @@ FacetColumn.prototype = {
                 }
                 newLoc.customFacets = cfacet;
             }
-            
+
             /**
              * if it has path, we have to pass the whole facetObjectWrapper
              * as a join. this is so we can properly share path
@@ -3127,7 +3127,7 @@ FacetColumn.prototype = {
                     table.schema.name,
                     table.name
                 );
-            } 
+            }
             // if it only has filter (and no path, then we can just add the filter to path)
             else if (self._facetObjectWrapper.isFiltered) {
                 // TODO can this be improved?

--- a/js/reference.js
+++ b/js/reference.js
@@ -6048,7 +6048,7 @@
                     if (Array.isArray(sm[col.name])) {
                         // compute it once and use it for all the self-links.
                         if (!selfLinkValue) {
-                            selfLinkValue = module._getRowTemplateVariables(col.table, context, self._data, null, col.key);
+                            selfLinkValue = module._getRowTemplateVariables(col.table, context, self._data, null);
                         }
 
                         sm[col.name].forEach(function (key) {

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -937,11 +937,11 @@
      * @param  {string} context    current context
      * @param  {Object} data       the raw data
      * @param  {Object} linkedData the raw data of foreignkeys
-     * @param  {ERMrest.Reference=} ref to avoid creating a new reference
      * @return {Object}
      */
-    module._getRowTemplateVariables = function (table, context, data, linkedData, key) {
-        var uri = _generateRowURI(table, data, key);
+    module._getRowTemplateVariables = function (table, context, data, linkedData) {
+        // generate the uri based on the shortest key
+        var uri = _generateRowURI(table, data);
         if (uri == null) return {};
         var ref = new Reference(module.parse(uri), table.schema.catalog);
         return {
@@ -1077,7 +1077,8 @@
 
         var value, caption, unformatted, i;
         var cols = key.colset.columns,
-            rowURI = _generateRowURI(key.table, data, key);
+            // generate the uri based on the shortestkey
+            rowURI = _generateRowURI(key.table, data);
 
         // if any of key columns don't have data, this link is not valid.
         if (rowURI == null) {
@@ -1218,6 +1219,8 @@
 
         var value, rowname, i, caption, unformatted;
         var table = key.table;
+        // this is mainly used for making sure the data is valid,
+        // the actual url will use the shortest key
         var rowURI = _generateRowURI(table, data, key);
 
         // if any of key columns don't have data, this link is not valid.

--- a/test/specs/column/tests/01.columns_list.js
+++ b/test/specs/column/tests/01.columns_list.js
@@ -94,6 +94,7 @@ exports.execute = function (options) {
 
         var referenceRawData = [
             {
+                "RID": "rid-1", // needed by the self_link logic
                 "id": "1",
                 "col_1": "9000",
                 "col_2": null,
@@ -105,6 +106,7 @@ exports.execute = function (options) {
                 "columns_schema_outbound_fk_7": "12"
             },
             {
+                "RID": "rid-2", // needed by the self_link logic
                 "id": "2",
                 "col_1": "9001",
                 "col_2": null,
@@ -118,7 +120,7 @@ exports.execute = function (options) {
         ];
 
         var compactRefExpectedPartialValue = [
-            '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/id=1">1</a>',
+            '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/RID=rid-1">1</a>',
             '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_simple_key/id=9000">9000</a>',
             '',
             '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_simple_key/id=4000">4000</a>',
@@ -341,7 +343,7 @@ exports.execute = function (options) {
             });
 
             compactRefExpectedLinkedValue = [
-                '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/id=1">1</a>',
+                '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/RID=' + utils.findEntityRID(options, schemaName, "columns_table", "id", "1") +'">1</a>',
                 '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_simple_key/RID=' + utils.findEntityRID(options, schemaName, "table_w_simple_key", "id", "9000") + '">Hank</a>',
                 '',
                 '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_simple_key/RID=' + utils.findEntityRID(options, schemaName, "table_w_simple_key", "id", "4000") + '">John</a>',
@@ -360,7 +362,7 @@ exports.execute = function (options) {
             ];
             var html = "";
             assetCompactExpectedValue = [
-                '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_asset/id=1">1</a>',
+                '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:table_w_asset/RID=' + utils.findEntityRID(options, schemaName, "table_w_asset", "id", "1") + '">1</a>',
                 '<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/RID=' + utils.findEntityRID(options, schemaName, "columns_table", "id", "1") + '">1</a>',
                 '1000', '10001', 'filename', '1,242', 'md5', 'sha256',
                 '',

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -813,22 +813,22 @@ exports.execute = function (options) {
                         expect(val).toBe('');
                     });
 
-                    it('should use `markdown_pattern` from key display annotation with a link.', function () {
-                        val = compactBriefRef.columns[1].formatPresentation({"col_1":1, "col_3":2, "col_4":"value"}, "compact/brief", {"col_4":"value"}).value;
-                        expect(val).toEqual('<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/col_1=1&col_3=2"><strong>value</strong></a>');
+                    it('should use `markdown_pattern` from key display annotation with a link based on shortest key.', function () {
+                        val = compactBriefRef.columns[1].formatPresentation({"RID": "rid-val", "col_1":1, "col_3":2, "col_4":"value"}, "compact/brief", {"col_4":"value"}).value;
+                        expect(val).toEqual('<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/RID=rid-val"><strong>value</strong></a>');
                     });
 
                     describe('otherwise, ', function () {
-                        it ("should use key columns values separated with colon for caption. The URL should refer to the current reference.", function(){
-                            val = compactColumns[0].formatPresentation({"id":2}, "detailed", {"id":2}).value;
-                            expect(val).toEqual('<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/id=2">2</a>');
+                        it ("should use key columns values separated with colon for caption. The URL should refer to the current reference and use RID.", function(){
+                            val = compactColumns[0].formatPresentation({"RID": "val-1", "id":2}, "detailed", {"RID": "val-1" ,"id":2}).value;
+                            expect(val).toEqual('<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/RID=val-1">2</a>');
 
-                            val = compactBriefRef.columns[0].formatPresentation({"col_3":"3", "col_6":"6"}, "compact/brief", {"col_3":"3", "col_6":"6"}).value;
-                            expect(val).toEqual('<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/col_3=3&col_6=6">3:6</a>');
+                            val = compactBriefRef.columns[0].formatPresentation({"RID": "val2", "col_3":"3", "col_6":"6"}, "compact/brief", {"RID": "val2", "col_3":"3", "col_6":"6"}).value;
+                            expect(val).toEqual('<a href="https://dev.isrd.isi.edu/chaise/record/columns_schema:columns_table/RID=val2">3:6</a>');
                         });
 
                         it('should not add link if the key columns produce a link.', function () {
-                            val = compactBriefRef.columns[2].formatPresentation({"columns_schema_outbound_fk_7":"value"}, "compact/brief", {"columns_schema_outbound_fk_7":"value"}).value;
+                            val = compactBriefRef.columns[2].formatPresentation({"RID": "v" ,"columns_schema_outbound_fk_7":"value"}, "compact/brief", {"RID": "v", "columns_schema_outbound_fk_7":"value"}).value;
                             expect(val).toEqual('<p><a href="http://example.com" class="external-link-icon external-link">value</a></p>\n');
                         })
                     });

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -906,23 +906,23 @@ exports.execute = function (options) {
             describe ("formatPresentation, ", function () {
                 it ("in entry mode should return null.", function () {
                     detailedPseudoColumnIndices.forEach(function (i) {
-                        expect(detailedColsWTuple[i].formatPresentation({"id":"1", "col":"1"}, "entry").value).toEqual("", "missmatch for index=" + i);
+                        expect(detailedColsWTuple[i].formatPresentation({"RID": "v", "id":"1", "col":"1"}, "entry").value).toEqual("", "missmatch for index=" + i);
                     });
                 });
 
                 it ("if aggregate is defined should return null.", function () {
                     for (var i = 11; i <= 15; i++) {
-                        expect(detailedColsWTuple[i].formatPresentation({"id":"1", "col":"1"}, "detailed").value).toEqual("", "missmatch for index=" + i);
+                        expect(detailedColsWTuple[i].formatPresentation({"RID": "v", "id":"1", "col":"1"}, "detailed").value).toEqual("", "missmatch for index=" + i);
                     }
                 });
 
                 it ("if it's not a one-to-one path, should return null.", function () {
-                    expect(detailedColsWTuple[9].formatPresentation({"main_table_id_col":"1", "col":"1"}, "detailed").value).toEqual("", "missmatch for index=" + i);
+                    expect(detailedColsWTuple[9].formatPresentation({"RID": "v", "main_table_id_col":"1", "col":"1"}, "detailed").value).toEqual("", "missmatch for index=" + i);
                 });
 
                 describe("if it's a self-link (KeyPseudoColumn in entity mode), ", function () {
                     it ("should honor the given `show_key_link`.", function () {
-                        expect(detailedColsWTuple[2].formatPresentation({"main_table_id_col": "1"},"detailed").value).toEqual('1', "index=5 missmatch.");
+                        expect(detailedColsWTuple[2].formatPresentation({"RID": "v", "main_table_id_col": "1"},"detailed").value).toEqual('1', "index=5 missmatch.");
                     });
                     // the rest of test cases are in 02.reference_column.js
                 });

--- a/test/specs/column/tests/04.pseudo_column_display_self.js
+++ b/test/specs/column/tests/04.pseudo_column_display_self.js
@@ -70,7 +70,7 @@ exports.execute = function (options) {
             detailedExpectedValues = [
                 {
                     title: 'self-link',
-                    value: '<p>self_link <a href="' + recordURL + '/pseudo_column_display_self_schema:main/main_id=01">main one(1234501, 1,234,501)</a></p>\n'
+                    value: '<p>self_link <a href="' + getRecordURL('main', 'main_id', '01') + '">main one(1234501, 1,234,501)</a></p>\n'
                 },
                 {
                     title: 'normal column',

--- a/test/specs/column/tests/05.active_list.js
+++ b/test/specs/column/tests/05.active_list.js
@@ -407,7 +407,7 @@ exports.execute = function (options) {
                 "title": "self_link_rowname",
                 "waitFor": [],
                 "hasWaitFor": false,
-                "value": '<a href="' + recordURL + '/' + schemaName + ':' + tableName + '/rowname_col=main%20one">main one</a>'
+                "value": '<a href="' + getRecordURL(tableName, 'rowname_col', 'main one') + '">main one</a>'
             },
             {
                 "title": "self_link_id",

--- a/test/specs/common/tests/01.foreignkey.js
+++ b/test/specs/common/tests/01.foreignkey.js
@@ -294,7 +294,8 @@ exports.execute = function(options) {
             }
 
             var testFKValue = function (col, context) {
-                var val = col.formatPresentation({table_1_int_key: 101}, context).value;
+                // since we're using the RID value for the link, its value is needed.
+                var val = col.formatPresentation({table_1_int_key: 101, RID: "test"}, context).value;
                 expect(val).toEqual("101");
             };
 


### PR DESCRIPTION
This PR will change self_link presentation logic to always use the shortest key. Most of the changes was updating the test cases.  We should be able to merge this PR after making sure chaise test cases are also updated and passing. To do so, I created [this branch](https://github.com/informatics-isi-edu/chaise/tree/test-self-link-changes) in chaise.