### PR TITLE
New handlebars and markdown functions

### DIFF
--- a/docs/user-docs/handlebars.md
+++ b/docs/user-docs/handlebars.md
@@ -27,6 +27,7 @@ This document summarizes the key concepts of Handlebars that are relevant to Der
   - [printf helper](#printf-helper)
   - [formatDate helper](#formatdate-helper)
   - [humanizeBytes helper](#humanizebytes-helper)
+  - [stringLength helper](#stringLength-helper)
   - [Math Helpers](#math-helpers)
     - [add](#add)
     - [subtract](#subtract)
@@ -587,6 +588,27 @@ A boolean value specifying whether you want the output to include a tooltip or n
 ```
 {{humanizeBytes value tooltip=true}}
 ```
+
+### stringLength helper
+
+You can use `stringLength` helper to get the length of a given string.
+
+Syntax:
+```
+{{stringLength value }}
+```
+
+Example:
+```
+{{stringLength "123123" }} ==> 6
+
+{{stringLength value }} ==> assuming value is "sometext" returns 8.
+
+
+[{{{caption}}}](https://example.com){ {{#if (gt (stringLength caption) 100)}}.lengthy-caption{{else}}.short-caption{{/if}} }
+```
+
+
 
 ### Math Helpers
 

--- a/docs/user-docs/markdown-formatting.md
+++ b/docs/user-docs/markdown-formatting.md
@@ -51,7 +51,7 @@ For common markdown syntax please refer to [this reference sheet](http://commonm
     + [14. Escape markdown content](#14-escape-markdown-content)
     + [15. RID link](#15-rid-link)
     + [16. Table](#15-table)
-
+    + [Gene Sequence](#17-gene-sequence)
 
 
 ## Inline Vs. Block
@@ -188,6 +188,10 @@ The following is the list of special class names that you can use:
     - `.chaise-content-top`: Aligns the inner content to the top of the container this class is attached to
     - `.chaise-content-middle`: Aligns the inner content to the middle of the container this class is attached to
     - `.chaise-content-bottom`: Aligns the inner content to the bottom of the container this class is attached to
+- `.chaise-word-break-all`: This enforces the given content to be broken at any character if it's overflowing. Useful for long an arbitary content. 
+  - For example you can add this to the asset presentation to ensure better UI in `compact` contexts: `[{{{filename}}}]({{{url}}}){download .chaise-word-break-all}`. Make sure to also add a `min-width` to the column header, otherwise the column might become very narrow.
+
+- `.chaise-gene-sequence-compact`: When applied to a [Gene Sequence](#17-gene-sequence) block, it will ensure showing a more compact version. This is recommended for `compact` contexts.
 
 
 ## Examples
@@ -233,6 +237,8 @@ Download button is a link with some predefined attributes. You can use these att
   - `.asset-permission` can be added to validate whether the user can download the asset before a download is attempted.
 
   - `.external-link` can be added to show a notification to the user when they are being navigated away from chaise for external links and assets hosted elsewhere.
+
+  - `.chaise-word-break-all` can be added to download buttons that have a very long filename in `compact` contexts. It will force the content to be broken into multiple lines. Make sure to also add a `min-width` to the column header, otherwise the column might become very narrow.
 
 Example:
 ```html
@@ -1085,3 +1091,34 @@ The table is broken at the first empty line, or beginning of another block eleme
     <a href="example.com">caption</h4>
     ```
     > <table><thead><tr><th>foo</th><th>bar</th></tr></thead><tbody><tr><td>baz</td><td>bim</td></tr></tbody></table><a href="example.com">caption</a>
+
+
+### 17. Gene Sequence
+
+This is not part of commonMark specification and it will result in a [block](#inline-vs-block). You have to follow the syntax completely (notice the newline in the closing tag). The following is the basic syntax structure:
+```mkdn
+::: geneSequence SEQUENCE {<attribute>=<value>} \n:::
+```
+**There must be a space before `\n:::`**.
+
+**Examples**
+
+- Without any attributes:
+    ```
+    ::: geneSequence MPVKGGSKCIKYLLFGFNFIFWLAGIAVLAIGLWLRFDSQTK \n:::
+    ```
+
+- Without any attributes as part of a `markdown_pattern` (assume `sequence` column returns the gene sequence string):
+    ```
+    ::: geneSequence {{{_sequence}}} \n:::
+    ```
+
+- A compact version for `compact` contexts:
+    ```
+    ::: geneSequence MPVKGGSKCIKYLLFGFNFIFWLAGIAVLAIGLWLRFDSQTK {.chaise-gene-sequence-compact} \n:::
+    ```
+
+- A compact version for `compact` contexts as part of a `markdown_pattern` (assume `sequence` column returns the gene sequence string):
+    ```
+    ::: geneSequence {{{_sequence}}} {.chaise-gene-sequence-compact} \n:::
+    ```

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -228,7 +228,7 @@
         "eq", "ne", "lt", "gt", "lte", "gte", "and", "or", "not", "ifCond",
         "escape", "encode", "formatDate", "encodeFacet",
         "regexMatch", "regexFindFirst", "regexFindAll",
-        "jsonStringify", "toTitleCase", "replace", "humanizeBytes", 'printf',
+        "jsonStringify", "toTitleCase", "replace", "humanizeBytes", 'printf', 'stringLength',
         // math helpers
         "add", "subtract"
     ];

--- a/js/utils/handlebar_helpers.js
+++ b/js/utils/handlebar_helpers.js
@@ -215,6 +215,15 @@
                     tooltip = options.hash.tooltip;
                 }
                 return module._formatUtils.humanizeBytes(value, mode, precision, tooltip);
+            },
+
+            /**
+             * {{stringLength value }}
+             * @ignore
+             * @returns the length of the given string
+             */
+            stringLength: function (value) {
+                return value.length;
             }
 
         });

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -2795,6 +2795,62 @@
             }
         });
 
+        md.use(mdContainer, 'geneSequence', {
+            validate: function (params) {
+                return params.trim().match(/geneSequence\s+(.*)$/i);
+            },
+
+            render: function (tokens, idx) {
+                var m = tokens[idx].info.trim().match(/geneSequence(.*)$/i);
+                var html = '';
+                // opening tag
+                if (tokens[idx].nesting === 1 && m.length > 0) {
+                    var attrs = md.parse(m[1]);
+                    if (
+                        !attrs || attrs.length !== 3 || attrs[0].type !== 'paragraph_open' ||
+                        attrs[1].type !== 'inline' || attrs[1].children.length !== 1
+                    ) {
+                        return html;
+                    }
+
+                    var containerAttributes = '', containerClasses = ['chaise-gene-sequence'];
+
+                    // get the attributes of the container
+                    if (Array.isArray(attrs[0].attrs)) {
+                        attrs[0].attrs.forEach(function (attr) {
+                            switch(attr[0]) {
+                                case 'class':
+                                    if (attr[1].length > 0 && containerClasses.indexOf(attr[1]) === -1) {
+                                        containerClasses.push(attr[1]);
+                                    }
+                                    break;
+                                default:
+                                    containerAttributes += ' ' + attr[0] + '="' + attr[1] + '"';
+                                    break;
+                            }
+                        });
+                    }
+
+                    // get the content 
+                    var sequence = attrs[1].children[0].content, inc = 10, sequenceHTML = '';
+                    while (sequence.length >= inc) {
+                        var chunk = sequence.slice(0, inc);
+                        sequenceHTML += '<span class="chaise-gene-sequence-chunk">' + chunk + '</span>';
+                        sequence = sequence.slice(inc);
+                    }
+                    sequenceHTML += '<span class="chaise-gene-sequence-chunk">' + sequence + '</span>';
+                    html += '<div class="' + containerClasses.join(" ") + '" ' + containerAttributes + ' >';
+                    html += '<div class="chaise-gene-sequence-toolbar">';
+                    // html += '<div class="chaise-btn chaise-btn-tertiary chaise-btn-chaise-gene-sequence-copy-btn" data-chaise-tooltip="Copy the sequence to clipboard">Copy sequence</div>';
+                    html += '</div>';
+                    html += sequenceHTML;
+                    html += '</div>';
+                }
+
+                return html;
+            }
+        });
+
         // Note: Following how this was done in markdown-it-sub and markdown-it-span
         md.use(function rid_plugin(md) {
             // same as UNESCAPE_MD_RE plus a space

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -391,6 +391,66 @@ exports.execute = function (options) {
                     })
                 });
             });
+
+            it ("should support :::GeneSequence", () => {
+                const seq1 = [
+                    'MPVKGGSKCIKYLLFGFNFIFWLAGIAVLAIGLWLRFDSQTKSIFEQENNHSSFYTGVYILIGAGALMMLVGFLGCCGAVQESQCMLGLFFGFLLVIF',
+                    'AIEIAAAVWGYTHKDEVIKELQEFYKDTYQKLRSKDEPQRETLKAIHMALDCCGIAGPLEQFISDTCPKKQLLESFQVKPCPEAISEVFNNKFHIIGA',
+                    'VGIGIAVVMIFGMIFSMILCCAIRRSREMV'
+                ].join('');
+
+                const seq2 = 'AIEIAAAVWGYTHKDEVIKELQEFYKDTYQKLRSKDEPQRETLKAIHMALDCCGIAGPLEQFISDTCPKKQLLESFQVKPCPEAISEVF';
+
+                testPrintMarkdown(
+                    `::: GeneSequence ${seq1} \n:::`,
+                    [
+                        '<div class="chaise-gene-sequence"  ><div class="chaise-gene-sequence-toolbar"></div>',
+                        '<span class="chaise-gene-sequence-chunk">MPVKGGSKCI</span><span class="chaise-gene-sequence-chunk">KYLLFGFNFI</span>',
+                        '<span class="chaise-gene-sequence-chunk">FWLAGIAVLA</span><span class="chaise-gene-sequence-chunk">IGLWLRFDSQ</span>',
+                        '<span class="chaise-gene-sequence-chunk">TKSIFEQENN</span><span class="chaise-gene-sequence-chunk">HSSFYTGVYI</span>',
+                        '<span class="chaise-gene-sequence-chunk">LIGAGALMML</span><span class="chaise-gene-sequence-chunk">VGFLGCCGAV</span>',
+                        '<span class="chaise-gene-sequence-chunk">QESQCMLGLF</span><span class="chaise-gene-sequence-chunk">FGFLLVIFAI</span>',
+                        '<span class="chaise-gene-sequence-chunk">EIAAAVWGYT</span><span class="chaise-gene-sequence-chunk">HKDEVIKELQ</span>',
+                        '<span class="chaise-gene-sequence-chunk">EFYKDTYQKL</span><span class="chaise-gene-sequence-chunk">RSKDEPQRET</span>',
+                        '<span class="chaise-gene-sequence-chunk">LKAIHMALDC</span><span class="chaise-gene-sequence-chunk">CGIAGPLEQF</span>',
+                        '<span class="chaise-gene-sequence-chunk">ISDTCPKKQL</span><span class="chaise-gene-sequence-chunk">LESFQVKPCP</span>',
+                        '<span class="chaise-gene-sequence-chunk">EAISEVFNNK</span><span class="chaise-gene-sequence-chunk">FHIIGAVGIG</span>',
+                        '<span class="chaise-gene-sequence-chunk">IAVVMIFGMI</span><span class="chaise-gene-sequence-chunk">FSMILCCAIR</span>',
+                        '<span class="chaise-gene-sequence-chunk">RSREMV</span></div>'
+                    ].join(''),
+                    false,
+                    'test 01'
+                )
+
+                testPrintMarkdown(
+                    `::: GeneSequence ${seq2} {.chaise-gene-sequence-compact data-chaise-tooltip="some-tooltip"} \n:::`,
+                    [
+                        '<div class="chaise-gene-sequence chaise-gene-sequence-compact"  data-chaise-tooltip="some-tooltip" >',
+                        '<div class="chaise-gene-sequence-toolbar"></div>',
+                        '<span class="chaise-gene-sequence-chunk">AIEIAAAVWG</span><span class="chaise-gene-sequence-chunk">YTHKDEVIKE</span>',
+                        '<span class="chaise-gene-sequence-chunk">LQEFYKDTYQ</span><span class="chaise-gene-sequence-chunk">KLRSKDEPQR</span>',
+                        '<span class="chaise-gene-sequence-chunk">ETLKAIHMAL</span><span class="chaise-gene-sequence-chunk">DCCGIAGPLE</span>',
+                        '<span class="chaise-gene-sequence-chunk">QFISDTCPKK</span><span class="chaise-gene-sequence-chunk">QLLESFQVKP</span>',
+                        '<span class="chaise-gene-sequence-chunk">CPEAISEVF</span></div>'
+                    ].join(''),
+                    false,
+                    'test 02'
+                )
+
+                testPrintMarkdown(
+                    `::: GeneSequence ${seq2} {.chaise-gene-sequence-compact .another-class class="third-class" width="300px"} \n:::`,
+                    [
+                        '<div class="chaise-gene-sequence chaise-gene-sequence-compact another-class third-class"  width="300px" >',
+                        '<div class="chaise-gene-sequence-toolbar"></div><span class="chaise-gene-sequence-chunk">AIEIAAAVWG</span>',
+                        '<span class="chaise-gene-sequence-chunk">YTHKDEVIKE</span><span class="chaise-gene-sequence-chunk">LQEFYKDTYQ</span>',
+                        '<span class="chaise-gene-sequence-chunk">KLRSKDEPQR</span><span class="chaise-gene-sequence-chunk">ETLKAIHMAL</span>',
+                        '<span class="chaise-gene-sequence-chunk">DCCGIAGPLE</span><span class="chaise-gene-sequence-chunk">QFISDTCPKK</span>',
+                        '<span class="chaise-gene-sequence-chunk">QLLESFQVKP</span><span class="chaise-gene-sequence-chunk">CPEAISEVF</span></div>'
+                    ].join(''),
+                    false,
+                    'test 03'
+                )
+            });
         });
 
 
@@ -663,6 +723,15 @@ exports.execute = function (options) {
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 1237940039285380274899124223 mode="binary" }}')).toBe('1.2,379,400,392,853,803e+27');
                 expect(module.renderHandlebarsTemplate('{{humanizeBytes 1237940039285380274899124223 mode="binary" tooltip=true }}')).toBe('1.2,379,400,392,853,803e+27');
 
