### PR TITLE
Format scientific float

### DIFF
--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1817,7 +1817,21 @@
             if (options.numFracDigits) {
                 value = value.toFixed(options.numFracDigits); // toFixed() rounds the value, is ok?
             } else {
-                value = value.toFixed(4);
+                // if the float has 13 digits or more (1 trillion or greater)
+                // or the float has 7 decimals or more, use scientific notation
+                //    NOTE: javascript in browser uses 22 as the threshold for large numbers
+                //          If there are 22 digits or more, then scientific notation is used
+                //          ecmascript language spec: https://262.ecma-international.org/5.1/#sec-9.8.1
+                if (Math.abs(value) >= 1000000000000 || Math.abs(value) < 0.000001) {
+                    // this also ensures there are more digits than the precision used 
+                    // so the number will be converted to scientific notation instead of
+                    // being padded with zeroes with no conversion
+                    // for example: 0.000001.toPrecision(4) ==> '0.000001000'
+                    value = value.toPrecision(5)
+                } else {
+                    value = value.toFixed(4);
+                }
+                
             }
 
             // Remove leading zeroes

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -12,6 +12,17 @@ exports.execute = function (options) {
             expect(printFloat(1234.0, options)).toBe('1,234.0000');
             expect(printFloat(23.0)).toBe('23.0000');
             expect(printFloat(.000)).toBe('0.0000');
+
+            // scientific notation tests
+            expect(printFloat(100000000000)).toBe('100,000,000,000.0000');
+            expect(printFloat(1000000000000)).toBe('1.0000e+12');
+            expect(printFloat(.000001)).toBe('0.0000');
+            expect(printFloat(.0000001)).toBe('1.0000e-7');
+
+            expect(printFloat(1e11)).toBe('100,000,000,000.0000');
+            expect(printFloat(1e12)).toBe('1.0000e+12');
+            expect(printFloat(1e-6)).toBe('0.0000');
+            expect(printFloat(1e-7)).toBe('1.0000e-7');
         });
 
         it('printBoolean() should format booleans correctly.', function () {


### PR DESCRIPTION
Changes in this PR are intended to improve how we are displaying formatted float values when no pre-format annotation is provided. We noticed the browser will automatically change a `number` after a certain threshold to display in scientific notation.

We discussed in our meeting with Hongsuda that the thresholds for our code should be 1 trillion (or more than 12 digits) and `0.0000007` (or more than 6 decimal places before the first non zero digit is present).

I noted in the code that this is still not ideal since there is a range where some values won't "display" since our default display is `4` digits after the zero. So when there are 5 or 6 digits after the zero, the digits in the 5th and 6th place might be lost when displayed. The workaround for this is to use the pre-format annotation. This limitation exists in the code before this branch is merged. If this needs to be addressed, we should do it separately and also discuss handling trailing values being truncated too (10000000000001 will have the last 1 changed to a 0).