### PR TITLE
Continue file upload

### DIFF
--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -626,7 +626,7 @@ var ERMrest = (function(module) {
                     start = end;
                 }
 
-                this.startChunkIdx = startChunkIdx;
+                this.startChunkIdx = startChunkIdx || 0;
                 this.chunkTracker = Array(this.chunks.length);
                 for (var j = 0; j < startChunkIdx; j++) this.chunkTracker[j] = true;
             }
@@ -1153,7 +1153,7 @@ var ERMrest = (function(module) {
             deferred.resolve();
 
             // this chunk was successfully uploaded, update the chunkTracker
-            this.chunkTracker[self.index] = true;
+            upload.chunkTracker[self.index] = true;
             upload._updateProgressBar();
         }, function(response) {
             self.progress = 0;

--- a/js/hatrac.js
+++ b/js/hatrac.js
@@ -321,6 +321,7 @@ var ERMrest = (function(module) {
 
         this.chunks = [];
         this.chunkTracker = [];
+        this.startChunkIdx = 0;
 
         this.log = console.log;
 
@@ -620,6 +621,7 @@ var ERMrest = (function(module) {
 
                 var areChunksUploaded = Array(this.chunks.length);
                 for (var j = 0; j < startChunkIdx; j++) areChunksUploaded[j] = true;
+                this.startChunkIdx = startChunkIdx;
                 this.chunkTracker = areChunksUploaded;
             }
         }
@@ -978,8 +980,9 @@ var ERMrest = (function(module) {
         }
 
         var length = this.chunks.length;
-        var progressDone = 0;
-        var chunksComplete = 0;
+        // progressDone and chunksComplete should be intiialized if we had an existing upload job
+        var progressDone = this.startChunkIdx * this.PART_SIZE;
+        var chunksComplete = this.startChunkIdx;
         for (var i = 0; i < length; i++) {
             progressDone = progressDone + this.chunks[i].progress;
             if (this.chunks[i].completed) chunksComplete++;

--- a/js/http.js
+++ b/js/http.js
@@ -48,7 +48,8 @@
      * @private
      * @type {Number}
      */
-    var _default_max_retries = 10;
+    // var _default_max_retries = 10;
+    var _default_max_retries = 2;
 
     /**
      * Initial timeout delay. This dely will be doubled each time to perform

--- a/js/http.js
+++ b/js/http.js
@@ -48,8 +48,7 @@
      * @private
      * @type {Number}
      */
-    // var _default_max_retries = 10;
-    var _default_max_retries = 2;
+    var _default_max_retries = 10;
 
     /**
      * Initial timeout delay. This dely will be doubled each time to perform


### PR DESCRIPTION
The changes made in this PR for `ermrestJS` better communicate the status of the current upload job after each chunk is successfully uploaded and resuming an upload job if there is a pending one tracked locally that is verified by the server.

The changes include:
 - adding a `chunkTracker` for tracking which chunks in `chunks[]` are marked as `complete` determined by chaise which manages the local upload state
 - store the `startChunkIdx` for initializing `chunkTracker` and initializing the upload progress on resume
 - `upload.prototype.fileExists` accepts a `jobUrl` parameter that it will use as the `chunkUrl` if a `409` is returned when checking if the file exists (more details in the comments in the code)
 - `upload.prototype.start` accepts a `startChunkIdx` to initialize `chunkTracker` and for skipping which chunks are added to the `chunkQueue` to avoid re-uploading chunks that already exist for this upload job
 - `Chunk.prototype.sendToHatrac` will update `chunkTracker` when each chunk has finished uploading
 
These changes resolve step 1 of issue [#2379](https://github.com/informatics-isi-edu/chaise/issues/2379) in chaise