### PR TITLE
Humanize bytes handlebars function

### DIFF
--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -701,10 +701,6 @@ Supported JSON payload patterns:
 Supported display _displayoption_ JSON payload patterns:
 
 - `{`... `"image_preview": true` ... `}`: Display a preview of the selected image below the default presentation of the asset. Be mindful that the client will not do any extra checks whether the selected file is an image, and you should guard against it by using `filename_ext_filter`. Current implementation of Chaise only supports this property in `entry` contexts and defining this for other contexts will not have any effect on Chaise.
-- `{`... `"byte_count":` _byte count format_ ... `}`: This property can be used to specify how the _byte_count_column_ value should be presented. The _byte count format_ can be any of the following (f this property is not defined for a specific context or is invalid, we wil use the `"binary"` format):
-  - `"binary"`: Convert to human readable format in binary (using 1024 as the divisor). For example `41235532` would be `39.33 MiB`.
-  - `"si"`: Convert to human readable format in SI (using 1000 as the divisor). For example `41235532` would be `41.24 MB`.
-  - `"raw"`: Don't apply additional formats.
 
 Default heuristics:
 - The `2017 Asset` annotation explicitly indicates that the associated column is the asset location.

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -701,6 +701,10 @@ Supported JSON payload patterns:
 Supported display _displayoption_ JSON payload patterns:
 
 - `{`... `"image_preview": true` ... `}`: Display a preview of the selected image below the default presentation of the asset. Be mindful that the client will not do any extra checks whether the selected file is an image, and you should guard against it by using `filename_ext_filter`. Current implementation of Chaise only supports this property in `entry` contexts and defining this for other contexts will not have any effect on Chaise.
+- `{`... `"byte_count":` _byte count format_ ... `}`: This property can be used to specify how the _byte_count_column_ value should be presented. The _byte count format_ can be any of the following (f this property is not defined for a specific context or is invalid, we wil use the `"binary"` format):
+  - `"binary"`: Convert to human readable format in binary (using 1024 as the divisor). For example `41235532` would be `39.33 MiB`.
+  - `"si"`: Convert to human readable format in SI (using 1000 as the divisor). For example `41235532` would be `41.24 MB`.
+  - `"raw"`: Don't apply additional formats.
 
 Default heuristics:
 - The `2017 Asset` annotation explicitly indicates that the associated column is the asset location.

--- a/docs/user-docs/handlebars.md
+++ b/docs/user-docs/handlebars.md
@@ -280,6 +280,23 @@ Example:
 {{formatDate '30-08-2018' 'YYYY'}} ==> '2018'
 ```
 
+### HumanizeBytes
+
+You can use `humanizeBytes` helper to convert byte count to human readable format. The first parameter is the value (or the column name that has the value). The second parameter can either be `"binary"` or `"si"` depending on the format that you would like.
+
+Syntax
+```
+{{humanizeBytes value format}}
+```
+
+Example:
+```
+{{formatDate 41235532 'binary'}} ==> '39.33 MiB'
+
+{{formatDate 41235532 'si'}} ==> '41.24 MB'
+```
+
+
 ### Math Helpers
 
 We have basic math functionality support available in handlebars templating. The following are the currently available math helpers.

--- a/docs/user-docs/handlebars.md
+++ b/docs/user-docs/handlebars.md
@@ -282,18 +282,22 @@ Example:
 
 ### HumanizeBytes
 
-You can use `humanizeBytes` helper to convert byte count to human readable format. The first parameter is the value (or the column name that has the value). The second parameter can either be `"binary"` or `"si"` depending on the format that you would like.
-
+You can use `humanizeBytes` helper to convert byte count to human readable format.
 Syntax
 ```
-{{humanizeBytes value format}}
+{{humanizeBytes value format precision}}
 ```
+
+The parameters are:
+- `value`: The value (or the column name that has the value).
+- `format`: Can either be `"binary"` or `"si"` depending on the output format that you would like.
+- `precision`: An integer specifying the number of significant digits. If missing, the value `3` will be used.
 
 Example:
 ```
