### PR TITLE
Properly handle URL length imitation while validating filter facets 

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -1147,7 +1147,7 @@ PseudoColumn.prototype.getAggregatedValue = function (page, contextHeaderParams)
     }
 
     // get the computed filters
-    var keyValueRes = module._generateKeyValueFilters(
+    var keyValueRes = module.generateKeyValueFilters(
         mainTable.shortestKey,
         page.tuples.map(function (t) { return t.data;  }),
         mainTable.schema.catalog,
@@ -3557,8 +3557,8 @@ FacetColumn.prototype = {
         // otherwise generate an ermrest request to get the displaynames.
         else {
             // if we already fetched the page, then just use it
-            if (self.sourceObjectWrapper.entityChoiceFilterPage) {
-                self.sourceObjectWrapper.entityChoiceFilterPage.tuples.forEach(function (t) {
+            if (self.sourceObjectWrapper.entityChoiceFilterTuples) {
+                self.sourceObjectWrapper.entityChoiceFilterTuples.forEach(function (t) {
                     filters.push({uniqueId: t.data[columnName], displayname: t.displayname, tuple: t});
                 });
                 defer.resolve(filters);

--- a/js/reference.js
+++ b/js/reference.js
@@ -819,7 +819,7 @@
                     // if in entity mode some choices were invalid
                     if (Array.isArray(resp.invalidChoices) && resp.invalidChoices.length > 0) {
                         // if no choices was left, then we don't need to merge it with anything and we should ignore it
-                        if (resp.andFilterObject.sourceObject.choices.length === 0 || resp.andFilterObject.entityChoiceFilterPage.length === 0) {
+                        if (resp.andFilterObject.sourceObject.choices.length === 0 || resp.andFilterObject.entityChoiceFilterTuples.length === 0) {
                             // adding the choices back so we can produce proper error message
                             resp.andFilterObject.sourceObject.choices = resp.originalChoices;
                             addToIssues(resp.andFilterObject.sourceObject, "None of the encoded choices were available");
@@ -848,8 +848,8 @@
                                 helpers.mergeFacetObjects(res.facetObjectWrappers[j].sourceObject, resp.andFilterObject.sourceObject);
 
                                 // make sure the page object is stored
-                                if (resp.andFilterObject.entityChoiceFilterPage) {
-                                    res.facetObjectWrappers[j].entityChoiceFilterPage = resp.andFilterObject.entityChoiceFilterPage;
+                                if (resp.andFilterObject.entityChoiceFilterTuples) {
+                                    res.facetObjectWrappers[j].entityChoiceFilterTuples = resp.andFilterObject.entityChoiceFilterTuples;
                                 }
                             }
                         }
@@ -1985,7 +1985,7 @@
                     // build the url using the helper function
                     var schemaTable = urlEncode(self.table.schema.name) + ':' + urlEncode(self.table.name);
                     var uri = self._location.service + "/catalog/" + self.table.schema.catalog.id + "/entity/" + schemaTable;
-                    var keyValueRes = module._generateKeyValueFilters(
+                    var keyValueRes = module.generateKeyValueFilters(
                         self.table.shortestKey,
                         pageData,
                         self.table.schema.catalog,
@@ -2150,7 +2150,7 @@
                     }
 
                     // might throw an error
-                    var keyValueRes = module._generateKeyValueFilters(
+                    var keyValueRes = module.generateKeyValueFilters(
                         self.table.shortestKey,
                         deletableData,
                         self.table.schema.catalog,
@@ -2256,7 +2256,7 @@
                     });
                     return res;
                 });
-                var keyValueRes = module._generateKeyValueFilters(
+                var keyValueRes = module.generateKeyValueFilters(
                     keyColumns,
                     keyFromAssocToRelatedData,
                     associationRef.table.schema.catalog,

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1297,7 +1297,7 @@
      *                                  if the given value is negative, we will not check the url length limitation.
      * @param {string} displayname the displayname of reference, used for error message
      */
-    module._generateKeyValueFilters = function (keyColumns, data, catalogObject, pathOffsetLength, displayname) {
+    module.generateKeyValueFilters = function (keyColumns, data, catalogObject, pathOffsetLength, displayname) {
         var encode = module._fixedEncodeURIComponent, pathLimit = module.URL_PATH_LENGTH_LIMIT;
 
         // see if the quantified syntax can be used


### PR DESCRIPTION
In #899, we added validation logic to the existing filters in the URL. With this, we're checking the encoded `choices` with the database, and if we can't find them, we will throw a popup error and ignore the invalid choices.

I didn't add a URL length limitation logic when I implemented this. So, this PR will ensure we're using the same API as other places in chaise for generating key-value requests, which will handle URL length limitations and use `any` syntax if the server allows it.

I also renamed the `generateKeyValueFilters` API to be "public" since Chaise needs it for favorites logic (https://github.com/informatics-isi-edu/chaise/pull/2302).