### PR TITLE
Use the published ermrest-data-utils

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -80,11 +80,6 @@ jobs:
           cd ../ermrestjs
           sudo cp test/ermrest_config.json /home/ermrest/
           sudo chmod a+r /home/ermrest/ermrest_config.json
-      - name: Install ermrest-data-utils
-        run: |
-          git clone https://github.com/informatics-isi-edu/ErmrestDataUtils.git
-          cd ErmrestDataUtils
-          sudo npm install
       - name: Install ermrestjs
         run: |
           cd ermrestjs

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ $(BIN): $(MODULES)
 
 # Rule to install Node modules locally
 $(MODULES): package.json
-	npm install
+	@npm clean-install
 	@touch $(MODULES)
 
 # generate makefile_variables file
@@ -180,9 +180,10 @@ FORCE:
 .PHONY: deps
 deps: $(BIN)
 
-.PHONY: updeps
-updeps:
-	npm update
+# for test cases we have to make sure we're installing dev dependencies
+.PHONY: deps-test
+deps-test:
+	@npm clean-install --production=false
 
 # Rule to clean project directory
 .PHONY: clean
@@ -198,12 +199,12 @@ distclean: clean
 
 # Rule to run the unit tests
 .PHONY: test
-test: ../ErmrestDataUtils
+test:
 	node test/jasmine-runner.js
 
 # Rule to run the unit tests
 .PHONY: testsingle
-test-single: ../ErmrestDataUtils
+test-single:
 	node test/single-test-runner.js
 
 # Rule to run the linter
@@ -229,7 +230,7 @@ usage:
 	@echo "    dist   	     - local install of node dependencies, and build the pacakge"
 	@echo "    deploy   	   - deploy the package to $(ERMRESTJSDIR)"
 	@echo "    deps          - local install of node dependencies"
-	@echo "    updeps        - update local dependencies"
+	@echo "    deps-test     - local install of dev node dependencies"
 	@echo "    lint          - lint the source"
 	@echo "    test          - run tests"
 	@echo "    clean         - remove the files and folders created during build"

