### PR TITLE
Implement column-defaults annotation

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -207,33 +207,36 @@ to use for ERMrest JavaScript agents.
         * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ [<code>Column</code>](#ERMrest.Column)
     * [.Column](#ERMrest.Column)
         * [new Column(table, jsonColumn)](#new_ERMrest.Column_new)
-        * [.position](#ERMrest.Column+position) : <code>number</code>
-        * [.table](#ERMrest.Column+table) : [<code>Table</code>](#ERMrest.Table)
-        * [.rights](#ERMrest.Column+rights) : <code>Object</code>
-        * [.isHiddenPerACLs](#ERMrest.Column+isHiddenPerACLs) : <code>Boolean</code>
-        * [.isGeneratedPerACLs](#ERMrest.Column+isGeneratedPerACLs) : <code>Boolean</code>
-        * [.isSystemColumn](#ERMrest.Column+isSystemColumn) : <code>Boolean</code>
-        * [.isImmutablePerACLs](#ERMrest.Column+isImmutablePerACLs) : <code>Boolean</code>
-        * [.name](#ERMrest.Column+name) : <code>string</code>
-        * [.RID](#ERMrest.Column+RID) : <code>string</code>
-        * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
-        * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
-        * [.annotations](#ERMrest.Column+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
-        * [.comment](#ERMrest.Column+comment) : <code>string</code>
-        * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
-        * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
-        * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
-        * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
-        * [.ermrestDefault](#ERMrest.Column+ermrestDefault) : <code>object</code>
-        * [.default](#ERMrest.Column+default) ⇒ <code>string</code>
-        * [.isUniqueNotNull](#ERMrest.Column+isUniqueNotNull) : <code>Boolean</code>
-        * [.uniqueNotNullKey](#ERMrest.Column+uniqueNotNullKey) : [<code>Key</code>](#ERMrest.Key)
-        * [.formatvalue(data, context)](#ERMrest.Column+formatvalue) ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code>
-        * [.formatPresentation(data, context, templateVariables, options)](#ERMrest.Column+formatPresentation) ⇒ <code>Object</code>
-        * [.toString()](#ERMrest.Column+toString) ⇒ <code>string</code>
-        * [._getNullValue()](#ERMrest.Column+_getNullValue) : <code>object</code>
-        * [.getDisplay(context)](#ERMrest.Column+getDisplay)
-        * [.compare(a, b)](#ERMrest.Column+compare) ⇒ <code>integer</code>
+        * _instance_
+            * [.position](#ERMrest.Column+position) : <code>number</code>
+            * [.table](#ERMrest.Column+table) : [<code>Table</code>](#ERMrest.Table)
+            * [.rights](#ERMrest.Column+rights) : <code>Object</code>
+            * [.isHiddenPerACLs](#ERMrest.Column+isHiddenPerACLs) : <code>Boolean</code>
+            * [.isGeneratedPerACLs](#ERMrest.Column+isGeneratedPerACLs) : <code>Boolean</code>
+            * [.isSystemColumn](#ERMrest.Column+isSystemColumn) : <code>Boolean</code>
+            * [.isImmutablePerACLs](#ERMrest.Column+isImmutablePerACLs) : <code>Boolean</code>
+            * [.name](#ERMrest.Column+name) : <code>string</code>
+            * [.RID](#ERMrest.Column+RID) : <code>string</code>
+            * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
+            * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
+            * [.annotations](#ERMrest.Column+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+            * [.comment](#ERMrest.Column+comment) : <code>string</code>
+            * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
+            * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
+            * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
+            * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+            * [.ermrestDefault](#ERMrest.Column+ermrestDefault) : <code>object</code>
+            * [.default](#ERMrest.Column+default) ⇒ <code>string</code>
+            * [.isUniqueNotNull](#ERMrest.Column+isUniqueNotNull) : <code>Boolean</code>
+            * [.uniqueNotNullKey](#ERMrest.Column+uniqueNotNullKey) : [<code>Key</code>](#ERMrest.Key)
+            * [.formatvalue(data, context)](#ERMrest.Column+formatvalue) ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code>
+            * [.formatPresentation(data, context, templateVariables, options)](#ERMrest.Column+formatPresentation) ⇒ <code>Object</code>
+            * [.toString()](#ERMrest.Column+toString) ⇒ <code>string</code>
+            * [._getNullValue()](#ERMrest.Column+_getNullValue) : <code>object</code>
+            * [.getDisplay(context)](#ERMrest.Column+getDisplay)
+            * [.compare(a, b)](#ERMrest.Column+compare) ⇒ <code>integer</code>
+        * _inner_
+            * [~defaultAnnotKey](#ERMrest.Column..defaultAnnotKey)
     * [.Annotations](#ERMrest.Annotations)
         * [new Annotations()](#new_ERMrest.Annotations_new)
         * [.all()](#ERMrest.Annotations+all) ⇒ [<code>Array.&lt;Annotation&gt;</code>](#ERMrest.Annotation)
@@ -1762,33 +1765,36 @@ Constructor for Columns.
 
 * [.Column](#ERMrest.Column)
     * [new Column(table, jsonColumn)](#new_ERMrest.Column_new)
-    * [.position](#ERMrest.Column+position) : <code>number</code>
-    * [.table](#ERMrest.Column+table) : [<code>Table</code>](#ERMrest.Table)
-    * [.rights](#ERMrest.Column+rights) : <code>Object</code>
-    * [.isHiddenPerACLs](#ERMrest.Column+isHiddenPerACLs) : <code>Boolean</code>
-    * [.isGeneratedPerACLs](#ERMrest.Column+isGeneratedPerACLs) : <code>Boolean</code>
-    * [.isSystemColumn](#ERMrest.Column+isSystemColumn) : <code>Boolean</code>
-    * [.isImmutablePerACLs](#ERMrest.Column+isImmutablePerACLs) : <code>Boolean</code>
-    * [.name](#ERMrest.Column+name) : <code>string</code>
-    * [.RID](#ERMrest.Column+RID) : <code>string</code>
-    * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
-    * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
-    * [.annotations](#ERMrest.Column+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
-    * [.comment](#ERMrest.Column+comment) : <code>string</code>
-    * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
-    * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
-    * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
-    * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
-    * [.ermrestDefault](#ERMrest.Column+ermrestDefault) : <code>object</code>
-    * [.default](#ERMrest.Column+default) ⇒ <code>string</code>
-    * [.isUniqueNotNull](#ERMrest.Column+isUniqueNotNull) : <code>Boolean</code>
-    * [.uniqueNotNullKey](#ERMrest.Column+uniqueNotNullKey) : [<code>Key</code>](#ERMrest.Key)
-    * [.formatvalue(data, context)](#ERMrest.Column+formatvalue) ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code>
-    * [.formatPresentation(data, context, templateVariables, options)](#ERMrest.Column+formatPresentation) ⇒ <code>Object</code>
-    * [.toString()](#ERMrest.Column+toString) ⇒ <code>string</code>
-    * [._getNullValue()](#ERMrest.Column+_getNullValue) : <code>object</code>
-    * [.getDisplay(context)](#ERMrest.Column+getDisplay)
-    * [.compare(a, b)](#ERMrest.Column+compare) ⇒ <code>integer</code>
+    * _instance_
+        * [.position](#ERMrest.Column+position) : <code>number</code>
+        * [.table](#ERMrest.Column+table) : [<code>Table</code>](#ERMrest.Table)
+        * [.rights](#ERMrest.Column+rights) : <code>Object</code>
+        * [.isHiddenPerACLs](#ERMrest.Column+isHiddenPerACLs) : <code>Boolean</code>
+        * [.isGeneratedPerACLs](#ERMrest.Column+isGeneratedPerACLs) : <code>Boolean</code>
+        * [.isSystemColumn](#ERMrest.Column+isSystemColumn) : <code>Boolean</code>
+        * [.isImmutablePerACLs](#ERMrest.Column+isImmutablePerACLs) : <code>Boolean</code>
+        * [.name](#ERMrest.Column+name) : <code>string</code>
+        * [.RID](#ERMrest.Column+RID) : <code>string</code>
+        * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
+        * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
+        * [.annotations](#ERMrest.Column+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
+        * [.comment](#ERMrest.Column+comment) : <code>string</code>
+        * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
+        * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
+        * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
+        * [.memberOfForeignKeys](#ERMrest.Column+memberOfForeignKeys) : [<code>Array.&lt;ForeignKeyRef&gt;</code>](#ERMrest.ForeignKeyRef)
+        * [.ermrestDefault](#ERMrest.Column+ermrestDefault) : <code>object</code>
+        * [.default](#ERMrest.Column+default) ⇒ <code>string</code>
+        * [.isUniqueNotNull](#ERMrest.Column+isUniqueNotNull) : <code>Boolean</code>
+        * [.uniqueNotNullKey](#ERMrest.Column+uniqueNotNullKey) : [<code>Key</code>](#ERMrest.Key)
+        * [.formatvalue(data, context)](#ERMrest.Column+formatvalue) ⇒ <code>string</code> \| <code>Array.&lt;string&gt;</code>
+        * [.formatPresentation(data, context, templateVariables, options)](#ERMrest.Column+formatPresentation) ⇒ <code>Object</code>
+        * [.toString()](#ERMrest.Column+toString) ⇒ <code>string</code>
+        * [._getNullValue()](#ERMrest.Column+_getNullValue) : <code>object</code>
+        * [.getDisplay(context)](#ERMrest.Column+getDisplay)
+        * [.compare(a, b)](#ERMrest.Column+compare) ⇒ <code>integer</code>
+    * _inner_
+        * [~defaultAnnotKey](#ERMrest.Column..defaultAnnotKey)
 
 <a name="new_ERMrest.Column_new"></a>
 
@@ -1998,6 +2004,12 @@ NOTE: null is greater than any not-null values.
 | a | <code>\*</code> | raw value |
 | b | <code>\*</code> | raw value |
 
+<a name="ERMrest.Column..defaultAnnotKey"></a>
+
+#### Column~defaultAnnotKey
+go over the catalog, schema, and table and copy the relative column defaults annotations.
+
+**Kind**: inner property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Annotations"></a>
 
 ### ERMrest.Annotations

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -52,6 +52,7 @@
         ASSET: "tag:isrd.isi.edu,2017:asset",
         CHAISE_CONFIG: "tag:isrd.isi.edu,2019:chaise-config",
         CITATION: "tag:isrd.isi.edu,2018:citation",
+        COLUMN_DEFAULTS: "tag:isrd.isi.edu,2023:column-defaults",
         COLUMN_DISPLAY: "tag:isrd.isi.edu,2016:column-display",
         DISPLAY: "tag:misd.isi.edu,2015:display",
         EXPORT: "tag:isrd.isi.edu,2016:export",

--- a/test/specs/annotation/conf/column_defaults.conf.json
+++ b/test/specs/annotation/conf/column_defaults.conf.json
@@ -1,0 +1,11 @@
+{
+    "catalog": {},
+    "schema": {
+        "name": "column_defaults_schema",
+        "createNew": true,
+        "path": "test/specs/annotation/conf/column_defaults/schema.json"
+    },
+    "tables": {
+        "createNew": true
+    }
+}

--- a/test/specs/annotation/conf/column_defaults/schema.json
+++ b/test/specs/annotation/conf/column_defaults/schema.json
@@ -1,0 +1,131 @@
+{
+  "schema_name": "column_defaults_schema",
+  "annotations": {
+    "tag:isrd.isi.edu,2023:column-defaults" : {
+      "by_type": {
+        "timestamptz": {
+          "tag:isrd.isi.edu,2016:column-display": {
+            "defined_on": "schema_by_type"
+          }
+        }
+      },
+      "by_name": {
+        "RID": {
+          "tag:misd.isi.edu,2015:display": {
+            "defined_on": "schema_by_name"
+          }
+        }
+      }
+    }
+  },
+  "tables": {
+    "table_1": {
+      "kind": "table",
+      "table_name": "table_1",
+      "schema_name": "column_defaults_schema",
+      "keys": [{"unique_columns": ["id"]}],
+      "annotations": {
+        "tag:isrd.isi.edu,2023:column-defaults" : {
+          "by_type": {
+            "boolean[]": {
+              "tag:isrd.isi.edu,2015:display": {
+                "defined_on": "table_by_type"
+              }
+            }
+          }
+        }
+      },
+      "column_definitions": [
+        {
+          "name": "id",
+          "nullok": false,
+          "type" :{
+            "typename": "text"
+          }
+        },
+        {
+          "name": "boolean_array_col_1",
+          "type": {
+            "is_array": true,
+            "typename": "boolean[]",
+            "base_type": {
+              "typename": "boolean"
+            }
+          }
+        },
+        {
+          "name": "boolean_array_col_2",
+          "type": {
+            "is_array": true,
+            "typename": "boolean[]",
+            "base_type": {
+              "typename": "boolean"
+            }
+          }
+        },
+        {
+          "name": "timestamptz_col_1",
+          "type": {
+            "typename": "timestamptz"
+          },
+          "annotations": {
+            "tag:isrd.isi.edu,2016:column-display": {
+              "defined_on": "timestamptz_col_1"
+            }
+          }
+        },
+        {
+          "name": "timestamptz_col_2",
+          "type": {
+            "typename": "timestamptz"
+          }
+        }
+      ]
+    },
+    "table_2": {
+      "kind": "table",
+      "table_name": "table_2",
+      "schema_name": "column_defaults_schema",
+      "keys": [{"unique_columns": ["id"]}],
+      "column_definitions": [
+        {
+          "name": "id",
+          "nullok": false,
+          "type" :{
+            "typename": "text"
+          }
+        },
+        {
+          "name": "boolean_array_col_1",
+          "type": {
+            "is_array": true,
+            "typename": "boolean[]",
+            "base_type": {
+              "typename": "boolean"
+            }
+          },
+          "annotations": {
+            "tag:isrd.isi.edu,2015:display": {
+              "defined_on": "boolean_array_col_1"
+            }
+          }
+        },
+        {
+          "name": "boolean_array_col_2",
+          "type": {
+            "is_array": true,
+            "typename": "boolean[]",
+            "base_type": {
+              "typename": "boolean"
+            }
+          },
+          "annotations": {
+            "tag:isrd.isi.edu,2016:column-display": {
+              "defined_on": "boolean_array_col_2"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/specs/annotation/spec.js
+++ b/test/specs/annotation/spec.js
@@ -9,7 +9,8 @@ require('./../../utils/starter.spec.js').runTests({
         "/annotation/tests/07.source_definitions.js",
         "/annotation/tests/08.show_saved_queries.js",
         "/annotation/tests/09.show_saved_queries_catalog.js",
-        "/annotation/tests/10.table_config.js"
+        "/annotation/tests/10.table_config.js",
+        '/annotation/tests/11.column_defaults.js'
     ],
     schemaConfigurations: [
         "/annotation/conf/displayname.conf.json",
@@ -20,6 +21,7 @@ require('./../../utils/starter.spec.js').runTests({
         "/annotation/conf/source_definitions.conf.json",
         "/annotation/conf/show_saved_queries.conf.json",
         "/annotation/conf/show_saved_queries_catalog.conf.json",
-        "/annotation/conf/table_config.conf.json"
+        "/annotation/conf/table_config.conf.json",
+        '/annotation/conf/column_defaults.conf.json'
     ]
 });

--- a/test/specs/annotation/tests/11.column_defaults.js
+++ b/test/specs/annotation/tests/11.column_defaults.js
@@ -1,0 +1,193 @@
+const utils = require("../../../utils/utilities.js");
+
+/**
+ * The following is how the annotations are defined and the expected result.
+ *
+ * Given that the annotation can come from multiple levels, it was easier to test
+ * it this way instead of listing each individual case that I tested.
+ * Given that we're only testing the logic of populating column.annotations, and
+ * not how each individual annotations works, I chose easier to debug names instead
+ * of actual annotation values.
+ * The following are the scenarios that it's testing:
+ * - column-level annotations have priority over everything else.
+ * - we should mix and match annotation. so for example column-display might come
+ *  from the catalog and the display from the column itself.
+ * - by_name has always priority over by_type even if it's defined on a more general
+ *   level (catalog vs schema for example)
+ *
+ * catalog:
+ *  by_name: RCT (display), RID (display), boolean_array_col_1 (both column-dsplay and display)
+ *  by_type: boolean[] (column-display), timestamptz (column-display, display)
+ *    - column_defaults_schema:
+ *      by_type: timestamptz(column-display)
+ *      by_name: RID  (display)
+ *        - table_1
+ *          by_type: boolean[] (display)
+ *            - RID
+ *              result: display from schema
+ *            - RCT
+ *              result: display from catalog
+ *            - boolean_array_col_1 (boolean[])
+ *                result: column-display and display defined on catalog
+ *            - boolean_array_col_2 (boolean[])
+ *                result: column-display on catalog, display on table_1
+ *            - timestamptz_col_1 (timestamptz)
+ *              with column-display
+ *                result: column-display on itself, display on catalog
+ *            - timestamptz_col_2 (timestamptz)
+ *                result: column-display on schema, display on catalog
+ *        - table_2
+ *            - RID
+ *              result: display from schema
+ *            - RCT
+ *              result: display from catalog
+ *            - boolean_array_col_1 (boolean[])
+ *              with display
+ *                result: column-display on catalog, display on itself
+ *            - boolean_array_col_2 (boolean[])
+ *              with column-display
+ *                result: column-display on itself
+ */
+exports.execute = function (options) {
+  describe('column-defaults annotations,', function () {
+
+    const schemaName = 'column_defaults_schema';
+
+    const catalogAnnotations = {
+      "tag:isrd.isi.edu,2023:column-defaults": {
+        "by_name": {
+          "RID": {
+            "tag:misd.isi.edu,2015:display": {
+              "defined_on": "catalog_by_name"
+            }
+          },
+          "RCT": {
+            "tag:misd.isi.edu,2015:display": {
+              "defined_on": "catalog_by_name"
+            }
+          },
+          "boolean_array_col_1": {
+            "tag:isrd.isi.edu,2015:display": {
+              "defined_on": "catalog_by_name"
+            },
+            "tag:isrd.isi.edu,2016:column-display": {
+              "defined_on": "catalog_by_name"
+            }
+          }
+        },
+        "by_type": {
+          "boolean[]": {
+            "tag:isrd.isi.edu,2016:column-display": {
+              "defined_on": "catalog_by_type"
+            }
+          },
+          "timestamptz": {
+            "tag:isrd.isi.edu,2015:display": {
+              "defined_on": "catalog_by_type"
+            },
+            "tag:isrd.isi.edu,2016:column-display": {
+              "defined_on": "catalog_by_type"
+            }
+          }
+        }
+      }
+    }
+
+    const expectedAnnotations = {
+      'table_1': {
+        'RID': {
+          "tag:misd.isi.edu,2015:display": {
+            "defined_on": "schema_by_name"
+          }
+        },
+        'RCT': {
+          "tag:misd.isi.edu,2015:display": {
+            "defined_on": "catalog_by_name"
+          }
+        },
+        'boolean_array_col_1': {
+          "tag:isrd.isi.edu,2015:display": {
+            "defined_on": "catalog_by_name"
+          },
+          "tag:isrd.isi.edu,2016:column-display": {
+            "defined_on": "catalog_by_name"
+          }
+        },
+        'boolean_array_col_2': {
+          "tag:isrd.isi.edu,2016:column-display": {
+            "defined_on": "catalog_by_type"
+          },
+          "tag:isrd.isi.edu,2015:display": {
+            "defined_on": "table_by_type"
+          }
+        },
+        'timestamptz_col_1': {
+          "tag:isrd.isi.edu,2016:column-display": {
+            "defined_on": "timestamptz_col_1"
+          },
+          "tag:isrd.isi.edu,2015:display": {
+            "defined_on": "catalog_by_type"
+          }
+        },
+        'timestamptz_col_2': {
+          "tag:isrd.isi.edu,2016:column-display": {
+            "defined_on": "schema_by_type"
+          },
+          "tag:isrd.isi.edu,2015:display": {
+            "defined_on": "catalog_by_type"
+          }
+        }
+      },
+      'table_2': {
+        'boolean_array_col_1': {
+          "tag:isrd.isi.edu,2016:column-display": {
+            "defined_on": "catalog_by_name"
+          },
+          "tag:isrd.isi.edu,2015:display": {
+            "defined_on": "boolean_array_col_1"
+          }
+        },
+        'boolean_array_col_2': {
+          "tag:isrd.isi.edu,2016:column-display": {
+            "defined_on": "boolean_array_col_2"
+          }
+        }
+      }
+    }
+
+    let schema;
+    beforeAll((done) => {
+      utils.setCatalogAnnotations(options, catalogAnnotations).then(() => {
+        schema = options.catalog.schemas.get(schemaName);
+        done();
+      }).catch((err) => done.fail(err));
+    });
+
+    Object.keys(expectedAnnotations).forEach((tableName) => {
+      describe(`for table ${tableName}, `, () => {
+        Object.keys(expectedAnnotations[tableName]).forEach((columnName) => {
+          it(`column ${columnName} should have the proper annotations.`, () => {
+            const annots = schema.tables.get(tableName).columns.get(columnName).annotations;
+            const columnAnnots = expectedAnnotations[tableName][columnName];
+            const message = `table=${tableName}, col=${columnName}`;
+
+            expect(annots.length()).toEqual(Object.keys(columnAnnots).length, `length missmatch. ${message}`);
+            annots.names().forEach((k) => {
+              expect(k in columnAnnots).toEqual(true, `annotation missing. ${message}, key='${k}'`);
+              expect(annots.get(k).content).toEqual(columnAnnots[k], `annotation value missmatch. ${message}, key='${k}'`);
+            });
+          });
+        });
+      });
+    })
+
+    afterAll((done) => {
+      // removed the catalog annotation
+      utils.setCatalogAnnotations(options, {}).then(() => {
+        done();
+      }).catch((err) => done.fail(err));
+    });
+
+  });
+
+}


### PR DESCRIPTION
This PR will implement the annotation described in #971. 

There are two things that I think @jrchudy should review as I'm not fully sure of:

- I'm not entirely sure how to explain the behavior. I explained in both ways, which might be confusing. One is closer to how it's implemented, and the other is a summary of what happens at the end, which is more or less the reverse of the actual code. 
- While the code changes are minimal and easy to understand, testing it was a pain. Given that there are a lot of different combinations of annotations, I couldn't realistically test every combination. So I picked several scenarios that are more interesting. But as a result, I cannot write the test `it`s in a way to explain which scenario they are testing, and instead, I'm just iterating over all the expected values and making sure those are the same. I'm not a fan of how I wrote the tests, but this is the cleanest version I could think of. We also have already done similar tests in ermrestjs. 