### PR TITLE
Phsids map and lookup helper

### DIFF
--- a/docs/user-docs/handlebars.md
+++ b/docs/user-docs/handlebars.md
@@ -482,6 +482,8 @@ The example that will be used in CFDE uses a map attached to the `$session` temp
 {{lookup $session.client.extensions.ras_dbgap_phs_ids dbgap_study_id}}
 ```
 
+NOTE: When looking up a key to get its value, `null` (if value is `null`) or `undefined` (if key is not present) will be returned so make sure to guard against those negative cases in templating.
+
 ### Encode helper
 
 You can use the `encode` helper to get strings in URL encoded format. It accepts more than one string that needs to be encoded

--- a/docs/user-docs/handlebars.md
+++ b/docs/user-docs/handlebars.md
@@ -47,6 +47,7 @@ Handlebars supports more complicated expression syntax and allow the comparison 
    * [Unless](#unless-helper)
    * [Each](#each-helper)
    * [With](#with-helper)
+   * [Lookup](#lookup-helper)
    * [Encode](#encode-helper)
    * [Escape](#escape-helper)
    * [EncodeFacet](#encodefacet-helper)
@@ -463,6 +464,22 @@ You can optionally provide an `{{else}}` section which will display only when th
 {{else}}
   No content
 {{/with}}
+```
+
+### Lookup helper
+
+You can use the `lookup` helper to do dynamic parameter resolution with Handlebars variables.
+
+One example assumes you have a map similar to what is defined below and use an `id` to resolve the value of one of the keys in the map.
+```
+var map = {"id1": true, "id2": "alpha", "id3": 123}
+
+{{lookup map id}}
+```
+
+The example that will be used in CFDE uses a map attached to the `$session` template variable:
+```
+{{lookup $session.client.extensions.ras_dbgap_phs_ids dbgap_study_id}}
 ```
 
 ### Encode helper

--- a/docs/user-docs/mustache-templating.md
+++ b/docs/user-docs/mustache-templating.md
@@ -296,3 +296,8 @@ Each object in the `attributes` array has the same values as the objects returne
  - `identities`: the identities array of the current identity (if present)
  - `type`: the type of the entry (`identity` or `globus_group`). The type is set as a `globus_group` if the display_name is defined and the id is NOT in the list of identities associated with the logged in user. The type is set as an `identity` if the id is in the list of identities associated with the logged in user (`client.identities`). Otherwise, no type will be set.
  - `webpage`: If the `type` is set to `globus_group`, the webpage is then set to the globus group page. If the globus group id is "https://auth.globus.org/ff766864-a03f-11e5-b097-22000aef184d", then the webpage will be created by extracting the id value and setting it like "https://app.globus.org/groups/ff766864-a03f-11e5-b097-22000aef184d/about".
+
+ The `extensions` object currently contains 3 properties with permissions for dbgap studies. These properties are:
+  - `has_ras_permissions`: boolean value if ras dbgap permissions are present
+  - `ras_dbgap_permissions`: array of objects with information about which dbgap studies the user has permissions for
+  - `ras_dbgap_phs_ids`: map of `phs_id` values as the keys with `true` as the value

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -208,7 +208,7 @@
         "regexMatch", "regexFindFirst", "regexFindAll",
         "jsonStringify", "toTitleCase", "replace",
         // math helpers
-        "add", "subtract"
+        "add", "subtract", "lookup"
     ];
 
     module._operationsFlag = Object.freeze({

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -201,14 +201,14 @@
 
     module._handlebarsHelpersList = [
         // default helpers - NOTE: 'log' and 'lookup' not included
-        "blockHelperMissing", "each", "if", "helperMissing", "unless", "with",
+        "blockHelperMissing", "each", "if", "helperMissing", "unless", "with", "lookup",
         // ermrestJS helpers
         "eq", "ne", "lt", "gt", "lte", "gte", "and", "or", "not", "ifCond",
         "escape", "encode", "formatDate", "encodeFacet",
         "regexMatch", "regexFindFirst", "regexFindAll",
         "jsonStringify", "toTitleCase", "replace",
         // math helpers
-        "add", "subtract", "lookup"
+        "add", "subtract"
     ];
 
     module._operationsFlag = Object.freeze({

--- a/js/utils/handlebar_helpers.js
+++ b/js/utils/handlebar_helpers.js
@@ -140,6 +140,21 @@
                 });
             },
 
+            /**
+             * {{#if (hasKey structure key}}
+             *  ... content
+             * {{/if}}
+             *
+             * @returns boolean stating if value is present in array
+             */
+            hasKey: function (structure, key) {
+                if (Array.isArray(structure)) {
+                    return array.includes(value);
+                } else if (typeof structure === "object") {
+                    return (key in structure);
+                }
+            }
+
         });
 
         // compare helpers

