### PR TITLE
Update Github Actions workflow to install missing deriva dependencies

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,7 +22,7 @@ jobs:
           node --version
           sudo timedatectl set-timezone America/Los_Angeles
           export PATH="$(systemd-path user-binaries):$PATH"
-          sudo apt-get update
+          sudo apt-get -y update
           sudo apt-get -y install libcurl4-openssl-dev libjson-c-dev
           sudo service postgresql stop || true
           sudo service postgresql start 12
@@ -31,16 +31,18 @@ jobs:
           sudo a2enmod ssl
           sudo a2ensite default-ssl
           sudo groupadd -o -g $(id -g www-data) apache
+          sudo apt-get install -y python3-setuptools python3-ply
           sudo python3 --version
           sudo pip3 --version
-          sudo apt-get install -y python3-setuptools python3-ply
+          sudo su -c 'echo /usr/lib/python3.8/site-packages > /usr/local/lib/python3.8/dist-packages/sys-site-packages.pth'
           sudo su -c 'python3 -c "import site;print(site.PREFIXES);"'
           sudo su -c 'python3 -c "import site;print(site.getsitepackages())"'
           sudo pip3 install flask
           sudo pip3 install requests
+          sudo pip3 install globus_sdk
           sudo pip3 install psycopg2-binary
           sudo pip3 install oauth2client
-          sudo pip3 install globus_sdk
+          sudo pip3 install -U pyopenssl cryptography
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -36,9 +36,11 @@ jobs:
           sudo apt-get install -y python3-setuptools python3-ply
           sudo su -c 'python3 -c "import site;print(site.PREFIXES);"'
           sudo su -c 'python3 -c "import site;print(site.getsitepackages())"'
+          sudo pip3 install flask
           sudo pip3 install requests
           sudo pip3 install psycopg2-binary
-          sudo pip3 install git+https://github.com/informatics-isi-edu/webpy.git
+          sudo pip3 install oauth2client
+          sudo pip3 install globus_sdk
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,12 +37,13 @@ jobs:
           sudo su -c 'echo /usr/lib/python3.8/site-packages > /usr/local/lib/python3.8/dist-packages/sys-site-packages.pth'
           sudo su -c 'python3 -c "import site;print(site.PREFIXES);"'
           sudo su -c 'python3 -c "import site;print(site.getsitepackages())"'
+          : # the line below will make sure pyopenssl and cryptography have compatible versions
+          sudo pip3 install -U pyopenssl cryptography
           sudo pip3 install flask
           sudo pip3 install requests
           sudo pip3 install globus_sdk
           sudo pip3 install psycopg2-binary
           sudo pip3 install oauth2client
-          sudo pip3 install -U pyopenssl cryptography
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
The `flask` branch of webauthn, hatrac, and ermrest is now merged with master. So I had to update some dependencies to make sure our test cases are passing.

P.S. After adding the missing dependencies, Actions was throwing this error during installation:

```
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
``` 

So I had to add the following line (borrowed from [here](https://stackoverflow.com/questions/74981558/error-updating-python3-pip-attributeerror-module-lib-has-no-attribute-openss)):
```
sudo pip3 install -U pyopenssl cryptography
```

Not sure if this the best way to install dependencies or not, but it seems to be working properly.