+            });
+
+            it('stringLength helper', function () {
+                expect(module.renderHandlebarsTemplate('{{stringLength "123" }}', {})).toBe('3', 'test 01');
+                expect(module.renderHandlebarsTemplate('{{stringLength val }}', {'val': "751231asd"})).toBe('9', 'test 02');
+
+                const pattern = '[{{{val}}}](https://example.com){ {{#if (gt (stringLength val) 5)}}.lengthy-str{{else}}.short-str{{/if}} }';
+                expect(module.renderHandlebarsTemplate(pattern, {'val': "751231asd"})).toBe('[751231asd](https://example.com){ .lengthy-str }', 'test 03');
+                expect(module.renderHandlebarsTemplate(pattern, {'val': "abc"})).toBe('[abc](https://example.com){ .short-str }', 'test 04');
             });
 
             it('encodeFacet helper', function () {


### PR DESCRIPTION
This PR adds the following,

- A custom markdown block called `geneSequence` to display gene sequences. This uses the same syntax as our other custom markdown blocks (e.g. iframe):
  ```
  ::: geneSequence MPVKGGSKCIKYLLFGFNFIFWLAGIAVLAIGLWLRFDSQTK \n:::
  ```
- A handlebars helper function called `stringLength` that returns the length of the given string.
  ```
  {{stringLength "123123" }} ==> 6
  
  {{stringLength value }} ==> assuming value is "sometext" returns 8.
  
  [{{{caption}}}](https://example.com){ {{#if (gt (stringLength caption) 100)}}.lengthy-caption{{else}}.short-caption{{/if}} }
  ```
