### PR TITLE
Modify update to compare dates/timestamps better

### DIFF
--- a/js/reference.js
+++ b/js/reference.js
@@ -1673,29 +1673,26 @@
                     // don't add a column name in if it's already there
                     // this can be the case for multi-edit
                     // and if the data is unchanged, no need to add the column name to the projections list
-                    // NOTE: This doesn't properly verify if date/timestamp/timestamptz values were changed
-                    if (columnProjections.indexOf(colName) === -1) {
-                        var typename = colType.rootName;
-                        var compareWithMoment = typename === 'date' || typename === 'timestamp' || typename === 'timestamptz';
-                        if (compareWithMoment) {
-                            var moment = module._moment;
-                            var formats = module._dataFormats;
+                    if (columnProjections.indexOf(colName) !== -1) return;
 
-                            // default to DATE format, if timestamp or timestamptz, change the format used
-                            var formatToUse = formats.DATE;
-                            if (typename === 'timestamp') {
-                                formatToUse = formats.TIMESTAMP;
-                            } else if (typename === 'timestamptz') {
-                                formatToUse = formats.DATETIME.return;
-                            }
+                    var oldVal = oldData[colName]
+                    var newVal = newData[colName]
 
-                            var oldVal = moment(oldData[colName], formatToUse, true).format(formatToUse);
-                            var newVal = moment(newData[colName], formatToUse, true).format(formatToUse);
+                    var typename = colType.rootName;
+                    var compareWithMoment = typename === 'date' || typename === 'timestamp' || typename === 'timestamptz';
+                    // test with moment if datetime column type and one of the 2 values are defined
+                    // NOTE: moment will test 2 null values as different even though they are both null
+                    if (compareWithMoment && (oldVal || newVal)) {
+                        var moment = module._moment;
+                        
+                        var oldMoment = moment(oldData[colName])
+                        var newMoment = moment(newData[colName])
 
-                            if (oldVal != newVal) columnProjections.push(colName);
-                        } else if ( (oldData[colName] != newData[colName]) ) {
+                        if (!oldMoment.isSame(newMoment)) {
                             columnProjections.push(colName);
                         }
+                    } else if (oldData[colName] != newData[colName]) {
+                        columnProjections.push(colName);
                     }
                 };
 

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -103,11 +103,10 @@
         DEFAULT: '*',
         ROWNAME: 'row_name'
     });
-  
+
     module._dataFormats = Object.freeze({
         DATE: "YYYY-MM-DD",
         TIME: "HH:mm:ss",
-        TIMESTAMP: 'YYYY-MM-DDTHH:mm:ss',
         DATETIME: {
             display: "YYYY-MM-DD HH:mm:ss",
             return: "YYYY-MM-DDTHH:mm:ssZ", // the format that the database returns when there are no fractional seconds to show

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -103,10 +103,11 @@
         DEFAULT: '*',
         ROWNAME: 'row_name'
     });
-
+  
     module._dataFormats = Object.freeze({
         DATE: "YYYY-MM-DD",
         TIME: "HH:mm:ss",
+        TIMESTAMP: 'YYYY-MM-DDTHH:mm:ss',
         DATETIME: {
             display: "YYYY-MM-DD HH:mm:ss",
             return: "YYYY-MM-DDTHH:mm:ssZ", // the format that the database returns when there are no fractional seconds to show

--- a/test/specs/reference/conf/update_schema/data/update_table_with_date_and_timestamps.json
+++ b/test/specs/reference/conf/update_schema/data/update_table_with_date_and_timestamps.json
@@ -1,0 +1,1 @@
+[{"key": 1, "date_col": null, "timestamp_col": "2024-02-27T14:14:12", "timestamptz_col": "2024-02-28T20:39:25+00:00"}]

--- a/test/specs/reference/conf/update_schema/schema.json
+++ b/test/specs/reference/conf/update_schema/schema.json
@@ -243,6 +243,50 @@
             ],
             "annotations": {}
         },
+        "update_table_with_date_and_timestamps": {
+            "comment": "Table to represent a reference object with date and timestamp columns.",
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "key"
+                    ]
+                }
+            ],
+            "foreign_keys": [],
+            "table_name": "update_table_with_date_and_timestamps",
+            "schema_name": "update_schema",
+            "column_definitions": [
+                {
+                    "name": "key",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                }, {
+                    "name": "date_col",
+                    "nullok": true,
+                    "type": {
+                        "typename": "date"
+                    }
+                }, {
+                    "name": "timestamp_col",
+                    "nullok": true,
+                    "type": {
+                        "typename": "timestamp"
+                    }
+                }, {
+                    "name": "timestamptz_col",
+                    "nullok": true,
+                    "type": {
+                        "typename": "timestamptz"
+                    }
+                }
+            ],
+            "annotations": {}
+        },
         "table_w_composite_key": {
             "comment": "Table with composite key",
             "kind": "table",
@@ -383,6 +427,7 @@
         "alias_table",
         "update_table",
         "update_table_with_foreign_key",
+        "update_table_with_date_and_timestamps",
         "table_w_composite_key",
         "table_w_composite_key_as_shortest_key",
         "table_w_independent_key"


### PR DESCRIPTION
This PR addresses an issue in chaise where a timestamptz value can be submitted to ermrest for update but the value was unchanged. This can occur if the old/new value has fractional seconds and the other value doesn't. This can also occur when the timezone of the user is different from the timezone the data is returned in.

For the case of date and timestamp, it's almost unlikely that this precision matters but it's still worth converting these values to similar formats anyways to ensure a consistent comparison.

#### using `isSame()` from moment
For comparing dates and timestamps, instead of defining the format and outputting the moment object using `.format()`, I’m letting moment parse the value without telling it the format. To compare the values, using `isSame()` works how we expect when the values can be properly parsed to moment objects.

On thing to note, f the values are both null, moment will create an object with “invalid date” as the value for both. When you use `isSame()` for 2 invalid dates that both were created from null, they are considered different.

Related ermrestJS issue #463 