--- a/js/utils/handlebar_helpers.js
+++ b/js/utils/handlebar_helpers.js
@@ -138,21 +138,6 @@
                 return str.replace(/\w\S*/g, function(txt) {
                     return txt.charAt(0).toUpperCase() + txt.substr(1);
                 });
-            },
-
-            /**
-             * {{#if (hasKey structure key}}
-             *  ... content
-             * {{/if}}
-             *
-             * @returns boolean stating if value is present in array
-             */
-            hasKey: function (structure, key) {
-                if (Array.isArray(structure)) {
-                    return array.includes(value);
-                } else if (typeof structure === "object") {
-                    return (key in structure);
-                }
             }
 
         });

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -2776,10 +2776,10 @@
             // If extensions is present, put all dbgap permissions into a map
             // NOTE: not sure if we want to check for `has_ras_permissions` too or not since if that is true, it means ras_dbgap_permissions is also defined
             //       if it's false, the array won't be defined
-            if (session.client.extensions && session.client.extensions.ras_dbgap_permissions) {
+            if (session.client.extensions && session.client.extensions.ras_dbgap_permissions && Array.isArray(session.client.extensions.ras_dbgap_permissions)) {
                 var map = {};
                 session.client.extensions.ras_dbgap_permissions.forEach(function (perm) {
-                    map[perm.phs_id] = true;
+                    if (typeof perm === "object" && perm.phs_id) map[perm.phs_id] = true;
                 });
 
                 obj.$session.client.extensions.ras_dbgap_phs_ids = map;

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -2774,19 +2774,15 @@
             });
 
             // If extensions is present, put all dbgap permissions into a map
+            // NOTE: not sure if we want to check for `has_ras_permissions` too or not since if that is true, it means ras_dbgap_permissions is also defined
+            //       if it's false, the array won't be defined
             if (session.client.extensions && session.client.extensions.ras_dbgap_permissions) {
                 var map = {};
                 session.client.extensions.ras_dbgap_permissions.forEach(function (perm) {
                     map[perm.phs_id] = true;
                 });
 
-                obj.$session.client.extensions.phs_ids = map;
-
-                // extensions = {
-                //     has_dbgap_permisisons
-                //     ras_dbgap_permissions: ["phs000012678"] | [{phs_id: "phs000012678", ras_id: "", }]
-                //     ras_permission_ids
-                //     ras_dbgap_phs_ids
+                obj.$session.client.extensions.ras_dbgap_phs_ids = map;
             }
         }
     };

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -2772,6 +2772,22 @@
             Object.keys(session).forEach(function (key) {
                 obj.$session[key] = session[key];
             });
+
+            // If extensions is present, put all dbgap permissions into a map
+            if (session.client.extensions && session.client.extensions.ras_dbgap_permissions) {
+                var map = {};
+                session.client.extensions.ras_dbgap_permissions.forEach(function (perm) {
+                    map[perm.phs_id] = true;
+                });
+
+                obj.$session.client.extensions.phs_ids = map;
+
+                // extensions = {
+                //     has_dbgap_permisisons
+                //     ras_dbgap_permissions: ["phs000012678"] | [{phs_id: "phs000012678", ras_id: "", }]
+                //     ras_permission_ids
+                //     ras_dbgap_phs_ids
+            }
         }
     };
 

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -720,6 +720,16 @@ exports.execute = function (options) {
                 expect(module.renderHandlebarsTemplate(template2, {string: string2})).toBe("HellO World MiXed Case TitleCase String", "missmatch for 2nd test");
             });
 
+            it('lookup helper', function () {
+                var map = {"id1": true, "id2": "alpha", "id3": 123}
+                var template = "{{lookup map id}}"
+
+                expect(module.renderHandlebarsTemplate("boolean: " + template, {map: map, id: "id1"})).toBe("boolean: true", "missmatch for 1st test");
+                expect(module.renderHandlebarsTemplate("string: " + template, {map: map, id: "id2"})).toBe("string: alpha", "missmatch for 2nd test");
+                expect(module.renderHandlebarsTemplate("integer: " + template, {map: map, id: "id3"})).toBe("integer: 123", "missmatch for 3rd test");
+                expect(module.renderHandlebarsTemplate("undefined: " + template, {map: map, id: "id4"})).toBe("undefined: ", "missmatch for 4th test");
+            });
+
             it('suppressed default helper log', function () {
                 try {
                     module.renderHandlebarsTemplate("{{log 'Hello World'}}", {});


### PR DESCRIPTION
This PR creates an extra object in the `$session` templating variable to iterate over the `$session.client.extensions.ras_dbgap_permissions` array and use each `phs_id` as a key in the created object with `true` as the value. This is being done for a CFDE use case to prevent looping over a potentially large array for every single generated template.

This PR also adds the `lookup` helper to our templating environment.