### PR TITLE
Column RID exposed for use in chaise

### DIFF
--- a/js/column.js
+++ b/js/column.js
@@ -230,10 +230,13 @@ ReferenceColumn.prototype = {
     },
 
 
+    /**
+     * @type {string}
+     * @desc ermrest generated RID for this column
+     */
     get RID() {
         if (this._RID === undefined) {
-            // what do we use if not simple?
-            this._RID = this._simple ? this._baseCols[0].RID : null;
+            this._RID = this._baseCols[0].RID;
         }
         return this._RID;
     },
@@ -2028,6 +2031,11 @@ Object.defineProperty(ForeignKeyPseudoColumn.prototype, "name", {
     }
 });
 
+/**
+ * returns the ermrest generated RID for the foreign key relationship this pseudo clumn represents
+ * @member {string} RID
+ * @memberof ERMrest.ForeignKeyPseudoColumn#
+ */
 Object.defineProperty(ForeignKeyPseudoColumn.prototype, "RID", {
     get: function () {
         if (this._RID === undefined) {

--- a/js/column.js
+++ b/js/column.js
@@ -2028,6 +2028,15 @@ Object.defineProperty(ForeignKeyPseudoColumn.prototype, "name", {
     }
 });
 
+Object.defineProperty(ForeignKeyPseudoColumn.prototype, "RID", {
+    get: function () {
+        if (this._RID === undefined) {
+            this._RID = this.foreignKey.RID;
+        }
+        return this._RID;
+    }
+});
+
 /**
  * 1. If `to_name` in `foreign key` annotation is available, use it as the displayname.
  * 2. Otherwise,

--- a/js/column.js
+++ b/js/column.js
@@ -229,6 +229,14 @@ ReferenceColumn.prototype = {
         return this._displayname;
     },
 
+
+    get RID() {
+        if (this._RID === undefined) {
+            // what do we use if not simple?
+            this._RID = this._simple ? this._baseCols[0].RID : null;
+        }
+        return this._RID;
+    },
     /**
      *
      * @type {ERMrest.Type}

--- a/js/reference.js
+++ b/js/reference.js
@@ -5304,7 +5304,7 @@
                     for (j = 0; j < fks.length; j++) {
                         fkName = fks[j].name;
                         tempData[fkName] = {};
-                        linkedDataMap[fks[j].name] = fks[j].RID
+                        linkedDataMap[fkName] = fks[j].RID
 
                         for (k = 0; k < fks[j].colset.columns.length; k++) {
                             col = fks[j].colset.columns[k];
@@ -5672,6 +5672,8 @@
      * @param {!ERMrest.Page} page The Page object from which
      * this data was acquired.
      * @param {!Object} data The unprocessed tuple of data returned from ERMrest.
+     * @param {!Object} linkedData extra foreign key data that is fetched during read
+     * @param {!Object} linkedDataRIDs map of column name keys with column RID as values
      */
     function Tuple(pageReference, page, data, linkedData, linkedDataRIDs, rightsSummary, associationRightsSummary) {
         this._pageRef = pageReference;

--- a/js/reference.js
+++ b/js/reference.js
@@ -5767,10 +5767,8 @@
 
           /**
           * Foreign key data RID names.
-          * During the read we get extra information about the foreign keys,
-          * client could use these extra information for different purposes.
-          * One of these usecases is domain_filter_pattern which they can
-          * include foreignkey data in the pattern language.
+          * Map of `column.name` keys with the `column.RID` as the value so RIDs
+          * can be used in cases that require safe strings
           *
           * @type {Object}
           */

--- a/test/specs/common/tests/01.foreignkey.js
+++ b/test/specs/common/tests/01.foreignkey.js
@@ -302,6 +302,7 @@ exports.execute = function(options) {
             var testFKColumn = function (col, message) {
                 expect(col.isForeignKey).toBe(true, "is not foreignkey: " + message);
                 expect(col.foreignKey._constraintName).toEqual("common_schema_2_table_show_fk_links_fk1", "invalid constraint name: " + message);
+                expect(col.RID).toBeDefined();
             }
 
             var testFKValue = function (col, context) {

--- a/test/specs/common/tests/02.column.js
+++ b/test/specs/common/tests/02.column.js
@@ -29,6 +29,7 @@ exports.execute = function(options) {
                 expect(column.position).not.toBeDefined();
                 expect(column.table).toBeDefined();
                 expect(column.name).toBe(columnName);
+                expect(column.RID).toBeDefined();
 
                 expect(column.type).toEqual(jasmine.any(Object));
                 expect(column.type.name).toBe("text");


### PR DESCRIPTION
Added functions to ermrestJS to allow for chaise to use column RID values instead of column names for unique information cases where special characters shouldn't be used. We don't have control over the column names that are used in the database but we do know the format of RIDs.

Changes include:
 - added `RID` to `ReferenceColumn` and `ForeignKeyPseudoColumn`
 - added `linkedDataRIDs` to `Tuple` for getting the RID of the column linked data is used for