### PR TITLE
Add support for pattern_sources in domain_filter

### DIFF
--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -540,6 +540,8 @@ to use for ERMrest JavaScript agents.
         * [.reference](#ERMrest.ForeignKeyPseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
         * [.foreignKey](#ERMrest.ForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
         * [.hasDomainFilter](#ERMrest.ForeignKeyPseudoColumn+hasDomainFilter) : <code>Boolean</code>
+        * [.domainFilterUsedColumns](#ERMrest.ForeignKeyPseudoColumn+domainFilterUsedColumns) : [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+        * [.domainFilterRawString](#ERMrest.ForeignKeyPseudoColumn+domainFilterRawString) : <code>string</code>
         * [.defaultValues](#ERMrest.ForeignKeyPseudoColumn+defaultValues) : <code>Object</code>
         * [.defaultReference](#ERMrest.ForeignKeyPseudoColumn+defaultReference) : <code>ERMrest.Refernece</code>
         * [.displayname](#ERMrest.ForeignKeyPseudoColumn+displayname) : <code>Object</code>
@@ -4935,6 +4937,8 @@ In other cases, the returned data will only include the scalar value.
     * [.reference](#ERMrest.ForeignKeyPseudoColumn+reference) : [<code>Reference</code>](#ERMrest.Reference)
     * [.foreignKey](#ERMrest.ForeignKeyPseudoColumn+foreignKey) : [<code>ForeignKeyRef</code>](#ERMrest.ForeignKeyRef)
     * [.hasDomainFilter](#ERMrest.ForeignKeyPseudoColumn+hasDomainFilter) : <code>Boolean</code>
+    * [.domainFilterUsedColumns](#ERMrest.ForeignKeyPseudoColumn+domainFilterUsedColumns) : [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+    * [.domainFilterRawString](#ERMrest.ForeignKeyPseudoColumn+domainFilterRawString) : <code>string</code>
     * [.defaultValues](#ERMrest.ForeignKeyPseudoColumn+defaultValues) : <code>Object</code>
     * [.defaultReference](#ERMrest.ForeignKeyPseudoColumn+defaultReference) : <code>ERMrest.Refernece</code>
     * [.displayname](#ERMrest.ForeignKeyPseudoColumn+displayname) : <code>Object</code>
@@ -4980,6 +4984,18 @@ The Foreign key object that this PseudoColumn is created based on
 
 #### foreignKeyPseudoColumn.hasDomainFilter : <code>Boolean</code>
 Whether this column has domain-filter annotation
+
+**Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+<a name="ERMrest.ForeignKeyPseudoColumn+domainFilterUsedColumns"></a>
+
+#### foreignKeyPseudoColumn.domainFilterUsedColumns : [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+The visible columns that are used as part of the domain-filter
+
+**Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
+<a name="ERMrest.ForeignKeyPseudoColumn+domainFilterRawString"></a>
+
+#### foreignKeyPseudoColumn.domainFilterRawString : <code>string</code>
+The raw string value of the ermerst_path_pattern used in domain filter
 
 **Kind**: instance property of [<code>ForeignKeyPseudoColumn</code>](#ERMrest.ForeignKeyPseudoColumn)  
 <a name="ERMrest.ForeignKeyPseudoColumn+defaultValues"></a>

--- a/docs/dev-docs/api.md
+++ b/docs/dev-docs/api.md
@@ -449,7 +449,7 @@ to use for ERMrest JavaScript agents.
         * [.getAggregates(aggregateList)](#ERMrest.Reference+getAggregates) ⇒ <code>Promise</code>
         * [.setSamePaging(page)](#ERMrest.Reference+setSamePaging) ⇒ [<code>Reference</code>](#ERMrest.Reference)
         * [.getColumnByName(name)](#ERMrest.Reference+getColumnByName) ⇒ [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)
-        * [.generateColumnsList(tuple)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+        * [.generateColumnsList(tuple, columnsList, dontChangeReference, skipLog)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
         * [.generateActiveList([tuple])](#ERMrest.Reference+generateActiveList) ⇒ <code>Object</code>
         * [._getReadPath(useEntity, getTRS, getTCRS, getUnlinkTRS)](#ERMrest.Reference+_getReadPath) : <code>Object</code>
             * [~processSortObject()](#ERMrest.Reference+_getReadPath..processSortObject)
@@ -783,7 +783,7 @@ to use for ERMrest JavaScript agents.
         * [.getAggregates(aggregateList)](#ERMrest.Reference+getAggregates) ⇒ <code>Promise</code>
         * [.setSamePaging(page)](#ERMrest.Reference+setSamePaging) ⇒ [<code>Reference</code>](#ERMrest.Reference)
         * [.getColumnByName(name)](#ERMrest.Reference+getColumnByName) ⇒ [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)
-        * [.generateColumnsList(tuple)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+        * [.generateColumnsList(tuple, columnsList, dontChangeReference, skipLog)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
         * [.generateActiveList([tuple])](#ERMrest.Reference+generateActiveList) ⇒ <code>Object</code>
         * [._getReadPath(useEntity, getTRS, getTCRS, getUnlinkTRS)](#ERMrest.Reference+_getReadPath) : <code>Object</code>
             * [~processSortObject()](#ERMrest.Reference+_getReadPath..processSortObject)
@@ -3198,7 +3198,7 @@ Constructor for a ParsedFilter.
     * [.getAggregates(aggregateList)](#ERMrest.Reference+getAggregates) ⇒ <code>Promise</code>
     * [.setSamePaging(page)](#ERMrest.Reference+setSamePaging) ⇒ [<code>Reference</code>](#ERMrest.Reference)
     * [.getColumnByName(name)](#ERMrest.Reference+getColumnByName) ⇒ [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)
-    * [.generateColumnsList(tuple)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+    * [.generateColumnsList(tuple, columnsList, dontChangeReference, skipLog)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
     * [.generateActiveList([tuple])](#ERMrest.Reference+generateActiveList) ⇒ <code>Object</code>
     * [._getReadPath(useEntity, getTRS, getTCRS, getUnlinkTRS)](#ERMrest.Reference+_getReadPath) : <code>Object</code>
         * [~processSortObject()](#ERMrest.Reference+_getReadPath..processSortObject)
@@ -3910,7 +3910,7 @@ Will throw an error if
 
 <a name="ERMrest.Reference+generateColumnsList"></a>
 
-#### reference.generateColumnsList(tuple) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+#### reference.generateColumnsList(tuple, columnsList, dontChangeReference, skipLog) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
 Generates the list of visible columns
 The logic is as follows:
 
@@ -3963,6 +3963,9 @@ NOTE:
 | Param | Type | Description |
 | --- | --- | --- |
 | tuple | [<code>Tuple</code>](#ERMrest.Tuple) | the data for the current refe |
+| columnsList | <code>Array.&lt;Object&gt;</code> | if passed, we will skip the annotation and heuristics and use this list instead. |
+| dontChangeReference | <code>boolean</code> | whether we should mutate the reference or just return the generated list. |
+| skipLog | <code>boolean</code> | whether we should skip logging the warning messages |
 
 <a name="ERMrest.Reference+generateActiveList"></a>
 
@@ -7046,7 +7049,7 @@ get PathColumn object by column name
     * [.getAggregates(aggregateList)](#ERMrest.Reference+getAggregates) ⇒ <code>Promise</code>
     * [.setSamePaging(page)](#ERMrest.Reference+setSamePaging) ⇒ [<code>Reference</code>](#ERMrest.Reference)
     * [.getColumnByName(name)](#ERMrest.Reference+getColumnByName) ⇒ [<code>ReferenceColumn</code>](#ERMrest.ReferenceColumn)
-    * [.generateColumnsList(tuple)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+    * [.generateColumnsList(tuple, columnsList, dontChangeReference, skipLog)](#ERMrest.Reference+generateColumnsList) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
     * [.generateActiveList([tuple])](#ERMrest.Reference+generateActiveList) ⇒ <code>Object</code>
     * [._getReadPath(useEntity, getTRS, getTCRS, getUnlinkTRS)](#ERMrest.Reference+_getReadPath) : <code>Object</code>
         * [~processSortObject()](#ERMrest.Reference+_getReadPath..processSortObject)
@@ -7758,7 +7761,7 @@ Will throw an error if
 
 <a name="ERMrest.Reference+generateColumnsList"></a>
 
-#### reference.generateColumnsList(tuple) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
+#### reference.generateColumnsList(tuple, columnsList, dontChangeReference, skipLog) ⇒ [<code>Array.&lt;ReferenceColumn&gt;</code>](#ERMrest.ReferenceColumn)
 Generates the list of visible columns
 The logic is as follows:
 
@@ -7811,6 +7814,9 @@ NOTE:
 | Param | Type | Description |
 | --- | --- | --- |
 | tuple | [<code>Tuple</code>](#ERMrest.Tuple) | the data for the current refe |
+| columnsList | <code>Array.&lt;Object&gt;</code> | if passed, we will skip the annotation and heuristics and use this list instead. |
+| dontChangeReference | <code>boolean</code> | whether we should mutate the reference or just return the generated list. |
+| skipLog | <code>boolean</code> | whether we should skip logging the warning messages |
 
 <a name="ERMrest.Reference+generateActiveList"></a>
 

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -470,7 +470,7 @@ Supported _domainfilter_ syntax:
 
 Supported _columnlist_ patterns:
 
- - `[` ... _columndirective_ `,` ... `]`: The list of [columns directives](#column-directive) that are used in the pattern.
+ - `[` ... _columndirective_ `,` ... `]`: The list of [columns directives](#column-directive) that are used in the `ermrest_path_pattern`. Make sure to use the same column directive as visible columns. For example if you've used column named `fk_col` in the pattern, but the foreign key that this column is part of visible, you should include the foreign key column here (and not the `fk_col` itself).
 
 Supported _filter_ syntax:
 

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -463,8 +463,14 @@ Supported _columnorder_key_ syntax:
 
 Supported _domainfilter_ syntax:
 - `{ "ermrest_path_pattern":` _pathpattern_ `}`: The _pathpattern_ yields a _filter_ via [Pattern Expansion](#pattern-expansion). With this syntax, the applied filter will be hidden from the user.
+- `{ "ermrest_path_pattern":` _pathpattern_ `, "pattern_sources":` _columnlist_ `}`: The added `pattern_sources` allows the client to proceed more meaningful errors to users.
 - `{ "ermrest_path_pattern":` _pathpattern_ `, "display_markdown_pattern":` _displaypattern_ `}`: The _pathpattern_ yields a _filter_ via [Pattern Expansion](#pattern-expansion). _displaypattern_ will provide the visual presentation of the filter which will be computed by performing [Pattern Expansion](#pattern-expansion) to obtain a markdown-formatted text value which MAY be rendered using a markdown-aware renderer.
   - If the computed _filter_ is an empty string, the _domain_filter_ will be ignored, and the client behaves as if this annotation is not even defined. Therefore, while rendering the list of allowed foreign key rows in recordedit, users will see the whole list.
+- `{ "ermrest_path_pattern":` _pathpattern_ `, "display_markdown_pattern":` _displaypattern_ `, "pattern_sources":` _columnlist_ `}`:  The added `pattern_sources` allows the client to proceed more meaningful errors to users.
+
+Supported _columnlist_ patterns:
+
+ - `[` ... _columndirective_ `,` ... `]`: The list of [columns directives](#column-directive) that are used in the pattern.
 
 Supported _filter_ syntax:
 

--- a/js/column.js
+++ b/js/column.js
@@ -1918,6 +1918,8 @@ Object.defineProperty(ForeignKeyPseudoColumn.prototype, "hasDomainFilter", {
             var populateDomainFilterProps = function (self) {
                 // the annotaion didn't exist
                 if (!self.foreignKey.annotations.contains(module._annotations.FOREIGN_KEY)) {
+                    self._domainFilterRawString = '';
+                    self._domainFilterUsedColumns = [];
                     return false;
                 }
 
@@ -1929,19 +1931,7 @@ Object.defineProperty(ForeignKeyPseudoColumn.prototype, "hasDomainFilter", {
 
                     var usedColumns = [];
                     if (Array.isArray(content.domain_filter.pattern_sources)) {
-                        content.domain_filter.pattern_sources.forEach(function (col) {
-                            var visCol;
-                            try {
-                                // TODO we might be more smart about this
-                                // for example if a raw column is used but the fk is visible, should we mention the fk?
-                                // TODO I should most probably move the vis-col logic somewhere so it can be called from here
-                                // that way they can use sourcekey etc...
-                                visCol = self._baseReference.getColumnByName(Array.isArray(col) ? col.join('_') : col);
-                            } catch(exp) {
-                                // fail silently
-                            }
-                            if (visCol) usedColumns.push(visCol);
-                        });
+                        usedColumns = self._baseReference.generateColumnsList(undefined, content.domain_filter.pattern_sources, true, true);
                     }
                     self._domainFilterUsedColumns = usedColumns;
 

--- a/js/column.js
+++ b/js/column.js
@@ -1915,7 +1915,7 @@ ForeignKeyPseudoColumn.prototype._determineSortable = function () {
 Object.defineProperty(ForeignKeyPseudoColumn.prototype, "hasDomainFilter", {
     get: function () {
         if (this._hasDomainFilter === undefined) {
-            var checkDomainFilter = function (self) {
+            var populateDomainFilterProps = function (self) {
                 // the annotaion didn't exist
                 if (!self.foreignKey.annotations.contains(module._annotations.FOREIGN_KEY)) {
                     return false;
@@ -1925,21 +1925,74 @@ Object.defineProperty(ForeignKeyPseudoColumn.prototype, "hasDomainFilter", {
 
                 // the annotation is properly defined
                 if (isObjectAndNotNull(content.domain_filter) && isStringAndNotEmpty(content.domain_filter.ermrest_path_pattern)) {
+                    self._domainFilterRawString = content.domain_filter.ermrest_path_pattern;
+
+                    var usedColumns = [];
+                    if (Array.isArray(content.domain_filter.pattern_sources)) {
+                        content.domain_filter.pattern_sources.forEach(function (col) {
+                            var visCol;
+                            try {
+                                // TODO we might be more smart about this
+                                // for example if a raw column is used but the fk is visible, should we mention the fk?
+                                // TODO I should most probably move the vis-col logic somewhere so it can be called from here
+                                // that way they can use sourcekey etc...
+                                visCol = self._baseReference.getColumnByName(Array.isArray(col) ? col.join('_') : col);
+                            } catch(exp) {
+                                // fail silently
+                            }
+                            if (visCol) usedColumns.push(visCol);
+                        });
+                    }
+                    self._domainFilterUsedColumns = usedColumns;
+
                     return true;
                 }
                 // backward compatibility
                 else if (typeof content.domain_filter_pattern === "string") {
+                    self._domainFilterRawString = content.domain_filter_pattern;
+                    self._domainFilterUsedColumns = [];
                     return true;
                 }
 
+                self._domainFilterRawString = '';
+                self._domainFilterUsedColumns = [];
                 return false;
             };
 
-            this._hasDomainFilter = checkDomainFilter(this);
+            this._hasDomainFilter = populateDomainFilterProps(this);
         }
         return this._hasDomainFilter;
     }
 });
+/**
+ * The visible columns that are used as part of the domain-filter
+ * @member {ERMrest.ReferenceColumn[]} domainFilterUsedColumns
+ * @memberof ERMrest.ForeignKeyPseudoColumn#
+ */
+Object.defineProperty(ForeignKeyPseudoColumn.prototype, 'domainFilterUsedColumns', {
+    get: function () {
+        if (this._domainFilterUsedColumns === undefined) {
+            // this will popuplate _domainFilterUsedColumns too
+            var temp = this.hasDomainFilter;
+        }
+        return this._domainFilterUsedColumns;
+    }
+});
+/**
+ * The raw string value of the ermerst_path_pattern used in domain filter
+ * @member {string} domainFilterRawString
+ * @memberof ERMrest.ForeignKeyPseudoColumn#
+ */
+Object.defineProperty(ForeignKeyPseudoColumn.prototype, 'domainFilterRawString', {
+    get: function () {
+        if (this._domainFilterRawString === undefined) {
+            // this will popuplate _domainFilterRawString too
+            var temp = this.hasDomainFilter;
+        }
+        return this._domainFilterRawString;
+    }
+});
+
 
 /**
  * returns the raw default values of the constituent columns.

--- a/test/specs/column/conf/columns_schema/schema.json
+++ b/test/specs/column/conf/columns_schema/schema.json
@@ -1299,7 +1299,8 @@
                         "tag:isrd.isi.edu,2016:foreign-key": {
                             "domain_filter": {
                                 "ermrest_path_pattern": "position_type_col={{{_position_text_col}}}",
-                                "display_markdown_pattern": "**position_type_col**: {{{_position_text_col}}}"
+                                "display_markdown_pattern": "**position_type_col**: {{{_position_text_col}}}",
+                                "pattern_sources": ["position_text_col"]
                             }
                         }
                     },
@@ -1325,7 +1326,8 @@
                         "tag:isrd.isi.edu,2016:foreign-key": {
                             "domain_filter": {
                                 "ermrest_path_pattern": "fk2={{{_fk1}}}&position_col={{{_position_text_col}}}",
-                                "display_markdown_pattern": "**fk2**: {{{_fk1}}} and **position_col**:{{{_position_text_col}}}"
+                                "display_markdown_pattern": "**fk2**: {{{_fk1}}} and **position_col**:{{{_position_text_col}}}",
+                                "pattern_sources": ["position_text_col", ["columns_schema", "fk_no_constraint"], "some_invalid_column"]
                             }
                         }
                     },
@@ -1351,7 +1353,16 @@
                         "tag:isrd.isi.edu,2016:foreign-key": {
                             "domain_filter": {
                                 "ermrest_path_pattern": "fk2={{{$fkeys.columns_schema.fk_position_predefined.values._int_value}}}&position_col={{{$fkeys.columns_schema.fk_position_user_defined.values._int_value}}}&id={{{_fk1}}}",
-                                "display_markdown_pattern": "**fk2**: {{{$fkeys.columns_schema.fk_position_predefined.values._int_value}}} and **position_col**:{{{$fkeys.columns_schema.fk_position_user_defined.values._int_value}}}"
+                                "display_markdown_pattern": "**fk2**: {{{$fkeys.columns_schema.fk_position_predefined.values._int_value}}} and **position_col**:{{{$fkeys.columns_schema.fk_position_user_defined.values._int_value}}}",
+                                "pattern_sources": [
+                                    {"sourcekey": "fk2"},
+                                    {
+                                        "source": [
+                                            {"outbound": ["columns_schema", "fk_position_user_defined"]},
+                                            "RID"
+                                        ]
+                                    }
+                                ]
                             }
                         }
                     },
@@ -1439,6 +1450,18 @@
                         "position_text_col", ["columns_schema", "fk_position_user_defined"],
                         ["columns_schema", "fk_multi_constrained"], ["columns_schema", "fk_using_fkeys"]
                     ]
+                },
+                "tag:isrd.isi.edu,2019:source-definitions": {
+                    "columns": true,
+                    "fkeys": true,
+                    "sources": {
+                        "fk2": {
+                            "source": [
+                                {"outbound": ["columns_schema", "fk_position_predefined"]},
+                                "RID"
+                            ]
+                        }
+                    }
                 }
             }
         },

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -1,3 +1,5 @@
+const utils = require('./../../../utils/utilities.js');
+
 /**
  * All the test cases related to the ReferenceColumn object.
  */
@@ -577,7 +579,7 @@ exports.execute = function (options) {
             });
         });
 
-        describe('.filteredRef and .hasDomainFilter, ', function() {
+        describe('domain-filter related APIs, ', function() {
             var mainEntityReference, mainEntityColumns, filteredReference, mainEntityData, foreignKeyData,
                 mainEntityTableName = "main-entity-table",
                 schemaUri = options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":";
@@ -633,6 +635,32 @@ exports.execute = function (options) {
                         expect(mainEntityColumns.map(function (col) {
                             return !!col.hasDomainFilter;
                         })).toEqual(jasmine.arrayContaining([false, false, true, true, false, true, true, true]), "fkeys elements missmatch.");
+                    });
+
+                    it ('domainFilterRawString should return the proper values.', () => {
+                        expect(mainEntityColumns.map(col => col.domainFilterRawString)).toEqual(jasmine.arrayContaining([
+                            undefined, '',
+                            'fk2={{{_fk1}}}', 'position_type_col=fixed', undefined,
+                            'position_type_col={{{_position_text_col}}}', 'fk2={{{_fk1}}}&position_col={{{_position_text_col}}}',
+                            'fk2={{{$fkeys.columns_schema.fk_position_predefined.values._int_value}}}&position_col={{{$fkeys.columns_schema.fk_position_user_defined.values._int_value}}}&id={{{_fk1}}}',
+                        ]));
+                    });
+
+                    it ('domainFilterUsedColumns should return the proper values (should be able to handle different type of columns).', () => {
+                        utils.checkColumnList(mainEntityColumns[5].domainFilterUsedColumns, ['position_text_col'], 'mainEntityColumns[5]');
+
+                        utils.checkColumnList(
+                            mainEntityColumns[6].domainFilterUsedColumns,
+                            ['position_text_col', 'columns_schema_fk_no_constraint'],
+                            'mainEntityColumns[6]'
+                        );
+
+                        utils.checkColumnList(
+                            mainEntityColumns[7].domainFilterUsedColumns,
+                            ["columns_schema_fk_position_predefined", "columns_schema_fk_position_user_defined"],
+                            'mainEntityColumns[7]'
+                        );
+                        // mainEntityColumns
                     });
 
                     describe('should return a filtered reference based on provided data.', function () {

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -1,3 +1,5 @@
+const utils = require('./../../../utils/utilities.js');
+
 /**
  * The structure of table and contexts used:
  * main -> f1 -> f2
@@ -64,8 +66,6 @@
  * 1: inbound_3 association
  * 1: inbound_3_outbound_1 (association -> fk)
  */
-
- var utils = require('./../../../utils/utilities.js');
 
 
 exports.execute = function (options) {
@@ -1321,18 +1321,7 @@ exports.execute = function (options) {
 
     function checkReferenceColumns(tesCases) {
         tesCases.forEach(function (test) {
-            var expected;
-            expect(test.ref.columns.map(function (col) {
-                // the name for pseudoColumns is a hash, this way of testing it is easier to read
-                if (col.isPathColumn) {
-                    return col.sourceObject.source;
-                }
-                if (col.isPseudo && (col.isKey || col.isForeignKey || col.isInboundForeignKey)) {
-
-                    return col._constraintName;
-                }
-                return  col.name;
-            })).toEqual(test.expected, test.message ? test.message : "checkReferenceColumns");
+            utils.checkColumnList(test.ref.columns, test.expected, test.message ? test.message : "checkReferenceColumns");
         });
     }
 

--- a/test/utils/utilities.js
+++ b/test/utils/utilities.js
@@ -26,6 +26,20 @@ exports.checkPageValues = function(pageData, tuples, sortBy) {
     }
 };
 
+exports.checkColumnList = function (columns, expectedColNames, message) {
+    expect(columns.map(function (col) {
+        // the name for pseudoColumns is a hash, this way of testing it is easier to read
+        if (col.isPathColumn) {
+            return col.sourceObject.source;
+        }
+        if (col.isPseudo && (col.isKey || col.isForeignKey || col.isInboundForeignKey)) {
+
+            return col._constraintName;
+        }
+        return  col.name;
+    })).toEqual(expectedColNames, message);
+}
+
 
 exports.setCatalogAcls = function (ERMrest, done, uri, catalogId, acls, cb, userCookie) {
     ermrestImport.importAcls(acls).then(function () {


### PR DESCRIPTION
This PR introduces new APIs that are needed for [this PR in chaise](https://github.com/informatics-isi-edu/chaise/pull/2400).

As part of this we've added `pattern_sources` property to `domain_filter`:

This is used to generate better error messages in chaise (refer to [the chaise issue](https://github.com/informatics-isi-edu/chaise/issues/2397) for more information). 

