### PR TITLE
Treat null value of json the same as other types

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -2780,12 +2780,10 @@
 
             var self = this;
 
-            //This check has been added to show "null" in all the rows if the user inputs blank string
-            //We are opting json out here because we want null in the UI instead of "", so we do not call _getNullValue for json
-            if (data === undefined || (data === null && this.type.name.indexOf('json') === -1)) {
+            // this used to treat json differently but we don't want that anymore.
+            // since we cannot distinguish between json null and database null, we decided to show it as database null anyways.
+            if (data === undefined || data === null) {
                 return this._getNullValue(context);
-            } else if (data === null && this.type.name.indexOf('json') !== 0) {
-                return data;
             }
 
             var display = this.getDisplay(context);
@@ -2848,7 +2846,13 @@
              * If column doesn't has column-display annotation and is not of type markdown
              * but the column type is json then append <pre> tag and return the value
              */
-            if (!display.isHTML && this.type.name.indexOf('json') !== -1) {
+            if (!display.isHTML && this.type.name.indexOf('json') === 0) {
+                // jsonb column should be treated similar to other columns, so
+                // If value is null or empty, return value on based on `show_null` instead of adding the code block.
+                if (rawValue === null || rawValue === undefined) {
+                    return { isHTML: false, value: this._getNullValue(context), unformatted: this._getNullValue(context) };
+                }
+
                 return { isHTML: true, value: '<pre>' + formattedValue + '</pre>', unformatted: formattedValue};
             }
 

--- a/test/specs/reference/tests/17.reference_pre_format_values.js
+++ b/test/specs/reference/tests/17.reference_pre_format_values.js
@@ -67,13 +67,13 @@ exports.execute = function (options) {
 
         describe("testing tuple values for format", function() {
             var testObjects = [{
-                "expectedValues": ["4000","Hank","http://example.com/google.com","No","10000000000 1024 1024 1.024e+3","   0.234","<pre>null</pre>", "", ""]
+                "expectedValues": ["4000","Hank","http://example.com/google.com","No","10000000000 1024 1024 1.024e+3","   0.234","", "", ""]
             },
             {
                 "expectedValues": ["4001","Harold", "","Yes","", "10,000.345", "<pre>My name is Harold Durden. My age is 29 years and I study at USC located in Los Angeles, CA. My GPA is 3.93</pre>", "", ""]
             },
             {
-                "expectedValues": ["4002", null, "http://example.com/google.com","","10001100101001 9001 9001 9.001e+3","","<pre>null</pre>", "<p>YES, NOPE, <em>No value</em></p>\n", "<p>2.340, 2.400, <em>No value</em></p>\n"]
+                "expectedValues": ["4002", null, "http://example.com/google.com","","10001100101001 9001 9001 9.001e+3","","", "<p>YES, NOPE, <em>No value</em></p>\n", "<p>2.340, 2.400, <em>No value</em></p>\n"]
             }];
 
             var i = 0;


### PR DESCRIPTION
This PR will apply the change described [here](https://github.com/informatics-isi-edu/chaise/issues/2394#issuecomment-1922625444).

> We should stop treating `json`/`jsonb` columns differently in read-only modes. So, a `null` value should be treated like a database null, and therefore, we should honor the `show_null` annotation for it (instead of forcefully showing the `null` in a code block).


The other changed mentioned in the comment required more changes, so I decided to not include it in the same PR.