### PR TITLE
Display human readable value for asset byte count

### DIFF
--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -701,6 +701,10 @@ Supported JSON payload patterns:
 Supported display _displayoption_ JSON payload patterns:
 
 - `{`... `"image_preview": true` ... `}`: Display a preview of the selected image below the default presentation of the asset. Be mindful that the client will not do any extra checks whether the selected file is an image, and you should guard against it by using `filename_ext_filter`. Current implementation of Chaise only supports this property in `entry` contexts and defining this for other contexts will not have any effect on Chaise.
+- `{`... `"byte_count":` _byte count format_ ... `}`: This property can be used to specify how the _byte_count_column_ value should be presented. The _byte count format_ can be any of the following (f this property is not defined for a specific context or is invalid, we wil use the `"binary"` format):
+  - `"binary"`: Convert to human readable format in binary (using 1024 as the divisor). For example `41235532` would be `39.33 MiB`.
+  - `"si"`: Convert to human readable format in SI (using 1000 as the divisor). For example `41235532` would be `41.24 MB`.
+  - `"raw"`: Don't apply additional formats.
 
 Default heuristics:
 - The `2017 Asset` annotation explicitly indicates that the associated column is the asset location.

--- a/docs/user-docs/handlebars.md
+++ b/docs/user-docs/handlebars.md
@@ -280,6 +280,23 @@ Example:
 {{formatDate '30-08-2018' 'YYYY'}} ==> '2018'
 ```
 
+### HumanizeBytes
+
+You can use `humanizeBytes` helper to convert byte count to human readable format. The first parameter is the value (or the column name that has the value). The second parameter can either be `"binary"` or `"si"` depending on the format that you would like.
+
+Syntax
+```
+{{humanizeBytes value format}}
+```
+
+Example:
+```
+{{formatDate 41235532 'binary'}} ==> '39.33 MiB'
+
+{{formatDate 41235532 'si'}} ==> '41.24 MB'
+```
+
+
 ### Math Helpers
 
 We have basic math functionality support available in handlebars templating. The following are the currently available math helpers.

--- a/js/core.js
+++ b/js/core.js
@@ -2739,6 +2739,12 @@
                     return v.toString();
                 }
 
+                // if the byte count of an asset, humanize it based on the given setting
+                var byteCountFormat = self.getByteCountFormat(context);
+                if (isStringAndNotEmpty(byteCountFormat)) {
+                    return module._formatUtils(v, self.byteCountFormat);
+                }
+
                 return _formatValueByType(self.type, v, options);
             };
 
@@ -3289,7 +3295,55 @@
                 var dummy = this.isUniqueNotNull;
             }
             return this._uniqueNotNullKey;
-         }
+        },
+
+        /**
+         * @param {string} context 
+         * 
+         * if this is a byte_count_column of one of the asset columns,
+         * it will return the format that we should use.
+         * the returned value will either be empty string, or the format that 
+         * should be used 'si', 'binary', 'raw'.
+         */
+        getByteCountFormat: function (context) {
+            if (typeof this._byteCountFormat === 'undefined') {
+                this._byteCountFormat = {};
+            }
+
+            if (!(context in this._byteCountFormat)) {
+                var populate = function (self) {
+                    var columns = self.table.columns.all();
+                    for (var i = 0; i < columns.length; i++) {
+                        var col = columns[i];
+
+                        // find asset columns
+                        if (col.type.name !== "text" || !col.annotations.contains(module._annotations.ASSET)) {
+                            continue;
+                        }
+
+                        // see if the current column is listed as a byte_count_column of one of the assets
+                        var annot = col.annotations.get(module._annotations.ASSET).content;
+                        if (annot.byte_count_column === self.name) {
+                            // check if the byte_counte display is defined. if not, return binary
+                            var disp = annot.display;
+                            var currDisplay = isObjectAndNotNull(disp) ? module._getAnnotationValueByContext(context, disp) : null;
+                            var isValid = isObjectAndNotNull(currDisplay) && ['si', 'binary', 'raw'].indexOf(currDisplay.byte_count) !== -1;
+                            if (isValid) {
+                                return currDisplay.byte_count;
+                            } else {
+                                return 'binary';
+                            }
+                        }
+                    }
+
+                    // empty string means that we should not format it as a byte
+                    return '';
+                };
+                
+                this._byteCountFormat[context] = populate(this);
+            }
+            return this._byteCountFormat;
+        }
     };
 
     /**

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -221,7 +221,7 @@
         "eq", "ne", "lt", "gt", "lte", "gte", "and", "or", "not", "ifCond",
         "escape", "encode", "formatDate", "encodeFacet",
         "regexMatch", "regexFindFirst", "regexFindAll",
-        "jsonStringify", "toTitleCase", "replace",
+        "jsonStringify", "toTitleCase", "replace", "humanizeBytes",
         // math helpers
         "add", "subtract"
     ];

--- a/js/utils/handlebar_helpers.js
+++ b/js/utils/handlebar_helpers.js
@@ -138,6 +138,17 @@
                 return str.replace(/\w\S*/g, function(txt) {
                     return txt.charAt(0).toUpperCase() + txt.substr(1);
                 });
+            },
+
+            /**
+             * {{humanizeBytes value mode}}
+             * 
+             * mode can be `si`, `binary`, or `raw`.
+             *
+             * @returns formatted string of `value` with corresponding `mode`
+             */
+            humanizeBytes: function (value, mode) {
+                return module._formatUtils.humanizeBytes(value, mode);
             }
 
         });

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1903,6 +1903,29 @@
 
             value = value.toUpperCase();
             return ':span: :/span:{.' + module._classNames.colorPreview + ' style=background-color:' + value +'} ' + value;
+        },
+
+        /**
+         * Return the humanize value of byte count
+         * @param {*} value 
+         * @param {string} mode must be either `raw`, `si`, or `binary`
+         * @returns 
+         */
+        humanizeBytes: function (value, mode) {
+            var v = parseInt(value);
+            if (isNaN(v) || ['raw', 'si', 'binary'].indexOf(mode) === -1) return '';
+            if (v === 0 || mode === 'raw') {
+                // TODO which one?
+                return v.toString(); 
+                // return module._formatUtils.printInteger(v); 
+            }
+
+            var divisor = mode === 'si' ? 1000 : 1024;
+            var units = mode === 'si' ? ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'] 
+                : ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+
+            var i = Math.floor(Math.log(v) / Math.log(divisor));
+            return (v / Math.pow(divisor, i)).toFixed(2) * 1 + ' ' + units[i];
         }
     };
 

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -586,6 +586,20 @@ exports.execute = function (options) {
                 expect(module.renderHandlebarsTemplate("{{formatDate date 'YYYY'}}", {date: null})).toBe("");
             });
 
+            it('humanizeByte helper', function () {
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'binary\'}}')).toBe('39.33 MiB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'si\'}}')).toBe('41.24 MB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'raw\'}}')).toBe('41235532');
+
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 \'binary\'}}')).toBe('0');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 \'si\'}}')).toBe('0');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 \'raw\'}}')).toBe('0');
+
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'invalid\'}}')).toBe('');
+
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 }}')).toBe('');
+            });
+
             it('encodeFacet helper', function () {
                 var facet = '{"and": [{"source": "id", "choices": ["1"]}]}';
                 expect(module.renderHandlebarsTemplate("{{#encodeFacet}}" + facet + "{{/encodeFacet}}")).toBe('N4IghgdgJiBcAEBtUBnA9gVwE4GMCmc8IAljADRE4AWax+KhiIAjCALoC+nQA');


### PR DESCRIPTION
In #903, we talked about ways to allow data modelers to change raw integer values into a more readable values.

While we still want to pursue this, in this PR we defined a similar mechanism in asset annotation. This PR adds a new `byte_count` property to `display` settings of asset annotation to provide the "default" presentation setting for `byte_count_column`.

```json
"tag:isrd.isi.edu,2017:asset": {
  "url_pattern": "..",
  "byte_count_column": "bytes",
  "display": {
    "*": {
      "byte_count": "raw|si|binary",
    }
   }
}
```
Where,
- `raw`: Just return the value
-  `si`: 1000 divisor
-  `binary`: 1024 divisor

If the `byte_count` display setting is missing, we will use the "binary" method by default.


As part of this PR I also added the `humanizeBytes` handlebar function that calls the same function. The following is how it can be used:

```
{{humanizeBytes value format number_of_digits}}
{{humanizeBytes 1230000 "si" 3 }}
```


**What's left**:
- We need to finalize the property name and also the handlebar name.
- I only added test cases for the handlebar function. So test cases for the asset integration is missing.
- Depending on how chaise is using assets, this might break some test cases since I've changed the default presentation of byte count.
- Some test cases are failing locally. All of the are related to the error messages that we expect. This is most probably due to the postgres (or ermrest) update. 


