### PR TITLE
Change search to use the new quantified value list syntax

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -4336,7 +4336,7 @@ ColumnGroupAggregateFn.prototype = {
             path +=")";
         }
 
-        var loc = new AttributeGroupLocation(self._ref.location.service, self._ref.table.schema.catalog.id, path, searchObj, sortObj);
+        var loc = new AttributeGroupLocation(self._ref.location.service, self._ref.table.schema.catalog, path, searchObj, sortObj);
 
         var aggregateColumns = [];
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -1509,8 +1509,19 @@
      * @return {string} corresponding ermrest filter
      * @private
      */
-    _convertSearchTermToFilter = function (term, column, alias) {
+    _convertSearchTermToFilter = function (term, column, alias, catalogObject) {
         var filterString = "";
+
+        // see if the quantified_value_lists syntax can be used
+        var useQuantified = false;
+        if (catalogObject) {
+            if (column === module._systemColumnNames.RID) {
+                useQuantified = catalogObject.features[module._ERMrestFeatures.QUANTIFIED_RID_LISTS];
+            } else {
+                useQuantified = catalogObject.features[module._ERMrestFeatures.QUANTIFIED_VALUE_LISTS];
+            }
+        }
+
         column = (typeof column !== 'string' || column === "*") ? "*": module._fixedEncodeURIComponent(column);
         if (isStringAndNotEmpty(alias)) {
             column = alias + ":" + column;
@@ -1533,6 +1544,12 @@
 
             if (term.trim().length > 0 ) terms = terms.concat(term.trim().split(/[\s]+/)); // split by white spaces
 
+            // the quantified syntax only makes sense when we have more than one term
+            if (terms.length < 2) useQuantified = false; 
+
+            if (useQuantified) {
+                filterString = column + module._ERMrestFilterPredicates.CASE_INS_REG_EXP + 'all('
+            }
             terms.forEach(function(t, index, array) {
                 var exp;
                 // matches an integer, aka just a number
@@ -1546,8 +1563,15 @@
                     exp = module._encodeRegexp(t);
                 }
 
-                filterString += (index === 0? "" : "&") + column + module._ERMrestFilterPredicates.CASE_INS_REG_EXP + module._fixedEncodeURIComponent(exp);
+                if (useQuantified) {
+                    filterString += (index === 0? "" : ",") + module._fixedEncodeURIComponent(exp);
+                } else {
+                    filterString += (index === 0? "" : "&") + column + module._ERMrestFilterPredicates.CASE_INS_REG_EXP + module._fixedEncodeURIComponent(exp);
+                }
             });
+            if (useQuantified) {
+                filterString += ')';
+            }
         }
 
         return filterString;

--- a/js/utils/pseudocolumn_helpers.js
+++ b/js/utils/pseudocolumn_helpers.js
@@ -29,7 +29,7 @@
             }
 
             var encode = module._fixedEncodeURIComponent, nullFilter = module._ERMrestFilterPredicates.NULL;
-            var canUseQualified = false, hasNull = false, colsString ='', notFirst = false;
+            var canUseQuantified = false, hasNull = false, colsString ='', notFirst = false;
 
             // returns a simple key=value
             var eqSyntax = function (val) {
@@ -45,16 +45,16 @@
                 return eqSyntax(choices[0]);
             } 
 
-            // see if the qualified syntax can be used
+            // see if the quantified syntax can be used
             if (catalogObject) {
                 if (column === module._systemColumnNames.RID) {
-                    canUseQualified = catalogObject.features[module._ERMrestFeatures.QUANTIFIED_RID_LISTS];
+                    canUseQuantified = catalogObject.features[module._ERMrestFeatures.QUANTIFIED_RID_LISTS];
                 } else {
-                    canUseQualified = catalogObject.features[module._ERMrestFeatures.QUANTIFIED_VALUE_LISTS];
+                    canUseQuantified = catalogObject.features[module._ERMrestFeatures.QUANTIFIED_VALUE_LISTS];
                 }
             }
 
