### PR TITLE
Changes related to sourcekey and visible columns

### DIFF
--- a/docs/user-docs/column-directive.md
+++ b/docs/user-docs/column-directive.md
@@ -86,6 +86,9 @@ In this category, the [`sourcekey`](#sourcekey) proprety is used to refer to one
 ```
 {
   "sourcekey" : <source key>,
+  "entity": <true or false>,
+  "aggregate": <aggregate function>,
+  "self_link": <boolean>,
   "markdown_name": <display name>,
   "comment": <tooltip message>,
   "comment_display": <inline|tooltip>,
@@ -324,7 +327,7 @@ RID;M:=array_d(M:*),F3:=array_d(F3:*),F2:=array_d(M_P1:*),F1:=array_d(M_P2:*)@so
 ```
 
 #### sourcekey
-Instead of defining a column directive in place, you can define them in the [`source-definitions` annotations](annotation.md#tag-2019-source-definitions), and refer to those definitions using `sourcekey`. If `sourcekey` is defined on a column directive, the rest of _data source attributes_ defined on the column directive will be ignored (but you still can modify the display and other types of attributes).
+Instead of defining a column directive in place, you can define them in the [`source-definitions` annotations](annotation.md#tag-2019-source-definitions), and refer to those definitions using `sourcekey`. You can also use this property to refer to an existing source definition and modify the display or data source attributes (apart from `source`) for this instance.
 
 #### entity
  If the column directive can be treated as entity (the column that is defined in source path is key of the table), setting `entity` attribute to `false` will force the scalar mode. This will affect different logic and heuristics. In a nutshell, entity-mode means we try to provide a UX around a set of entities (table rows).  Scalar mode means we try to provide a UX around a set of values like strings, integers, etc.

--- a/js/core.js
+++ b/js/core.js
@@ -1598,34 +1598,7 @@
                     hasPrefix = typeof sourceDef === "object" && Array.isArray(sourceDef.source) &&
                                 sourceDef.source.length > 1 && ("sourcekey" in sourceDef.source[0]);
 
-                    // a sugar syntax that allows referring to an existing sourcekey
-                    hasSourcekey = typeof sourceDef === "object" && isStringAndNotEmpty(sourceDef.sourcekey);
-
-                    if (hasSourcekey) {
-                        // keep track of dependencies for cycle detection
-                        keysThatDependOnThis.push(key);
-
-                        usedSourcekey = sourceDef.sourcekey;
-
-                        // make sure we've processed the referred sourcekey
-                        valid = addSourceDef(usedSourcekey, keysThatDependOnThis);
-                        processedSources[key] = valid;
-                        if (!valid) {
-                            module._log.info(message + ": " + "given sourcekey is invalid.");
-                            return false;
-                        }
-
-                        /**
-                         * remove the sourcekey as it was only used for copying (refer to the comment of previous line) and
-                         * just copy the definition from the sourcekey to here
-                         * TODO this way the inner sourcekey is getting lost so it cannot be used for sharing path.
-                         * is there any way to fix this?
-                         */
-                        delete sourceDef.sourcekey;
-                        module._shallowCopyExtras(sourceDef, res.sources[usedSourcekey].sourceObject, module._sourceDefinitionAttributes);
-
-                    }
-                    else if (hasPrefix) {
+                    if (hasPrefix) {
 
                         // keep track of dependencies for cycle detection
                         keysThatDependOnThis.push(key);

--- a/js/core.js
+++ b/js/core.js
@@ -1748,6 +1748,7 @@
                         var src = sbDef[orOperator][index];
                         var pSource, sd;
 
+                        // sourcekey has priority over source. if both used, ignore source and only honor source.
                         if (src.sourcekey) {
                             sd = self.sourceDefinitions.sources[src.sourcekey];
                             if (!sd) {
@@ -4077,18 +4078,19 @@
                 else if (typeof orders[i] === "object") {
                     var wrapper;
                     if (orders[i].source || orders[i].sourcekey) {
-                        if (orders[i].source) {
+                        // if both source and sourcekey are defined, ignore the source and use sourcekey
+                        if (orders[i].sourcekey) {
+                            var def = definitions.sources[orders[i].sourcekey];
+                            if (def) {
+                                wrapper = def.clone(orders[i], this._table, module._constraintNames);
+                            }
+                        } else {
                             try {
                                 wrapper = new SourceObjectWrapper(orders[i], this._table, module._constraintNames);
                             } catch (exp) {
                                 // we might want to show a better error message later.
                                 logErr(true, exp.message, i);
                                 invalid = true;
-                            }
-                        } else {
-                            var def = definitions.sources[orders[i].sourcekey];
-                            if (def) {
-                                wrapper = def.clone(orders[i], this._table, module._constraintNames);
                             }
                         }
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -523,6 +523,7 @@
                     obj = module._simpleDeepCopy(obj);
 
                     var sd, wrapper;
+                    // if both source and sourcekey are defined, ignore the source and use sourcekey
                     if (obj.sourcekey) {
                         sd = self.table.sourceDefinitions.sources[obj.sourcekey];
                         if (!sd) return;
@@ -3368,6 +3369,7 @@
 
                         // pseudo-column
                         var sd, wrapper;
+                        // if both source and sourcekey are defined, ignore the source and use sourcekey
                         if (col.sourcekey) {
                             sd = self.table.sourceDefinitions.sources[col.sourcekey];
                             if (logCol(!sd, wm.INVALID_SOURCEKEY, i)) {

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -313,6 +313,7 @@
         INVALID_SOURCEKEY: "given object is invalid. The defined `sourcekey` is invalid.",
         INVALID_VIRTUAL_NO_NAME: "`markdown_name` is required when `source` and `sourcekey` are undefiend.",
         INVALID_VIRTUAL_NO_VALUE: "`display.markdown_pattern` is required when `source` and `sourcekey` are undefiend.",
+        INVALID_BOTH_SOURCE: 'given object is invalid. only one of `source` or `sourcekey` are allowed not both.',
         DUPLICATE_COLUMN: "ignoring duplicate column definition.",
         DUPLICATE_KEY: "ignoring duplicate key definition.",
         DUPLICATE_FK: "ignoring duplicate foreign key definition.",
@@ -387,7 +388,8 @@
         TEXT_SEARCH: "::ts::"
     });
 
-    module._sourceDefinitionAttributes = ["source", "aggregate", "entity", "self_link"];
+    // the attributes that cannot be changed when using sourcekey
+    module._sourceDefinitionAttributes = ["source"];
 
     module._classNames = Object.freeze({
         externalLink: "external-link",

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -267,7 +267,7 @@
      */
     module._shallowCopyExtras = function (copyTo, copyFrom, enforcedList) {
         for (var key in copyFrom) {
-            if (copyFrom.hasOwnProperty(key) && (!copyTo.hasOwnProperty(key) || enforcedList.indexOf(key) !== -1)) {
+            if (copyFrom.hasOwnProperty(key) && (!copyTo.hasOwnProperty(key) || (Array.isArray(enforcedList) && enforcedList.indexOf(key) !== -1))) {
                 copyTo[key] = copyFrom[key];
             }
         }

--- a/js/utils/pseudocolumn_helpers.js
+++ b/js/utils/pseudocolumn_helpers.js
@@ -1218,6 +1218,27 @@
 
     SourceObjectWrapper.prototype = {
 
+        /**
+         * return a new sourceObjectWrapper that is created by merging the given sourceObject and existing object.
+         * 
+         * Useful when we have an object with sourcekey and want to find the actual definition. You can then call
+         * clone on the source-def and pass the object.
+         * 
+         * const myCol = {"sourcekey": "some_key"};
+         * const sd = table.sourceDefinitions.sources[myCol.sourcekey];
+         * if (sd) {
+         *   const wrapper = sd.clone(myCol, table, consNames);
+         * }
+         * 
+         * - attributes in sourceObject will override the similar ones in the current object.
+         * - "source" of sourceObject will be ignored. so "sourcekey" always has priority over "source".
+         * 
+         * @param {Object} sourceObject the source object
+         * @param {ERMrest.Table} table the table that these sources belong to.
+         * @param {Object} consNames the constraint names
+         * @param {boolean} isFacet whether this is for a facet or not
+         * @returns 
+         */
         clone: function (sourceObject, table, consNames, isFacet) {
             var key, res, self = this;
 
@@ -1235,9 +1256,7 @@
                 }
             }
 
-            res = new SourceObjectWrapper(sourceObject, table, consNames, isFacet);
-
-            return res;
+            return new SourceObjectWrapper(sourceObject, table, consNames, isFacet);
         },
 
         /**

--- a/js/utils/pseudocolumn_helpers.js
+++ b/js/utils/pseudocolumn_helpers.js
@@ -1237,7 +1237,6 @@
          * @param {ERMrest.Table} table the table that these sources belong to.
          * @param {Object} consNames the constraint names
          * @param {boolean} isFacet whether this is for a facet or not
-         * @returns 
          */
         clone: function (sourceObject, table, consNames, isFacet) {
             var key, res, self = this;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "uglify-js": "3.9.2"
       },
       "devDependencies": {
-        "@isrd-isi-edu/ermrest-data-utils": "0.0.2",
+        "@isrd-isi-edu/ermrest-data-utils": "0.0.4",
         "axios": "0.25.0",
         "buffer-slice": "0.0.1",
         "file-api": "^0.10.4",
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@isrd-isi-edu/ermrest-data-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@isrd-isi-edu/ermrest-data-utils/-/ermrest-data-utils-0.0.2.tgz",
-      "integrity": "sha512-x1pdGiqkCUwazRSEo/LWQ/b4nYD11+qKXqbV5vhOBym5WcM/EQjHoLTzG27Pa73CIpTblEumh5988MzdnUTk1w==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@isrd-isi-edu/ermrest-data-utils/-/ermrest-data-utils-0.0.4.tgz",
+      "integrity": "sha512-Sq5AGmyY5p/q3l22/kGXNw82uW55bESiOnssKYdhCMc0y5fwSQ9d7U4eRfUsh9s1JD7ZPNVhmrJuhYG3NXvgGw==",
       "dev": true,
       "dependencies": {
         "axios": "^0.24.0",
@@ -1487,9 +1487,9 @@
       "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw=="
     },
     "@isrd-isi-edu/ermrest-data-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@isrd-isi-edu/ermrest-data-utils/-/ermrest-data-utils-0.0.2.tgz",
-      "integrity": "sha512-x1pdGiqkCUwazRSEo/LWQ/b4nYD11+qKXqbV5vhOBym5WcM/EQjHoLTzG27Pa73CIpTblEumh5988MzdnUTk1w==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@isrd-isi-edu/ermrest-data-utils/-/ermrest-data-utils-0.0.4.tgz",
+      "integrity": "sha512-Sq5AGmyY5p/q3l22/kGXNw82uW55bESiOnssKYdhCMc0y5fwSQ9d7U4eRfUsh9s1JD7ZPNVhmrJuhYG3NXvgGw==",
       "dev": true,
       "requires": {
         "axios": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "uglify-js": "3.9.2"
   },
   "devDependencies": {
-    "@isrd-isi-edu/ermrest-data-utils": "0.0.2",
+    "@isrd-isi-edu/ermrest-data-utils": "0.0.4",
     "axios": "0.25.0",
     "buffer-slice": "0.0.1",
     "file-api": "^0.10.4",

--- a/test/specs/column/conf/columns_schema/schema.json
+++ b/test/specs/column/conf/columns_schema/schema.json
@@ -857,6 +857,112 @@
                 }
             }
         },
+        "table_w_name_column": {
+            "kind": "table",
+            "table_name": "table_w_name_column",
+            "schema_name": "columns_schema",
+            "keys": [
+                {"unique_columns": ["id"], "names": [["columns_schema", "table_w_name_column_id_key"]]},
+                {"unique_columns": ["Name"], "names": [["columns_schema", "table_w_name_column_Name_key"]]}
+            ],
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "Name",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ]
+        },
+        "table_w_accession_id_column": {
+            "kind": "table",
+            "table_name": "table_w_accession_id_column",
+            "schema_name": "columns_schema",
+            "keys": [
+                {"unique_columns": ["id"], "names": [["columns_schema", "table_w_accession_id_column_id_key"]]},
+                {"unique_columns": ["Accession_ID"], "names": [["columns_schema", "table_w_accession_id_column_accession_key"]]}
+            ],
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "Accession_ID",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ]
+        },
+        "table_w_asset_key": {
+            "kind": "table",
+            "table_name": "table_w_asset_key",
+            "schema_name": "columns_schema",
+            "keys": [
+                {"unique_columns": ["url"], "names": [["columns_schema", "table_w_asset_key_url_key"]]},
+                {"unique_columns": ["url_md5"], "names": [["columns_schema", "table_w_asset_key_url_md5_key"]]},
+                {"unique_columns": ["url_sha256"], "names": [["columns_schema", "table_w_asset_key_url_sha256_key"]]},
+                {"unique_columns": ["url_filename"], "names": [["columns_schema", "table_w_asset_key_url_filename_key"]]},
+                {"unique_columns": ["other_column"], "names": [["columns_schema", "table_w_asset_key_other_key"]]}
+            ],
+            "column_definitions": [
+                {
+                    "name": "url",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2017:asset": {
+                            "url_pattern": "/hatrac/{{url_md5}}",
+                            "md5": "url_md5",
+                            "sha256": "url_sha256"
+                        }
+                    }
+                },
+                {
+                    "name": "url_md5",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "url_sha256",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "url_filename",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "other_column",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ]
+        },
         "table_w_asset": {
             "comment": "table that has some columns with asset annotation",
             "kind": "table",
@@ -891,15 +997,9 @@
             "column_definitions": [
                 {
                     "name": "id",
-                    "comment": "id, asset should be ignored",
                     "nullok": false,
                     "type": {
                         "typename": "text"
-                    },
-                    "annotations": {
-                        "tag:isrd.isi.edu,2017:asset": {
-                            "url_pattern": "/hatrac/{{id}}"
-                        }
                     }
                 },
                 {

--- a/test/specs/column/conf/columns_schema/schema.json
+++ b/test/specs/column/conf/columns_schema/schema.json
@@ -857,112 +857,6 @@
                 }
             }
         },
-        "table_w_name_column": {
-            "kind": "table",
-            "table_name": "table_w_name_column",
-            "schema_name": "columns_schema",
-            "keys": [
-                {"unique_columns": ["id"], "names": [["columns_schema", "table_w_name_column_id_key"]]},
-                {"unique_columns": ["Name"], "names": [["columns_schema", "table_w_name_column_Name_key"]]}
-            ],
-            "column_definitions": [
-                {
-                    "name": "id",
-                    "nullok": false,
-                    "type": {
-                        "typename": "text"
-                    }
-                },
-                {
-                    "name": "Name",
-                    "nullok": false,
-                    "type": {
-                        "typename": "text"
-                    }
-                }
-            ]
-        },
-        "table_w_accession_id_column": {
-            "kind": "table",
-            "table_name": "table_w_accession_id_column",
-            "schema_name": "columns_schema",
-            "keys": [
-                {"unique_columns": ["id"], "names": [["columns_schema", "table_w_accession_id_column_id_key"]]},
-                {"unique_columns": ["Accession_ID"], "names": [["columns_schema", "table_w_accession_id_column_accession_key"]]}
-            ],
-            "column_definitions": [
-                {
-                    "name": "id",
-                    "nullok": false,
-                    "type": {
-                        "typename": "text"
-                    }
-                },
-                {
-                    "name": "Accession_ID",
-                    "nullok": false,
-                    "type": {
-                        "typename": "text"
-                    }
-                }
-            ]
-        },
-        "table_w_asset_key": {
-            "kind": "table",
-            "table_name": "table_w_asset_key",
-            "schema_name": "columns_schema",
-            "keys": [
-                {"unique_columns": ["url"], "names": [["columns_schema", "table_w_asset_key_url_key"]]},
-                {"unique_columns": ["url_md5"], "names": [["columns_schema", "table_w_asset_key_url_md5_key"]]},
-                {"unique_columns": ["url_sha256"], "names": [["columns_schema", "table_w_asset_key_url_sha256_key"]]},
-                {"unique_columns": ["url_filename"], "names": [["columns_schema", "table_w_asset_key_url_filename_key"]]},
-                {"unique_columns": ["other_column"], "names": [["columns_schema", "table_w_asset_key_other_key"]]}
-            ],
-            "column_definitions": [
-                {
-                    "name": "url",
-                    "nullok": false,
-                    "type": {
-                        "typename": "text"
-                    },
-                    "annotations": {
-                        "tag:isrd.isi.edu,2017:asset": {
-                            "url_pattern": "/hatrac/{{url_md5}}",
-                            "md5": "url_md5",
-                            "sha256": "url_sha256"
-                        }
-                    }
-                },
-                {
-                    "name": "url_md5",
-                    "nullok": false,
-                    "type": {
-                        "typename": "text"
-                    }
-                },
-                {
-                    "name": "url_sha256",
-                    "nullok": false,
-                    "type": {
-                        "typename": "text"
-                    }
-                },
-                {
-                    "name": "url_filename",
-                    "nullok": false,
-                    "type": {
-                        "typename": "text"
-                    }
-                },
-                {
-                    "name": "other_column",
-                    "nullok": false,
-                    "type": {
-                        "typename": "text"
-                    }
-                }
-            ]
-        },
         "table_w_asset": {
             "comment": "table that has some columns with asset annotation",
             "kind": "table",
@@ -997,9 +891,15 @@
             "column_definitions": [
                 {
                     "name": "id",
+                    "comment": "id, asset should be ignored",
                     "nullok": false,
                     "type": {
                         "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2017:asset": {
+                            "url_pattern": "/hatrac/{{id}}"
+                        }
                     }
                 },
                 {

--- a/test/specs/column/conf/pseudo_column_schema/schema.json
+++ b/test/specs/column/conf/pseudo_column_schema/schema.json
@@ -208,12 +208,7 @@
                             {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
                             "id"
                         ], "markdown_name": "**association table**", "comment": false},
-                        {"source": [
-                            {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
-                            {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
-                            {"outbound": ["pseudo_column_schema", "inbound_2_fk1"]},
-                            "id"
-                        ]},
+                        {"sourcekey": "path_to_inbound_2_outbound_1", "source": "RID", "comment": "make sure sourcekey is used and source is ignored"},
                         {"source": [{"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]}, "id"]},
                         {"source": [
                             {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
@@ -233,10 +228,10 @@
                             {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
                             "id"
                         ], "aggregate": "array", "entity": false},
-                        {"sourcekey": "main_inbound_2_association_fk1_fk2_path_id_array", "aggregate": "cnt", "array_display": "csv"},
+                        {"sourcekey": "path_to_inbound_2", "aggregate": "array", "array_display": "csv"},
                         {
-                            "sourcekey": "main_inbound_2_association_fk1_fk2_path_id_array_d",
-                            "aggregate": "cnt_d",
+                            "sourcekey": "main_inbound_2_association_fk1_fk2_path_id_cnt_d",
+                            "aggregate": "array_d",
                             "display": {"array_ux_mode": "ulist"},
                             "array_options": {"invalid values": true}
                         },
@@ -400,21 +395,20 @@
                     "columns": true,
                     "fkeys": true,
                     "sources": {
-                        "main_inbound_2_association_fk1_fk2_path_id_array": {
+                        "path_to_inbound_2": {
                             "source": [
                                 {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
                                 {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
                                 "id"
-                            ],
-                            "aggregate": "array"
+                            ]
                         },
-                        "main_inbound_2_association_fk1_fk2_path_id_array_d": {
+                        "main_inbound_2_association_fk1_fk2_path_id_cnt_d": {
                             "source": [
                                 {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
                                 {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
                                 "id"
                             ],
-                            "aggregate": "array_d"
+                            "aggregate": "cnt_d"
                         },
                         "path_to_inbound_1": {
                             "source": [
@@ -427,6 +421,14 @@
                                 {"sourcekey": "path_to_inbound_1"},
                                 {"outbound": ["pseudo_column_schema", "inbound_1_fk2"]},
                                 "RID"
+                            ]
+                        },
+                        "path_to_inbound_2_outbound_1": {
+                            "source": [
+                                {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                                {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                                {"outbound": ["pseudo_column_schema", "inbound_2_fk1"]},
+                                "id"
                             ]
                         }
                     }

--- a/test/specs/column/tests/01.columns_list.js
+++ b/test/specs/column/tests/01.columns_list.js
@@ -23,10 +23,6 @@ exports.execute = function (options) {
             editContext = "entry/edit",
             detailedContext = "detailed";
 
-        var getURL = (table) => {
-            return `${options.url}/catalog/${catalog_id}/entity/${schemaName}:${table}/id=${entityId}`;
-        }
-
         var singleEnitityUri = options.url + "/catalog/" + catalog_id + "/entity/" +
             schemaName + ":" + tableName + "/id=" + entityId;
 
@@ -621,34 +617,6 @@ exports.execute = function (options) {
                             });
                         });
 
-                        it ('if there\'s a simple key made of "candidate" column (same logic as rowname), it should use that.', (done) => {
-                            options.ermRest.resolve(getURL('table_w_name_column'), {cid:"test"}).then(function(ref) {
-                                expect(ref.columns[0].isPseudo).toBe(true);
-                                expect(ref.columns[0]._constraintName).toEqual(["columns_schema", "table_w_name_column_Name_key"].join("_"));
-
-                                return options.ermRest.resolve(getURL('table_w_accession_id_column'), {cid:"test"});
-                            }).then(function(ref) {
-                                expect(ref.columns[0].isPseudo).toBe(true);
-                                expect(ref.columns[0]._constraintName).toEqual(["columns_schema", "table_w_accession_id_column_accession_key"].join("_"));
-                                done();
-                            }, function (err) {
-                                console.dir(err);
-                                done.fail();
-                            });
-                        });
-
-                        it ('it should depriotize picking a key that is made of asset metadata (other than filename).', (done) => {
-                            options.ermRest.resolve(getURL('table_w_asset_key'), {cid:"test"}).then(function(ref) {
-                                expect(ref.columns[0].isPseudo).toBe(true);
-                                expect(ref.columns[0]._constraintName).toEqual(["columns_schema", "table_w_asset_key_url_filename_key"].join("_"));
-
-                                done();
-                            }, function (err) {
-                                console.dir(err);
-                                done.fail();
-                            });
-                        })
-
                     });
                 });
 
@@ -777,6 +745,11 @@ exports.execute = function (options) {
                       expect(assetRefCompactCols[13].isPseudo).toBe(false, "invalid isPseudo for compact");
                       expect(assetRefEntry.columns[8].name).toBe("col_asset_5", "invalid name for entry");
                       expect(assetRefEntry.columns[8].isPseudo).toBe(false, "invalid isPseudo for entry");
+                    });
+
+                    it('if columns has been used as the keyReferenceColumn, should ignore the asset annotation.', function () {
+                        expect(assetRefCompactCols[0]._constraintName).toBe(["columns_schema", "table_w_asset_key_1"].join("_"));
+                        expect(assetRefCompactCols[0].isKey).toBe(true);
                     });
 
                     it('if column is part of any foreignkeys, should ignore the asset annotation.', function() {

--- a/test/specs/column/tests/01.columns_list.js
+++ b/test/specs/column/tests/01.columns_list.js
@@ -23,6 +23,9 @@ exports.execute = function (options) {
             editContext = "entry/edit",
             detailedContext = "detailed";
 
+        var getURL = (table) => {
+            return `${options.url}/catalog/${catalog_id}/entity/${schemaName}:${table}/id=${entityId}`;
+        }
 
         var singleEnitityUri = options.url + "/catalog/" + catalog_id + "/entity/" +
             schemaName + ":" + tableName + "/id=" + entityId;
@@ -618,6 +621,34 @@ exports.execute = function (options) {
                             });
                         });
 
+                        it ('if there\'s a simple key made of "candidate" column (same logic as rowname), it should use that.', (done) => {
+                            options.ermRest.resolve(getURL('table_w_name_column'), {cid:"test"}).then(function(ref) {
+                                expect(ref.columns[0].isPseudo).toBe(true);
+                                expect(ref.columns[0]._constraintName).toEqual(["columns_schema", "table_w_name_column_Name_key"].join("_"));
+
+                                return options.ermRest.resolve(getURL('table_w_accession_id_column'), {cid:"test"});
+                            }).then(function(ref) {
+                                expect(ref.columns[0].isPseudo).toBe(true);
+                                expect(ref.columns[0]._constraintName).toEqual(["columns_schema", "table_w_accession_id_column_accession_key"].join("_"));
+                                done();
+                            }, function (err) {
+                                console.dir(err);
+                                done.fail();
+                            });
+                        });
+
+                        it ('it should depriotize picking a key that is made of asset metadata (other than filename).', (done) => {
+                            options.ermRest.resolve(getURL('table_w_asset_key'), {cid:"test"}).then(function(ref) {
+                                expect(ref.columns[0].isPseudo).toBe(true);
+                                expect(ref.columns[0]._constraintName).toEqual(["columns_schema", "table_w_asset_key_url_filename_key"].join("_"));
+
+                                done();
+                            }, function (err) {
+                                console.dir(err);
+                                done.fail();
+                            });
+                        })
+
                     });
                 });
 
@@ -746,11 +777,6 @@ exports.execute = function (options) {
                       expect(assetRefCompactCols[13].isPseudo).toBe(false, "invalid isPseudo for compact");
                       expect(assetRefEntry.columns[8].name).toBe("col_asset_5", "invalid name for entry");
                       expect(assetRefEntry.columns[8].isPseudo).toBe(false, "invalid isPseudo for entry");
-                    });
-
-                    it('if columns has been used as the keyReferenceColumn, should ignore the asset annotation.', function () {
-                        expect(assetRefCompactCols[0]._constraintName).toBe(["columns_schema", "table_w_asset_key_1"].join("_"));
-                        expect(assetRefCompactCols[0].isKey).toBe(true);
                     });
 
                     it('if column is part of any foreignkeys, should ignore the asset annotation.', function() {

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -18,8 +18,8 @@
  * 13: same as 10 in non-entity mode with `min` aggregate (PseudoColumn)
  * 14: col - max (PseudoColumn)
  * 15: same as 8 with `array` in non entity mode
- * 16: same as 8 with `array` in entity mode
- * 17: same as 8 with `array_d` in entity with array_display ulist
+ * 16: same as 8 with `array` in entity mode (use sourcekey, array in vis-col)
+ * 17: same as 8 with `array_d` in entity with array_display ulist (use sourcekey, diff agg in vis-col)
  * 18: same as 8 with `array_d` in entity with array_display olist
  * 19: same path as 8 ending in RID with array_d and array_options
  * 20: same path as 8 ending in timestamp_col with array_d and array_options
@@ -1284,9 +1284,6 @@ exports.execute = function (options) {
                     return col.sourceObject.source;
                 }
                 if (col.isPseudo && (col.isKey || col.isForeignKey || col.isInboundForeignKey)) {
-                    if (col.isKey) {
-                        console.log("HERE: "+ col.key.colset.columns[0].name);
-                    }
 
                     return col._constraintName;
                 }

--- a/test/specs/faceting/conf/faceting_schema/schema.json
+++ b/test/specs/faceting/conf/faceting_schema/schema.json
@@ -253,14 +253,11 @@
                                 {"inbound": ["faceting_schema", "secondpath_2_fk1"]},
                                 "id"
                             ], "hide_null_choice": true},
-                            {"sourcekey": "second_path_source_defnition", "entity": false},
+                            {"sourcekey": "second_path_source_definition"},
                             {
-                                "source": [
-                                    {"inbound": ["faceting_schema", "secondpath_1_fk1"]},
-                                    {"inbound": ["faceting_schema", "secondpath_2_fk1"]},
-                                    "RID"
-                                ],
-                                "entity": false
+                                "sourcekey": "second_path_source_definition",
+                                "entity": false,
+                                "comment": "test changing the entity mode while using sourcekey"
                             },
                             {"sourcekey": "path_to_f3_id"},
                             {"source": "numeric_col"},
@@ -311,7 +308,7 @@
                             "source": "text_col",
                             "ux_mode": "choices"
                         },
-                        "second_path_source_defnition": {
+                        "second_path_source_definition": {
                             "source": [
                                 {"inbound": ["faceting_schema", "secondpath_1_fk1"]},
                                 {"inbound": ["faceting_schema", "secondpath_2_fk1"]},
@@ -1652,7 +1649,8 @@
             "table_name": "path_prefix_o1",
             "schema_name": "parse_schema",
             "keys": [
-                {"unique_columns": ["id"]}
+                {"unique_columns": ["id"]},
+                {"unique_columns": ["path_prefix_o1_col"]}
             ],
             "foreign_keys": [
                 {
@@ -1705,7 +1703,8 @@
             "table_name": "path_prefix_o1_o1",
             "schema_name": "parse_schema",
             "keys": [
-                {"unique_columns": ["id"]}
+                {"unique_columns": ["id"]},
+                {"unique_columns": ["path_prefix_o1_o1_col"]}
             ],
             "foreign_keys": [
                 {

--- a/test/specs/faceting/tests/01.faceting.js
+++ b/test/specs/faceting/tests/01.faceting.js
@@ -994,7 +994,7 @@ exports.execute = function (options) {
                                 },
                                 //8
                                 {
-                                    "sourcekey": "second_path_source_defnition",
+                                    "sourcekey": "second_path_source_definition",
                                     "source_domain": {
                                         "schema": "faceting_schema",
                                         "table": "secondpath_2",
@@ -1004,7 +1004,7 @@ exports.execute = function (options) {
                                 },
                                 //9
                                 {
-                                    "sourcekey": "second_path_source_defnition",
+                                    "sourcekey": "second_path_source_definition",
                                     "markdown_name": "Name 9",
                                     "source_domain": {
                                         "schema": "faceting_schema",
@@ -1049,7 +1049,7 @@ exports.execute = function (options) {
                             expectedSubMessage += "  - test2\n";
                             expectedSubMessage += "- path_to_path_prefix_o1_o1 (1 choice):\n";
                             expectedSubMessage += "  - test3\n";
-                            expectedSubMessage += "- second_path_source_defnition (2 choices):\n";
+                            expectedSubMessage += "- second_path_source_definition (2 choices):\n";
                             expectedSubMessage += "  - 213145\n";
                             expectedSubMessage += "  - 213147\n";
                             expectedSubMessage += "- Name 9 (2 choices):\n";
@@ -2542,13 +2542,14 @@ exports.execute = function (options) {
                         );
                     });
 
-                    // sourcekey used before the prefix
+                    // sourcekey used before the prefix (also using scalar mode instead of entity)
                     describe("case 2", function () {
                         testReadAndReadPath(
                             {
                                 "and": [
                                     {
                                         "sourcekey": "path_to_path_prefix_o1_o1",
+                                        "entity": false, // just to make sure it's ignored when matching facets
                                         "choices": ["two_o1_o1"]
                                     },
                                     {

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -166,8 +166,8 @@
                     "compact/select": [
                         {"invalid": true},
                         {"source": "id"},
-                        {"sourcekey": "path_w_length_three_scalar", "entity": true},
-                        {"sourcekey": "path_w_length_three_cnt_array"},
+                        {"sourcekey": "path_w_length_three", "entity": false, "comment": "should be ignored since it's scalar"},
+                        {"sourcekey": "path_w_length_three", "aggregate": "cnt", "comment": "should be ignored since it has aggregate"},
                         {
                             "source": [{"inbound": ["reference_schema", "id_fk_association_related_to_reference"]}, "ID"],
                             "display": {
@@ -277,24 +277,6 @@
                                 {"outbound": ["reference_schema", "fromname_fk_inbound_related_to_reference"]},
                                 "id"
                             ]
-                        },
-                        "path_w_length_three_scalar": {
-                            "source": [
-                                {"inbound": ["reference_schema", "id_fk_association_related_to_reference"]},
-                                {"outbound": ["reference_schema", "fk_to_inbound_related_reference_table"]},
-                                {"outbound": ["reference_schema", "fromname_fk_inbound_related_to_reference"]},
-                                "id"
-                            ],
-                            "entity": false
-                        },
-                        "path_w_length_three_cnt_array": {
-                            "source": [
-                                {"inbound": ["reference_schema", "id_fk_association_related_to_reference"]},
-                                {"outbound": ["reference_schema", "fk_to_inbound_related_reference_table"]},
-                                {"outbound": ["reference_schema", "fromname_fk_inbound_related_to_reference"]},
-                                "id"
-                            ],
-                            "aggregate": "cnt"
                         },
                         "path_to_outbound1": {
                             "source": [


### PR DESCRIPTION
In this PR,

- Modified the `sourcekey` support to allow changing `entity`, `aggregate`, and `self_link` at the same time (#909).
- Improved the default visible columns heuristics regarding the display key (more info [here](https://github.com/informatics-isi-edu/ermrestjs/issues/858#issuecomment-807848587)).


In #909 we talked about allowing source definitions to refer to other definitions like this

```json
"tag:isrd.isi.edu,2019:source-definitions": {
  "sources": {
    "S_core_fact": {
      "source": [{"inbound": ["CFDE", "core_fact_id_namespace_fkey"]}, "nid"]
    },
    "S_taxonomy": {
      "markdown_name": "Taxonomy",
      "source": [
        {"sourcekey": "S_core_fact"},
        {"inbound": ["CFDE", "core_fact_ncbi_taxonomy_core_fact_fkey"]},
        {"outbound": ["CFDE", "core_fact_ncbi_taxonomy_ncbi_taxon_fkey"]},
        "nid"
      ]
    },
    "S_taxonomy_array": {
      "sourcekey": "S_taxonomy",
      "aggregate": "array_d"
    }
  }
}
```

What I pushed is just a simple syntactic sugar to avoid copy/paste, and so when this source is used in a visible-column, there is not signal that it's using a different sourcekey. So It cannot properly do the path sharing. But if we want this to also properly handle path sharing, we would need to think more about it and decide how it should be done.