-{{formatDate 41235532 'binary'}} ==> '39.33 MiB'
+{{humanizeBytes 41235532 'binary' 3}} ==> '39.3 MiB'
 
-{{formatDate 41235532 'si'}} ==> '41.24 MB'
+{{humanizeBytes 41235532 'si' 3}} ==> '41.24 MB'
 ```
 
 

--- a/docs/user-docs/handlebars.md
+++ b/docs/user-docs/handlebars.md
@@ -40,7 +40,8 @@ Handlebars supports more complicated expression syntax and allow the comparison 
 * [Accessing keys with spaces and special characters](#accessing-keys-with-spaces-and-special-characters)
 * [Subexpressions](#subexpressions)
 * [Helpers](#helpers)
-   * [FormatDate](#formatdate-helper)
+   * [formatDate](#formatdate-helper)
+   * [humanizeBytes](#humanizebytes-helper)
    * [Math Helpers](#math-helpers)
 * [Block Helpers](#block-helpers)
    * [If](#if-helper)
@@ -266,7 +267,7 @@ A Handlebars helper call is a simple identifier, followed by zero or more parame
 {{HELPER_NAME PARAM1 PARAM2 }}
 ```
 
-### FormatDate helper
+### formatDate helper
 
 You can use the `formatDate` helper to take any `date` or `timestamp[tz]` value and format it according to the [Pre Format Guide](pre-format.md#syntax-for-dates-and-timestamps).
 
@@ -280,12 +281,17 @@ Example:
 {{formatDate '30-08-2018' 'YYYY'}} ==> '2018'
 ```
 
-### HumanizeBytes
+### humanizeBytes helper
 
 You can use `humanizeBytes` helper to convert byte count to human readable format.
-Syntax
+
+Syntax:
 ```
 {{humanizeBytes value format precision}}
+
+{{humanizeBytes value}}
+
+{{humanizeBytes value format}}
 ```
 
 The parameters are:

--- a/docs/user-docs/handlebars.md
+++ b/docs/user-docs/handlebars.md
@@ -290,14 +290,21 @@ Syntax
 
 The parameters are:
 - `value`: The value (or the column name that has the value).
-- `format`: Can either be `"binary"` or `"si"` depending on the output format that you would like.
-- `precision`: An integer specifying the number of significant digits. If missing, the value `3` will be used.
+- `format`: Can either be `"binary"` or `"si"` depending on the output format that you would like. If missing or invalid, `"si"` will be used.
+- `precision`: An optional integer specifying the number of digits.
+  - If we cannot show all the fractional digits of a number due to the defined precision, we will truncate the number (we will not round up or down). So for example `999999` with precision=3 will result in `999 kB`, and with precision=4 will be `999.9 kB`.
+  - In 'si' mode, you cannot define precision of less than 3 since it would mean that we have to potentially truncate the integer part of the `value`. Similarly, precision of less than 4 are not allowed in `binary`.
+  - Any invalid precision will be ignored and the minimum number allowed will be used (3 in `si` and 4 in `binary`).
 
 Example:
 ```
-{{humanizeBytes 41235532 'binary' 3}} ==> '39.3 MiB'
+{{humanizeBytes 41235532}} ==> '41.2 MB'
 
-{{humanizeBytes 41235532 'si' 3}} ==> '41.24 MB'
+{{humanizeBytes 41235532 'si' 4 }} ==> '41.23 MB'
+
+{{humanizeBytes 41235532 'binary'}} ==> '39.32 MiB'
+
+{{humanizeBytes 41235532 'binary' 5}} ==> '39.325 MiB'
 ```
 
 

--- a/js/core.js
+++ b/js/core.js
@@ -2739,12 +2739,6 @@
                     return v.toString();
                 }
 
-                // if the byte count of an asset, humanize it based on the given setting
-                var byteCountFormat = self.getByteCountFormat(context);
-                if (isStringAndNotEmpty(byteCountFormat)) {
-                    return module._formatUtils(v, self.byteCountFormat);
-                }
-
                 return _formatValueByType(self.type, v, options);
             };
 
@@ -3296,54 +3290,6 @@
             }
             return this._uniqueNotNullKey;
         },
-
-        /**
-         * @param {string} context 
-         * 
-         * if this is a byte_count_column of one of the asset columns,
-         * it will return the format that we should use.
-         * the returned value will either be empty string, or the format that 
-         * should be used 'si', 'binary', 'raw'.
-         */
-        getByteCountFormat: function (context) {
-            if (typeof this._byteCountFormat === 'undefined') {
-                this._byteCountFormat = {};
-            }
-
-            if (!(context in this._byteCountFormat)) {
-                var populate = function (self) {
-                    var columns = self.table.columns.all();
-                    for (var i = 0; i < columns.length; i++) {
-                        var col = columns[i];
-
-                        // find asset columns
-                        if (col.type.name !== "text" || !col.annotations.contains(module._annotations.ASSET)) {
-                            continue;
-                        }
-
-                        // see if the current column is listed as a byte_count_column of one of the assets
-                        var annot = col.annotations.get(module._annotations.ASSET).content;
-                        if (annot.byte_count_column === self.name) {
-                            // check if the byte_counte display is defined. if not, return binary
-                            var disp = annot.display;
-                            var currDisplay = isObjectAndNotNull(disp) ? module._getAnnotationValueByContext(context, disp) : null;
-                            var isValid = isObjectAndNotNull(currDisplay) && ['si', 'binary', 'raw'].indexOf(currDisplay.byte_count) !== -1;
-                            if (isValid) {
-                                return currDisplay.byte_count;
-                            } else {
-                                return 'binary';
-                            }
-                        }
-                    }
-
-                    // empty string means that we should not format it as a byte
-                    return '';
-                };
-                
-                this._byteCountFormat[context] = populate(this);
-            }
-            return this._byteCountFormat;
-        }
     };
 
     /**

--- a/js/core.js
+++ b/js/core.js
@@ -2739,6 +2739,12 @@
                     return v.toString();
                 }
 
+                // if the byte count of an asset, humanize it based on the given setting
+                var byteCountFormat = self.getByteCountFormat(context);
+                if (isStringAndNotEmpty(byteCountFormat)) {
+                    return module._formatUtils(v, self.byteCountFormat);
+                }
+
                 return _formatValueByType(self.type, v, options);
             };
 
@@ -3289,7 +3295,55 @@
                 var dummy = this.isUniqueNotNull;
             }
             return this._uniqueNotNullKey;
-         }
+        },
+
+        /**
+         * @param {string} context 
+         * 
+         * if this is a byte_count_column of one of the asset columns,
+         * it will return the format that we should use.
+         * the returned value will either be empty string, or the format that 
+         * should be used 'si', 'binary', 'raw'.
+         */
+        getByteCountFormat: function (context) {
+            if (typeof this._byteCountFormat === 'undefined') {
+                this._byteCountFormat = {};
+            }
+
+            if (!(context in this._byteCountFormat)) {
+                var populate = function (self) {
+                    var columns = self.table.columns.all();
+                    for (var i = 0; i < columns.length; i++) {
+                        var col = columns[i];
+
+                        // find asset columns
+                        if (col.type.name !== "text" || !col.annotations.contains(module._annotations.ASSET)) {
+                            continue;
+                        }
+
+                        // see if the current column is listed as a byte_count_column of one of the assets
+                        var annot = col.annotations.get(module._annotations.ASSET).content;
+                        if (annot.byte_count_column === self.name) {
+                            // check if the byte_counte display is defined. if not, return binary
+                            var disp = annot.display;
+                            var currDisplay = isObjectAndNotNull(disp) ? module._getAnnotationValueByContext(context, disp) : null;
+                            var isValid = isObjectAndNotNull(currDisplay) && ['si', 'binary', 'raw'].indexOf(currDisplay.byte_count) !== -1;
+                            if (isValid) {
+                                return currDisplay.byte_count;
+                            } else {
+                                return 'binary';
+                            }
+                        }
+                    }
+
+                    // empty string means that we should not format it as a byte
+                    return '';
+                };
+                
+                this._byteCountFormat[context] = populate(this);
+            }
+            return this._byteCountFormat;
+        }
     };
 
     /**

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -221,7 +221,7 @@
         "eq", "ne", "lt", "gt", "lte", "gte", "and", "or", "not", "ifCond",
         "escape", "encode", "formatDate", "encodeFacet",
         "regexMatch", "regexFindFirst", "regexFindAll",
-        "jsonStringify", "toTitleCase", "replace",
+        "jsonStringify", "toTitleCase", "replace", "humanizeBytes",
         // math helpers
         "add", "subtract"
     ];

--- a/js/utils/handlebar_helpers.js
+++ b/js/utils/handlebar_helpers.js
@@ -141,16 +141,17 @@
             },
 
             /**
+             * {{humanizeBytes value }}
              * {{humanizeBytes value mode }}
              * {{humanizeBytes value mode precision}}
-             * 
+             *
              * @param {*} value - the value
              * @param {string} mode - mode can be `si`, `binary`, or `raw`.
              * @param {number} precision - An integer specifying the number of significant digits.
-             * 
+             *
              * @returns formatted string of `value` with corresponding `mode`
              */
-            humanizeBytes: function (value, mode, precision, options) {
+            humanizeBytes: function (value, mode, precision) {
                 return module._formatUtils.humanizeBytes(value, mode, precision);
             }
 

--- a/js/utils/handlebar_helpers.js
+++ b/js/utils/handlebar_helpers.js
@@ -138,6 +138,17 @@
                 return str.replace(/\w\S*/g, function(txt) {
                     return txt.charAt(0).toUpperCase() + txt.substr(1);
                 });
+            },
+
+            /**
+             * {{humanizeBytes value mode}}
+             * 
+             * mode can be `si`, `binary`, or `raw`.
+             *
+             * @returns formatted string of `value` with corresponding `mode`
+             */
+            humanizeBytes: function (value, mode) {
+                return module._formatUtils.humanizeBytes(value, mode);
             }
 
         });

--- a/js/utils/handlebar_helpers.js
+++ b/js/utils/handlebar_helpers.js
@@ -141,14 +141,17 @@
             },
 
             /**
-             * {{humanizeBytes value mode}}
+             * {{humanizeBytes value mode }}
+             * {{humanizeBytes value mode precision}}
              * 
-             * mode can be `si`, `binary`, or `raw`.
-             *
+             * @param {*} value - the value
+             * @param {string} mode - mode can be `si`, `binary`, or `raw`.
+             * @param {number} precision - An integer specifying the number of significant digits.
+             * 
              * @returns formatted string of `value` with corresponding `mode`
              */
-            humanizeBytes: function (value, mode) {
-                return module._formatUtils.humanizeBytes(value, mode);
+            humanizeBytes: function (value, mode, precision, options) {
+                return module._formatUtils.humanizeBytes(value, mode, precision);
             }
 
         });

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1909,15 +1909,18 @@
          * Return the humanize value of byte count
          * @param {*} value 
          * @param {string} mode must be either `raw`, `si`, or `binary`
+         * @param {number} precision An integer specifying the number of significant digits 
+         *                           (if invalid or missing, `3` will be used by default.)
          * @returns 
          */
-        humanizeBytes: function (value, mode) {
+        humanizeBytes: function (value, mode, precision) {
+            precision = parseInt(precision);
+            precision = (isNaN(precision) || precision <= 0) ? 3 : precision;
+
             var v = parseInt(value);
             if (isNaN(v) || ['raw', 'si', 'binary'].indexOf(mode) === -1) return '';
             if (v === 0 || mode === 'raw') {
-                // TODO which one?
-                return v.toString(); 
-                // return module._formatUtils.printInteger(v); 
+                return module._formatUtils.printInteger(v); 
             }
 
             var divisor = mode === 'si' ? 1000 : 1024;
@@ -1925,7 +1928,7 @@
                 : ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
 
             var i = Math.floor(Math.log(v) / Math.log(divisor));
-            return (v / Math.pow(divisor, i)).toFixed(2) * 1 + ' ' + units[i];
+            return (v / Math.pow(divisor, i)).toPrecision(precision) * 1 + ' ' + units[i];
         }
     };
 

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1903,6 +1903,29 @@
 
             value = value.toUpperCase();
             return ':span: :/span:{.' + module._classNames.colorPreview + ' style=background-color:' + value +'} ' + value;
+        },
+
+        /**
+         * Return the humanize value of byte count
+         * @param {*} value 
+         * @param {string} mode must be either `raw`, `si`, or `binary`
+         * @returns 
+         */
+        humanizeBytes: function (value, mode) {
+            var v = parseInt(value);
+            if (isNaN(v) || ['raw', 'si', 'binary'].indexOf(mode) === -1) return '';
+            if (v === 0 || mode === 'raw') {
+                // TODO which one?
+                return v.toString(); 
+                // return module._formatUtils.printInteger(v); 
+            }
+
+            var divisor = mode === 'si' ? 1000 : 1024;
+            var units = mode === 'si' ? ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'] 
+                : ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+
+            var i = Math.floor(Math.log(v) / Math.log(divisor));
+            return (v / Math.pow(divisor, i)).toFixed(2) * 1 + ' ' + units[i];
         }
     };
 

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1945,7 +1945,7 @@
         /**
          * Return the humanize value of byte count
          *
-         * This function will not round up or down and will only truncate the number
+         * This function will not round up and will only truncate the number
          * to honor the given precision. In 'si', precision below 3 is not allowed.
          * Similarly, precision below 4 is not allowed in 'binary'.
          * 'raw' will return the "formatted" value.

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1964,7 +1964,7 @@
 
             if (isNaN(v)) return '';
             if (v === 0 || mode === 'raw') {
-                return module._formatUtils.printInteger(v);
+                return module._formatUtils.printInteger(value);
             }
 
             var divisor = 1000, units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
@@ -1981,8 +1981,9 @@
                 u++;
             }
 
+            // our units don't support this, so just return the "raw" mode value.
             if (u >= units.length) {
-                return module._formatUtils.printInteger(v);
+                return module._formatUtils.printInteger(value);
             }
 
             // we don't want to truncate the value, so we should set a minimum

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -594,11 +594,15 @@ exports.execute = function (options) {
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 12345678 "invalid"}}')).toBe('12.3 MB');
 
                 // test si
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 999 "si"}}')).toBe('999 B');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 999 "si" 1}}')).toBe('999 B');
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235552 "si"}}')).toBe('41.2 MB');
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235552 "si" 1}}')).toBe('41.2 MB');
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235552 "si" 6}}')).toBe('41.2355 MB');
 
                 // test binary
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 1023 "binary"}}')).toBe('1023 B');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 1023 "binary" 1}}')).toBe('1023 B');
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 "binary"}}')).toBe('39.32 MiB');
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 "binary" 1}}')).toBe('39.32 MiB');
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 "binary" 6}}')).toBe('39.3252 MiB');

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -587,17 +587,43 @@ exports.execute = function (options) {
             });
 
             it('humanizeByte helper', function () {
-                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'binary\'}}')).toBe('39.33 MiB');
-                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'si\'}}')).toBe('41.24 MB');
-                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'raw\'}}')).toBe('41235532');
+                // test overloading
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes data }}', {data: 12345678})).toBe('12.3 MB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 12345678 }}')).toBe('12.3 MB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes "12345678" }}')).toBe('12.3 MB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 12345678 "invalid"}}')).toBe('12.3 MB');
 
-                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 \'binary\'}}')).toBe('0');
-                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 \'si\'}}')).toBe('0');
-                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 \'raw\'}}')).toBe('0');
+                // test si
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235552 "si"}}')).toBe('41.2 MB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235552 "si" 1}}')).toBe('41.2 MB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235552 "si" 6}}')).toBe('41.2355 MB');
 
-                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'invalid\'}}')).toBe('');
+                // test binary
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 "binary"}}')).toBe('39.32 MiB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 "binary" 1}}')).toBe('39.32 MiB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 "binary" 6}}')).toBe('39.3252 MiB');
 
-                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 }}')).toBe('');
+                // test raw
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 "raw"}}')).toBe('41,235,532');
+
+                // test truncation (si)
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 9999999999999 }}')).toBe('9.99 TB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 9999999999999 "si"}}')).toBe('9.99 TB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 9999999999999 "si" 4}}')).toBe('9.999 TB');
+
+                // test truncation (binary)
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 1125899906842623 "binary"}}')).toBe('1023 TiB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 1125899906842623 "binary" 6}}')).toBe('1023.99 TiB');
+
+
+                // test 0
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 }}')).toBe('0');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 "binary"}}')).toBe('0');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 "si"}}')).toBe('0');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 "raw"}}')).toBe('0');
+
+
+
             });
 
             it('encodeFacet helper', function () {

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -626,7 +626,11 @@ exports.execute = function (options) {
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 "si"}}')).toBe('0');
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 "raw"}}')).toBe('0');
 
-
+                // test very large numbers
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 123456712345671234656742232 }}')).toBe('123 YB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 1234567123456712346567422321 }}')).toBe('1.2,345,671,234,567,124e+27');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 1197940039285380274899124224 "binary" }}')).toBe('990.9 YiB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 1237940039285380274899124223 "binary" }}')).toBe('1.2,379,400,392,853,803e+27');
 
             });
 

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -586,6 +586,20 @@ exports.execute = function (options) {
                 expect(module.renderHandlebarsTemplate("{{formatDate date 'YYYY'}}", {date: null})).toBe("");
             });
 
+            it('humanizeByte helper', function () {
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'binary\'}}')).toBe('39.33 MiB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'si\'}}')).toBe('41.24 MB');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'raw\'}}')).toBe('41235532');
+
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 \'binary\'}}')).toBe('0');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 \'si\'}}')).toBe('0');
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 0 \'raw\'}}')).toBe('0');
+
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 \'invalid\'}}')).toBe('');
+
+                expect(module.renderHandlebarsTemplate('{{humanizeBytes 41235532 }}')).toBe('');
+            });
+
             it('encodeFacet helper', function () {
                 var facet = '{"and": [{"source": "id", "choices": ["1"]}]}';
                 expect(module.renderHandlebarsTemplate("{{#encodeFacet}}" + facet + "{{/encodeFacet}}")).toBe('N4IghgdgJiBcAEBtUBnA9gVwE4GMCmc8IAljADRE4AWax+KhiIAjCALoC+nQA');


### PR DESCRIPTION
This PR will add the `humanizeBytes` handlebars function that we described in #903. 

Notes:

- This is the updated version of #977. The following are the summary of changes since that PR:
  - Removed the asset related changes. We will merge the asset changes as part of another PR later.
  - Precision support has changed. I'm not using the built-in function anymore as it would round up in some scenarios. 
  - I was using `parseInt` to be able to support both string and number, but it wasn't allowing large numbers. So I'm doing `parseFloat` now.
  - Instead of using `Math.log` I'm now simply dividing the number until it is less than the divisor. `Math.log` wasn't working the way I wanted in the case of large numbers and was rounding the numbers. 