-            if (canUseQualified) {
+            if (canUseQuantified) {
                 var notNulls = [];
                 choices.forEach(function (ch) {
                     if (!isDefinedAndNotNull(ch)) {
@@ -122,15 +122,21 @@
             return res;
         },
 
-        // parse search constraint
-        parseSearch: function (search, column, alias) {
+        /**
+         * parse search constraint
+         * @param {string} search the search term
+         * @param {string} column the column name
+         * @param {string} [alias] the alias name (could be undefined)
+         * @param {ERMrest.Catalog} catalogObject the catalog object (to check if alternative syntax is available)
+         */
+        parseSearch: function (search, column, alias, catalogObject) {
             var res, invalid = false;
             res = search.reduce(function (prev, curr, i) {
                 if (curr == null) {
                     invalid = true;
                     return "";
                 } else {
-                    return prev + (i !== 0 ? ";": "") + _convertSearchTermToFilter(_renderFacetHelpers.valueToString(curr), column, alias);
+                    return prev + (i !== 0 ? ";": "") + _convertSearchTermToFilter(_renderFacetHelpers.valueToString(curr), column, alias, catalogObject);
                 }
             }, "");
 
@@ -156,9 +162,10 @@
          * @param {ERMrest.Table} rootTable the root table
          * @param {string} alias the alias for the root table
          * @param {Object} pathPrefixAliasMapping the path prefix alias mapping object (used for sharing prefix)
+         * @param {ERMrest.Catalog} catalogObject the catalog object (to check if alternative syntax is available)
          * @returns the path that represents the search and join statments needed for search
          */
-        parseSearchBox: function (search, rootTable, alias, pathPrefixAliasMapping) {
+        parseSearchBox: function (search, rootTable, alias, pathPrefixAliasMapping, catalogObject) {
             // by default we're going to apply search to all the columns
             var searchColumns = [{name: "*"}], path = "", searchDef,
                 usedAlias = "", proposedAlias = "", addAliasPerPath = false, addedAliasIndex = 1;
@@ -212,7 +219,7 @@
             }
 
             return path + searchColumns.map(function (col) {
-                return _renderFacetHelpers.parseSearch(search, col.name, col.alias);
+                return _renderFacetHelpers.parseSearch(search, col.name, col.alias, catalogObject);
             }).join(";") + ((!addAliasPerPath && path.length > 0) ? ("/$" + alias) : "");
         },
 
@@ -364,7 +371,7 @@
                     }
 
                     // add the main search filter
-                    innerJoins.push(_renderFacetHelpers.parseSearchBox(term[module._facetFilterTypes.SEARCH], rootTable, alias, pathPrefixAliasMapping));
+                    innerJoins.push(_renderFacetHelpers.parseSearchBox(term[module._facetFilterTypes.SEARCH], rootTable, alias, pathPrefixAliasMapping, catalogObject));
 
                     // we can go to the next source in the and filter
                     continue;
@@ -435,7 +442,7 @@
                 constraints.push(parsed);
             }
             if (Array.isArray(term[module._facetFilterTypes.SEARCH])) {
-                parsed = _renderFacetHelpers.parseSearch(term[module._facetFilterTypes.SEARCH], col);
+                parsed = _renderFacetHelpers.parseSearch(term[module._facetFilterTypes.SEARCH], col, null, catalogObject);
                 if (!parsed) {
                     return _renderFacetHelpers.getErrorOutput(facetErrors.invalidSearch, i);
                 }

--- a/test/specs/ag_reference/tests/01.ag_reference.js
+++ b/test/specs/ag_reference/tests/01.ag_reference.js
@@ -35,7 +35,7 @@ exports.execute = function (options) {
         var checkLocation = function (objName, obj, path) {
             expect(obj).toBeDefined(objName + " was not defined.");
             expect(obj.service).toBe(options.url, objName + " service missmatch.");
-            expect(obj.catalogId).toBe(catID, objName + " catalogId missmatch.");
+            expect(obj.catalog.id).toBe(catID, objName + " catalog missmatch.");
             expect(obj.path).toBe(path, objName + " path missmatch.");
         };
 
@@ -59,10 +59,10 @@ exports.execute = function (options) {
 
         describe("AttributeGroupLocation, ", function () {
             beforeAll(function () {
-                loc = new options.ermRest.AttributeGroupLocation(options.url, catID, schemaName + ":" + mainTable);
+                loc = new options.ermRest.AttributeGroupLocation(options.url, options.catalog, schemaName + ":" + mainTable);
                 locWithModifiers = new options.ermRest.AttributeGroupLocation(
                     options.url,
-                    catID,
+                    options.catalog,
                     schemaName + ":" + mainTable,
                     {"column": "col", "term": "test"}, // search
                     [{"column": "alias"}], // sort
@@ -583,7 +583,7 @@ exports.execute = function (options) {
             it ("Location should handle it.", function () {
                 unicodeLoc = new options.ermRest.AttributeGroupLocation(
                     options.url,
-                    catID,
+                    options.catalog,
                     schemaName + ":" + unicodeTableEncoded,
                     {"column": decodedCol, "term": "test"}, // search
                     [{"column": decodedCol}], // sort

--- a/test/specs/parser/tests/01.parser.js
+++ b/test/specs/parser/tests/01.parser.js
@@ -1331,10 +1331,11 @@ exports.execute = function(options) {
                             true
                         );
 
+                        var useQuantifiedSyntax = options.catalog.features.quantified_value_lists;
                         expectLocation(
                             "N4IghgdgJiBcDaoDOB7ArgJwMYFM4ixABoQkcxsALOecAAgCMQBdAXzaA",
                             {"and": [ {"source": "c", "search": ["a b"]} ]},
-                            "c::ciregexp::a&c::ciregexp::b/$M",
+                            useQuantifiedSyntax ? 'c::ciregexp::all(a,b)/$M' : 'c::ciregexp::a&c::ciregexp::b/$M',
                             true
                         );
                     });

--- a/test/specs/reference/tests/13.search.js
+++ b/test/specs/reference/tests/13.search.js
@@ -37,8 +37,10 @@ exports.execute = function (options) {
         return url;
     };
 
+    var useQuantifiedSyntax = false;
     beforeAll(function() {
         options.ermRest.appLinkFn(appLinkFn);
+        useQuantifiedSyntax = options.catalog.features.quantified_value_lists;
     });
 
     describe("Reference Search,", function () {
@@ -118,8 +120,9 @@ exports.execute = function (options) {
             it('search() using conjunction of words. ', function(done) {
                 reference2 = reference1.search("\"hanks\" 111111");
                 expect(reference2.location.searchTerm).toBe("\"hanks\" 111111", "searchTerm missmatch.");
+                var encodedNumber = options.ermRest._fixedEncodeURIComponent(intRegexPrefix + "111111" + intRegexSuffix);
                 expect(reference2.location.ermrestCompactPath).toBe(
-                    path + "*::ciregexp::hanks&*::ciregexp::" +  options.ermRest._fixedEncodeURIComponent(intRegexPrefix + "111111" + intRegexSuffix),
+                    useQuantifiedSyntax ? `${path}*::ciregexp::all(hanks,${encodedNumber})` : `${path}*::ciregexp::hanks&*::ciregexp::${encodedNumber}`,
                     "ermrestCompactPath missmatch."
                 );
 
@@ -350,7 +353,7 @@ exports.execute = function (options) {
                 reference2 = reference1.search("\"wallace\" \"VIIII\"");
                 expect(reference2.location.searchTerm).toBe("\"wallace\" \"VIIII\"", "searchTerm missmatch.");
                 expect(reference2.location.ermrestCompactPath).toBe(
-                    path + "*::ciregexp::wallace&*::ciregexp::VIIII",
+                    useQuantifiedSyntax ? `${path}*::ciregexp::all(wallace,VIIII)` : `${path}*::ciregexp::wallace&*::ciregexp::VIIII`,
                     "ermrestCompactPath missmatch."
                 );
 
@@ -376,8 +379,9 @@ exports.execute = function (options) {
                 // searching for integer values converts them into a regular expressio
                 reference2 = reference1.search("\"william\" \"171717\"");
                 expect(reference2.location.searchTerm).toBe("\"william\" \"171717\"", "searchTerm missmatch.");
+                var encodedNumber = options.ermRest._fixedEncodeURIComponent(intRegexPrefix + "171717" + intRegexSuffix);
                 expect(reference2.location.ermrestCompactPath).toBe(
-                    path + "*::ciregexp::william&*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(intRegexPrefix + "171717" + intRegexSuffix),
+                     useQuantifiedSyntax ? `${path}*::ciregexp::all(william,${encodedNumber})` : `${path}*::ciregexp::william&*::ciregexp::${encodedNumber}`,
                     "ermrestCompactPath missmatch."
                 );
 
@@ -469,8 +473,9 @@ exports.execute = function (options) {
 
             it('location should have correct search parameters ', function() {
                 expect(reference3.location.searchTerm).toBe("hanks 111111", "searchTerm missmatch.");
+                var encodedNumber = options.ermRest._fixedEncodeURIComponent(intRegexPrefix + "111111" + intRegexSuffix);
                 expect(reference3.location.ermrestCompactPath).toBe(
-                    path + "*::ciregexp::hanks" + "&" + "*::ciregexp::" + options.ermRest._fixedEncodeURIComponent(intRegexPrefix + "111111" + intRegexSuffix),
+                    useQuantifiedSyntax ? `${path}*::ciregexp::all(hanks,${encodedNumber})` : `${path}*::ciregexp::hanks&*::ciregexp::${encodedNumber}`,
                     "ermrestCompactPath missmatch."
                 );
             });


### PR DESCRIPTION
As the title suggests, the changes in this PR will ensure using the new syntax if the server supports it.

Changes are simple, and a review is not needed. I created this PR mainly for testing in CI and history purposes.