### PR TITLE
Small changes to unit-test.yml

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -88,8 +88,7 @@ jobs:
       - name: Install ermrestjs
         run: |
           cd ermrestjs
-          make dist
-          sudo make deploy
+          make root-install
       - name: Add tests users
         run: |
           sudo -H -u webauthn webauthn2-manage adduser test1

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,6 +16,7 @@ jobs:
           path: ermrestjs
       - name: Setup the system
         run: |
+          whoami
           echo "npm version:"
           npm --version
           echo "node version:"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,7 @@ on: [push]
 
 jobs:
   install-and-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       PYTHONWARNINGS: ignore:Unverified HTTPS request
     timeout-minutes: 15

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,13 +5,13 @@ on: [push]
 
 jobs:
   install-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       PYTHONWARNINGS: ignore:Unverified HTTPS request
     timeout-minutes: 15
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ermrestjs
       - name: Setup the system
@@ -44,10 +44,6 @@ jobs:
           sudo pip3 install globus_sdk
           sudo pip3 install psycopg2-binary
           sudo pip3 install oauth2client
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
       - name: Install webauthn
         run: |
           sudo useradd -m -r webauthn
@@ -88,7 +84,7 @@ jobs:
       - name: Install ermrestjs
         run: |
           cd ermrestjs
-          make root-install
+          sudo make root-install
       - name: Add tests users
         run: |
           sudo -H -u webauthn webauthn2-manage adduser test1


### PR DESCRIPTION
Summary of changes:

- Use `make root-install` instead of `make dist and make deploy`.
- Remove the JDK installation since it's not needed (it was copy/pasted from chaise)
- Use the latest version of actions/checkout to get rid of the warning about nodejs version.