### PR TITLE
Modify comment related APIs

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -153,7 +153,7 @@ to use for ERMrest JavaScript agents.
         * [.rights](#ERMrest.Schema+rights) : <code>Object</code>
         * [.displayname](#ERMrest.Schema+displayname) : <code>object</code>
         * [.tables](#ERMrest.Schema+tables) : [<code>Tables</code>](#ERMrest.Tables)
-        * [.comment](#ERMrest.Schema+comment) : <code>string</code>
+        * [.comment](#ERMrest.Schema+comment) : <code>Object</code>
     * [.Tables](#ERMrest.Tables)
         * [new Tables()](#new_ERMrest.Tables_new)
         * [.all()](#ERMrest.Tables+all) ⇒ <code>Array</code>
@@ -177,7 +177,7 @@ to use for ERMrest JavaScript agents.
             * [.rights](#ERMrest.Table+rights) : <code>Object</code>
             * [.foreignKeys](#ERMrest.Table+foreignKeys) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
             * [.referredBy](#ERMrest.Table+referredBy) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
-            * [.comment](#ERMrest.Table+comment) : <code>string</code>
+            * ~~[.comment](#ERMrest.Table+comment) : <code>Object</code>~~
             * [._showSavedQuery](#ERMrest.Table+_showSavedQuery) : <code>boolean</code>
             * [.favoritesPath](#ERMrest.Table+favoritesPath) : <code>string</code>
             * [.kind](#ERMrest.Table+kind) : <code>string</code>
@@ -246,7 +246,7 @@ to use for ERMrest JavaScript agents.
             * [.isAssetMd5](#ERMrest.Column+isAssetMd5) : <code>boolean</code>
             * [.isAssetSha256](#ERMrest.Column+isAssetSha256) : <code>boolean</code>
             * [.annotations](#ERMrest.Column+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
-            * [.comment](#ERMrest.Column+comment) : <code>string</code>
+            * ~~[.comment](#ERMrest.Column+comment) : <code>Object</code>~~
             * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
             * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
             * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
@@ -286,7 +286,7 @@ to use for ERMrest JavaScript agents.
         * [.table](#ERMrest.Key+table) : <code>Table</code>
         * [.colset](#ERMrest.Key+colset) : [<code>ColSet</code>](#ERMrest.ColSet)
         * [.annotations](#ERMrest.Key+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
-        * [.comment](#ERMrest.Key+comment) : <code>string</code>
+        * [.comment](#ERMrest.Key+comment) : <code>Object</code>
         * [.RID](#ERMrest.Key+RID) : <code>string</code>
         * [.constraint_names](#ERMrest.Key+constraint_names) : <code>Array</code>
         * [.name](#ERMrest.Key+name) : <code>string</code>
@@ -325,13 +325,13 @@ to use for ERMrest JavaScript agents.
         * [.constraint_names](#ERMrest.ForeignKeyRef+constraint_names) : <code>Array</code>
         * [.from_name](#ERMrest.ForeignKeyRef+from_name) : <code>string</code>
         * [.to_name](#ERMrest.ForeignKeyRef+to_name) : <code>string</code>
-        * [.to_comment](#ERMrest.ForeignKeyRef+to_comment) : <code>string</code>
-        * [.from_comment](#ERMrest.ForeignKeyRef+from_comment) : <code>string</code>
-        * [.to_comment_display](#ERMrest.ForeignKeyRef+to_comment_display) : <code>string</code>
-        * [.from_comment_display](#ERMrest.ForeignKeyRef+from_comment_display) : <code>string</code>
+        * [.to_comment](#ERMrest.ForeignKeyRef+to_comment) : <code>string</code> \| <code>null</code>
+        * [.from_comment](#ERMrest.ForeignKeyRef+from_comment) : <code>string</code> \| <code>null</code>
+        * [.to_comment_display](#ERMrest.ForeignKeyRef+to_comment_display) : <code>string</code> \| <code>null</code>
+        * [.from_comment_display](#ERMrest.ForeignKeyRef+from_comment_display) : <code>string</code> \| <code>null</code>
         * [.ignore](#ERMrest.ForeignKeyRef+ignore) : <code>boolean</code>
         * [.annotations](#ERMrest.ForeignKeyRef+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
-        * [.comment](#ERMrest.ForeignKeyRef+comment) : <code>string</code>
+        * [.comment](#ERMrest.ForeignKeyRef+comment) : <code>Object</code>
         * [.compressedDataSource](#ERMrest.ForeignKeyRef+compressedDataSource)
         * [.name](#ERMrest.ForeignKeyRef+name) : <code>string</code>
         * [.simple](#ERMrest.ForeignKeyRef+simple) : <code>Boolean</code>
@@ -407,8 +407,7 @@ to use for ERMrest JavaScript agents.
         * [.contextualize](#ERMrest.Reference+contextualize)
         * [.aggregate](#ERMrest.Reference+aggregate) : [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)
         * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
-        * [.comment](#ERMrest.Reference+comment) : <code>String</code>
-        * [.commentDisplay](#ERMrest.Reference+commentDisplay) : <code>String</code>
+        * [.comment](#ERMrest.Reference+comment) : <code>Object</code>
         * [.uri](#ERMrest.Reference+uri) : <code>string</code>
         * [.table](#ERMrest.Reference+table) : [<code>Table</code>](#ERMrest.Table)
         * [.facetBaseTable](#ERMrest.Reference+facetBaseTable) : [<code>Table</code>](#ERMrest.Table)
@@ -530,7 +529,6 @@ to use for ERMrest JavaScript agents.
         * [.isUnique](#ERMrest.PseudoColumn+isUnique) : <code>boolean</code>
         * [.hasAggregate](#ERMrest.PseudoColumn+hasAggregate) : <code>boolean</code>
         * [.comment](#ERMrest.PseudoColumn+comment) : <code>Object</code>
-        * [.commentDisplay](#ERMrest.PseudoColumn+commentDisplay) : <code>Object</code>
         * [.displayname](#ERMrest.PseudoColumn+displayname) : <code>Object</code>
         * [.key](#ERMrest.PseudoColumn+key) : <code>boolean</code>
         * [.reference](#ERMrest.PseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
@@ -741,8 +739,7 @@ to use for ERMrest JavaScript agents.
         * [.contextualize](#ERMrest.Reference+contextualize)
         * [.aggregate](#ERMrest.Reference+aggregate) : [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)
         * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
-        * [.comment](#ERMrest.Reference+comment) : <code>String</code>
-        * [.commentDisplay](#ERMrest.Reference+commentDisplay) : <code>String</code>
+        * [.comment](#ERMrest.Reference+comment) : <code>Object</code>
         * [.uri](#ERMrest.Reference+uri) : <code>string</code>
         * [.table](#ERMrest.Reference+table) : [<code>Table</code>](#ERMrest.Table)
         * [.facetBaseTable](#ERMrest.Reference+facetBaseTable) : [<code>Table</code>](#ERMrest.Table)
@@ -1124,7 +1121,7 @@ it will throw an error
     * [.rights](#ERMrest.Schema+rights) : <code>Object</code>
     * [.displayname](#ERMrest.Schema+displayname) : <code>object</code>
     * [.tables](#ERMrest.Schema+tables) : [<code>Tables</code>](#ERMrest.Tables)
-    * [.comment](#ERMrest.Schema+comment) : <code>string</code>
+    * [.comment](#ERMrest.Schema+comment) : <code>Object</code>
 
 <a name="new_ERMrest.Schema_new"></a>
 
@@ -1179,7 +1176,7 @@ this.displayname.value has the value
 **Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
 <a name="ERMrest.Schema+comment"></a>
 
-#### schema.comment : <code>string</code>
+#### schema.comment : <code>Object</code>
 Documentation for this schema
 
 **Kind**: instance property of [<code>Schema</code>](#ERMrest.Schema)  
@@ -1265,7 +1262,7 @@ check for table name existence
         * [.rights](#ERMrest.Table+rights) : <code>Object</code>
         * [.foreignKeys](#ERMrest.Table+foreignKeys) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
         * [.referredBy](#ERMrest.Table+referredBy) : [<code>ForeignKeys</code>](#ERMrest.ForeignKeys)
-        * [.comment](#ERMrest.Table+comment) : <code>string</code>
+        * ~~[.comment](#ERMrest.Table+comment) : <code>Object</code>~~
         * [._showSavedQuery](#ERMrest.Table+_showSavedQuery) : <code>boolean</code>
         * [.favoritesPath](#ERMrest.Table+favoritesPath) : <code>string</code>
         * [.kind](#ERMrest.Table+kind) : <code>string</code>
@@ -1371,7 +1368,9 @@ All the FKRs to this table.
 **Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
 <a name="ERMrest.Table+comment"></a>
 
-#### table.comment : <code>string</code>
+#### ~~table.comment : <code>Object</code>~~
+***Deprecated***
+
 Documentation for this table
 
 **Kind**: instance property of [<code>Table</code>](#ERMrest.Table)  
@@ -1843,7 +1842,7 @@ Constructor for Columns.
         * [.isAssetMd5](#ERMrest.Column+isAssetMd5) : <code>boolean</code>
         * [.isAssetSha256](#ERMrest.Column+isAssetSha256) : <code>boolean</code>
         * [.annotations](#ERMrest.Column+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
-        * [.comment](#ERMrest.Column+comment) : <code>string</code>
+        * ~~[.comment](#ERMrest.Column+comment) : <code>Object</code>~~
         * [.nullok](#ERMrest.Column+nullok) : <code>Boolean</code>
         * [.displayname](#ERMrest.Column+displayname) : <code>object</code>
         * [.memberOfKeys](#ERMrest.Column+memberOfKeys) : [<code>Array.&lt;Key&gt;</code>](#ERMrest.Key)
@@ -1984,7 +1983,9 @@ if this column is a sha256 for an asset column
 **Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
 <a name="ERMrest.Column+comment"></a>
 
-#### column.comment : <code>string</code>
+#### ~~column.comment : <code>Object</code>~~
+***Deprecated***
+
 Documentation for this column
 
 **Kind**: instance property of [<code>Column</code>](#ERMrest.Column)  
@@ -2277,7 +2278,7 @@ get the key by the column set
     * [.table](#ERMrest.Key+table) : <code>Table</code>
     * [.colset](#ERMrest.Key+colset) : [<code>ColSet</code>](#ERMrest.ColSet)
     * [.annotations](#ERMrest.Key+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
-    * [.comment](#ERMrest.Key+comment) : <code>string</code>
+    * [.comment](#ERMrest.Key+comment) : <code>Object</code>
     * [.RID](#ERMrest.Key+RID) : <code>string</code>
     * [.constraint_names](#ERMrest.Key+constraint_names) : <code>Array</code>
     * [.name](#ERMrest.Key+name) : <code>string</code>
@@ -2311,7 +2312,7 @@ Reference to the table that this Key belongs to.
 **Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
 <a name="ERMrest.Key+comment"></a>
 
-#### key.comment : <code>string</code>
+#### key.comment : <code>Object</code>
 Documentation for this key
 
 **Kind**: instance property of [<code>Key</code>](#ERMrest.Key)  
@@ -2553,13 +2554,13 @@ get the foreign key of the given column set
     * [.constraint_names](#ERMrest.ForeignKeyRef+constraint_names) : <code>Array</code>
     * [.from_name](#ERMrest.ForeignKeyRef+from_name) : <code>string</code>
     * [.to_name](#ERMrest.ForeignKeyRef+to_name) : <code>string</code>
-    * [.to_comment](#ERMrest.ForeignKeyRef+to_comment) : <code>string</code>
-    * [.from_comment](#ERMrest.ForeignKeyRef+from_comment) : <code>string</code>
-    * [.to_comment_display](#ERMrest.ForeignKeyRef+to_comment_display) : <code>string</code>
-    * [.from_comment_display](#ERMrest.ForeignKeyRef+from_comment_display) : <code>string</code>
+    * [.to_comment](#ERMrest.ForeignKeyRef+to_comment) : <code>string</code> \| <code>null</code>
+    * [.from_comment](#ERMrest.ForeignKeyRef+from_comment) : <code>string</code> \| <code>null</code>
+    * [.to_comment_display](#ERMrest.ForeignKeyRef+to_comment_display) : <code>string</code> \| <code>null</code>
+    * [.from_comment_display](#ERMrest.ForeignKeyRef+from_comment_display) : <code>string</code> \| <code>null</code>
     * [.ignore](#ERMrest.ForeignKeyRef+ignore) : <code>boolean</code>
     * [.annotations](#ERMrest.ForeignKeyRef+annotations) : [<code>Annotations</code>](#ERMrest.Annotations)
-    * [.comment](#ERMrest.ForeignKeyRef+comment) : <code>string</code>
+    * [.comment](#ERMrest.ForeignKeyRef+comment) : <code>Object</code>
     * [.compressedDataSource](#ERMrest.ForeignKeyRef+compressedDataSource)
     * [.name](#ERMrest.ForeignKeyRef+name) : <code>string</code>
     * [.simple](#ERMrest.ForeignKeyRef+simple) : <code>Boolean</code>
@@ -2625,19 +2626,19 @@ The constraint names for this foreign key
 **Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+to_comment"></a>
 
-#### foreignKeyRef.to\_comment : <code>string</code>
+#### foreignKeyRef.to\_comment : <code>string</code> \| <code>null</code>
 **Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+from_comment"></a>
 
-#### foreignKeyRef.from\_comment : <code>string</code>
+#### foreignKeyRef.from\_comment : <code>string</code> \| <code>null</code>
 **Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+to_comment_display"></a>
 
-#### foreignKeyRef.to\_comment\_display : <code>string</code>
+#### foreignKeyRef.to\_comment\_display : <code>string</code> \| <code>null</code>
 **Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+from_comment_display"></a>
 
-#### foreignKeyRef.from\_comment\_display : <code>string</code>
+#### foreignKeyRef.from\_comment\_display : <code>string</code> \| <code>null</code>
 **Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+ignore"></a>
 
@@ -2649,7 +2650,7 @@ The constraint names for this foreign key
 **Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
 <a name="ERMrest.ForeignKeyRef+comment"></a>
 
-#### foreignKeyRef.comment : <code>string</code>
+#### foreignKeyRef.comment : <code>Object</code>
 Documentation for this foreign key reference
 
 **Kind**: instance property of [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)  
@@ -3179,8 +3180,7 @@ Constructor for a ParsedFilter.
     * [.contextualize](#ERMrest.Reference+contextualize)
     * [.aggregate](#ERMrest.Reference+aggregate) : [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)
     * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
-    * [.comment](#ERMrest.Reference+comment) : <code>String</code>
-    * [.commentDisplay](#ERMrest.Reference+commentDisplay) : <code>String</code>
+    * [.comment](#ERMrest.Reference+comment) : <code>Object</code>
     * [.uri](#ERMrest.Reference+uri) : <code>string</code>
     * [.table](#ERMrest.Reference+table) : [<code>Table</code>](#ERMrest.Table)
     * [.facetBaseTable](#ERMrest.Reference+facetBaseTable) : [<code>Table</code>](#ERMrest.Table)
@@ -3283,15 +3283,8 @@ displayname.value has the value
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+comment"></a>
 
-#### reference.comment : <code>String</code>
+#### reference.comment : <code>Object</code>
 The comment for this reference.
-
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
-<a name="ERMrest.Reference+commentDisplay"></a>
-
-#### reference.commentDisplay : <code>String</code>
-The comment display property for this reference.
-can be either "tooltip" or "inline"
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+uri"></a>
@@ -4793,7 +4786,6 @@ it will append "-<integer>" to it.
     * [.isUnique](#ERMrest.PseudoColumn+isUnique) : <code>boolean</code>
     * [.hasAggregate](#ERMrest.PseudoColumn+hasAggregate) : <code>boolean</code>
     * [.comment](#ERMrest.PseudoColumn+comment) : <code>Object</code>
-    * [.commentDisplay](#ERMrest.PseudoColumn+commentDisplay) : <code>Object</code>
     * [.displayname](#ERMrest.PseudoColumn+displayname) : <code>Object</code>
     * [.key](#ERMrest.PseudoColumn+key) : <code>boolean</code>
     * [.reference](#ERMrest.PseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
@@ -4861,16 +4853,6 @@ It will return the first applicable rule:
 3. if aggregate and entity use the "<function> <table_displayname>"
 3. In entity mode, return the table's displayname.
 4. In scalar return the column's displayname.
-
-**Kind**: instance property of [<code>PseudoColumn</code>](#ERMrest.PseudoColumn)  
-<a name="ERMrest.PseudoColumn+commentDisplay"></a>
-
-#### pseudoColumn.commentDisplay : <code>Object</code>
-The mode the tooltip should be displayed in for this column.
-It will return the first applicable rule:
-1. commentDisplay that is defined on the sourceObject
-2. commentDisplay that is defined on the table in the display annotation
-3. default to "tooltip"
 
 **Kind**: instance property of [<code>PseudoColumn</code>](#ERMrest.PseudoColumn)  
 <a name="ERMrest.PseudoColumn+displayname"></a>
@@ -7029,8 +7011,7 @@ get PathColumn object by column name
     * [.contextualize](#ERMrest.Reference+contextualize)
     * [.aggregate](#ERMrest.Reference+aggregate) : [<code>ReferenceAggregateFn</code>](#ERMrest.ReferenceAggregateFn)
     * [.displayname](#ERMrest.Reference+displayname) : <code>object</code>
-    * [.comment](#ERMrest.Reference+comment) : <code>String</code>
-    * [.commentDisplay](#ERMrest.Reference+commentDisplay) : <code>String</code>
+    * [.comment](#ERMrest.Reference+comment) : <code>Object</code>
     * [.uri](#ERMrest.Reference+uri) : <code>string</code>
     * [.table](#ERMrest.Reference+table) : [<code>Table</code>](#ERMrest.Table)
     * [.facetBaseTable](#ERMrest.Reference+facetBaseTable) : [<code>Table</code>](#ERMrest.Table)
@@ -7133,15 +7114,8 @@ displayname.value has the value
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+comment"></a>
 
-#### reference.comment : <code>String</code>
+#### reference.comment : <code>Object</code>
 The comment for this reference.
-
-**Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
-<a name="ERMrest.Reference+commentDisplay"></a>
-
-#### reference.commentDisplay : <code>String</code>
-The comment display property for this reference.
-can be either "tooltip" or "inline"
 
 **Kind**: instance property of [<code>Reference</code>](#ERMrest.Reference)  
 <a name="ERMrest.Reference+uri"></a>

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -91,7 +91,7 @@ element and its nested model elements.
 Supported JSON payload patterns:
 
 - `{`... `"comment":` _comment_ || `{` _context_: _ccomment_ `}` ...`}`: The _comment_ (tooltip) to be used in place of the model element's original comment. Set this to `false` if you don't want any tooltips.
-- `{`... `"comment_display":` `{` _context_: `{` `"table_comment_display"`: _comment_display_ `,` `"column_comment_display"`: _comment_display_ `}` ... `}`
+- `{`... `"comment_display":` `{` _context_: `{` `"table_comment_display"`: _comment_display_ `,` `"column_comment_display"`: _comment_display_ `,` `"comment_render_markdown"`: _comment_render_markdown_ `}` ... `}`
 - `{`... `"name":` _name_ ...`}`: The _name_ to use in place of the model element's original name.
 - `{`... `"markdown_name"`: _markdown_ `}`: The _markdown_ to use in place of the model element's original name.
 - `{`... `"name_style":` `{` `"underline_space"`: _uspace_ `,` `"title_case":` _tcase_ `,` `"markdown"`: _render_ `}` ...`}`: Element name conversion instructions.
@@ -110,6 +110,11 @@ Supported JSON _comment_display_ patterns:
 
 - `tooltip`: Set to tooltip to show the comment as a hover over tooltip.
 - `inline`: Set to inline to show the comment as an inline tooltip.
+
+Supported JSON _comment_render_markdown_ patterns:
+
+- `false`: Don't treat the defined `comment` on this model and its descendants as markdown.
+- `true`: Treat the defined `comment` on this model and its descendants as markdown.
 
 Supported JSON _uspace_ patterns:
 
@@ -158,7 +163,7 @@ Supported JSON _context_ patterns:
 #### Tag: 2015 Display Settings Hierarchy
 
 - The `"comment"` setting applies *only* to the model element which is annotated.
-  - Currently the contextualized `comment` is only supported for tables.
+- The `"_comment_render_markdown_": false` should be used if you don't want us to treat the comment as a markdown value. By default we're assuming given comments are markdown.
 - The `"table_comment_display"` and `"column_comment_display"` setting applies *only* to the model element which is annotated.
   - Currently the contextualized `table_comment_display` is supported for `compact` context for the title and the tables in detailed context when they are part of a foreign key relationship in `visible-columns` or `visible-foreign-keys`.
   - `column_comment_display` is accepted as a parameter, but currently doesn't do anything.
@@ -426,6 +431,7 @@ Supported JSON payload patterns:
 - `{` ... `"from_name":` _fname_ ... `}`: The _fname_ string is a preferred name for the set of entities containing foreign key references described by this constraint.
 - `{` ... `"to_name":` _tname_ ... `}`: The _tname_ string is a preferred name for the set of entities containing keys described by this constraint.
 - `{` ... `"from_comment":` _comment_ ... `}`: The _comment_ string is a preferred comment for the set of entities containing keys described by this constraint.
+- `{` ... `"comment_render_markdown":` _boolean_value_ ... `}`: The _boolean_value_ dictates whether the comments for this foreignkey should be treated as markdown or not. If not defined, its value will be inherited from the table (which could be inherited from the schema or the catalog. If it's not defined on any of the models, the default behavior is to treat comments as markdown).
 - `{` ... `"to_comment":` _comment_ ... `}`: The _comment_ string is a preferred comment for the set of entities containing keys described by this constraint.
 - `{` ... `"from_comment_display":` _comment_display_ ... `}`: The display mode for the tooltip. Set to `inline` to show it as text or `tooltip` to show as a hover tooltip.
     - Currently the `comment_display` is only supported for foreign key relationships in detailed context when they are part of `visible-columns` or `visible-foreign-keys`.
@@ -1300,6 +1306,7 @@ The following attributes can be used to manipulate the presentation settings of 
 
 - `markdown_name`: The markdown to use in place of the default heuristics for title of column.
 - `comment`: The tooltip to be used in place of the default heuristics for the column. Set this to `false` if you don't want any tooltip.
+- `comment_render_markdown`: A boolean value that dictates whether the comment should be treated as markdown or not. If not defined, its value will be inherited from the underlying column or table (which could be inherited from the schema or the catalog. If it's not defined on any of the models, the default behavior is to treat comments as markdown).
 - `comment_display`: The display mode for the tooltip. Set to `inline` to show it as text or `tooltip` to show as a hover tooltip.
   - Currently `comment_display` is only supported for related tables in detailed context.
 - `hide_column_header`: Hide the column header (and still show the value). This is only supported in `detailed` context of `visible-columns` annotation.

--- a/docs/user-docs/column-directive.md
+++ b/docs/user-docs/column-directive.md
@@ -23,6 +23,7 @@ Column directive allows instruction of a data source and modification of its pre
   - [2. Presentation properties](#2-presentation-properties)
     - [markdown\_name](#markdown_name)
     - [comment](#comment)
+    - [comment\_render\_markdown](#comment-render-markdown)
     - [comment\_display](#comment_display)
     - [hide\_column\_header](#hide_column_header)
     - [self-link](#self-link)
@@ -359,6 +360,14 @@ In Chaise, comment is displayed as tooltip associated with columns. To change th
 
     "comment": "New comment"
 
+#### comment_render_markdown
+
+A boolean value that dictates whether the comment should be treated as markdown or not. If not defined, its value will be inherited from the underlying column or table which could be inherited from the schema or the catalog. If it's not defined on any of the models, the default behavior is to treat comments as markdown.
+
+    "comment_render_markdown": false
+
+This boolean works independent of the `comment` property. Which means that you can define `commen_render_markdown` to be used in combination with the comment that is derived based on the heuristics.
+
 #### comment_display
 
 By default Chaise will display `comment` as a tooltip. Set this value to `inline` to show it as text or `tooltip` to show as a hover tooltip. This property is only supported for related tables in detailed context of `visible-foreign-keys` annotation, and is not honored in other annotations.
@@ -404,7 +413,7 @@ While generating a default presentation for all outbound foreign key paths, ERMr
 
 ##### selector_ux_mode
 
-While generating a default presentation in `entry` mode for single outbound foreign key paths, Chaise will show a modal popup dialog for selecting rows. Using this attribute, you can modify this behavior. If this attribute is missing, we are going to use the inherited behavior from the [foreign key](annotation.md#tag-2016-foreign-key) annotation defined on the foreign key relationship. If that one is missing too, [table display](annotation.md#tag-2016-table-display) annotation will be applied. Supported values are `"facet-search-popup"` and `"simple-search-dropdown"`, with `"facet-search-popup"` being the default. 
+While generating a default presentation in `entry` mode for single outbound foreign key paths, Chaise will show a modal popup dialog for selecting rows. Using this attribute, you can modify this behavior. If this attribute is missing, we are going to use the inherited behavior from the [foreign key](annotation.md#tag-2016-foreign-key) annotation defined on the foreign key relationship. If that one is missing too, [table display](annotation.md#tag-2016-table-display) annotation will be applied. Supported values are `"facet-search-popup"` and `"simple-search-dropdown"`, with `"facet-search-popup"` being the default.
 
 ##### show_key_link
 

--- a/js/ag_reference.js
+++ b/js/ag_reference.js
@@ -938,9 +938,17 @@ function AttributeGroupColumn(alias, term, baseColumn, displayname, colType, com
 
     /**
      * tooltip
-     * @type {string}
+     * @type {Object}
      */
     this.comment = comment;
+    if (typeof comment === 'string') {
+        this.comment = {
+            isHTML: false,
+            value: comment,
+            unformatted: comment,
+            displayMode: module._commentDisplayModes.tooltip
+        };
+    }
 
     if (sortable === false) {
         this._sortable = false;
@@ -1290,7 +1298,7 @@ function BucketAttributeGroupReference(baseColumn, baseRef, min, max, numberOfBu
     }
 
     var aggregateColumns = [
-        new AttributeGroupColumn("c2", countName, null, "Number of Occurrences", new Type({typename: "int"}), "", true, true)
+        new AttributeGroupColumn("c2", countName, null, "Number of Occurrences", new Type({typename: "int"}), null, true, true)
     ];
 
     // call the parent constructor

--- a/js/core.js
+++ b/js/core.js
@@ -1175,26 +1175,26 @@
         getDisplay: function (context) {
             // check _display for information about current context
             if (!(context in this._display)) {
-                var comment_annotation = null;
+                var annotComment = null;
                 if (this.annotations.contains(module._annotations.DISPLAY)) {
                     // comment can be a string or an object
-                    comment_annotation = this.annotations.get(module._annotations.DISPLAY).get("comment");
+                    annotComment = this.annotations.get(module._annotations.DISPLAY).get("comment");
                     // point to comment since that is what is contextualized in this annotation
                     // if it's an object, that means it's contextualized
-                    if (typeof comment_annotation == "object") {
-                        comment_annotation = module._getAnnotationValueByContext(context, comment_annotation);
+                    if (typeof annotComment == "object") {
+                        annotComment = module._getAnnotationValueByContext(context, annotComment);
                     }
                 }
 
-                var comment = this.comment;
-                if (_isValidModelComment(comment_annotation)) {
-                    comment = comment_annotation;
+                var comment = this.comment ? this.comment.unformatted : null;
+                if (_isValidModelComment(annotComment)) {
+                    comment = annotComment;
                 }
 
                 var displayProps = module._getHierarchicalDisplayAnnotationValue(this, context, "comment_display", true);
                 var tableCommentDisplayMode = module._commentDisplayModes.tooltip,
                     columnCommentDisplayMode = module._commentDisplayModes.tooltip,
-                    commentRenderMd = true;
+                    commentRenderMarkdown;
                 if (isObjectAndNotNull(displayProps)) {
                     if (_isValidModelCommentDisplay(displayProps.table_comment_display)) {
                         tableCommentDisplayMode = displayProps.table_comment_display;
@@ -1205,15 +1205,15 @@
                     }
 
                     if (typeof displayProps.comment_render_markdown === 'boolean') {
-                        commentRenderMd = displayProps.comment_render_markdown;
+                        commentRenderMarkdown = displayProps.comment_render_markdown;
                     }
                 }
 
                 this._display[context] = {
                     "columnCommentDisplayMode": columnCommentDisplayMode,
                     "tableCommentDisplayMode": tableCommentDisplayMode,
-                    "comment": _processModelComment(comment, commentRenderMd, tableCommentDisplayMode),
-                    "commentRenderMarkdown": commentRenderMd
+                    "comment": _processModelComment(comment, commentRenderMarkdown, tableCommentDisplayMode),
+                    "commentRenderMarkdown": commentRenderMarkdown
                 };
             }
             return this._display[context];
@@ -3114,7 +3114,7 @@
 
         // If the comment is not defined for a system column, then it is assigned a default comment
         if((this.comment === null || this.comment === undefined) && this.isSystemColumn){
-            this.comment = _processModelComment(module._defaultColumnComment[this.name]);
+            this.comment = _processModelComment(module._defaultColumnComment[this.name], false);
         }
 
         /**
@@ -3327,7 +3327,7 @@
                     }
                 }
 
-                var comment = this.comment;
+                var comment = this.comment ? this.comment.unformatted : null;
                 if (this.annotations.contains(module._annotations.DISPLAY)) {
                     // comment can be a string or an object
                     var commentAnnot = this.annotations.get(module._annotations.DISPLAY).get("comment");
@@ -3342,13 +3342,13 @@
                 }
 
                 var displayProps = module._getHierarchicalDisplayAnnotationValue(this, context, "comment_display", false);
-                var columnCommentDisplayMode = module._commentDisplayModes.tooltip, commentRenderMd = true;
+                var columnCommentDisplayMode = module._commentDisplayModes.tooltip, commentRenderMarkdown;
                 if (isObjectAndNotNull(displayProps)) {
                     if (_isValidModelCommentDisplay(displayProps.column_comment_display)) {
                         columnCommentDisplayMode = displayProps.column_comment_display;
                     }
                     if (typeof displayProps.comment_render_markdown === 'boolean') {
-                        commentRenderMd = displayProps.comment_render_markdown;
+                        commentRenderMarkdown = displayProps.comment_render_markdown;
                     }
                 }
 
@@ -3362,8 +3362,8 @@
                     "markdownPattern": annotation.markdown_pattern,
                     "templateEngine": annotation.template_engine,
                     "columnOrder": columnOrder,
-                    "comment": _processModelComment(comment, commentRenderMd, columnCommentDisplayMode),
-                    "commentRenderMarkdown": commentRenderMd,
+                    "comment": _processModelComment(comment, commentRenderMarkdown, columnCommentDisplayMode),
+                    "commentRenderMarkdown": commentRenderMarkdown,
                     "commentDisplayMode": columnCommentDisplayMode
                 };
             }
@@ -3736,6 +3736,7 @@
         /**
          * @desc Documentation for this key
          * @type {Object}
+         * @deprecated comment can be contextualized, so please do `this.getDisplay(context).comment` instead.
          */
         this.comment = _processModelComment(jsonKey.comment);
         if (this.annotations.contains(module._annotations.DISPLAY)) {
@@ -3874,12 +3875,37 @@
                     }
                 }
 
+                var annotComment = null;
+                if (this.annotations.contains(module._annotations.DISPLAY)) {
+                    annotComment = this.annotations.get(module._annotations.DISPLAY).get("comment");
+                    if (typeof annotComment == "object") {
+                        annotComment = module._getAnnotationValueByContext(context, annotComment);
+                    }
+                }
+
+                var comment = this.comment ? this.comment.unformatted : null;
+                if (_isValidModelComment(annotComment)) {
+                    comment = annotComment;
+                }
+
+                var displayProps = module._getHierarchicalDisplayAnnotationValue(this, context, "comment_display", false);
+                var commentDisplay = module._commentDisplayModes.tooltip, commentRenderMarkdown;
+                if (isObjectAndNotNull(displayProps)) {
+                    if (_isValidModelCommentDisplay(displayProps.column_comment_display)) {
+                        commentDisplay = displayProps.column_comment_display;
+                    }
+                    if (typeof displayProps.comment_render_markdown === 'boolean') {
+                        commentRenderMarkdown = displayProps.comment_render_markdown;
+                    }
+                }
+
                 this._display[context] = {
                     "columnOrder": columnOrder,
                     "isMarkdownPattern": (typeof annotation.markdown_pattern === 'string'),
                     "templateEngine": annotation.template_engine,
                     "markdownPattern": annotation.markdown_pattern,
-                    "showKeyLink": showKeyLink
+                    "showKeyLink": showKeyLink,
+                    "comment": _processModelComment(comment, commentRenderMarkdown, commentDisplay)
                 };
             }
 
@@ -4392,36 +4418,6 @@
         }
 
         /**
-         * @type {string}
-         */
-        this.from_name = "";
-
-        /**
-         * @type {string}
-         */
-        this.to_name = "";
-
-        /**
-         * @type {string}
-         */
-        this.to_comment = "";
-
-        /**
-         * @type {string}
-         */
-        this.from_comment = "";
-
-        /**
-         * @type {string}
-         */
-        this.to_comment_display = module._commentDisplayModes.tooltip;
-
-        /**
-         * @type {string}
-         */
-        this.from_comment_display = module._commentDisplayModes.tooltip;
-
-        /**
          * @type {boolean}
          */
         this.ignore = false;
@@ -4440,33 +4436,12 @@
                 (jsonAnnotation === null || isEmptyArray(jsonAnnotation))) {
                 this.ignore = true;
             }
-
-            // determine the from_name and to_name using the annotation
-            if (uri == module._annotations.FOREIGN_KEY && jsonAnnotation) {
-                if(jsonAnnotation.from_name){
-                    this.from_name = jsonAnnotation.from_name;
-                }
-                if(jsonAnnotation.to_name){
-                    this.to_name = jsonAnnotation.to_name;
-                }
-
-                if (_isValidModelComment(jsonAnnotation.to_comment)) {
-                    // check for null, false, empty string when digesting comment for first time
-                    this.to_comment = _processModelComment(jsonAnnotation.to_comment);
-                    if (_isValidModelCommentDisplay(jsonAnnotation.to_comment_display)) this.to_comment_display = jsonAnnotation.to_comment_display;
-                }
-
-                if (_isValidModelComment(jsonAnnotation.from_comment)) {
-                    // check for null, false, empty string when digesting comment for first time
-                    this.from_comment = _processModelComment(jsonAnnotation.from_comment);
-                    if (_isValidModelCommentDisplay(jsonAnnotation.from_comment_display)) this.from_comment_display = jsonAnnotation.from_comment_display;
-                }
-            }
         }
 
         /**
          * @desc Documentation for this foreign key reference
          * @type {Object}
+         * @deprecated comment can be contextualized, so please do `this.getDisplay(context).comment` instead.
          */
         this.comment = _processModelComment(jsonFKR.comment);
 
@@ -4560,15 +4535,48 @@
 
         getDisplay: function(context) {
             if (!(context in this._display)) {
-                var self = this, annotation = -1, columnOrder = [], showFKLink = true, inputDisplayMode = module._foreignKeyInputModes[0], toTableAnnotation = -1;
-                // NOTE: commenting out contextualized functionality since it isn't being supported just yet
-                // var fromComment = null, fromCommentDisplay = "tooltip", toComment = null, toCommentDisplay = "tooltip";
+                var self = this, fkAnnot, displayAnnot = -1, columnOrder = [], showFKLink = true,
+                    inputDisplayMode = module._foreignKeyInputModes[0], toTableAnnotation = -1;
+
+                var fromName, toName,
+                    fromComment = null, toComment = null,
+                    fromCommentDisplayMode, toCommentDisplayMode,
+                    commentRenderMarkdown;
+
                 if (this.annotations.contains(module._annotations.FOREIGN_KEY)) {
-                    annotation = module._getAnnotationValueByContext(context, this.annotations.get(module._annotations.FOREIGN_KEY).get("display"));
+                    fkAnnot = this.annotations.get(module._annotations.FOREIGN_KEY);
+                    displayAnnot = module._getAnnotationValueByContext(context, fkAnnot.get("display"));
+
+                    fkAnnot = fkAnnot.content;
                 }
 
-                columnOrder = _processColumnOrderList(annotation.column_order, this.key.table);
-                showFKLink = annotation.show_foreign_key_link;
+                // from_name and to_name
+                if (fkAnnot && fkAnnot.from_name) {
+                    fromName = fkAnnot.from_name;
+                }
+                if (fkAnnot && fkAnnot.to_name) {
+                    toName = fkAnnot.to_name;
+                }
+
+                // comment related props
+                if (fkAnnot && _isValidModelComment(fkAnnot.from_comment)) {
+                    fromComment = _processModelComment(fkAnnot.from_comment).unformatted;
+                }
+                if (fkAnnot && _isValidModelCommentDisplay(fkAnnot.from_comment_display)) {
+                    fromCommentDisplayMode = fkAnnot.from_comment_display;
+                }
+                if (fkAnnot && _isValidModelComment(fkAnnot.to_comment)) {
+                    toComment = _processModelComment(fkAnnot.to_comment).unformatted;
+                }
+                if (fkAnnot && _isValidModelCommentDisplay(fkAnnot.to_comment_display)) {
+                    toCommentDisplayMode = fkAnnot.to_comment_display;
+                }
+                if (fkAnnot && typeof fkAnnot.comment_render_markdown === 'boolean') {
+                    commentRenderMarkdown = fkAnnot.comment_render_markdown;
+                }
+
+                columnOrder = _processColumnOrderList(displayAnnot.column_order, this.key.table);
+                showFKLink = displayAnnot.show_foreign_key_link;
                 if (typeof showFKLink !== "boolean") {
                     showFKLink = module._getHierarchicalDisplayAnnotationValue(
                         self, context, "show_foreign_key_link"
@@ -4595,7 +4603,6 @@
                  *
                  * supported _foreignKeyInputModes are ['facet-search-popup', 'simple-search-dropdown']
                  */
-
                 // NOTE: this property is only used when the table is used as the leaf for a foreign key
                 // using index 0 ensures we only support this on single outbound foreign key relationships when table-display is on the leaf table
                 var fromCol = this.colset.columns[0];
@@ -4608,23 +4615,23 @@
                     }
                 }
 
-                if (annotation.selector_ux_mode && module._foreignKeyInputModes.indexOf(annotation.selector_ux_mode) !== -1) {
-                    inputDisplayMode = annotation.selector_ux_mode;
+                if (displayAnnot.selector_ux_mode && module._foreignKeyInputModes.indexOf(displayAnnot.selector_ux_mode) !== -1) {
+                    inputDisplayMode = displayAnnot.selector_ux_mode;
                 }
-
-                // fromComment = _processModelComment(annotation.from_comment);
-                // toComment = _processModelComment(annotation.to_comment);
-                // fromCommentDisplay = (annotation.from_comment && typeof annotation.from_comment_display === "string") ? annotation.from_comment_display : "tooltip";
-                // toCommentDisplay = (annotation.to_comment && typeof annotation.to_comment_display === "string") ? annotation.to_comment_display : "tooltip";
 
                 this._display[context] = {
                     "columnOrder": columnOrder,
-                    // "fromComment": fromComment,
-                    // "fromCommentDisplay": fromCommentDisplay,
                     "inputDisplayMode": inputDisplayMode,
                     "showForeignKeyLink": showFKLink,
-                    // "toComment": toComment,
-                    // "toCommentDisplay": toCommentDisplay
+                    "fromName": fromName,
+                    "fromComment": _processModelComment(fromComment, commentRenderMarkdown, fromCommentDisplayMode),
+                    "fromCommentDisplayMode": fromCommentDisplayMode,
+                    "toName": toName,
+                    "toComment": _processModelComment(toComment, commentRenderMarkdown, toCommentDisplayMode),
+                    "toCommentDisplayMode": toCommentDisplayMode,
+                    "commentRenderMarkdown": commentRenderMarkdown,
+                    // TODO this is left for backwards compatibility and should most probably be removed in favor of toComment and fromComment
+                    "comment": _processModelComment(this.comment ? this.comment.unformatted : null, commentRenderMarkdown),
                 };
             }
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -4002,7 +4002,7 @@
             // the main table
             newRef.mainTable = this.table;
 
-            var comment, commentDisplayMode, commentRenderMarkdown, tableDisplay;
+            var comment, commentDisplayMode, commentRenderMarkdown, tableDisplay, fkDisplay;
 
             dataSource.push({"inbound": fkr.constraint_names[0]});
 
@@ -4023,30 +4023,29 @@
                 newRef._table = otherFK.key.table;
                 newRef._shortestKey = newRef._table.shortestKey;
 
+                fkDisplay = otherFK.getDisplay(this._context);
+                tableDisplay = otherFK.key.colset.columns[0].table.getDisplay(this._context);
+
                 // displayname
-                if (otherFK.to_name) {
-                    newRef._displayname = {"isHTML": false, "value": otherFK.to_name, "unformatted": otherFK.to_name};
+                if (fkDisplay.toName) {
+                    newRef._displayname = {"isHTML": false, "value": fkDisplay.toName, "unformatted": fkDisplay.toName};
                 } else {
                     newRef._displayname = otherFK.colset.columns[0].table.displayname;
                 }
 
-                // NOTE: this is for contextualized toComment and toCommentDisplay, to be implemented later
-                // display = otherFK.getDisplay(this._context);
-
                 // comment
-                tableDisplay = otherFK.key.colset.columns[0].table.getDisplay(this._context);
-                if (_isValidModelComment(otherFK.from_comment)) {
-                    comment = otherFK.from_comment;
+                if (fkDisplay.toComment) {
+                    comment = fkDisplay.toComment.unformatted;
                 } else {
                     comment = tableDisplay.comment ? tableDisplay.comment.unformatted : null;
                 }
-                if (_isValidModelCommentDisplay(otherFK.from_comment_display)) {
-                    commentDisplayMode = otherFK.from_comment_display;
+                if (_isValidModelCommentDisplay(fkDisplay.toCommentDisplayMode)) {
+                    commentDisplayMode = fkDisplay.toCommentDisplayMode;
                 } else {
                     commentDisplayMode = tableDisplay.tableCommentDisplayMode;
                 }
-                if (typeof otherFK.comment_render_markdown === 'boolean') {
-                    commentRenderMarkdown = otherFK.comment_render_markdown;
+                if (typeof fkDisplay.commentRenderMarkdown === 'boolean') {
+                    commentRenderMarkdown = fkDisplay.commentRenderMarkdown;
                 } else {
                     commentRenderMarkdown = tableDisplay.commentRenderMarkdown;
                 }
@@ -4076,30 +4075,29 @@
                 newRef._table = fkrTable;
                 newRef._shortestKey = newRef._table.shortestKey;
 
+                fkDisplay = fkr.getDisplay(this._context);
+                tableDisplay = newRef._table.getDisplay(this._context);
+
                 // displayname
-                if (fkr.from_name) {
-                    newRef._displayname = {"isHTML": false, "value": fkr.from_name, "unformatted": fkr.from_name};
+                if (fkDisplay.fromName) {
+                    newRef._displayname = {"isHTML": false, "value": fkDisplay.fromName, "unformatted": fkDisplay.fromName};
                 } else {
                     newRef._displayname = newRef._table.displayname;
                 }
 
-                // NOTE: this is for contextualized toComment and toCommentDisplay, to be implemented later
-                // display = fkr.getDisplay(this._context);
-
                 // comment
-                tableDisplay = newRef._table.getDisplay(this._context);
-                if (_isValidModelComment(fkr.from_comment)) {
-                    comment = fkr.from_comment;
+                if (fkDisplay.fromComment) {
+                    comment = fkDisplay.fromComment;
                 } else {
                     comment = tableDisplay.comment ? tableDisplay.comment.unformatted : null;
                 }
-                if (_isValidModelCommentDisplay(fkr.from_comment_display)) {
-                    commentDisplayMode = fkr.from_comment_display;
+                if (_isValidModelCommentDisplay(fkDisplay.fromCommentDisplayMode)) {
+                    commentDisplayMode = fkDisplay.fromCommentDisplayMode;
                 } else {
                     commentDisplayMode = tableDisplay.tableCommentDisplayMode;
                 }
-                if (typeof fkr.comment_render_markdown === 'boolean') {
-                    commentRenderMarkdown = fkr.comment_render_markdown;
+                if (typeof fkDisplay.commentRenderMarkdown === 'boolean') {
+                    commentRenderMarkdown = fkDisplay.commentRenderMarkdown;
                 } else {
                     commentRenderMarkdown = tableDisplay.commentRenderMarkdown;
                 }

--- a/js/reference.js
+++ b/js/reference.js
@@ -4087,7 +4087,7 @@
 
                 // comment
                 if (fkDisplay.fromComment) {
-                    comment = fkDisplay.fromComment;
+                    comment = fkDisplay.fromComment.unformatted;
                 } else {
                     comment = tableDisplay.comment ? tableDisplay.comment.unformatted : null;
                 }

--- a/js/utils/handlebar_helpers.js
+++ b/js/utils/handlebar_helpers.js
@@ -124,7 +124,7 @@
              *
              * @returns boolean if the value matches the regexp
              */
-            regexMatch: function (value, regexp, options) {
+            regexMatch: function (value, regexp) {
                 var regexpObj = new RegExp(regexp);
                 return regexpObj.test(value);
             },

--- a/js/utils/handlebar_helpers.js
+++ b/js/utils/handlebar_helpers.js
@@ -124,7 +124,7 @@
              *
              * @returns boolean if the value matches the regexp
              */
-            regexMatch: function (value, regexp) {
+            regexMatch: function (value, regexp, options) {
                 var regexpObj = new RegExp(regexp);
                 return regexpObj.test(value);
             },

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -835,7 +835,7 @@
      * @private
      */
     _processSourceObjectComment = function (sourceObject, defaultComment, defaultCommentRenderMd, defaultDisplayMode) {
-        if (sourceObject && _isValidModelComment(sourceObject)) {
+        if (sourceObject && _isValidModelComment(sourceObject.comment)) {
             defaultComment = sourceObject.comment;
         }
         if (sourceObject && _isValidModelCommentDisplay(sourceObject.comment_display)) {
@@ -852,6 +852,7 @@
      *   - if =false : returns empty string.
      *   - if =string: returns the string.
      *   - otherwise returns null
+     * TODO update comment
      * @private
      */
     _processModelComment = function (comment, isMarkdown, displayMode) {
@@ -859,15 +860,15 @@
             return null;
         }
 
-        var usedDisplayMode = _isValidModelComment(displayMode) ? displayMode : module._commentDisplayModes.tooltip;
+        var usedDisplayMode = _isValidModelCommentDisplay(displayMode) ? displayMode : module._commentDisplayModes.tooltip;
         if (comment === false) {
             return { isHTML: false, unformatted: '', value: '', displayMode: usedDisplayMode };
         }
 
         return {
-            isHTML: isMarkdown === true,
+            isHTML: isMarkdown !== false,
             unformatted: comment,
-            value: (isMarkdown === true) ? module.renderMarkdown(comment) : comment,
+            value: (isMarkdown !== false && comment.length > 0) ? module.renderMarkdown(comment) : comment,
             displayMode: usedDisplayMode
         };
     };

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -831,17 +831,20 @@
     };
 
     /**
-     * Given the source object, will return the comment that should be used.
-     * - if sourceObject.comment=false: use empty string.
-     * - if sourceObject.comment=string: use the defined value
-     * - otherwise return null
-     * TODO should be renamed or changed. the name doesn't make sense.
-     * (I wanted to use _processSourceObjectComment but called it this way accidentally)
+     * Given the source object and default comment props, will return the comment that should be used.
      * @private
      */
-    _processSourceObjectColumn = function (sourceObject) {
-        if (!sourceObject) return null;
-        return _processModelComment(sourceObject.comment);
+    _processSourceObjectComment = function (sourceObject, defaultComment, defaultCommentRenderMd, defaultDisplayMode) {
+        if (sourceObject && _isValidModelComment(sourceObject)) {
+            defaultComment = sourceObject.comment;
+        }
+        if (sourceObject && _isValidModelCommentDisplay(sourceObject.comment_display)) {
+            defaultDisplayMode = sourceObject.comment_display;
+        }
+        if (sourceObject && typeof sourceObject.comment_render_markdown === 'boolean') {
+            defaultCommentRenderMd = sourceObject.comment_render_markdown;
+        }
+        return _processModelComment(defaultComment, defaultCommentRenderMd, defaultDisplayMode);
     };
 
     /**
@@ -851,10 +854,22 @@
      *   - otherwise returns null
      * @private
      */
-    _processModelComment = function (comment) {
-        if (comment === false) return "";
-        if (typeof comment === "string") return comment;
-        return null;
+    _processModelComment = function (comment, isMarkdown, displayMode) {
+        if (comment !== false && typeof comment !== 'string') {
+            return null;
+        }
+
+        var usedDisplayMode = _isValidModelComment(displayMode) ? displayMode : module._commentDisplayModes.tooltip;
+        if (comment === false) {
+            return { isHTML: false, unformatted: '', value: '', displayMode: usedDisplayMode };
+        }
+
+        return {
+            isHTML: isMarkdown === true,
+            unformatted: comment,
+            value: (isMarkdown === true) ? module.renderMarkdown(comment) : comment,
+            displayMode: usedDisplayMode
+        };
     };
 
     /**

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -848,11 +848,10 @@
     };
 
     /**
-     * Given an input string for the comment, will return the actual strng that should be used.
-     *   - if =false : returns empty string.
-     *   - if =string: returns the string.
-     *   - otherwise returns null
-     * TODO update comment
+     * Turn a comment annotaiton/string value into a proper comment object.
+     * @param {string|null|false} comment
+     * @param {boolean=true} isMarkdown whether the given comment should be rendered as markdown (default: true).
+     * @param {string} displayMode the display mode of the comment (inline, tooltip)
      * @private
      */
     _processModelComment = function (comment, isMarkdown, displayMode) {

--- a/test/specs/ag_reference/tests/01.ag_reference.js
+++ b/test/specs/ag_reference/tests/01.ag_reference.js
@@ -31,6 +31,7 @@ exports.execute = function (options) {
         var ref, refWithModifiers, refColumnOrder, refColumnOrderSorted, unicodeRef;
         var loc, locWithModifiers, unicodeLoc;
         var keyColVisible, keyColVisible2, keyColInvisible, keyColOrder, keyColOrder2, aggColVisible, aggColInvisible, aggColNoSort, unicodeID, unicodeCol;
+        var mdComment = { isHTML: true, value: '<p><strong>comment</strong></p>\n', unformatted: '**comment**', displayMode: 'tooltip' };
 
         var checkLocation = function (objName, obj, path) {
             expect(obj).toBeDefined(objName + " was not defined.");
@@ -44,7 +45,15 @@ exports.execute = function (options) {
             expect(obj.term).toBe(term, objName + " term missmatch");
             expect(obj.displayname.value).toBe(displayname, objName + " displayname missmatch");
             expect(obj.type.name).toBe(typeName, objName + " type missmatch");
-            expect(obj.comment).toBe(comment, objName + " comment missmatch");
+            if (typeof comment === 'string') {
+                comment = {
+                    isHTML: false,
+                    value: comment,
+                    unformatted: comment,
+                    displayMode: 'tooltip'
+                }
+            }
+            expect(obj.comment).toEqual(comment, objName + " comment missmatch");
             expect(obj.sortable).toBe(sortable, objName + " sortable missmatch");
         };
 
@@ -152,7 +161,7 @@ exports.execute = function (options) {
                 );
 
                 keyColInvisible = new options.ermRest.AttributeGroupColumn(
-                    "alias", "invis_col", null, "invisible column", "text", "", true, false
+                    "alias", "invis_col", null, "invisible column", "text", mdComment, true, false
                 );
 
 
@@ -184,7 +193,7 @@ exports.execute = function (options) {
 
                 checkColumn("keyColVisible with base column", keyColVisible2, "col_w_pre_format", "col_w_pre_format", "boolean", null, true);
 
-                checkColumn("keyColInvisible", keyColInvisible, "invis_col", "invisible column", "text", "", true);
+                checkColumn("keyColInvisible", keyColInvisible, "invis_col", "invisible column", "text", mdComment, true);
 
                 checkColumn("aggColVisible", aggColVisible, "cnt(*)", "count", "int4", "", true);
 

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -441,21 +441,46 @@ exports.execute = function (options) {
         describe('.comment, ', function () {
             describe('for pseudoColumns, ', function () {
                 it('that are inbound foreignkey should return table\'s comment.', function () {
-                    expect(detailedColumns[3].comment).toEqual("inbound related to columns_table");
+                    expect(detailedColumns[3].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>inbound related to columns_table</p>\n',
+                        unformatted: 'inbound related to columns_table'
+                    });
                 });
 
                 it('when key/foreign key is simple should use column\'s comment.', function () {
-                    expect(compactColumns[0].comment).toBe("not part of any FKRs.");
-                    expect(compactColumns[1].comment).toBe("simple fk to reference, col_1");
+                    expect(compactColumns[0].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>not part of any FKRs.</p>\n',
+                        unformatted: 'not part of any FKRs.'
+                    });
+                    expect(compactColumns[1].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>simple fk to reference, col_1</p>\n',
+                        unformatted: 'simple fk to reference, col_1'
+                    });
                 });
 
                 it('otherwise should use key/foreignkey\'s comment.', function () {
-                    expect(compactColumns[16].comment).toBe("composite fk to table_w_composite_key with to_name");
+                    expect(compactColumns[16].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>composite fk to table_w_composite_key with to_name</p>\n',
+                        unformatted: 'composite fk to table_w_composite_key with to_name'
+                    });
                 });
             });
 
             it('for other columns should return the base column\'s comment.', function () {
-                expect(compactColumns[9].comment).toBe("not part of any FKRs.");
+                expect(compactColumns[9].comment).toEqual({
+                    isHTML: true,
+                    displayMode: 'tooltip',
+                    value: '<p>not part of any FKRs.</p>\n',
+                    unformatted: 'not part of any FKRs.'
+                });
             });
         });
 

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -553,7 +553,21 @@ exports.execute = function (options) {
                     };
 
                     for (var i in expectedComments) {
-                        expect(detailedColsWTuple[i].comment).toBe(expectedComments[i],"missmatch for index=" + i);
+                        if (expectedComments[i] === '') {
+                            expect(detailedColsWTuple[i].comment).toEqual({
+                                isHTML: false,
+                                displayMode: 'tooltip',
+                                value: '',
+                                unformatted: ''
+                            }, "missmatch for index=" + i);
+                        } else {
+                            expect(detailedColsWTuple[i].comment).toEqual({
+                                isHTML: true,
+                                displayMode: 'tooltip',
+                                value: `<p>${expectedComments[i]}</p>\n`,
+                                unformatted: expectedComments[i]
+                            }, "missmatch for index=" + i);
+                        }
                     }
                 });
 
@@ -601,7 +615,12 @@ exports.execute = function (options) {
 
                 describe(".comment", function () {
                     it ("should return the defined comment.", function () {
-                        expect(detailedColsWTuple[26].comment).toBe("virtual comment", "missmatch for index=26");
+                        expect(detailedColsWTuple[26].comment).toEqual({
+                            isHTML: true,
+                            displayMode: 'tooltip',
+                            value: '<p>virtual comment</p>\n',
+                            unformatted: 'virtual comment'
+                        }, "missmatch for index=26");
                     });
 
                     it ("otherwise it should be null", function () {
@@ -715,8 +734,18 @@ exports.execute = function (options) {
 
             describe("comment, ", function () {
                 it ('if `comment` is defined, should use it.', function () {
-                    expect(detailedColsWTuple[6].comment).toBe("outbound len 2 cm", "missmatch for index=6");
-                    expect(detailedColsWTuple[21].comment).toBe("has long values", "missmatch for index=6");
+                    expect(detailedColsWTuple[6].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>outbound len 2 cm</p>\n',
+                        unformatted: 'outbound len 2 cm'
+                    }, "missmatch for index=6");
+                    expect(detailedColsWTuple[21].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>has long values</p>\n',
+                        unformatted: 'has long values'
+                    }, "missmatch for index=6");
                 });
 
                 it ("if it has aggregate, should append the aggregate function to the column comment.", function () {
@@ -724,16 +753,31 @@ exports.execute = function (options) {
                         'Number of inbound_2', 'Number of distinct inbound_2_outbound_1', 'Minimum id', 'Maximum col name', "List of id", "List of inbound_2", "List of distinct inbound_2"
                     ];
                     for (var i = 11; i <= 17; i++) {
-                        expect(detailedColsWTuple[i].comment).toBe(aggregateComments[i-11], "missmatch for index =" + i);
+                        expect(detailedColsWTuple[i].comment).toEqual({
+                            isHTML: false,
+                            displayMode: 'tooltip',
+                            value: aggregateComments[i-11],
+                            unformatted: aggregateComments[i-11]
+                        }, "missmatch for index =" + i);
                     }
                 });
 
                 it ("if it's in entity mode, should return the table's comment.", function () {
-                    expect(detailedColsWTuple[5].comment).toBe("outbound_1_outbound_1 comment");
+                    expect(detailedColsWTuple[5].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>outbound_1_outbound_1 comment</p>\n',
+                        unformatted: 'outbound_1_outbound_1 comment'
+                    });
                 });
 
                 it ("if it's in scalar mode, should return the column's comment.", function () {
-                    expect(detailedColsWTuple[4].comment).toBe("id of outbound_1");
+                    expect(detailedColsWTuple[4].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>id of outbound_1</p>\n',
+                        unformatted: 'id of outbound_1'
+                    });
                 });
             });
 

--- a/test/specs/comment/tests/01.comment.js
+++ b/test/specs/comment/tests/01.comment.js
@@ -11,14 +11,14 @@ exports.execute = function (options) {
         // Test Cases:
         it('schema_with_comment should have a non-null .comment property.', function () {
             expect(schema.hasOwnProperty('comment')).toBe(true);
-            expect(schema.comment).toBe("schema with a comment");
+            expect(schema.comment.unformatted).toBe("schema with a comment");
         });
 
         describe("table, ", function () {
             it('table_with_comment should have a non-null .comment property.', function () {
                 var table = schema.tables.get('table_with_comment');
                 expect(table.hasOwnProperty('comment')).toBe(true);
-                expect(table.comment).toBe("table with a comment");
+                expect(table.comment.unformatted).toBe("table with a comment");
             });
 
             it('table_with_null_comment should have a null .comment property.', function () {
@@ -29,26 +29,33 @@ exports.execute = function (options) {
 
             it('table_w_display_comment should use the display comment.', function () {
                 var table = schema.tables.get('table_w_display_comment');
-                expect(table.comment).toBe("");
+                const expectedComment = {
+                    isHTML: true,
+                    value: '',
+                    unformatted: '',
+                    displayMode: 'tooltip'
+                };
                 // comment should be the same when fetched with getDisplay function
-                expect(table.getDisplay("detailed").comment).toBe("", "comment from getDisplay is incorrect");
+                expect(table.getDisplay("detailed").comment).toEqual(expectedComment, "comment from getDisplay is incorrect");
                 // should use the default comment display value
-                expect(table.getDisplay("detailed").columnCommentDisplayMode).toBe("tooltip", "default column comment display is incorrect");
-                expect(table.getDisplay("detailed").tableCommentDisplayMode).toBe("tooltip", "default table comment display is incorrect");
+                expect(table.getDisplay("detailed").columnCommentDisplayMode).toBe('tooltip', "default column comment display is incorrect");
+                expect(table.getDisplay("detailed").tableCommentDisplayMode).toBe('tooltip', "default table comment display is incorrect");
             });
 
             it('table_w_contextualized_display_comment should use the contextualized display comment.', function () {
                 var table = schema.tables.get('table_w_contextualized_display_comment');
-                var annotationComment = "detailed comment";
-                // comment will be from the table not the annotation
-                expect(table.comment).not.toBe(annotationComment, "table comment is the same as annotaiton comment");
                 // should use the default values since this context is not defined
-                expect(table.getDisplay("*").columnCommentDisplayMode).toBe("tooltip", "* context, column comment display is incorrect");
-                expect(table.getDisplay("*").tableCommentDisplayMode).toBe("tooltip", "* context, table comment display is incorrect");
+                expect(table.getDisplay("*").columnCommentDisplayMode).toBe('tooltip', "* context, column comment display is incorrect");
+                expect(table.getDisplay("*").tableCommentDisplayMode).toBe('tooltip', "* context, table comment display is incorrect");
 
-                expect(table.getDisplay("detailed").comment).toBe(annotationComment, "detailed context, comment is incorrect");
+                expect(table.getDisplay("detailed").comment).toEqual({
+                    isHTML: true,
+                    value: '<p>detailed comment</p>\n',
+                    unformatted: 'detailed comment',
+                    displayMode: 'inline'
+                }, 'detailed context, comment is incorrect');
                 // should use the comment display values from annotation
-                expect(table.getDisplay("detailed").columnCommentDisplayMode).toBe("tooltip", "detailed context, column comment display is incorrect");
+                expect(table.getDisplay("detailed").columnCommentDisplayMode).toBe('tooltip', "detailed context, column comment display is incorrect");
                 expect(table.getDisplay("detailed").tableCommentDisplayMode).toBe("inline", "detailed context, table comment display is incorrect");
             });
         });
@@ -56,17 +63,32 @@ exports.execute = function (options) {
         describe("column, ", function () {
             it('column_with_display_comment should have a non-null .comment property.', function () {
                 var column = schema.tables.get('table_with_comment').columns.get("column_with_display_comment");
-                expect(column.comment).toBe("display comment");
+                expect(column.getDisplay("*").comment).toEqual({
+                    isHTML: true,
+                    value: '<p>display comment</p>\n',
+                    unformatted: 'display comment',
+                    displayMode: 'tooltip'
+                });
             });
 
             it('column_with_null_display_comment should use the model .comment property.', function () {
                 var column = schema.tables.get('table_with_comment').columns.get("column_with_null_display_comment");
-                expect(column.comment).toBe("column with a comment");
+                expect(column.getDisplay("*").comment).toEqual({
+                    isHTML: true,
+                    value: '<p>column with a comment</p>\n',
+                    unformatted: 'column with a comment',
+                    displayMode: 'tooltip'
+                });
             });
 
             it('column_with_empty_display_comment should have an empty .comment property.', function () {
                 var column = schema.tables.get('table_with_comment').columns.get("column_with_empty_display_comment");
-                expect(column.comment).toBe("");
+                expect(column.getDisplay("*").comment).toEqual({
+                    isHTML: true,
+                    value: '',
+                    unformatted: '',
+                    displayMode: 'tooltip'
+                });
             });
         });
 
@@ -75,7 +97,12 @@ exports.execute = function (options) {
         xit('this key with a comment should have a non-null .comment property.', function () {
             var key = schema.tables.get('table_with_comment').keys.all()[0];
             expect(key.hasOwnProperty('comment')).toBe(true);
-            expect(key.comment).toBe("key with a comment");
+            expect(key.comment).toEqual({
+                isHTML: true,
+                value: '<p>key with a comment</p>\n',
+                unformatted: 'key with a comment',
+                displayMode: 'tooltip'
+            });
         });
 
         it('this key in table_with_comment should have a null .comment property.', function() {
@@ -91,7 +118,7 @@ exports.execute = function (options) {
             for (var i = 0; i < fkeys.length; i++) {
                 if (fkeys[i].comment === null) {
                     fkeysWithNullComment++;
-                } else if (fkeys[i].comment === "foreign key with a comment") {
+                } else if (fkeys[i].comment.unformatted === "foreign key with a comment") {
                     fkeysWithSpecifiedComment++;
                 }
             }

--- a/test/specs/comment/tests/01.comment.js
+++ b/test/specs/comment/tests/01.comment.js
@@ -33,8 +33,8 @@ exports.execute = function (options) {
                 // comment should be the same when fetched with getDisplay function
                 expect(table.getDisplay("detailed").comment).toBe("", "comment from getDisplay is incorrect");
                 // should use the default comment display value
-                expect(table.getDisplay("detailed").columnCommentDisplay).toBe("tooltip", "default column comment display is incorrect");
-                expect(table.getDisplay("detailed").tableCommentDisplay).toBe("tooltip", "default table comment display is incorrect");
+                expect(table.getDisplay("detailed").columnCommentDisplayMode).toBe("tooltip", "default column comment display is incorrect");
+                expect(table.getDisplay("detailed").tableCommentDisplayMode).toBe("tooltip", "default table comment display is incorrect");
             });
 
             it('table_w_contextualized_display_comment should use the contextualized display comment.', function () {
@@ -43,13 +43,13 @@ exports.execute = function (options) {
                 // comment will be from the table not the annotation
                 expect(table.comment).not.toBe(annotationComment, "table comment is the same as annotaiton comment");
                 // should use the default values since this context is not defined
-                expect(table.getDisplay("*").columnCommentDisplay).toBe("tooltip", "* context, column comment display is incorrect");
-                expect(table.getDisplay("*").tableCommentDisplay).toBe("tooltip", "* context, table comment display is incorrect");
+                expect(table.getDisplay("*").columnCommentDisplayMode).toBe("tooltip", "* context, column comment display is incorrect");
+                expect(table.getDisplay("*").tableCommentDisplayMode).toBe("tooltip", "* context, table comment display is incorrect");
 
                 expect(table.getDisplay("detailed").comment).toBe(annotationComment, "detailed context, comment is incorrect");
                 // should use the comment display values from annotation
-                expect(table.getDisplay("detailed").columnCommentDisplay).toBe("tooltip", "detailed context, column comment display is incorrect");
-                expect(table.getDisplay("detailed").tableCommentDisplay).toBe("inline", "detailed context, table comment display is incorrect");
+                expect(table.getDisplay("detailed").columnCommentDisplayMode).toBe("tooltip", "detailed context, column comment display is incorrect");
+                expect(table.getDisplay("detailed").tableCommentDisplayMode).toBe("inline", "detailed context, table comment display is incorrect");
             });
         });
 

--- a/test/specs/common/tests/01.foreignkey.js
+++ b/test/specs/common/tests/01.foreignkey.js
@@ -233,44 +233,55 @@ exports.execute = function(options) {
                 });
             });
 
-            describe('.from_name and .to_name ', function() {
+            describe('fromName and toName ', function() {
                 it('should return the values that are defined in foreign-key annotation.', function() {
                     table1_schema1.foreignKeys.all().forEach(function(fk, index) {
                         // NOTE: this if statement assumes that only one foreignKey in table1_schema1 has annotation.
                         if (fk.annotations.length() > 0) {
-                            expect(fk.from_name).toBe("from_name_value");
-                            expect(fk.to_name).toBe("to_name_value");
+                            var disp = fk.getDisplay('*');
+                            expect(disp.fromName).toBe("from_name_value");
+                            expect(disp.toName).toBe("to_name_value");
                         }
                     });
                 });
 
-                it('should return empty strings when annotations are not defined.', function() {
-                    expect(table2_schema1.foreignKeys.all()[0].from_name).toBe("");
-                    expect(table2_schema1.foreignKeys.all()[0].to_name).toBe("");
+                it('should return null when annotations are not defined.', function() {
+                    var disp = table2_schema1.foreignKeys.all()[0].getDisplay('*');
+                    expect(disp.fromName).toBeFalsy();
+                    expect(disp.toName).toBeFalsy();
                 });
             });
 
-            describe('.from_comment with display and .to_comment with display ', function() {
+            describe('fromComment with display and toComment with display ', function() {
                 it('should return the values that are defined in foreign-key annotation.', function() {
                     table1_schema1.foreignKeys.all().forEach(function(fk, index) {
                         // NOTE: this if statement assumes that only one foreignKey in table1_schema1 has annotation.
                         if (fk.annotations.length() > 0) {
-                            expect(fk.from_comment).toBe("from_comment_value");
-                            expect(fk.from_comment_display).toBe("inline");
-                            expect(fk.to_comment).toBe("to_comment_value");
-                            expect(fk.to_comment_display).toBe("inline");
+                            var disp = fk.getDisplay('*');
+                            expect(disp.fromComment).toEqual({
+                                value: "<p>from_comment_value</p>\n",
+                                unformatted: "from_comment_value",
+                                isHTML: true,
+                                displayMode: "inline"
+                            });
+                            expect(disp.fromCommentDisplayMode).toBe("inline");
+                            expect(disp.toComment).toEqual({
+                                value: "<p>to_comment_value</p>\n",
+                                unformatted: "to_comment_value",
+                                isHTML: true,
+                                displayMode: "inline"
+                            });
+                            expect(disp.toCommentDisplayMode).toBe("inline");
                         }
                     });
                 });
 
-                it('should return empty strings when annotations are not defined.', function() {
-                    expect(table2_schema1.foreignKeys.all()[0].from_comment).toBe("");
-                    expect(table2_schema1.foreignKeys.all()[0].to_comment).toBe("");
-                });
-
-                it('should return default value when annotations are not defined.', function() {
-                    expect(table2_schema1.foreignKeys.all()[0].from_comment_display).toBe("tooltip");
-                    expect(table2_schema1.foreignKeys.all()[0].to_comment_display).toBe("tooltip");
+                it('should return null when annotations are not defined.', function() {
+                    var disp = table2_schema1.foreignKeys.all()[0].getDisplay('*');
+                    expect(disp.fromComment).toBeFalsy();
+                    expect(disp.toComment).toBeFalsy();
+                    expect(disp.fromCommentDisplayMode).toBeFalsy();
+                    expect(disp.toCommentDisplayMode).toBeFalsy();
                 });
             });
 

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -471,7 +471,15 @@ exports.execute = function(options) {
 
                 it('should have a default comment.', function(){
                     for(var i=0;i<systemColumns.length;i++){
-                        expect(table1_schema2.columns.get(systemColumns[i]).comment).toBe(comments[systemColumns[i]], "Column "+ systemColumns[i]+ " doesn't have the correct default comment.");
+                        expect(table1_schema2.columns.get(systemColumns[i]).comment).toEqual(
+                            {
+                                isHTML: false,
+                                unformatted: comments[systemColumns[i]],
+                                value: comments[systemColumns[i]],
+                                displayMode: 'tooltip'
+                            },
+                            "Column "+ systemColumns[i]+ " doesn't have the correct default comment."
+                        );
                     }
                 });
             });

--- a/test/specs/faceting/tests/01.faceting.js
+++ b/test/specs/faceting/tests/01.faceting.js
@@ -1364,20 +1364,45 @@ exports.execute = function (options) {
 
             describe("comment", function () {
                 it("return the comment defined on the facet.", function () {
-                    expect(mainFacets[6].comment).toBe("long text comment in facet");
+                    expect(mainFacets[6].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>long text comment in facet</p>\n',
+                        unformatted: 'long text comment in facet'
+                    });
                 });
 
                 it("return empty string if the defined comment is `false`.", function () {
-                    expect(mainFacets[7].comment).toBe("", "missmatch for index=7");
-                    expect(mainFacets[10].comment).toBe("", "missmatch for index=10");
+                    expect(mainFacets[7].comment).toEqual({
+                        isHTML: false,
+                        displayMode: 'tooltip',
+                        value: '',
+                        unformatted: ''
+                    }, "missmatch for index=7");
+                    expect(mainFacets[10].comment).toEqual({
+                        isHTML: false,
+                        displayMode: 'tooltip',
+                        value: '',
+                        unformatted: ''
+                    }, "missmatch for index=10");
                 });
 
                 it('if in scalar mode, return column\'s comment', function () {
-                    expect(mainFacets[5].comment).toBe("text comment");
+                    expect(mainFacets[5].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>text comment</p>\n',
+                        unformatted: 'text comment'
+                    });
                 });
 
                 it('otherwise return table\'s comment.', function () {
-                    expect(mainFacets[11].comment).toBe("has fk to main table + has rowname");
+                    expect(mainFacets[11].comment).toEqual({
+                        isHTML: true,
+                        displayMode: 'tooltip',
+                        value: '<p>has fk to main table + has rowname</p>\n',
+                        unformatted: 'has fk to main table + has rowname'
+                    });
                 });
             });
 

--- a/test/specs/reference/conf/comment_display_inline_schema/schema.json
+++ b/test/specs/reference/conf/comment_display_inline_schema/schema.json
@@ -49,7 +49,12 @@
                 },
                 "tag:isrd.isi.edu,2016:visible-columns": {
                     "detailed": [
-                        { "sourcekey": "simple_fk_1", "comment": "simple fk source syntax comment", "comment_display": "inline" },
+                        {
+                            "sourcekey": "simple_fk_1",
+                            "comment": "simple fk source syntax comment",
+                            "comment_display": "inline",
+                            "comment_render_markdown": true
+                        },
                         { "sourcekey": "simple_fk_2" },
                         { "sourcekey": "simple_fk_3" },
                         { "sourcekey": "simple_fk_4" }
@@ -146,7 +151,8 @@
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
                             "from_comment": "simple fk from_comment comment",
-                            "from_comment_display": "inline"
+                            "from_comment_display": "inline",
+                            "comment_render_markdown": false
                         }
                     }
                 }
@@ -204,7 +210,8 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "from_comment_display": "inline"
+                            "from_comment_display": "inline",
+                            "comment_render_markdown": false
                         }
                     }
                 }
@@ -287,7 +294,8 @@
                     },
                     "comment_display": {
                         "detailed": {
-                            "table_comment_display": "inline"
+                            "table_comment_display": "inline",
+                            "comment_render_markdown": true
                         }
                     }
                 }
@@ -379,18 +387,38 @@
                                 "RID"
                             ],
                             "entity": true
+                        },
+                        "multi_leaf_no_display": {
+                            "source": [
+                                {"inbound": ["comment_display_inline_schema", "association_related_to_reference"]},
+                                {"outbound": ["comment_display_inline_schema", "association_to_inbound_related"]},
+                                {"outbound": ["comment_display_inline_schema", "multi_hop_fk_4"]},
+                                "RID"
+                            ],
+                            "entity": true
                         }
                     }
                 },
                 "tag:isrd.isi.edu,2016:visible-columns": {
                     "detailed": [
-                        { "sourcekey": "pb_source_comment", "comment": "pure and binary fk source syntax comment", "comment_display": "inline" },
+                        {
+                            "sourcekey": "pb_source_comment",
+                            "comment": "pure and binary fk source syntax comment",
+                            "comment_display": "inline",
+                            "comment_render_markdown": true
+                        },
                         { "sourcekey": "pb_to_comment"},
                         { "sourcekey": "pb_to_comment_display" },
                         { "sourcekey": "pb_leaf_comment" },
-                        { "sourcekey": "multi_source_comment", "comment": "multi hop fk source syntax comment", "comment_display": "inline" },
+                        {
+                            "sourcekey": "multi_source_comment",
+                            "comment": "multi hop fk source syntax comment",
+                            "comment_display": "inline",
+                            "comment_render_markdown": true
+                        },
                         { "sourcekey": "multi_comment_display"},
-                        { "sourcekey": "multi_leaf_comment" }
+                        { "sourcekey": "multi_leaf_comment" },
+                        { "sourcekey": "multi_leaf_no_display" }
                     ]
                 }
             }
@@ -494,7 +522,8 @@
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
                             "to_comment": "pure and binary fk to_comment",
-                            "to_comment_display": "inline"
+                            "to_comment_display": "inline",
+                            "comment_render_markdown": false
                         }
                     }
                 }
@@ -652,14 +681,15 @@
                     },
                     "comment_display": {
                         "detailed": {
-                            "table_comment_display": "inline"
+                            "table_comment_display": "inline",
+                            "comment_render_markdown": true
                         }
                     }
                 }
             }
         },
         "inbound_related_reference_table_no_display": {
-            "comment": "foreign key to association table",
+            "comment": "foreign key to association table no display",
             "kind": "table",
             "table_name": "inbound_related_reference_table_no_display",
             "schema_name": "comment_display_inline_schema",
@@ -723,6 +753,25 @@
                         }
                     ],
                     "annotations": {}
+                },
+                {
+                    "comment": "simple fk multi_hop_col_4 with comment_display",
+                    "names": [["comment_display_inline_schema", "multi_hop_fk_4"]],
+                    "foreign_key_columns": [
+                        {
+                            "schema_name": "comment_display_inline_schema",
+                            "table_name": "inbound_related_reference_table_no_display",
+                            "column_name": "multi_hop_col_4"
+                        }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "schema_name": "comment_display_inline_schema",
+                            "table_name": "multi_hop_related_reference_table_no_leaf_display",
+                            "column_name": "id"
+                        }
+                    ],
+                    "annotations": {}
                 }
             ],
             "column_definitions": [
@@ -749,6 +798,13 @@
                 },
                 {
                     "name": "multi_hop_col_3",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "multi_hop_col_4",
                     "nullok": false,
                     "type": {
                         "typename": "text"
@@ -799,7 +855,8 @@
                 "tag:misd.isi.edu,2015:display": {
                     "comment_display": {
                         "detailed": {
-                            "table_comment_display": "inline"
+                            "table_comment_display": "inline",
+                            "comment_render_markdown": true
                         }
                     }
                 }
@@ -830,11 +887,32 @@
                     },
                     "comment_display": {
                         "detailed": {
-                            "table_comment_display": "inline"
+                            "table_comment_display": "inline",
+                            "comment_render_markdown": false
                         }
                     }
                 }
             }
+        },
+        "multi_hop_related_reference_table_no_leaf_display": {
+            "comment": "foreign key to association table with no leaf display",
+            "kind": "table",
+            "table_name": "multi_hop_related_reference_table_no_leaf_display",
+            "schema_name": "comment_display_inline_schema",
+            "keys": [{
+                "unique_columns": ["id"]
+            }],
+            "foreign_keys": [],
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "annotations": {}
         }
     }
 }

--- a/test/specs/reference/conf/comment_display_related_schema/schema.json
+++ b/test/specs/reference/conf/comment_display_related_schema/schema.json
@@ -49,7 +49,12 @@
                 },
                 "tag:isrd.isi.edu,2016:visible-foreign-keys": {
                     "detailed": [
-                        { "sourcekey": "simple_fk_1", "comment": "simple fk source syntax comment", "comment_display": "inline" },
+                        {
+                            "sourcekey": "simple_fk_1",
+                            "comment": "simple fk source syntax comment",
+                            "comment_display": "inline",
+                            "comment_render_markdown": false
+                        },
                         { "sourcekey": "simple_fk_2" },
                         { "sourcekey": "simple_fk_3" },
                         { "sourcekey": "simple_fk_4" }
@@ -146,7 +151,8 @@
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
                             "from_comment": "simple fk from_comment comment",
-                            "from_comment_display": "inline"
+                            "from_comment_display": "inline",
+                            "comment_render_markdown": true
                         }
                     }
                 }
@@ -204,7 +210,8 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "from_comment_display": "inline"
+                            "from_comment_display": "inline",
+                            "comment_render_markdown": true
                         }
                     }
                 }
@@ -287,7 +294,8 @@
                     },
                     "comment_display": {
                         "detailed": {
-                            "table_comment_display": "inline"
+                            "table_comment_display": "inline",
+                            "comment_render_markdown": false
                         }
                     }
                 }
@@ -379,18 +387,38 @@
                                 "RID"
                             ],
                             "entity": true
+                        },
+                        "multi_leaf_no_display": {
+                            "source": [
+                                {"inbound": ["comment_display_inline_schema", "association_related_to_reference"]},
+                                {"outbound": ["comment_display_inline_schema", "association_to_inbound_related"]},
+                                {"outbound": ["comment_display_inline_schema", "multi_hop_fk_4"]},
+                                "RID"
+                            ],
+                            "entity": true
                         }
                     }
                 },
                 "tag:isrd.isi.edu,2016:visible-foreign-keys": {
                     "detailed": [
-                        { "sourcekey": "pb_source_comment", "comment": "pure and binary fk source syntax comment", "comment_display": "inline" },
+                        {
+                            "sourcekey": "pb_source_comment",
+                            "comment": "pure and binary fk source syntax comment",
+                            "comment_display": "inline",
+                            "comment_render_markdown": false
+                        },
                         { "sourcekey": "pb_to_comment"},
                         { "sourcekey": "pb_to_comment_display" },
                         { "sourcekey": "pb_leaf_comment" },
-                        { "sourcekey": "multi_source_comment", "comment": "multi hop fk source syntax comment", "comment_display": "inline" },
+                        {
+                            "sourcekey": "multi_source_comment",
+                            "comment": "multi hop fk source syntax comment",
+                            "comment_display": "inline",
+                            "comment_render_markdown": false
+                        },
                         { "sourcekey": "multi_comment_display"},
-                        { "sourcekey": "multi_leaf_comment" }
+                        { "sourcekey": "multi_leaf_comment" },
+                        { "sourcekey": "multi_leaf_no_display" }
                     ]
                 }
             }
@@ -494,7 +522,8 @@
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
                             "to_comment": "pure and binary fk to_comment",
-                            "to_comment_display": "inline"
+                            "to_comment_display": "inline",
+                            "comment_render_markdown": true
                         }
                     }
                 }
@@ -652,14 +681,15 @@
                     },
                     "comment_display": {
                         "detailed": {
-                            "table_comment_display": "inline"
+                            "table_comment_display": "inline",
+                            "comment_render_markdown": false
                         }
                     }
                 }
             }
         },
         "inbound_related_reference_table_no_display": {
-            "comment": "foreign key to association table",
+            "comment": "foreign key to association table no display",
             "kind": "table",
             "table_name": "inbound_related_reference_table_no_display",
             "schema_name": "comment_display_related_schema",
@@ -723,6 +753,25 @@
                         }
                     ],
                     "annotations": {}
+                },
+                {
+                    "comment": "simple fk multi_hop_col_4 with comment_display",
+                    "names": [["comment_display_related_schema", "multi_hop_fk_4"]],
+                    "foreign_key_columns": [
+                        {
+                            "schema_name": "comment_display_related_schema",
+                            "table_name": "inbound_related_reference_table_no_display",
+                            "column_name": "multi_hop_col_4"
+                        }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "schema_name": "comment_display_related_schema",
+                            "table_name": "multi_hop_related_reference_table_no_leaf_display",
+                            "column_name": "id"
+                        }
+                    ],
+                    "annotations": {}
                 }
             ],
             "column_definitions": [
@@ -749,6 +798,13 @@
                 },
                 {
                     "name": "multi_hop_col_3",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "multi_hop_col_4",
                     "nullok": false,
                     "type": {
                         "typename": "text"
@@ -799,7 +855,8 @@
                 "tag:misd.isi.edu,2015:display": {
                     "comment_display": {
                         "detailed": {
-                            "table_comment_display": "inline"
+                            "table_comment_display": "inline",
+                            "comment_render_markdown": false
                         }
                     }
                 }
@@ -830,11 +887,32 @@
                     },
                     "comment_display": {
                         "detailed": {
-                            "table_comment_display": "inline"
+                            "table_comment_display": "inline",
+                            "comment_render_markdown": true
                         }
                     }
                 }
             }
+        },
+        "multi_hop_related_reference_table_no_leaf_display": {
+            "comment": "foreign key to association table with no leaf display",
+            "kind": "table",
+            "table_name": "multi_hop_related_reference_table_no_leaf_display",
+            "schema_name": "comment_display_inline_schema",
+            "keys": [{
+                "unique_columns": ["id"]
+            }],
+            "foreign_keys": [],
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "annotations": {}
         }
     }
 }

--- a/test/specs/reference/tests/18.comment_display_inline.js
+++ b/test/specs/reference/tests/18.comment_display_inline.js
@@ -39,7 +39,7 @@
  **/
 exports.execute = function (options) {
 
-    describe("testing visible columns annotation,", function () {
+    describe("comment related annotations,", function () {
 
         var catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "comment_display_inline_schema",
@@ -47,7 +47,7 @@ exports.execute = function (options) {
 
         // simple "inbound" FK
         // main <- inbound leaf
-        describe("testing comment and comment_display for simple foreign key", function() {
+        describe("testing comment for simple foreign key", function() {
 
             var tableSimpleFKName = "comment_display_simple_fk_table";
 
@@ -74,35 +74,39 @@ exports.execute = function (options) {
 
             });
 
-            describe("for comment,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(simpleReference.columns[0].comment).toBe("simple fk source syntax comment");
-                });
-
-                it("then the from_comment in foreign-key annotation", function () {
-                    expect(simpleReference.columns[1].comment).toBe("simple fk from_comment comment");
-                });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(simpleReference.columns[3].comment).toBe("simple fk leaf table display comment");
+            it("source syntax in visible foreign keys should be used first", () => {
+                expect(simpleReference.columns[0].comment).toEqual({
+                    value: "<p>simple fk source syntax comment</p>\n",
+                    unformatted: "simple fk source syntax comment",
+                    isHTML: true,
+                    displayMode: 'inline'
                 });
             });
 
-            describe("for comment_display,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(simpleReference.columns[0].commentDisplay).toBe("inline");
+            it("when from_comment and from_comment_display both are not defined", () => {
+                expect(simpleReference.columns[1].comment).toEqual({
+                    value: "<p>simple fk from_comment comment</p>\n",
+                    unformatted: "simple fk from_comment comment",
+                    isHTML: true,
+                    displayMode: 'inline'
                 });
+            });
 
-                it("then the from_comment_display property in foreign-key annotation if from_comment was defined", function () {
-                    expect(simpleReference.columns[1].commentDisplay).toBe("inline");
+            it ('if from_comment is not defined but from_comment_display is used', () => {
+                expect(simpleReference.columns[2].comment).toEqual({
+                    value: "<p>simple fk with NO from comment</p>\n",
+                    unformatted: "simple fk with NO from comment",
+                    isHTML: true,
+                    displayMode: 'inline'
                 });
+            })
 
-                it("ignore the from_comment_display property if from_comment is not defined", function () {
-                    expect(simpleReference.columns[2].commentDisplay).toBe("tooltip");
-                });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(simpleReference.columns[3].commentDisplay).toBe("inline");
+            it("when from_comment and from_comment_display both are not defined", function () {
+                expect(simpleReference.columns[3].comment).toEqual({
+                    value: '<p>simple fk leaf table display comment</p>\n',
+                    unformatted: 'simple fk leaf table display comment',
+                    isHTML: true,
+                    displayMode: 'inline'
                 });
             });
         });

--- a/test/specs/reference/tests/18.comment_display_inline.js
+++ b/test/specs/reference/tests/18.comment_display_inline.js
@@ -1,6 +1,10 @@
+const utils = require("../../../utils/utilities.js");
+
 /**
  * For testing comment and comment_display using the visible columns annotation, fk annotation, and table annotation.
  * This spec is divided into 3 chunks for testing "simple inbound FK", "pure and binary FK", and "inbound multi hop foreign key"
+ *
+ * there is a catalog annotstion that turns off markdown comments.
  *
  * The structure of the tables used for "simple inbound FK":
  * 1. comment_display_simple_fk_table <- table_w_simple_key_source_override
@@ -9,22 +13,23 @@
  * 4. comment_display_simple_fk_table <- table_w_simple_key_leaf_annotation
  *
  * Visible-columns for "comment_display_simple_fk_table" match the order of the above tables/foreign keys relationships:
- * 1. simple_fk_1 with comment in source syntax
- * 2. simple_fk_2 with from_comment in FK annotation
- * 3. simple_fk_3 with from_comment_display and no from_comment in FK annotation
- * 4. simple_fk_4 with comment in display annotation on table
+ * 1. simple_fk_1 with comment in source syntax (turns on markdown comment)
+ * 2. simple_fk_2 with from_comment in FK annotation (turns off markdown comment)
+ * 3. simple_fk_3 with from_comment_display and no from_comment in FK annotation (turns off markdown comment)
+ * 4. simple_fk_4 with comment in display annotation on table (turns on markdown comment)
  *
  *
  * The structure of tables used for "pure and binary FKs":
- * 1. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display
- * 2. comment_display_pb_table <- tocomment_fk_association_to_inbound_related -> inbound_related_reference_table_no_display
- * 3. comment_display_pb_table <- association_table_fk_to_comment_display -> inbound_related_reference_table_no_display
- * 4. comment_display_pb_table <- association_table_leaf_comment -> inbound_related_reference_table
+ * 1. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display (turns on markdown comment)
+ * 2. comment_display_pb_table <- tocomment_fk_association_to_inbound_related -> inbound_related_reference_table_no_display (turns off markdown comment)
+ * 3. comment_display_pb_table <- association_table_fk_to_comment_display -> inbound_related_reference_table_no_display (turns off markdown comment)
+ * 4. comment_display_pb_table <- association_table_leaf_comment -> inbound_related_reference_table (turns on markdown comment)
  *
  * The structure of tables used for "inbound multi hop foreign key":
- * 5. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table
- * 6. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table_comment_display
- * 7. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table_leaf_comment
+ * 5. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table (turns on markdown comment)
+ * 6. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table_comment_display (turns off markdown comment)
+ * 7. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table_leaf_comment (turns on markdown comment)
+ * 8. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table_no_leaf_display (turns off markdown comment)
  *
  * Visible-columns for "comment_display_pb_table" match the order of the above tables/foreign keys relationships:
  * 1. pb_source_comment with comment in source syntax
@@ -39,15 +44,28 @@
  **/
 exports.execute = function (options) {
 
-    describe("comment related annotations,", function () {
+    describe("comment annotations usage in visible columns,", () => {
 
-        var catalog_id = process.env.DEFAULT_CATALOG,
-            schemaName = "comment_display_inline_schema",
-            limit = 1;
+        const catalog_id = process.env.DEFAULT_CATALOG, schemaName = "comment_display_inline_schema";
+
+        beforeAll((done) => {
+            // changing the default behaior
+            utils.setCatalogAnnotations(options, {
+                "tag:misd.isi.edu,2015:display": {
+                    "comment_display": {
+                        "*": {
+                            "comment_render_markdown": false
+                        }
+                    }
+                }
+            }).then(() => {
+                done();
+            }).catch((err) => done.fail(err));
+        });
 
         // simple "inbound" FK
         // main <- inbound leaf
-        describe("testing comment for simple foreign key", function() {
+        describe("for simple foreign key", function() {
 
             var tableSimpleFKName = "comment_display_simple_fk_table";
 
@@ -83,25 +101,16 @@ exports.execute = function (options) {
                 });
             });
 
-            it("when from_comment and from_comment_display both are not defined", () => {
+            it("next from_comment and from_comment_display should be used.", () => {
                 expect(simpleReference.columns[1].comment).toEqual({
-                    value: "<p>simple fk from_comment comment</p>\n",
+                    value: "simple fk from_comment comment",
                     unformatted: "simple fk from_comment comment",
-                    isHTML: true,
+                    isHTML: false,
                     displayMode: 'inline'
                 });
             });
 
-            it ('if from_comment is not defined but from_comment_display is used', () => {
-                expect(simpleReference.columns[2].comment).toEqual({
-                    value: "<p>simple fk with NO from comment</p>\n",
-                    unformatted: "simple fk with NO from comment",
-                    isHTML: true,
-                    displayMode: 'inline'
-                });
-            })
-
-            it("when from_comment and from_comment_display both are not defined", function () {
+            it("by default the leaf table comment and comment_display should be used.", function () {
                 expect(simpleReference.columns[3].comment).toEqual({
                     value: '<p>simple fk leaf table display comment</p>\n',
                     unformatted: 'simple fk leaf table display comment',
@@ -109,11 +118,20 @@ exports.execute = function (options) {
                     displayMode: 'inline'
                 });
             });
+
+            it ('if from_comment_display is defined but not the from_comment, leaf table comment and this proeprty should be mixed', () => {
+                expect(simpleReference.columns[2].comment).toEqual({
+                    value: "table with simple key to reference and a foreign key annotation with no from comment display",
+                    unformatted: "table with simple key to reference and a foreign key annotation with no from comment display",
+                    isHTML: false,
+                    displayMode: 'inline'
+                });
+            });
         });
 
         // pure and binary FK
         // main <- inbound association outbound -> leaf
-        describe("testing comment and comment_display for pure and binary relation", function() {
+        describe("for pure and binary relation", () => {
 
             var tablePBName = "comment_display_pb_table";
 
@@ -140,35 +158,39 @@ exports.execute = function (options) {
 
             });
 
-            describe("for comment,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(pBReference.columns[0].comment).toBe("pure and binary fk source syntax comment");
-                });
-
-                it("then the to_comment in foreign-key annotation", function () {
-                    expect(pBReference.columns[1].comment).toBe("pure and binary fk to_comment");
-                });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(pBReference.columns[3].comment).toBe("pure and binary fk leaf table display comment");
+            it("source syntax in visible-columns should be used first", () => {
+                expect(pBReference.columns[0].comment).toEqual({
+                    value: "<p>pure and binary fk source syntax comment</p>\n",
+                    unformatted: "pure and binary fk source syntax comment",
+                    isHTML: true,
+                    displayMode: 'inline'
                 });
             });
 
-            describe("for comment_display,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(pBReference.columns[0].commentDisplay).toBe("inline");
+            it("next to_comment and to_comment_display should be used.", () => {
+                expect(pBReference.columns[1].comment).toEqual({
+                    value: "pure and binary fk to_comment",
+                    unformatted: "pure and binary fk to_comment",
+                    isHTML: false,
+                    displayMode: 'inline'
                 });
+            });
 
-                it("then the to_comment_display property in foreign-key annotation if to_comment was defined", function () {
-                    expect(pBReference.columns[1].commentDisplay).toBe("inline");
+            it("next the leaf table comment and comment_display should be used.", function () {
+                expect(pBReference.columns[3].comment).toEqual({
+                    value: '<p>pure and binary fk leaf table display comment</p>\n',
+                    unformatted: 'pure and binary fk leaf table display comment',
+                    isHTML: true,
+                    displayMode: 'inline'
                 });
+            });
 
-                it("ignore the to_comment_display property if to_comment is not defined", function () {
-                    expect(pBReference.columns[2].commentDisplay).toBe("tooltip");
-                });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(pBReference.columns[3].commentDisplay).toBe("inline");
+            it ('if to_comment_display is defined but not the to_comment, leaf table comment and this proeprty should be mixed', () => {
+                expect(pBReference.columns[2].comment).toEqual({
+                    value: "foreign key to association table no display",
+                    unformatted: "foreign key to association table no display",
+                    isHTML: false,
+                    displayMode: 'inline'
                 });
             });
         });
@@ -176,7 +198,7 @@ exports.execute = function (options) {
         // tests for pseudocolumn functionality when used for a related table
         // inbound multi hop foreign key
         // main <- inbound association outbound -> leaf outbound -> leaf
-        describe("testing comment and comment_display for multi hop foreign key", function() {
+        describe("for multi hop foreign key", function() {
 
             var tablePBName = "comment_display_pb_table";
 
@@ -203,31 +225,48 @@ exports.execute = function (options) {
 
             });
 
-            describe("for comment,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(multiHopReference.columns[4].comment).toBe("multi hop fk source syntax comment");
-                });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(multiHopReference.columns[6].comment).toBe("multi hop fk leaf table display comment");
-                });
-
-                it("next use comment on leaf table,", function () {
-                    expect(multiHopReference.columns[5].comment).toBe("foreign key to association table with comment_display and no comment");
+            it("source syntax in visible-columns should be used first", () => {
+                expect(multiHopReference.columns[4].comment).toEqual({
+                    isHTML: true,
+                    unformatted: "multi hop fk source syntax comment",
+                    value: "<p>multi hop fk source syntax comment</p>\n",
+                    displayMode: 'inline'
                 });
             });
 
-            describe("for comment_display,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(multiHopReference.columns[4].commentDisplay).toBe("inline");
+            it("next use display annotation on leaf table", function () {
+                expect(multiHopReference.columns[6].comment).toEqual({
+                    isHTML: false,
+                    unformatted: "multi hop fk leaf table display comment",
+                    value: "multi hop fk leaf table display comment",
+                    displayMode: 'inline'
                 });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(multiHopReference.columns[5].commentDisplay).toBe("inline", "missmatch for index=5");
-                    expect(multiHopReference.columns[6].commentDisplay).toBe("inline", "missmatch for index=6");
-                });
-
             });
+
+            it("next use comment on leaf table model while using comment_display and markdown of display annotation,", function () {
+                expect(multiHopReference.columns[5].comment).toEqual({
+                    isHTML: true,
+                    unformatted: "foreign key to association table with comment_display and no comment",
+                    value: "<p>foreign key to association table with comment_display and no comment</p>\n",
+                    displayMode: 'inline'
+                });
+            });
+
+            it("next use comment on leaf table model and display annotation of catalog,", function () {
+                expect(multiHopReference.columns[7].comment).toEqual({
+                    isHTML: false,
+                    unformatted: "foreign key to association table with no leaf display",
+                    value: "foreign key to association table with no leaf display",
+                    displayMode: 'tooltip'
+                });
+            });
+        });
+
+        afterAll((done) => {
+            // remove the catalog annotation
+            utils.setCatalogAnnotations(options, {}).then(() => {
+                done();
+            }).catch((err) => done.fail(err));
         });
 
     });

--- a/test/specs/reference/tests/19.comment_display_related.js
+++ b/test/specs/reference/tests/19.comment_display_related.js
@@ -2,6 +2,11 @@
  * For testing comment and comment_display using the visible foreign keys annotation, fk annotation, and table annotation.
  * This spec is divided into 3 chunks for testing "simple inbound FK", "pure and binary FK", and "inbound multi hop foreign key"
  *
+ * there are no catalog annotations in this spec
+ *   the main difference with the other test spec/schema. in the other one catalog is turning of comment markdown,
+ *   so the isHTML of that one is filpped from this one
+ *
+ *
  * The structure of the tables used for "simple inbound FK":
  * 1. comment_display_simple_fk_table <- table_w_simple_key_source_override
  * 2. comment_display_simple_fk_table <- table_w_simple_key_fk_comment
@@ -9,22 +14,22 @@
  * 4. comment_display_simple_fk_table <- table_w_simple_key_leaf_annotation
  *
  * Visible-foreign-keys for "comment_display_simple_fk_table" match the order of the above tables/foreign keys relationships:
- * 1. simple_fk_1 with comment in source syntax
- * 2. simple_fk_2 with from_comment in FK annotation
- * 3. simple_fk_3 with from_comment_display and no from_comment in FK annotation
- * 4. simple_fk_4 with comment in display annotation on table
+ * 1. simple_fk_1 with comment in source syntax (turns off markdown comment)
+ * 2. simple_fk_2 with from_comment in FK annotation (turns on markdown comment)
+ * 3. simple_fk_3 with from_comment_display and no from_comment in FK annotation (turns on markdown comment)
+ * 4. simple_fk_4 with comment in display annotation on table (turns off markdown comment)
  *
  *
  * The structure of tables used for "pure and binary FKs":
- * 1. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display
- * 2. comment_display_pb_table <- tocomment_fk_association_to_inbound_related -> inbound_related_reference_table_no_display
- * 3. comment_display_pb_table <- association_table_fk_to_comment_display -> inbound_related_reference_table_no_display
- * 4. comment_display_pb_table <- association_table_leaf_comment -> inbound_related_reference_table
+ * 1. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display (turns off markdown comment)
+ * 2. comment_display_pb_table <- tocomment_fk_association_to_inbound_related -> inbound_related_reference_table_no_display (turns on markdown comment)
+ * 3. comment_display_pb_table <- association_table_fk_to_comment_display -> inbound_related_reference_table_no_display (turns on markdown comment)
+ * 4. comment_display_pb_table <- association_table_leaf_comment -> inbound_related_reference_table (turns off markdown comment)
  *
  * The structure of tables used for "inbound multi hop foreign key":
- * 5. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table
- * 6. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table_comment_display
- * 7. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table_leaf_comment
+ * 5. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table (turns off markdown comment)
+ * 6. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table_comment_display (turns on markdown comment)
+ * 7. comment_display_pb_table <- association_table -> inbound_related_reference_table_no_display -> multi_hop_related_reference_table_leaf_comment (turns off markdown comment)
  *
  * Visible-foreign-keys for "comment_display_pb_table" match the order of the above tables/foreign keys relationships:
  * 1. pb_source_comment with comment in source syntax
@@ -39,13 +44,13 @@
  */
 exports.execute = function (options) {
 
-    xdescribe("testing foreign-key annotation,", function () {
+    describe("comment annotations usage in related references,", function () {
 
         var catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "comment_display_related_schema",
             limit = 1;
 
-        describe("testing comment and comment_display for simple foreign key", function() {
+        describe("for simple foreign key", function() {
 
             var tableSimpleFKName = "comment_display_simple_fk_table";
 
@@ -72,40 +77,45 @@ exports.execute = function (options) {
 
             });
 
-            describe("for comment,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(simpleReference.related[0].comment).toBe("simple fk source syntax comment");
-                });
-
-                it("then the from_comment in foreign-key annotation", function () {
-                    expect(simpleReference.related[1].comment).toBe("simple fk from_comment comment");
-                });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(simpleReference.related[3].comment).toBe("simple fk leaf table display comment");
+            it("source syntax in visible foreign keys should be used first", () => {
+                expect(simpleReference.related[0].comment).toEqual({
+                    value: "simple fk source syntax comment",
+                    unformatted: "simple fk source syntax comment",
+                    isHTML: false,
+                    displayMode: 'inline'
                 });
             });
 
-            describe("for comment_display,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(simpleReference.related[0].commentDisplay).toBe("inline");
-                });
-
-                it("then the from_comment_display property in foreign-key annotation if from_comment was defined", function () {
-                    expect(simpleReference.related[1].commentDisplay).toBe("inline");
-                });
-
-                it("ignore the from_comment_display property if from_comment is not defined", function () {
-                    expect(simpleReference.related[2].commentDisplay).toBe("tooltip");
-                });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(simpleReference.related[3].commentDisplay).toBe("inline");
+            it("next from_comment and from_comment_display should be used.", () => {
+                expect(simpleReference.related[1].comment).toEqual({
+                    value: "<p>simple fk from_comment comment</p>\n",
+                    unformatted: "simple fk from_comment comment",
+                    isHTML: true,
+                    displayMode: 'inline'
                 });
             });
+
+            it("by default the leaf table comment and comment_display should be used.", function () {
+                expect(simpleReference.related[3].comment).toEqual({
+                    value: 'simple fk leaf table display comment',
+                    unformatted: 'simple fk leaf table display comment',
+                    isHTML: false,
+                    displayMode: 'inline'
+                });
+            });
+
+            it ('if from_comment_display is defined but not the from_comment, leaf table comment and this proeprty should be mixed', () => {
+                expect(simpleReference.related[2].comment).toEqual({
+                    value: "<p>table with simple key to reference and a foreign key annotation with no from comment display</p>\n",
+                    unformatted: "table with simple key to reference and a foreign key annotation with no from comment display",
+                    isHTML: true,
+                    displayMode: 'inline'
+                });
+            });
+
         });
 
-        describe("testing comment and comment_display for pure and binary relation", function() {
+        describe("for pure and binary relation", function() {
 
             var tablePBName = "comment_display_pb_table";
 
@@ -132,41 +142,46 @@ exports.execute = function (options) {
 
             });
 
-            describe("for comment,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(pBReference.related[0].comment).toBe("pure and binary fk source syntax comment");
-                });
-
-                it("then the to_comment in foreign-key annotation", function () {
-                    expect(pBReference.related[1].comment).toBe("pure and binary fk to_comment");
-                });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(pBReference.related[3].comment).toBe("pure and binary fk leaf table display comment");
+            it("source syntax in visible-columns should be used first", () => {
+                expect(pBReference.related[0].comment).toEqual({
+                    value: "pure and binary fk source syntax comment",
+                    unformatted: "pure and binary fk source syntax comment",
+                    isHTML: false,
+                    displayMode: 'inline'
                 });
             });
 
-            describe("for comment_display,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(pBReference.related[0].commentDisplay).toBe("inline");
-                });
-
-                it("then the to_comment_display property in foreign-key annotation if to_comment was defined", function () {
-                    expect(pBReference.related[1].commentDisplay).toBe("inline");
-                });
-
-                it("ignore the to_comment_display property if to_comment is not defined", function () {
-                    expect(pBReference.related[2].commentDisplay).toBe("tooltip");
-                });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(pBReference.related[3].commentDisplay).toBe("inline");
+            it("next to_comment and to_comment_display should be used.", () => {
+                expect(pBReference.related[1].comment).toEqual({
+                    value: "<p>pure and binary fk to_comment</p>\n",
+                    unformatted: "pure and binary fk to_comment",
+                    isHTML: true,
+                    displayMode: 'inline'
                 });
             });
+
+            it("next the leaf table comment and comment_display should be used.", function () {
+                expect(pBReference.related[3].comment).toEqual({
+                    value: 'pure and binary fk leaf table display comment',
+                    unformatted: 'pure and binary fk leaf table display comment',
+                    isHTML: false,
+                    displayMode: 'inline'
+                });
+            });
+
+            it ('if to_comment_display is defined but not the to_comment, leaf table comment and this proeprty should be mixed', () => {
+                expect(pBReference.related[2].comment).toEqual({
+                    value: "<p>foreign key to association table no display</p>\n",
+                    unformatted: "foreign key to association table no display",
+                    isHTML: true,
+                    displayMode: 'inline'
+                });
+            });
+
         });
 
         // tests for pseudocolumn functionality when used for a related table
-        describe("testing comment and comment_display for multi hop foreign key", function() {
+        describe("for multi hop foreign key", function() {
 
             var tablePBName = "comment_display_pb_table";
 
@@ -193,28 +208,39 @@ exports.execute = function (options) {
 
             });
 
-            describe("for comment,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(multiHopReference.related[4].comment).toBe("multi hop fk source syntax comment");
-                });
-
-                it("next use display annotation on leaf table", function () {
-                    expect(multiHopReference.related[6].comment).toBe("multi hop fk leaf table display comment");
-                });
-
-                it("next use comment on leaf table,", function () {
-                    expect(multiHopReference.related[5].comment).toBe("foreign key to association table with comment_display and no comment");
+            it("source syntax in visible-columns should be used first", () => {
+                expect(multiHopReference.related[4].comment).toEqual({
+                    isHTML: false,
+                    unformatted: "multi hop fk source syntax comment",
+                    value: "multi hop fk source syntax comment",
+                    displayMode: 'inline'
                 });
             });
 
-            describe("for comment_display,", function () {
-                it("source syntax in visible foreign keys should be used first", function () {
-                    expect(multiHopReference.related[4].commentDisplay).toBe("inline");
+            it("next use display annotation on leaf table", function () {
+                expect(multiHopReference.related[6].comment).toEqual({
+                    isHTML: true,
+                    unformatted: "multi hop fk leaf table display comment",
+                    value: "<p>multi hop fk leaf table display comment</p>\n",
+                    displayMode: 'inline'
                 });
+            });
 
-                it("next use display annotation on leaf table", function () {
-                    expect(multiHopReference.related[5].commentDisplay).toBe("inline", "missmatch for index=5");
-                    expect(multiHopReference.related[6].commentDisplay).toBe("inline", "missmatch for index=6");
+            it("next use comment on leaf table model while using comment_display and markdown of display annotation,", function () {
+                expect(multiHopReference.related[5].comment).toEqual({
+                    isHTML: false,
+                    unformatted: "foreign key to association table with comment_display and no comment",
+                    value: "foreign key to association table with comment_display and no comment",
+                    displayMode: 'inline'
+                });
+            });
+
+            it("next use comment on leaf table model and display annotation of catalog,", function () {
+                expect(multiHopReference.related[7].comment).toEqual({
+                    isHTML: true,
+                    unformatted: "foreign key to association table with no leaf display",
+                    value: "<p>foreign key to association table with no leaf display</p>\n",
+                    displayMode: 'tooltip'
                 });
             });
         });

--- a/test/specs/reference/tests/19.comment_display_related.js
+++ b/test/specs/reference/tests/19.comment_display_related.js
@@ -39,7 +39,7 @@
  */
 exports.execute = function (options) {
 
-    describe("testing foreign-key annotation,", function () {
+    xdescribe("testing foreign-key annotation,", function () {
 
         var catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "comment_display_related_schema",


### PR DESCRIPTION
The main purpose of this PR is to add support for markdown in the raw value of `comment` APIs (#981). But instead of adding a separate `commentRenderMarkdown`, I changed `.comment` returned value to an object (similar to how `.displayname` works). This allows us also to remove `.commentDisplay` and have it as part of the object. 

Other changes are,

- Contextualized `comment` are now supported.

- Fix the inheritance of `comment_display` from the parent catalog, schema, or table.

- `comment`, `comment_display`, and `comment_render_markdown`  can come from different levels and don't affect each other. Before, we used to only get the `comment_display` from where the `comment` was defined. But now `comment_display` can come from the column directive while the `comment` is derived from the table (or vice versa). 

- Moved the comment-related APIs of `ForeignkeyRef` and `Key` to `getDisplay`, similar to how we've done it on `Table` and `Column`. 

Since I completely changed how the `.comment` API works in here, we have to merge this at the same time as the chaise one.