### PR TITLE
File already in Hatrac, update with new filename

### DIFF
--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -311,7 +311,6 @@ var ERMrest = (function(module) {
 
         this.http = this.reference._server.http;
 
-        this.updateDispositionOnly = false;
         this.isPaused = false;
         this.otherInfo = otherInfo;
 
@@ -445,11 +444,37 @@ var ERMrest = (function(module) {
             var filenameIndex = contentDisposition.indexOf(contentDispositionPrefix) + contentDispositionPrefix.length;
 
             // check if filename in content disposition is different from filename being uploaded
-            // if it is, instead set a different flag and don't mark it as done 
+            // if it is, create an update metadata request for updating the content-disposition
             if (contentDisposition.substring(filenameIndex, contentDisposition.length) != self.file.name.replace(FILENAME_REGEXP, '_')) {
-                self.updateDispositionOnly = true;
-                deferred.resolve(self.url);
-                return;
+                // Prepend the url with server uri if it is relative
+                var url =  self._getAbsoluteUrl(self.url + ";metadata/content-disposition");
+
+                var data = "filename*=UTF-8''" + self.file.name.replace(FILENAME_REGEXP, '_');
+
+                if (!contextHeaderParams || !_isObject(contextHeaderParams)) {
+                    contextHeaderParams = {
+                        action: "upload/metadata/update",
+                        referrer: self.reference.defaultLogInfo
+                    };
+                    contextHeaderParams.referrer.column = self.column.name;
+                }
+
+                var config = {
+                    headers: _generateContextHeader(contextHeaderParams)
+                };
+                config.headers['content-type'] = 'text/plain';
+
+                return self.http.put(url, data, config).then(function (response) {
+                    // mark as completed and job done since this is a metadata update request that doesn't transfer file data
+                    self.isPaused = false;
+                    self.completed = true;
+                    self.jobDone = true;
+
+                    deferred.resolve(self.url);
+                }, function(response) {
+                    var error = module.responseToError(response);
+                    deferred.reject(error);
+                });
             }
 
             self.isPaused = false;
@@ -542,58 +567,6 @@ var ERMrest = (function(module) {
 
         return deferred.promise;
     };
-
-    /**
-     * @desc Call this function to create an update metadata request for updating the content-disposition
-     *
-     * @returns {Promise} A promise resolved with no value or the url if it already exists
-     * or rejected with error
-     */
-    upload.prototype.createUpdateMetadataJob = function (contextHeaderParams) {
-        var self = this;
-        this.erred = false;
-
-        var deferred = module._q.defer();
-
-        if (this.completed && this.jobDone) {
-            deferred.resolve(this.chunkUrl);
-            return deferred.promise;
-        }
-
-        // Prepend the url with server uri if it is relative
-        var url =  self._getAbsoluteUrl(self.url + ";metadata/content-disposition");
-
-        var data = "filename*=UTF-8''" + self.file.name.replace(FILENAME_REGEXP, '_');
-
-        if (!contextHeaderParams || !_isObject(contextHeaderParams)) {
-            contextHeaderParams = {
-                action: "upload/metadata/update",
-                referrer: self.reference.defaultLogInfo
-            };
-            contextHeaderParams.referrer.column = self.column.name;
-        }
-
-        var config = {
-            headers: _generateContextHeader(contextHeaderParams)
-        };
-        config.headers['content-type'] = 'text/plain';
-
-        self.http.put(url, data, config).then(function (response) {
-            if (response) {
-                // mark as completed and job done since this is a metadata update request that doesn't transfer file data
-                self.isPaused = false;
-                self.completed = true;
-                self.jobDone = true;
-
-                deferred.resolve();
-            }
-        }, function(response) {
-            var error = module.responseToError(response);
-            deferred.reject(error);
-        });
-
-        return deferred.promise;
-    }
 
 
     /**

--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -543,6 +543,12 @@ var ERMrest = (function(module) {
         return deferred.promise;
     };
 
+    /**
+     * @desc Call this function to create an update metadata request for updating the content-disposition
+     *
+     * @returns {Promise} A promise resolved with no value or the url if it already exists
+     * or rejected with error
+     */
     upload.prototype.createUpdateMetadataJob = function (contextHeaderParams) {
         var self = this;
         this.erred = false;

--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -448,16 +448,8 @@ var ERMrest = (function(module) {
             if (contentDisposition.substring(filenameIndex, contentDisposition.length) != self.file.name.replace(FILENAME_REGEXP, '_')) {
                 // Prepend the url with server uri if it is relative
                 var url =  self._getAbsoluteUrl(self.url + ";metadata/content-disposition");
-
                 var data = "filename*=UTF-8''" + self.file.name.replace(FILENAME_REGEXP, '_');
-
-                if (!contextHeaderParams || !_isObject(contextHeaderParams)) {
-                    contextHeaderParams = {
-                        action: "upload/metadata/update",
-                        referrer: self.reference.defaultLogInfo
-                    };
-                    contextHeaderParams.referrer.column = self.column.name;
-                }
+                contextHeaderParams.action = "upload/metadata/update"
 
                 var config = {
                     headers: _generateContextHeader(contextHeaderParams)

--- a/test/specs/upload/tests/02.upload_obj.js
+++ b/test/specs/upload/tests/02.upload_obj.js
@@ -298,7 +298,7 @@ exports.execute = function (options) {
                 });
             });
 
-            it("should verify the job doesn't exist yet but a version of the same file does with a different filename.", function (done) {
+            it("should verify the job doesn't exist yet but a version of the same file does with a different filename. The file metadata update request should then run", function (done) {
                 uploadObjDiffName._getExistingJobStatus().then(function (response) {
                     expect(response).not.toBeDefined("Job status is defined");
 
@@ -306,7 +306,9 @@ exports.execute = function (options) {
                 }).then(function (response) {
                     expect(response).toBe(serverFilePath, "Server file path is incorrect");
 
-                    expect(uploadObjDiffName.updateDispositionOnly).toBeTruthy('update disposition only flag is incorrect');
+                    expect(uploadObjDiffName.isPaused).toBeFalsy("is paused is incorrect");
+                    expect(uploadObjDiffName.completed).toBeTruthy("completed is incorrect");
+                    expect(uploadObjDiffName.jobDone).toBeTruthy("job done is incorrect");
 
                     done();
                 }).catch(function (err) {
@@ -315,11 +317,9 @@ exports.execute = function (options) {
                 });
             });
 
-            it("should verify the update metadata job is created and succeeds.", function (done) {
-                uploadObjDiffName.createUpdateMetadataJob().then(function () {
-                    expect(uploadObjDiffName.isPaused).toBeFalsy("is paused is incorrect");
-                    expect(uploadObjDiffName.completed).toBeTruthy("completed is incorrect");
-                    expect(uploadObjDiffName.jobDone).toBeTruthy("job done is incorrect");
+            it("should verify the upload doesn't run and returns before getting existing job status.", function (done) {
+                uploadObjDiffName.createUploadJob().then(function (response) {
+                    expect(response).toBeFalsy("create upload job returned the wrong response")
 
                     done();
                 }, function (err) {


### PR DESCRIPTION
This PR intends to modify the `fileExists` check in `hatrac.js` for updating the `content-disposition` for a file that already exists (same md5 and content), except the new file has a different name.

One note about this PR is that a new logging action is being added, `"upload/metadata/update"`. This follows a similar pattern with the existing `createUploadJob` that sets `"upload/create"` as the action. I figured `"upload/update"` wasn't specific enough (since we are only updating metadata, not the whole file) and in this case we are "updating" existing content rather than creating something new.

For documentation, where should this "action" be added? I didn't see our other action for upload in the [Action List](https://docs.google.com/spreadsheets/d/1cHhPR0AacvuH2o3QavWlJCIIyPajfn93fJzFnc7VA5M/edit#gid=1180557009) spreadsheet.