--- a/docs/dev-docs/unit-test.md
+++ b/docs/dev-docs/unit-test.md
@@ -4,14 +4,10 @@
 
 - The test framework uses [Jasmine](http://jasmine.github.io/2.4/introduction.html) to write and run the test-cases.
 - It also depends on [ermrest-data-utils](https://www.npmjs.com/package/ermrest-data-utils) package to import and delete data for test-cases.
-- To start, first you need to install all npm dependencies. Run following command
-```sh
-# Install npm dependencies
-$ npm install
-
-# Update npm dependencies
-$ npm update
-```
+- To start, first you need to install all test dependencies. Run following command
+  ```sh
+  make deps-test
+  ```
 
 ## Terminology
 - Test Spec: Another name for [Test Suite](https://en.wikipedia.org/wiki/Test_suite). In jasmine terminology, test spec is a `describe` that can contains hierarchy of `describe` and multiple `it`.

--- a/docs/user-docs/installation.md
+++ b/docs/user-docs/installation.md
@@ -7,7 +7,7 @@ This pages documents how to install ERMrestJS, a Javascript client API for the
 
 1. [make](https://en.wikipedia.org/wiki/Makefile): Make is required for any build or development. With `make` only the non-minified package can be built and installed.
 2. [Node.js](https://www.nodejs.org): Node is required for most development operations including linting, minifying, and testing.
-3. [ErmrestDataUtils](https://github.com/informatics-isi-edu/ermrestdatautils): This package is only used in test framework. If you just want to install ERMrestJS, you won't need it.
+3. [NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm): used for installing dependencies used for both building and testing ERMrestJS.
 
 
 ## Building The Package

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "uglify-js": "3.9.2"
       },
       "devDependencies": {
+        "@isrd-isi-edu/ermrest-data-utils": "x",
         "axios": "0.25.0",
         "buffer-slice": "0.0.1",
         "file-api": "^0.10.4",
@@ -43,6 +44,29 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@isrd-isi-edu/ermrest-data-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@isrd-isi-edu/ermrest-data-utils/-/ermrest-data-utils-0.0.2.tgz",
+      "integrity": "sha512-x1pdGiqkCUwazRSEo/LWQ/b4nYD11+qKXqbV5vhOBym5WcM/EQjHoLTzG27Pa73CIpTblEumh5988MzdnUTk1w==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.24.0",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@isrd-isi-edu/ermrest-data-utils/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/@jsdoc/salty": {
@@ -1461,6 +1485,27 @@
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
       "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw=="
+    },
+    "@isrd-isi-edu/ermrest-data-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@isrd-isi-edu/ermrest-data-utils/-/ermrest-data-utils-0.0.2.tgz",
+      "integrity": "sha512-x1pdGiqkCUwazRSEo/LWQ/b4nYD11+qKXqbV5vhOBym5WcM/EQjHoLTzG27Pa73CIpTblEumh5988MzdnUTk1w==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.24.0",
+        "q": "^1.5.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        }
+      }
     },
     "@jsdoc/salty": {
       "version": "0.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "uglify-js": "3.9.2"
       },
       "devDependencies": {
-        "@isrd-isi-edu/ermrest-data-utils": "x",
+        "@isrd-isi-edu/ermrest-data-utils": "0.0.2",
         "axios": "0.25.0",
         "buffer-slice": "0.0.1",
         "file-api": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "uglify-js": "3.9.2"
   },
   "devDependencies": {
-    "@isrd-isi-edu/ermrest-data-utils": "x",
+    "@isrd-isi-edu/ermrest-data-utils": "0.0.2",
     "axios": "0.25.0",
     "buffer-slice": "0.0.1",
     "file-api": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "uglify-js": "3.9.2"
   },
   "devDependencies": {
+    "@isrd-isi-edu/ermrest-data-utils": "x",
     "axios": "0.25.0",
     "buffer-slice": "0.0.1",
     "file-api": "^0.10.4",

--- a/test/utils/ermrest-import.js
+++ b/test/utils/ermrest-import.js
@@ -1,7 +1,7 @@
 const q = require('q');
 const requireReload = require('./require-reload.js').reload;
 const includes = require(__dirname + '/../utils/ermrest-init.js').init();
-const ermrestUtils = require(process.env.PWD + "/../ErmrestDataUtils/import.js");
+const ermrestUtils = require('@isrd-isi-edu/ermrest-data-utils');
 
 /**
  * This function will import all the given schemas.

--- a/test/utils/ermrest-init.js
+++ b/test/utils/ermrest-init.js
@@ -12,7 +12,7 @@ exports.init = function (options) {
 	ermRest.setUserCookie(authCookie);
 
 	return {
-		ermrestUtils: require(process.env.PWD + "/../ErmrestDataUtils/import.js"),
+		ermrestUtils: require('@isrd-isi-edu/ermrest-data-utils'),
 		ermRest: ermRest,
 		url: url,
 		authCookie: authCookie,

--- a/test/utils/jasmine-runner-utils.js
+++ b/test/utils/jasmine-runner-utils.js
@@ -3,7 +3,7 @@ var Jasmine = require('jasmine');
 var SpecReporter = require('jasmine-spec-reporter');
 var jrunner = new Jasmine();
 jrunner.exitCodeReporter = new (require('./exit-code-reporter.js'))(jrunner);
-var ermrestUtils = require(process.env.PWD + "/../ErmrestDataUtils/import.js");
+var ermrestUtils = require('@isrd-isi-edu/ermrest-data-utils');
 
 // Util function to create a catalog before running all specs
 // Returns a promise


### PR DESCRIPTION
Thanks to changes in https://github.com/informatics-isi-edu/ErmrestDataUtils/pull/21, ermrest-data-utils is now a package published to npm. 

So in this PR I changed how we're using this package for testing.