### PR TITLE
Visible column and rowname heuristics changes

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -225,7 +225,7 @@ to use for ERMrest JavaScript agents.
         * [.get(name)](#ERMrest.Columns+get) ⇒ [<code>Column</code>](#ERMrest.Column)
         * [.getByPosition(pos)](#ERMrest.Columns+getByPosition) ⇒ [<code>Column</code>](#ERMrest.Column)
     * [.Column](#ERMrest.Column)
-        * [new Column(table, jsonColumn)](#new_ERMrest.Column_new)
+        * [new Column(table, jsonColumn, assetCategoryInfo)](#new_ERMrest.Column_new)
         * _instance_
             * [.position](#ERMrest.Column+position) : <code>number</code>
             * [.table](#ERMrest.Column+table) : [<code>Table</code>](#ERMrest.Table)
@@ -239,6 +239,7 @@ to use for ERMrest JavaScript agents.
             * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
             * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
             * [.assetCategory](#ERMrest.Column+assetCategory) : <code>string</code>
+            * [.assetURLColumn](#ERMrest.Column+assetURLColumn)
             * [.isAssetURL](#ERMrest.Column+isAssetURL) : <code>boolean</code>
             * [.isAssetFilename](#ERMrest.Column+isAssetFilename) : <code>boolean</code>
             * [.isAssetByteCount](#ERMrest.Column+isAssetByteCount) : <code>boolean</code>
@@ -1486,7 +1487,9 @@ this table for the given context.
 
 #### table.\_assignAssetCategories()
 returns an object that captures the asset category of columns.
-- the key of the returned object is the column name and value is the assigned category.
+- the key of the returned object is the column name and value and the value is an object. The object has the following:
+ - category: the assigned category name
+ - URLColumn: the url column.
 - if a column is used in multiple asset annotations, only the first usage is used and other asset annotations
   are discarded.
 
@@ -1804,7 +1807,7 @@ Constructor for Columns.
 **Kind**: static class of [<code>ERMrest</code>](#ERMrest)  
 
 * [.Column](#ERMrest.Column)
-    * [new Column(table, jsonColumn)](#new_ERMrest.Column_new)
+    * [new Column(table, jsonColumn, assetCategoryInfo)](#new_ERMrest.Column_new)
     * _instance_
         * [.position](#ERMrest.Column+position) : <code>number</code>
         * [.table](#ERMrest.Column+table) : [<code>Table</code>](#ERMrest.Table)
@@ -1818,6 +1821,7 @@ Constructor for Columns.
         * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
         * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
         * [.assetCategory](#ERMrest.Column+assetCategory) : <code>string</code>
+        * [.assetURLColumn](#ERMrest.Column+assetURLColumn)
         * [.isAssetURL](#ERMrest.Column+isAssetURL) : <code>boolean</code>
         * [.isAssetFilename](#ERMrest.Column+isAssetFilename) : <code>boolean</code>
         * [.isAssetByteCount](#ERMrest.Column+isAssetByteCount) : <code>boolean</code>
@@ -1845,7 +1849,7 @@ Constructor for Columns.
 
 <a name="new_ERMrest.Column_new"></a>
 
-#### new Column(table, jsonColumn)
+#### new Column(table, jsonColumn, assetCategoryInfo)
 Constructs a Column.
 
 
@@ -1853,6 +1857,7 @@ Constructs a Column.
 | --- | --- | --- |
 | table | [<code>Table</code>](#ERMrest.Table) | the table object. |
 | jsonColumn | <code>string</code> | the json column. |
+| assetCategoryInfo | <code>Object</code> | if the column is an asset, this must be an object with categroy and URLColumn properties |
 
 <a name="ERMrest.Column+position"></a>
 
@@ -1919,7 +1924,13 @@ The RID of this column (might not be defined)
 
 #### column.assetCategory : <code>string</code>
 if it's used in an asset annotation, will return its category. available values:
-'filename', 'byte_count', 'md5', 'sha256'
+'url', 'filename', 'byte_count', 'md5', 'sha256'
+
+**Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
+<a name="ERMrest.Column+assetURLColumn"></a>
+
+#### column.assetURLColumn
+if the column is storing of the extra asset metadata, this will return the actual url column
 
 **Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+isAssetURL"></a>

--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -239,7 +239,7 @@ to use for ERMrest JavaScript agents.
             * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
             * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
             * [.assetCategory](#ERMrest.Column+assetCategory) : <code>string</code>
-            * [.assetURLColumn](#ERMrest.Column+assetURLColumn)
+            * [.assetURLColumnName](#ERMrest.Column+assetURLColumnName)
             * [.isAssetURL](#ERMrest.Column+isAssetURL) : <code>boolean</code>
             * [.isAssetFilename](#ERMrest.Column+isAssetFilename) : <code>boolean</code>
             * [.isAssetByteCount](#ERMrest.Column+isAssetByteCount) : <code>boolean</code>
@@ -295,6 +295,8 @@ to use for ERMrest JavaScript agents.
     * [.ColSet](#ERMrest.ColSet)
         * [new ColSet(columns)](#new_ERMrest.ColSet_new)
         * [.columns](#ERMrest.ColSet+columns) : <code>Array</code>
+        * [.textColumnsCount](#ERMrest.ColSet+textColumnsCount) : <code>number</code>
+        * [.allSerialOrInt](#ERMrest.ColSet+allSerialOrInt) : <code>boolean</code>
         * [.toString()](#ERMrest.ColSet+toString) ⇒ <code>string</code>
         * [.length()](#ERMrest.ColSet+length) ⇒ <code>Number</code>
     * [.Mapping](#ERMrest.Mapping)
@@ -1413,7 +1415,14 @@ The columns that create the shortest key
 <a name="ERMrest.Table+displayKey"></a>
 
 #### table.displayKey : [<code>Array.&lt;Column&gt;</code>](#ERMrest.Column)
-The columns that create the shortest key that can be used for display purposes.
+The columns that create the shortest key that can be used for display purposes (rowname).
+
+sort the not-null keys based on the following and return the first one:
+1. not simple fk to somewhere
+2. not simple and made of any asset metadata (url, filename, bytecount, md5, sha256)
+3. is shorter
+4. has more text
+5. made of columns defined earlier (column position)
 
 **Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+stableKey"></a>
@@ -1468,6 +1477,12 @@ if the table is pure and binary, will return the two foreignkeys that create it
 #### table.\_getRowDisplayKey(context)
 This key will be used for referring to a row of data. Therefore it shouldn't be foreignkey and markdown type.
 It's the same as displaykey but with extra restrictions. It might return undefined.
+
+sort the "well formed" keys that are not simple fk based on the following and return the first one:
+2. not simple and made of hash asset metadata (md5, sha256)
+3. is shorter
+4. has more text
+5. made of columns defined earlier (column position)
 
 **Kind**: instance method of [<code>Table</code>](#ERMrest.Table)  
 **Returns{column[]|undefined}**: list of columns. If couldn't find a suitable columns will return undefined.  
@@ -1821,7 +1836,7 @@ Constructor for Columns.
         * [.type](#ERMrest.Column+type) : [<code>Type</code>](#ERMrest.Type)
         * [.ignore](#ERMrest.Column+ignore) : <code>boolean</code>
         * [.assetCategory](#ERMrest.Column+assetCategory) : <code>string</code>
-        * [.assetURLColumn](#ERMrest.Column+assetURLColumn)
+        * [.assetURLColumnName](#ERMrest.Column+assetURLColumnName)
         * [.isAssetURL](#ERMrest.Column+isAssetURL) : <code>boolean</code>
         * [.isAssetFilename](#ERMrest.Column+isAssetFilename) : <code>boolean</code>
         * [.isAssetByteCount](#ERMrest.Column+isAssetByteCount) : <code>boolean</code>
@@ -1927,9 +1942,9 @@ if it's used in an asset annotation, will return its category. available values:
 'url', 'filename', 'byte_count', 'md5', 'sha256'
 
 **Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
-<a name="ERMrest.Column+assetURLColumn"></a>
+<a name="ERMrest.Column+assetURLColumnName"></a>
 
-#### column.assetURLColumn
+#### column.assetURLColumnName
 if the column is storing of the extra asset metadata, this will return the actual url column
 
 **Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
@@ -2343,6 +2358,8 @@ whether key has a column
 * [.ColSet](#ERMrest.ColSet)
     * [new ColSet(columns)](#new_ERMrest.ColSet_new)
     * [.columns](#ERMrest.ColSet+columns) : <code>Array</code>
+    * [.textColumnsCount](#ERMrest.ColSet+textColumnsCount) : <code>number</code>
+    * [.allSerialOrInt](#ERMrest.ColSet+allSerialOrInt) : <code>boolean</code>
     * [.toString()](#ERMrest.ColSet+toString) ⇒ <code>string</code>
     * [.length()](#ERMrest.ColSet+length) ⇒ <code>Number</code>
 
@@ -2361,6 +2378,18 @@ Constructor for ColSet, a set of Column objects.
 #### colSet.columns : <code>Array</code>
 It won't preserve the order of given columns.
 Returns set of columns sorted by their names.
+
+**Kind**: instance property of [<code>ColSet</code>](#ERMrest.ColSet)  
+<a name="ERMrest.ColSet+textColumnsCount"></a>
+
+#### colSet.textColumnsCount : <code>number</code>
+how many text columns are in this colset
+
+**Kind**: instance property of [<code>ColSet</code>](#ERMrest.ColSet)  
+<a name="ERMrest.ColSet+allSerialOrInt"></a>
+
+#### colSet.allSerialOrInt : <code>boolean</code>
+whether all the columns are integer or serial
 
 **Kind**: instance property of [<code>ColSet</code>](#ERMrest.ColSet)  
 <a name="ERMrest.ColSet+toString"></a>

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -308,7 +308,7 @@ Supported _columnlist_ patterns:
   - Ignore listed _columndirective_ values that do not correspond to content from the table.
   - Do not present table columns that are not specified in the list. Please refer to [column directive](#column-directive) section for more information.
   - A list without any valid _columndirective_ will be treated the same as empty array `[]`. Client will not show any columns in this case.
-- Any non-string, non-array value (e.g., `null`): The client will use the default heuristics for generating list of visbile columns. 
+- Any non-string, non-array value (e.g., `null`): The client will use the default heuristics for generating list of visbile columns.
 
 
 Supported _facetlist_ pattern:
@@ -564,9 +564,16 @@ Supported JSON _option_ payload patterns:
 - `"collapse_toc_panel":` `_boolean_`: Controls whether the table of contents panel is collapsed on page load (only supported in `detailed` context).
 - `"hide_column_header":` `_boolean_`: Controls whether the column names headers and separators between column values are shown (only supported in `detailed` context).
 - `"page_markdown_pattern"`: _pagepattern_: Render the page by composing a markdown representation only when `page_markdown_pattern` is non-null.
-  - Expand _pagepattern_ to obtain a markdown representation of whole page of dat via [Pattern Expansion](#pattern-expansion. In the pattern, you have access to a `$page` object that has the following attributes:
-      - `values`: An array of values. You can access each column value using the `{{{$page.values.<index>.<column>}}}` where `<index>` is the index of array element that you want (starting with zero), and `<column>` is the column name (`{{{$page.values.0.RID}}}`).
-      - `parent`: This variable is available when used for getting table content of related entities. Currently the `row_markdown_pattern` in `compact` context is used to provide a brief summary of table data. When used in this context, you can access the parent attributes under `$page.parent`. The attributes are:
+  - Expand _pagepattern_ to obtain a markdown representation of whole page of dat via [Pattern Expansion](#pattern-expansion). In the pattern, you have access to a `$page` object that has the following structure:
+      - `rows`: An array of objects. Each object represents the row data and has the following properties:
+        - `values`: The raw and formatted values of each column.
+        - `rowName`: Row-name of the represented row.
+        - `uri.detailed`: a uri to the row in `detailed` context.
+        For instance:
+          - `{{{$page.rows.0.values.RID}}}` returns the value of `RID` column for the first row.
+          - `{{{$page.rows.1.rowName}}}` returns the row-name of the second row.
+          - `{{{$page.rows.0.uri.detailed}}}` returns the link to the detailed (record) page for the first row.
+      - `parent`: This variable is available when used for getting table content of related entities. Currently the `page_markdown_pattern` in `compact` context is used to provide a brief summary of table data. When used in this context, you can access the parent properties under `$page.parent`. The properties are:
         - `values`: the parent data `{{{$page.parent.values.RID}}}`.
         - `table`: the parent table name `{{{$page.parent.table}}}`.
         - `schema`: the parent schema name `{{{$page.parent.schema}}}`.

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -564,19 +564,15 @@ Supported JSON _option_ payload patterns:
 - `"collapse_toc_panel":` `_boolean_`: Controls whether the table of contents panel is collapsed on page load (only supported in `detailed` context).
 - `"hide_column_header":` `_boolean_`: Controls whether the column names headers and separators between column values are shown (only supported in `detailed` context).
 - `"page_markdown_pattern"`: _pagepattern_: Render the page by composing a markdown representation only when `page_markdown_pattern` is non-null.
-  - Expand _pagepattern_ to obtain a markdown representation of whole page of dat via [Pattern Expansion](#pattern-expansion). In the pattern, you have access to a `$page` object that has the following structure:
+  - Expand _pagepattern_ to obtain a markdown representation of whole page of dat via [Pattern Expansion](#pattern-expansion). In the pattern, you have access to a `$page` object that has the following properties:
       - `rows`: An array of objects. Each object represents the row data and has the following properties:
-        - `values`: The raw and formatted values of each column.
-        - `rowName`: Row-name of the represented row.
-        - `uri.detailed`: a uri to the row in `detailed` context.
-        For instance:
-          - `{{{$page.rows.0.values.RID}}}` returns the value of `RID` column for the first row.
-          - `{{{$page.rows.1.rowName}}}` returns the row-name of the second row.
-          - `{{{$page.rows.0.uri.detailed}}}` returns the link to the detailed (record) page for the first row.
+        - `values`: The raw and formatted values of each column (e.g., `{{{$page.rows.0.values.RID}}}` returns the value of `RID` column for the first row).
+        - `rowName`: Row-name of the represented row (e.g., `{{{$page.rows.1.rowName}}}` returns the row-name of the second row).
+        - `uri.detailed`: a uri to the row in `detailed` context (e.g., `{{{$page.rows.0.uri.detailed}}}` returns the link to the detailed page for the first row).
       - `parent`: This variable is available when used for getting table content of related entities. Currently the `page_markdown_pattern` in `compact` context is used to provide a brief summary of table data. When used in this context, you can access the parent properties under `$page.parent`. The properties are:
-        - `values`: the parent data `{{{$page.parent.values.RID}}}`.
-        - `table`: the parent table name `{{{$page.parent.table}}}`.
-        - `schema`: the parent schema name `{{{$page.parent.schema}}}`.
+        - `values`: the parent data (e.g., `{{{$page.parent.values.RID}}}` returns the value of `RID` column of the main record).
+        - `table`: the parent table name (e.g., `{{{$page.parent.table}}}` returns the name of the main table).
+        - `schema`: the parent schema name (e.g., `{{{$page.parent.schema}}}` return the schema of the main table).
 - `"row_markdown_pattern":` _rowpattern_: Render the row by composing a markdown representation only when `row_markdown_pattern` is non-null.
   - Expand _rowpattern_ to obtain a markdown representation of each row via [Pattern Expansion](#pattern-expansion).
   - The pattern has access to column values **after** any processing implied by [2016 Column Display](#column-display).

--- a/js/core.js
+++ b/js/core.js
@@ -1267,7 +1267,7 @@
                             }
 
                             // the one that has lower column position
-                            return (a.colset._getColumnPositions() > b.colset._getColumnPositions()) ? 1 : -1;
+                            return compareColumnPositions(a.colset._getColumnPositions(), b.colset._getColumnPositions(), true);
                         })[0].colset.columns;
                     }
 
@@ -1320,7 +1320,7 @@
                         }
 
                         // the one that has lower column position
-                        return (keyA.colset._getColumnPositions() > keyB.colset._getColumnPositions()) ? 1 : -1;
+                        return compareColumnPositions(keyA.colset._getColumnPositions(), keyB.colset._getColumnPositions(), true);
                     })[0].colset.columns;
                 } else {
                     this._displayKey = this.columns.all();
@@ -1446,7 +1446,7 @@
                             }
 
                             // the one that has lower column position
-                            return (keyA.colset._getColumnPositions() > keyB.colset._getColumnPositions()) ? 1 : -1;
+                            return compareColumnPositions(keyA.colset._getColumnPositions(), keyB.colset._getColumnPositions(), true);
                         })[0];
                     }
                 }

--- a/js/reference.js
+++ b/js/reference.js
@@ -3272,6 +3272,10 @@
                     // as part of heuristics, treat the asset filename the same as the asset itself.
                     // and only add one of them.
                     if (col.isAssetFilename) {
+                        if (col.assetURLColumnName in consideredColumns) {
+                            return;
+                        }
+                        consideredColumns[col.assetURLColumnName] = true;
                         _addAssetColumn(self.table.columns.get(col.assetURLColumnName), sourceObjectWrapper, name, heuristics);
                         return;
                     }

--- a/js/reference.js
+++ b/js/reference.js
@@ -5463,19 +5463,27 @@
             /*
              the object structure that is available on the annotation:
                $page = {
-                    values: [],
+                    rows: [
+                        {values, rowName, uri}
+                    ],
                     parent: {
                         values: [],
                         table: "",
                         schema: ""
                     }
+                    // deprecated
+                    values: [],
                 }
              */
             if (typeof display._pageMarkdownPattern === 'string') {
                 var $page = {
+                    rows: self.tuples.map(function (t, i) {
+                        return t.templateVariables;
+                    }),
+                    // (deprecated) should eventually be removed
                     values: self.tuples.map(function (t, i) {
                         return t.templateVariables.values;
-                    })
+                    }),
                 };
 
                 if (ref.mainTable) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -2608,12 +2608,14 @@
                     }
 
                     // columns
-                    if (a._related_key_column_positions.join(",") != b._related_key_column_positions.join(",")) {
-                        return a._related_key_column_positions > b._related_key_column_positions ? 1 : -1;
+                    var keyColPositions = compareColumnPositions(a._related_key_column_positions, b._related_key_column_positions);
+                    if (keyColPositions !== 0) {
+                        return keyColPositions;
                     }
 
                     // foreignkey columns
-                    return a._related_fk_column_positions >= b._related_fk_column_positions ? 1 : -1;
+                    var fkeyColPositions = compareColumnPositions(a._related_fk_column_positions, b._related_fk_column_positions);
+                    return fkeyColPositions === -1 ? -1 : 1;
                 });
             }
 

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -104,6 +104,15 @@
         return typeof obj === "object" && obj !== null;
     };
 
+    /**
+     * Returns true if given parameter is object and doesn't have any items.
+     * @param  {*} obj
+     * @return {boolean}
+     */
+    var isEmptyArray = function (obj) {
+        return Array.isArray(obj) && obj.length === 0;
+    };
+
     var isStringAndNotEmpty = function (obj) {
         return typeof obj === "string" && obj.length > 0;
     };

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -144,6 +144,36 @@
         return (typeof x === 'number') && (x % 1 === 0);
     };
 
+    /**
+     * can be used to compare the "position columns" of colsets.
+     *
+     * @private
+     * @param {Array} a an array of sorted integer values
+     * @param {Array} b an array of sorted integer values
+     * @param {boolean?} greater - whether we should do greater check instead of greater equal
+     *
+     * return,
+     *  -  1 if the position in the first argument are before the second one.
+     *  - -1 if the other way around.
+     *  - 0 if identical
+     * Notes:
+     * - both arguments are array and sorted ascendingly
+     * - if greater argument is true, we're doing a greater check so
+     *   in the identical case this function will return -1.
+     */
+    var compareColumnPositions = function (a, b, greater) {
+        for (var i = 0; i < a.length && i < b.length ; i++) {
+            if (a[i] !== b[i]) {
+                return a[i] > b[i] ? 1 : -1;
+            }
+        }
+        // all the columns were identical and only one has extra
+        if (a.length !== b.length) {
+            return a.length > b.length ? 1 : -1;
+        }
+        return greater ? -1 : 0;
+    };
+
     var verifyClientConfig = function () {
         if (module._clientConfig === null) {
             throw new module.InvalidInputError("this function requires cliet-config which is not set properly.");

--- a/test/specs/column/conf/columns_schema/schema.json
+++ b/test/specs/column/conf/columns_schema/schema.json
@@ -891,7 +891,7 @@
             "column_definitions": [
                 {
                     "name": "id",
-                    "comment": "id, asset should be ignored",
+                    "comment": "id, asset should be used and key ignored",
                     "nullok": false,
                     "type": {
                         "typename": "text"
@@ -1090,10 +1090,8 @@
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns": {
-                    "detailed": ["col_asset_3", "col_asset_4", "col_asset_6"],
-                    "entry/create": ["col_filename","col_byte","col_md5","col_sha256"],
                     "entry/edit": ["col_asset_3", "col_filename","col_byte","col_md5","col_sha256"],
-                    "compact/brief": ["col_asset_3", "col_filename","col_byte","col_md5","col_sha256"]
+                    "compact/brief": ["col_asset_3", "col_filename","col_byte","col_md5","col_sha256", "col_asset_6_byte_count"]
                 }
             }
         },

--- a/test/specs/column/tests/01.columns_list.js
+++ b/test/specs/column/tests/01.columns_list.js
@@ -253,43 +253,40 @@ exports.execute = function (options) {
          *
          * 2. table_w_asset:
          *  ref.columns for detailed (no context present):
-         *  0: table_w_asset_key_1 *KeyPseudoColumn*
+         *  0: table_w_asset_key_1 *AssetPseudoColumn*
          *  1: table_w_asset_fk_to_outbound *ForeignKeyPseudoColumn*
          *  2: col_1
          *  3: col_2
-         *  4: col_filename
+         *  4: col_asset_3 *AssetPseudoColumn* (asset with valid options) (was 10)
          *  5: col_byte
          *  6: col_md5
          *  7: col_sha256
          *  8: col_asset_1 *AssetPseudoColumn* disabeld (no url_pattern)
          *  9: col_asset_2 *AssetPseudoColumn* (asset with invalid options) has column-display (markdown and order)
-         *  10: col_asset_3 *AssetPseudoColumn* (asset with valid options)
-         *  11: col_asset_4 *AssetPseudoColumn* (asset with url_pattern and filename) has column-display (markdown)
-         *  12: col_asset_4_filename
-         *  13: col_asset_5 (asset with type not text)
-         *  14: col_asset_6 *AssetPseudoColumn* (asset with url_pattern, filename, and image_preview)
-         *  15: col_asset_6_filename
-         *  16: col_asset_6_byte_count
+         *  10: col_asset_4 *AssetPseudoColumn* (asset with url_pattern and filename) has column-display (markdown) (was 11)
+         *  11: col_asset_5 (asset with type not text) (was 13)
+         *  12: col_asset_6 *AssetPseudoColumn* (asset with url_pattern, filename, and image_preview) (wa 14)
+         *  13: col_asset_6_byte_count (was 16)
          *  + system columns
          *
-         *  ref.columns for entry (no context present):
-         *  0: id
+         * ref.columns for compact (no context present):
+         *  0: table_w_asset_key_1 *KeyPseudoColumn*
          *  1: table_w_asset_fk_to_outbound *ForeignKeyPseudoColumn*
          *  2: col_1
          *  3: col_2
-         *  4: col_asset_1 *AssetPseudoColumn* (disabled)
-         *  5: col_asset_2 *AssetPseudoColumn*
-         *  6: col_asset_3 *AssetPseudoColumn*
-         *  7: col_asset_4
-         *  8: col_asset_5
-         *  9: col_asset_6 *AssetPseudoColumn* (with image_preview)
-         *
+         *  4: col_asset_3 *AssetPseudoColumn* (asset with valid options) (was 10)
+         *  5: col_byte
+         *  6: col_asset_1 *AssetPseudoColumn* disabeld (no url_pattern) (was 8)
+         *  7: col_asset_2 *AssetPseudoColumn* (asset with invalid options) has column-display (markdown and order) (was 9)
+         *  8: col_asset_4 *AssetPseudoColumn* (asset with url_pattern and filename) has column-display (markdown) (was 11)
+         *  9: col_asset_5 (asset with type not text) (was 13)
+         *  10: col_asset_6 *AssetPseudoColumn* (asset with url_pattern, filename, and image_preview) (was 14)
+         *  11: col_asset_6_byte_count
+         *  + system columns
          *
          *  contexts that are used:
          *  - compact: no visible-columns
-         *  - detailed: valid assets: col_asset_3, col_asset_4, col_asset_6
-         *  - edit: no visible-columns
-         *  - entry/create: does not include col_asset_3 -> so no ignore
+         *  - detailed: no vis-columns
          *  - entry/edit: includes col_asset_3 and all its contituent columns
          *  - compact/brief: includes col_asset_3 and all its contituent columns
          *  - compact/brief/inline: inlcudes inline table that should not be visible
@@ -333,6 +330,8 @@ exports.execute = function (options) {
                 assetRefCompact = ref.contextualize.compact;
                 assetRefCompactCols = assetRefCompact.columns;
                 assetRefEntry = ref.contextualize.entry;
+                assetRefDetailed = ref.contextualize.detailed;
+                assetRefDetailedCols = assetRefDetailed.columns;
                 done();
             }).catch(function (err) {
                 console.dir(err);
@@ -364,18 +363,16 @@ exports.execute = function (options) {
             ];
 
             assetCompactExpectedValue = [
-                '<a href="https://example.org/chaise/record/columns_schema:table_w_asset/id=1">1</a>',
+                '<a href="1?uinit=1&amp;cid=test" download="" class="asset-permission">1</a>',
                 '<a href="https://example.org/chaise/record/columns_schema:columns_table/RID=' + utils.findEntityRID(options, schemaName, "columns_table", "id", "1") + '">1</a>',
-                '1000', '10001', 'filename',
+                '1000', '10001',
+                '<a href="https://example.org?uinit=1&amp;cid=test" download="" class="asset-permission">filename</a>',
                 '<p><span data-chaise-tooltip="1,242 bytes (1 kB = 1,000 bytes)">1.24 kB</span></p>\n',
-                'md5', 'sha256',
                 '',
                 '<h2>filename</h2>\n',
-                '<a href="https://example.org?uinit=1&amp;cid=test" download="" class="asset-permission">filename</a>',
-                'filename4',
+                '<p>filename4</p>\n',
                 '4',
                 '<a href="https://example.org/file.png?uinit=1&amp;cid=test" download="" class="asset-permission">filename6</a>',
-                'filename6',
                 '<p>9,234</p>\n'
             ];
 
@@ -460,20 +457,14 @@ exports.execute = function (options) {
                                     "col_asset_3"
                                 ]
                             }]);
-
-                            checkReferenceColumns([{
-                                ref: assetRef.contextualize.entryCreate,
-                                expected: [
-                                    "col_filename","col_byte","col_md5","col_sha256"
-                                ]
-                            }]);
                         });
 
                         it('otherwise, should not be ignored.', function() {
                             checkReferenceColumns([{
                                 ref: assetRef.contextualize.compactBrief,
                                 expected: [
-                                    "col_asset_3", "col_filename","col_byte","col_md5","col_sha256"
+                                    "col_asset_3", "col_filename","col_byte","col_md5","col_sha256",
+                                    "col_asset_6_byte_count"
                                 ]
                             }]);
                         });
@@ -715,24 +706,36 @@ exports.execute = function (options) {
                             }]);
                         });
 
+                        it ('only filename should be ignored in detailed context.', () => {
+                            expect(assetRefDetailed.columns.length).toBe(19);
+                            checkReferenceColumns([{
+                                ref: assetRefDetailed,
+                                expected: [
+                                    "id",
+                                    ["columns_schema", "table_w_asset_fk_to_outbound"].join("_"),
+                                    "col_1", "col_2",
+                                    "col_asset_3", // instead of filename
+                                    "col_byte", "col_md5", "col_sha256",
+                                    "col_asset_1", "col_asset_2",
+                                    "col_asset_4", "col_asset_5", "col_asset_6", "col_asset_6_byte_count"
+                                ]
+                            }]);
+                        });
+
                         it ('filename, md5, and sha256 should be ignored in compact context.', () => {
-
-                        });
-
-                        it ('filename should be ingored in detailed context.', () => {
-
-                        });
-
-                        it('should not be ignored in other contexts.', function() {
-                            expect(assetRefCompactCols.length).toBe(22);
-                            expect(assetRefCompactCols[4].name).toBe("col_filename");
-                            expect(assetRefCompactCols[4].isPseudo).toBe(false);
-                            expect(assetRefCompactCols[5].name).toBe("col_byte");
-                            expect(assetRefCompactCols[5].isPseudo).toBe(false);
-                            expect(assetRefCompactCols[6].name).toBe("col_md5");
-                            expect(assetRefCompactCols[6].isPseudo).toBe(false);
-                            expect(assetRefCompactCols[7].name).toBe("col_sha256");
-                            expect(assetRefCompactCols[7].isPseudo).toBe(false);
+                            expect(assetRefCompact.columns.length).toBe(17);
+                            checkReferenceColumns([{
+                                ref: assetRefCompact,
+                                expected: [
+                                    "id",
+                                    ["columns_schema", "table_w_asset_fk_to_outbound"].join("_"),
+                                    "col_1", "col_2",
+                                    "col_asset_3", // instead of filename
+                                    "col_byte",
+                                    "col_asset_1", "col_asset_2",
+                                    "col_asset_4", "col_asset_5", "col_asset_6"
+                                ]
+                            }]);
                         });
                     });
 
@@ -747,8 +750,8 @@ exports.execute = function (options) {
                     });
 
                     it("if column type is not `text`, should ignore the asset annotation.", function() {
-                      expect(assetRefCompactCols[13].name).toBe("col_asset_5", "invalid name for compact");
-                      expect(assetRefCompactCols[13].isPseudo).toBe(false, "invalid isPseudo for compact");
+                      expect(assetRefCompactCols[9].name).toBe("col_asset_5", "invalid name for compact");
+                      expect(assetRefCompactCols[9].isPseudo).toBe(false, "invalid isPseudo for compact");
                       expect(assetRefEntry.columns[8].name).toBe("col_asset_5", "invalid name for entry");
                       expect(assetRefEntry.columns[8].isPseudo).toBe(false, "invalid isPseudo for entry");
                     });
@@ -973,9 +976,10 @@ exports.execute = function (options) {
                 });
 
                 it('in detailed, should return the download button and image preview if applicaple.', function(done) {
-                    assetRefCompact.contextualize.detailed.read(limit).then(function (page) {
+                    assetRefDetailed.read(limit).then(function (page) {
                         var tuples = page.tuples;
                         expect(tuples[0].values).toEqual(jasmine.arrayContaining(assetDetailedExpectedValue));
+
                         done();
                     }, function (err) {
                         console.dir(err);

--- a/test/specs/column/tests/01.columns_list.js
+++ b/test/specs/column/tests/01.columns_list.js
@@ -453,16 +453,14 @@ exports.execute = function (options) {
 
                 describe('for asset columns,', function () {
                     describe('filname, byte, md5, and sha256 columns', function() {
-                        it('should be ignored in edit context if the asset column is present.', function() {
+                        it('should be ignored in edit and create context.', function() {
                             checkReferenceColumns([{
                                 ref: assetRef.contextualize.entryEdit,
                                 expected: [
                                     "col_asset_3"
                                 ]
                             }]);
-                        });
 
-                        it('should not be ignored in any contexts if the asset column is not present.', function() {
                             checkReferenceColumns([{
                                 ref: assetRef.contextualize.entryCreate,
                                 expected: [
@@ -705,7 +703,7 @@ exports.execute = function (options) {
 
                 describe('for asset columns,', function () {
                     describe('filename, byte, md5, and sha256 columns', function() {
-                        it('should be ignored in edit context.', function() {
+                        it('all should be ignored in edit context.', function() {
                             checkReferenceColumns([{
                                 ref: assetRefEntry,
                                 expected: [
@@ -715,6 +713,14 @@ exports.execute = function (options) {
                                     "col_asset_1", "col_asset_2", "col_asset_3", "col_asset_4", "col_asset_5"
                                 ]
                             }]);
+                        });
+
+                        it ('filename, md5, and sha256 should be ignored in compact context.', () => {
+
+                        });
+
+                        it ('filename should be ingored in detailed context.', () => {
+
                         });
 
                         it('should not be ignored in other contexts.', function() {
@@ -747,9 +753,9 @@ exports.execute = function (options) {
                       expect(assetRefEntry.columns[8].isPseudo).toBe(false, "invalid isPseudo for entry");
                     });
 
-                    it('if columns has been used as the keyReferenceColumn, should ignore the asset annotation.', function () {
-                        expect(assetRefCompactCols[0]._constraintName).toBe(["columns_schema", "table_w_asset_key_1"].join("_"));
-                        expect(assetRefCompactCols[0].isKey).toBe(true);
+                    it('if the chosen row display key for heuristics is also an asset, should add it as an asset.', function () {
+                        expect(assetRefCompactCols[0].name).toBe("id");
+                        expect(assetRefCompactCols[0].isAsset).toBe(true);
                     });
 
                     it('if column is part of any foreignkeys, should ignore the asset annotation.', function() {

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -149,9 +149,9 @@ exports.execute = function (options) {
                     expect(compactColumns[i].isPseudo).toBe(true, "problem with Outbound FKs, index=" + i);
                 }
 
-                for (i = 9; i < 12; i++) {
+                [4, 6, 7, 8, 10].forEach((i) => {
                     expect(assetRefCompactCols[i].isPseudo).toBe(true, "problem with Asset index=" + i);
-                }
+                });
 
                 expect(detailedColumns[3].isPseudo).toBe(true, "problem with Inbound FKs.");
 
@@ -195,15 +195,15 @@ exports.execute = function (options) {
 
         describe('.isAsset, ', function () {
             it ('for PseudoColumns that are asset should return true.', function () {
-                for (var i = 8; i < 12; i++) {
-                    expect(assetRefCompactCols[i].isAsset).toBe(true, "invalid isAsset for index="+ i);
-                }
+                expect(assetRefCompactCols[4].isAsset).toBe(true, "invalid isAsset for index=4");
 
-                expect(assetRefCompactCols[14].isAsset).toBe(true, "invalid isAsset for index=14");
+                [0, 4, 6, 7, 8, 10].forEach((i) => {
+                    expect(assetRefCompactCols[i].isAsset).toBe(true, "invalid isAsset for index="+ i);
+                });
             });
 
             it ('for other columns should return undefined.', function () {
-                for (var i = 0; i < 8; i++) {
+                for (var i = 1; i <=3; i++) {
                     expect(assetRefCompactCols[i].isAsset).toBe(undefined, "invalid isAsset for index="+ i);
                 }
             });
@@ -246,10 +246,6 @@ exports.execute = function (options) {
             it('for other columns should return the base column\'s table.', function () {
                 for (var i = 5; i < 12; i++) {
                     expect(compactColumns[i].table.name).toBe(tableName);
-                }
-
-                for (var i = 8; i < 12; i++) {
-                    expect(assetRefCompactCols[i].table.name).toBe(tableWithAsset);
                 }
             });
         });
@@ -361,9 +357,10 @@ exports.execute = function (options) {
                 for (var i = 16; i < 21; i++) {
                     expect(compactColumns[i].type.name).toBe("markdown");
                 }
-                for (var i = 9; i < 12; i++) {
+
+                [0, 4, 6, 7, 8, 10].forEach((i) => {
                     expect(assetRefCompactCols[i].type.name).toBe('markdown');
-                }
+                });
 
                 expect(detailedColumns[3].type.name).toBe("markdown");
             });
@@ -842,21 +839,21 @@ exports.execute = function (options) {
                             val = assetRefEntryCols[6].formatPresentation({"col_asset_3": "https://example.com"}, "entry", {"col_asset_3": "https://example.com"}).value;
                             expect(val).toEqual("https://example.com");
 
-                            val = assetRefCompactCols[9].formatPresentation({"col_filename": "filename", "col_asset_2": "value"}, "entry", {"col_filename": "filename"}).value;
+                            val = assetRefCompactCols[7].formatPresentation({"col_filename": "filename", "col_asset_2": "value"}, "entry", {"col_filename": "filename"}).value;
                             expect(val).toEqual("value");
                         });
 
                         it('otherwise, if coulmn has column-display annotation, use it.', function () {
-                            val = assetRefCompactCols[9].formatPresentation({"col_filename": "filename", "col_asset_2": "value"}, "compact", {"col_filename": "filename"}).value;
+                            val = assetRefCompactCols[7].formatPresentation({"col_filename": "filename", "col_asset_2": "value"}, "compact", {"col_filename": "filename"}).value;
                             expect(val).toEqual("<h2>filename</h2>\n");
                         });
 
                         describe('otherwise should create a download link,', () => {
                             it ('filename should be used as caption if it\'s defined and has non-empty value', () => {
-                                val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com", "col_filename": "filename"}).value;
+                                val = assetRefCompactCols[4].formatPresentation({"col_asset_3": "https://example.com", "col_filename": "filename"}).value;
                                 expect(val).toEqual('<a href="https://example.com" download="" class="external-link-icon external-link">filename</a>', "value missmatch.");
 
-                                val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com?query=1&v=1", "col_filename": "filename"}).value;
+                                val = assetRefCompactCols[4].formatPresentation({"col_asset_3": "https://example.com?query=1&v=1", "col_filename": "filename"}).value;
                                 //NOTE this is the output but it will be displayed correctly.
                                 expect(val).toEqual('<a href="https://example.com?query=1&amp;v=1" download="" class="external-link-icon external-link">filename</a>', "couldn't handle having query params in the url.");
                             });
@@ -864,34 +861,34 @@ exports.execute = function (options) {
                             it ("if url matches the expected hatrac format, extract the filename and use it as caption.", function () {
                                 var hatracSampleURL = "/hatrac/Zf/ZfDsy20170915D/file-test.csv:2J7IIX63WQRUDIALUGYDKDO36A";
                                 var expectedValue = '<a href="' + hatracSampleURL +'?uinit=1&amp;cid=test" download="" class="asset-permission">file-test.csv</a>';
-                                val = assetRefCompactCols[8].formatPresentation({"col_asset_1": hatracSampleURL}).value;
+                                val = assetRefCompactCols[6].formatPresentation({"col_asset_1": hatracSampleURL}).value;
                                 expect(val).toEqual(expectedValue, "value missmatch.");
 
                                 // has filenameColumn but its value is null
-                                val = assetRefCompactCols[10].formatPresentation({"col_asset_3": hatracSampleURL, "col_filename": null}).value;
+                                val = assetRefCompactCols[4].formatPresentation({"col_asset_3": hatracSampleURL, "col_filename": null}).value;
                                 expect(val).toEqual(expectedValue, "value missmatch.");
                             });
 
                             it ("if context is detailed and url is absolute, use last part of url as caption and add origin beside the button.", function () {
                                 var url = "http://example.com/folder/next/folder/image.png";
-                                val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "detailed").value;
+                                val = assetRefCompactCols[6].formatPresentation({"col_asset_1": url}, "detailed").value;
                                 expect(val).toEqual('<a href="' + url +'" download="" class="external-link-icon external-link">image.png</a><span class="asset-source-description">(source: example.com)</span>', "value missmatch for detailed");
                             });
 
                             it ("otherwise, use the last part of url for caption without any origin information.", function () {
                                 // has filenameColumn but its value is null
-                                val = assetRefCompactCols[10].formatPresentation({"col_asset_3": "https://example.com/asset.png", "col_filename": null}).value;
+                                val = assetRefCompactCols[4].formatPresentation({"col_asset_3": "https://example.com/asset.png", "col_filename": null}).value;
                                 expect(val).toEqual('<a href="https://example.com/asset.png" download="" class="external-link-icon external-link">asset.png</a>', "value missmatch.");
 
                                 var url = "http://example.com/folder/next/folder/image.png";
-                                val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "compact").value;
+                                val = assetRefCompactCols[6].formatPresentation({"col_asset_1": url}, "compact").value;
                                 expect(val).toEqual('<a href="' + url +'" download="" class="external-link-icon external-link">image.png</a>', "value missmatch for compact");
 
-                                val = assetRefCompactCols[8].formatPresentation({"col_asset_1": url}, "compact/brief").value;
+                                val = assetRefCompactCols[6].formatPresentation({"col_asset_1": url}, "compact/brief").value;
                                 expect(val).toEqual('<a href="' + url +'" download="" class="external-link-icon external-link">image.png</a>', "value missmatch for compact/brief");
 
                                 // detailed but relative url
-                                val = assetRefCompactCols[8].formatPresentation({"col_asset_1": "go/to/file.png"}, "detailed").value;
+                                val = assetRefCompactCols[6].formatPresentation({"col_asset_1": "go/to/file.png"}, "detailed").value;
                                 expect(val).toEqual('<a href="go/to/file.png?uinit=1&amp;cid=test" download="" class="asset-permission">file.png</a>', "value missmatch for detailed context");
                             })
                         });
@@ -904,7 +901,7 @@ exports.execute = function (options) {
                         });
 
                         it ('otherwise return the default presentation.', () => {
-                            const v = assetRefCompactCols[16].formatPresentation({"col_asset_6_byte_count": 123456789, }, "compact").value;
+                            const v = assetRefCompactCols[11].formatPresentation({"col_asset_6_byte_count": 123456789, }, "compact").value;
                             expect(v).toEqual("<p>123,456,789</p>\n");
                         });
                     });
@@ -998,31 +995,31 @@ exports.execute = function (options) {
 
             describe("for assets, ", function () {
                 it ("should return the defined column_order on the column.", function () {
-                    expect(assetRefCompactCols[9].sortable).toBe(true, "sortable missmatch, index=9.");
-                    expect(assetRefCompactCols[9]._sortColumns.length).toBe(2, "sort column length missmatch, index=9.");
-                    expect(assetRefCompactCols[9]._sortColumns.map(function (col) {
+                    expect(assetRefCompactCols[7].sortable).toBe(true, "sortable missmatch, index=9.");
+                    expect(assetRefCompactCols[7]._sortColumns.length).toBe(2, "sort column length missmatch, index=9.");
+                    expect(assetRefCompactCols[7]._sortColumns.map(function (col) {
                         return col.column.name
                     })).toEqual(['col_asset_2', 'col_filename'], "sort columns missmatch, index=9.");
                 });
 
                 it ("otherwise if filename column is defined should return it", function () {
-                    expect(assetRefCompactCols[10].sortable).toBe(true, "sortable missmatch, index=10.");
-                    expect(assetRefCompactCols[10]._sortColumns.length).toBe(1, "sort column length missmatch, index=10.");
-                    expect(assetRefCompactCols[10]._sortColumns.map(function (col) {
+                    expect(assetRefCompactCols[4].sortable).toBe(true, "sortable missmatch, index=10.");
+                    expect(assetRefCompactCols[4]._sortColumns.length).toBe(1, "sort column length missmatch, index=10.");
+                    expect(assetRefCompactCols[4]._sortColumns.map(function (col) {
                         return col.column.name
                     })).toEqual(['col_filename'], "sort columns missmatch, index=10.");
 
-                    expect(assetRefCompactCols[11].sortable).toBe(true, "sortable missmatch, index=11.");
-                    expect(assetRefCompactCols[11]._sortColumns.length).toBe(1, "sort column length missmatch, index=11.");
-                    expect(assetRefCompactCols[11]._sortColumns.map(function (col) {
+                    expect(assetRefCompactCols[8].sortable).toBe(true, "sortable missmatch, index=11.");
+                    expect(assetRefCompactCols[8]._sortColumns.length).toBe(1, "sort column length missmatch, index=11.");
+                    expect(assetRefCompactCols[8]._sortColumns.map(function (col) {
                         return col.column.name
                     })).toEqual(['col_asset_4_filename'], "sort columns missmatch, index=11.");
                 });
 
                 it ("otherwise should return the url column.", function () {
-                    expect(assetRefCompactCols[8].sortable).toBe(true, "sortable missmatch, index=8.");
-                    expect(assetRefCompactCols[8]._sortColumns.length).toBe(1, "sort column length missmatch, index=8.");
-                    expect(assetRefCompactCols[8]._sortColumns.map(function (col) {
+                    expect(assetRefCompactCols[6].sortable).toBe(true, "sortable missmatch, index=8.");
+                    expect(assetRefCompactCols[6]._sortColumns.length).toBe(1, "sort column length missmatch, index=8.");
+                    expect(assetRefCompactCols[6]._sortColumns.map(function (col) {
                         return col.column.name
                     })).toEqual(['col_asset_1'], "sort columns missmatch, index=8.");
                 });
@@ -1072,70 +1069,70 @@ exports.execute = function (options) {
 
             describe('.urlPattern', function() {
                 it('otherwise should return the defined url_pattern in annotation.', function () {
-                    expect(assetRefCompactCols[9].urlPattern).toBe("/hatrac/{{col_asset_2}}");
-                    expect(assetRefCompactCols[10].urlPattern).toBe("/hatrac/{{col_asset_3}}");
+                    expect(assetRefCompactCols[7].urlPattern).toBe("/hatrac/{{col_asset_2}}");
+                    expect(assetRefCompactCols[4].urlPattern).toBe("/hatrac/{{col_asset_3}}");
                 });
             });
 
             describe(".templateEngine", function () {
                 it ("should return the defined template_engine", function () {
-                    expect(assetRefCompactCols[9].templateEngine).toBe("", "missmatch for index=9");
-                    expect(assetRefCompactCols[10].templateEngine).toBe("handlebars", "missmatch for index=10");
+                    expect(assetRefCompactCols[7].templateEngine).toBe("", "missmatch for index=9");
+                    expect(assetRefCompactCols[4].templateEngine).toBe("handlebars", "missmatch for index=10");
                 });
             });
 
             describe('.filenameColumn', function() {
 
                 it('should return null if column is not valid or not present.', function () {
-                    expect(assetRefCompactCols[9].filenameColumn).toBe(null);
+                    expect(assetRefCompactCols[7].filenameColumn).toBe(null);
                 });
 
                 it('otherwise should return the column.', function () {
-                    expect(assetRefCompactCols[10].filenameColumn.name).toBe("col_filename");
+                    expect(assetRefCompactCols[4].filenameColumn.name).toBe("col_filename");
                 });
             });
 
             describe('.byteCountColumn', function() {
                 it('should return null if column is not valid or not present.', function () {
-                    expect(assetRefCompactCols[9].byteCountColumn).toBe(null);
+                    expect(assetRefCompactCols[7].byteCountColumn).toBe(null);
                 });
 
                 it('otherwise should return the column.', function () {
-                    expect(assetRefCompactCols[10].byteCountColumn.name).toBe("col_byte");
+                    expect(assetRefCompactCols[4].byteCountColumn.name).toBe("col_byte");
                 });
             });
 
             describe('.md5', function() {
                 it('should return the md5 defined.', function () {
-                    expect(assetRefCompactCols[9].md5).toBe(true);
-                    expect(assetRefCompactCols[10].md5.name).toBe("col_md5");
+                    expect(assetRefCompactCols[7].md5).toBe(true);
+                    expect(assetRefCompactCols[4].md5.name).toBe("col_md5");
                 });
             });
 
             describe('.sha256', function() {
                 it('should return the sha256 defined.', function () {
-                    expect(assetRefCompactCols[9].sha256).toBe(true);
-                    expect(assetRefCompactCols[10].sha256.name).toBe("col_sha256");
+                    expect(assetRefCompactCols[7].sha256).toBe(true);
+                    expect(assetRefCompactCols[4].sha256.name).toBe("col_sha256");
                 });
             });
 
             describe('.filenameExtFilter', function() {
                 it('should return empty array if file_name_ext is not present.', function () {
-                    expect(assetRefCompactCols[9].filenameExtFilter.length).toBe(0, "Returned value is not an empty array");
+                    expect(assetRefCompactCols[7].filenameExtFilter.length).toBe(0, "Returned value is not an empty array");
                 });
 
                 it('otherwise should return the defined array of file name extensions.', function () {
-                    expect(assetRefCompactCols[10].filenameExtFilter).toEqual(["*.jpg"]);
+                    expect(assetRefCompactCols[4].filenameExtFilter).toEqual(["*.jpg"]);
                 });
             });
 
             describe('.filenameExtRegexp', function() {
                 it('should return empty array if file_name_ext is not present.', function () {
-                    expect(assetRefCompactCols[9].filenameExtFilter.length).toBe(0, "Returned value is not an empty array");
+                    expect(assetRefCompactCols[7].filenameExtFilter.length).toBe(0, "Returned value is not an empty array");
                 });
 
                 it('otherwise should return the defined array of file name extensions.', function () {
-                    expect(assetRefCompactCols[10].filenameExtRegexp).toEqual([".special.jpg", ".jpg"]);
+                    expect(assetRefCompactCols[4].filenameExtRegexp).toEqual([".special.jpg", ".jpg"]);
                 });
             });
 
@@ -1180,32 +1177,32 @@ exports.execute = function (options) {
                 };
 
                 it ("should return empty values if the asset is null.", function () {
-                    testMetadata(assetRefCompactCols[9], {}, null, "empty asset index=9.", "", "", false, "", "", "", "");
+                    testMetadata(assetRefCompactCols[7], {}, null, "empty asset index=9.", "", "", false, "", "", "", "");
 
-                    testMetadata(assetRefCompactCols[10], {}, null, "empty asset index=10.", "", "", false, "", "", "", "");
+                    testMetadata(assetRefCompactCols[4], {}, null, "empty asset index=10.", "", "", false, "", "", "", "");
                 });
 
                 describe("regarding byteCount, md5, sha256.", function () {
                     it ("if annotation has metadata columns, should return their values.", function () {
-                        testMetadata(assetRefCompactCols[10], assetMetadataTestData, null, "empty asset index=10.", null, null, null, "filenamevalue.png",12400000, "md5value", "sha256value");
+                        testMetadata(assetRefCompactCols[4], assetMetadataTestData, null, "empty asset index=10.", null, null, null, "filenamevalue.png",12400000, "md5value", "sha256value");
                     });
 
                     it ("otherwise should return empty string.", function () {
-                        testMetadata(assetRefCompactCols[9], {"col_asset_2": "/hatrac/testurl"}, null, "empty asset index=10.", null, null, null, "", "", "", "");
+                        testMetadata(assetRefCompactCols[7], {"col_asset_2": "/hatrac/testurl"}, null, "empty asset index=10.", null, null, null, "", "", "", "");
                     });
                 });
 
                 describe("regarding caption, hostInformation, and sameHost ", function () {
                     it ("if asset column has filename column and its value is not empty, should return it as caption. hostInformation should be empty. sameHost should be false.", function () {
-                        testMetadata(assetRefCompactCols[10], assetMetadataTestData, null, "asset with filename value", "filenamevalue.png", "", true);
+                        testMetadata(assetRefCompactCols[4], assetMetadataTestData, null, "asset with filename value", "filenamevalue.png", "", true);
                     });
 
                     it ("otherwise, if the url value matches the format, should extract the filename. hostInformation should be empty. sameHost should be true.", function () {
-                        testMetadata(assetRefCompactCols[8], {col_asset_1: "/hatrac/Zf/ZfDsy20170915D/file-test.csv:2J7IIX63WQRUDIALUGYDKDO36A"}, null, "hatrac file", "file-test.csv", "", true);
+                        testMetadata(assetRefCompactCols[6], {col_asset_1: "/hatrac/Zf/ZfDsy20170915D/file-test.csv:2J7IIX63WQRUDIALUGYDKDO36A"}, null, "hatrac file", "file-test.csv", "", true);
                     });
 
                     it ("otherwise, should return the last part of url. hostInformation in detailed if url is absolute should be valid.", function () {
-                        testMetadata(assetRefCompactCols[8], {col_asset_1: "http://example.com/folder/next/folder/image.png"}, "compact", "non-hatrac compact file", "image.png", "", false);
+                        testMetadata(assetRefCompactCols[6], {col_asset_1: "http://example.com/folder/next/folder/image.png"}, "compact", "non-hatrac compact file", "image.png", "", false);
 
                         testMetadata(assetRefEntryCols[4], {col_asset_1: "http://example.com/folder/next/folder/image.png"}, "detailed", "non-hatrac entry file", "image.png", "example.com", false);
 
@@ -1228,11 +1225,11 @@ exports.execute = function (options) {
                 });
 
                 it ('otherwise should return false.', function () {
-                    for (var i = 8; i < 12; i++) {
+                    [0, 4, 6, 7, 8].forEach((i) => {
                         expect(assetRefCompactCols[i].displayImagePreview).toBe(false, "invalid isAsset for index="+ i);
-                    }
+                    });
 
-                    expect(assetRefCompactCols[14].displayImagePreview).toBe(false, "invalid isAsset for index=14");
+                    expect(assetRefCompactCols[10].displayImagePreview).toBe(false, "invalid isAsset for index=14");
                 });
 
             });

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -330,6 +330,85 @@
             ]
 
         },
+        "table_w_fkey_key": {
+            "kind": "table",
+            "keys": [
+                {"unique_columns": ["fk_col"]}
+            ],
+            "foreign_keys": [
+                {
+                    "foreign_key_columns": [{
+                        "schema_name": "common_schema_2",
+                        "table_name": "table_w_fkey_key",
+                        "column_name": "fk_col"
+                    }],
+                    "referenced_columns": [{
+                        "schema_name": "common_schema_2",
+                        "table_name": "table_w_dif_len_keys",
+                        "column_name": "col_3"
+                    }]
+                }
+            ],
+            "table_name": "table_w_fkey_key",
+            "schema_name": "common_schema_2",
+            "column_definitions": [
+                {
+                    "name": "fk_col",
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ]
+        },
+        "table_w_asset_key": {
+            "kind": "table",
+            "keys": [
+                {"unique_columns": ["asset_col"]},
+                {"unique_columns": ["asset_col_filename"]},
+                {"unique_columns": ["asset_col_md5"]},
+                {"unique_columns": ["asset_col_sha256"]}
+            ],
+            "table_name": "table_w_asset_key",
+            "schema_name": "common_schema_2",
+            "column_definitions": [
+                {
+                    "name": "asset_col",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2017:asset": {
+                        "url_pattern": "/hatrac/{{asset_col_1}}",
+                        "filename_column": "asset_col_filename",
+                        "md5": "asset_col_md5",
+                        "sha256": "asset_col_sha256"
+                        }
+                    }
+                },
+                {
+                    "name": "asset_col_filename",
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "asset_col_md5",
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "asset_col_sha256",
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ]
+        },
         "multi_w_same_len_keys_w_all_serial": {
             "comment": "",
             "kind": "table",

--- a/test/specs/common/tests/03.table.js
+++ b/test/specs/common/tests/03.table.js
@@ -31,8 +31,15 @@ exports.execute = function(options) {
             it ("should ignore the nullable keys.", function () {
                 checkDisplayKey("table_w_nullable_key", ["RID"]);
             });
-        });
 
+            it ("should prefer other keys over simple fk.", function () {
+                checkDisplayKey("table_w_fkey_key", ["RID"]);
+            });
+
+            it ("should prefer other keys to asset metadata keys.", function () {
+                checkDisplayKey("table_w_asset_key", ["RID"]);
+            });
+        });
 
         describe("supportHistory", function () {
             it ("if annotation is missing, should return true", function () {

--- a/test/specs/reference/conf/reference_schema/schema.json
+++ b/test/specs/reference/conf/reference_schema/schema.json
@@ -404,7 +404,7 @@
                 },
                 "tag:isrd.isi.edu,2016:table-display": {
                     "*": {
-                        "page_markdown_pattern": "{{#$page.parent}}{{{schema}}}:{{{table}}}{{/$page.parent}}, parent name={{{$page.parent.values._name}}}, where id is one of {{#each $page.values}}{{{this._id}}}{{/each}}",
+                        "page_markdown_pattern": "{{#$page.parent}}{{{schema}}}:{{{table}}}{{/$page.parent}}, parent name={{{$page.parent.values._name}}}, where (id,link) is one of {{#each $page.rows}}{{{this.values._id}}}: [{{{this.rowName}}}]({{{this.uri.detailed}}})){{/each}}",
                         "template_engine": "handlebars"
                     }
                 }

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -705,7 +705,9 @@ exports.execute = function(options) {
                 })
 
                 it ("should be able to use page_markdown_pattern and have access to the parent attributes.", function (done) {
-                    testPageContent(relatedWithTuple[1], 1, '<p>reference_schema:reference_table, parent name=Henry, where id is one of 1</p>\n', done);
+                    const linkVal = `https://example.org/chaise/record/reference_schema:inbound_related_reference_table/RID=${utils.findEntityRID(options, schemaName, inboundTableName, 'id', '1')}`;
+                    const expectedValue = `<p>reference_schema:reference_table, parent name=Henry, where (id,link) is one of 1: <a href="${linkVal}">1</a>)</p>\n`
+                    testPageContent(relatedWithTuple[1], 1, expectedValue, done);
                 });
 
                 it ("otherwise should use the row_markdown_pattern.", function (done) {


### PR DESCRIPTION
Summary of changes:

- Related to visible columns for asset columns,
  - Since the filename is used as part of the heuristics for the asset button, we don't need to display the filename in a separate column.
  - While going through the list of columns to generate the visible columns, as soon as we see the filename or the asset column, we should add the asset column to the visible column.
  - In compact contexts, we should hide the md5 and sha256 metadata columns.
- Related to the heuristics for picking a "row display key" (the self-link in compact),
  - We should deprioritize simple keys made of md5 and sha256.
If the picked key was an asset (or asset filename), we should display it as an asset download button, not a self-link.
- Related to the heuristics for picking a key for rowname,
  - We should deprioritize simple fkeys (similar to the "row display key" logic)
Simple keys made of asset metadata should be deprioritized (URL, filename, md5, sha256)
- `page_markdown_pattern` changes described [here](https://github.com/informatics-isi-edu/ermrestjs/issues/824#issuecomment-1765137354).
- Fix how we're comparing the column positions as part of heuristics for sorting keys or related entities. Previously I was blindly comparing arrays which was basically a string comparison. Now we're properly checking the values.

given that the values are already sorted, manually comparing them
is simple. 


Apart from making these changes, I refactored the code and added extra APIs to make it easier to read. I also had to add more test cases and modify the existing ones, given that the heuristics have been changed.

I also [ran the chaise test cases on this branch](https://github.com/informatics-isi-edu/chaise/actions/runs/6541154744), and it passed.

related issues: #858, #824
