### PR TITLE
HTML escape JSON values if displayed directly

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -3011,6 +3011,8 @@
                     return { isHTML: false, value: this._getNullValue(context), unformatted: this._getNullValue(context) };
                 }
 
+                // <pre> will render the html tags, so we have to make sure the tags are escaped.
+                formattedValue = module.escapeHTML(formattedValue);
                 return { isHTML: true, value: '<pre>' + formattedValue + '</pre>', unformatted: formattedValue};
             }
 

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -87,6 +87,19 @@
     };
 
     /**
+     * Make sure the text is not rendered as HTML (by replacing speciall characters).
+     * @param {string} text 
+     * @returns HTML-escaped text
+     */
+    module.escapeHTML = function (text) {
+        return String(text).replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;")
+          .replaceAll("'", "&#39;");
+    };
+
+    /**
      * Returns true if given parameter is not undefined and not null
      * @param  {*} obj
      * @return {boolean}

--- a/test/specs/reference/conf/reference_schema/data/jsontest_table.json
+++ b/test/specs/reference/conf/reference_schema/data/jsontest_table.json
@@ -3,5 +3,12 @@
 {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"},"json_col_with_markdownpattern":"Analysed", "col_markdown_blankable": null},
 {"id":"1004","json_col":false,"jsonb_col":false,"json_col_with_markdownpattern":"Shipped", "col_markdown_blankable": {"url":"https://madeby.google.com/abc.jpeg"}},
 {"id":"1005","json_col":2.9,"jsonb_col":2.9,"json_col_with_markdownpattern":"OnHold", "col_markdown_blankable": false},
-{"id":"1006","json_col":"","jsonb_col":"","json_col_with_markdownpattern":"Complete", "col_markdown_blankable": {"url": "myurl"}}
+{"id":"1006","json_col":"","jsonb_col":"","json_col_with_markdownpattern":"Complete", "col_markdown_blankable": {"url": "myurl"}},
+{
+  "id":"1007",
+  "json_col": {"value": "<script>alert('test')</script>", "value2": "<a href='example.com'>click</a>"},
+  "jsonb_col": "<script>alert('test!')</script>",
+  "json_col_with_markdownpattern": null,
+  "col_markdown_blankable": null
+}
 ]

--- a/test/specs/reference/tests/05.reference_values.js
+++ b/test/specs/reference/tests/05.reference_values.js
@@ -359,24 +359,59 @@ exports.execute = function (options) {
     });
 
     describe("Test JSON values with and without markdown,", function() {
-        //Tested these values as formatted values inside it, to get the exact string after JSON.stringify()
-        var expectedValues=[{"id":"1001","json_col":true,"jsonb_col":true,"json_col_with_markdownpattern": "<p>Status is: “processed”</p>\n", "col_markdown_blankable": '<p><a href="https://madeby.google.com/static/images/google_g_logo.svg" target="_blank"><img src="https://madeby.google.com/static/images/google_g_logo.svg" alt="" height="90" class="-chaise-post-load"></a></p>\n'},
-        {"id":"1002","json_col":{},"jsonb_col":{}, "json_col_with_markdownpattern": "<p>Status is: “Activated”</p>\n", "col_markdown_blankable": ""},
-        {"id":"1003","json_col":{"name":"test"},"jsonb_col":{"name":"test"}, "json_col_with_markdownpattern": "<p>Status is: “Analysed”</p>\n", "col_markdown_blankable": ""},
-        {"id":"1004","json_col":false,"jsonb_col":false, "json_col_with_markdownpattern": "<p>Status is: “Shipped”</p>\n", "col_markdown_blankable": '<p><a href="https://madeby.google.com/abc.jpeg" target="_blank"><img src="https://madeby.google.com/abc.jpeg" alt="" height="90" class="-chaise-post-load"></a></p>\n'},
-        {"id":"1005","json_col":2.9,"jsonb_col":2.9, "json_col_with_markdownpattern": "<p>Status is: “OnHold”</p>\n", "col_markdown_blankable": ""},
-        {"id":"1006","json_col":null,"jsonb_col":null, "json_col_with_markdownpattern": "<p>Status is: “Complete”</p>\n", "col_markdown_blankable": '<p><a href="myurl" target="_blank"><img src="myurl" alt="" height="90" class="-chaise-post-load"></a></p>\n'}];
+        const expectedValues = [
+            {
+                "json_col": 'true', 
+                "jsonb_col": 'true',
+                "json_col_with_markdownpattern": "<p>Status is: “processed”</p>\n", 
+                "col_markdown_blankable": '<p><a href="https://madeby.google.com/static/images/google_g_logo.svg" target="_blank"><img src="https://madeby.google.com/static/images/google_g_logo.svg" alt="" height="90" class="-chaise-post-load"></a></p>\n'
+            },
+            {
+                "json_col": '{}',
+                "jsonb_col": '{}',
+                "json_col_with_markdownpattern": "<p>Status is: “Activated”</p>\n", 
+                "col_markdown_blankable": ""
+            },
+            {
+                "json_col": '{\n  &quot;name&quot;: &quot;test&quot;\n}',
+                "jsonb_col": '{\n  &quot;name&quot;: &quot;test&quot;\n}', 
+                "json_col_with_markdownpattern": "<p>Status is: “Analysed”</p>\n", 
+                "col_markdown_blankable": ""
+            },
+            {
+                "json_col": 'false',
+                "jsonb_col": 'false', 
+                "json_col_with_markdownpattern": "<p>Status is: “Shipped”</p>\n",
+                "col_markdown_blankable": '<p><a href="https://madeby.google.com/abc.jpeg" target="_blank"><img src="https://madeby.google.com/abc.jpeg" alt="" height="90" class="-chaise-post-load"></a></p>\n'
+            },
+            {
+                "json_col": '2.9',
+                "jsonb_col": '2.9',
+                "json_col_with_markdownpattern": "<p>Status is: “OnHold”</p>\n",
+                "col_markdown_blankable": ""
+            },
+            {
+                "json_col": 'null',
+                "jsonb_col": 'null',
+                "json_col_with_markdownpattern": "<p>Status is: “Complete”</p>\n",
+                "col_markdown_blankable": '<p><a href="myurl" target="_blank"><img src="myurl" alt="" height="90" class="-chaise-post-load"></a></p>\n'
+            },
+            {
+                "json_col": '{\n  &quot;value&quot;: &quot;&lt;script&gt;alert(&#39;test&#39;)&lt;/script&gt;&quot;,\n  &quot;value2&quot;: &quot;&lt;a href=&#39;example.com&#39;&gt;click&lt;/a&gt;&quot;\n}',
+                "jsonb_col": '&quot;&lt;script&gt;alert(&#39;test!&#39;)&lt;/script&gt;&quot;',
+                "json_col_with_markdownpattern": "<p>Status is:</p>\n",
+                "col_markdown_blankable": ""
+            }
+        ];
 
-        var catalog_id = process.env.DEFAULT_CATALOG,
+        const catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "reference_schema",
             tableName = "jsontest_table",
-            lowerLimit = 1001,
-            upperLimit = 2001,
-            limit = 6;
+            limit = 7;
 
-        var multipleEntityUri=options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"+ tableName + "/@sort(id)";
+        const multipleEntityUri=options.url + "/catalog/" + catalog_id + "/entity/" + schemaName + ":"+ tableName + "/@sort(id)";
 
-        var reference, page, tuples, url;
+        let reference, page, tuples;
 
         beforeAll(function(done) {
 
@@ -406,15 +441,12 @@ exports.execute = function (options) {
         });
 
         it("JSON column should display pre tags without markdown and should not append pre tag with markdown", function() {
-
-            for( var i=0; i<limit; i++){
-                var values=tuples[i].values;
-                var json='<pre>'+JSON.stringify(expectedValues[i].json_col,"undefined",2)+'</pre>';
-                var jsonb='<pre>'+JSON.stringify(expectedValues[i].jsonb_col,"undefined",2)+'</pre>';
-                expect(values[0]).toBe(json, "Mismatch in tuple with index = "+ i +", column= json_col");
-                expect(values[1]).toBe(jsonb ,"Mismatch in tuple with index = "+ i +", column= jsonb_col");
-                expect(values[2]).toBe(expectedValues[i].json_col_with_markdownpattern, "Mismatch in tuple with index = "+ i +", column= json_col_with_markdownpattern");
-                expect(values[3]).toBe(expectedValues[i].col_markdown_blankable, "Mismatch in tuple with index = "+ i +", column= col_markdown_blankable");
+            for (const [i, expected] of expectedValues.entries()) {
+                const values = tuples[i].values;
+                expect(values[0]).toBe(`<pre>${expected.json_col}</pre>`, "Mismatch in tuple with index = "+ i +", column= json_col");
+                expect(values[1]).toBe(`<pre>${expected.jsonb_col}</pre>`,"Mismatch in tuple with index = "+ i +", column= jsonb_col");
+                expect(values[2]).toBe(expected.json_col_with_markdownpattern, "Mismatch in tuple with index = "+ i +", column= json_col_with_markdownpattern");
+                expect(values[3]).toBe(expected.col_markdown_blankable, "Mismatch in tuple with index = "+ i +", column= col_markdown_blankable");
             }
         });
 


### PR DESCRIPTION
To make sure the default presentation of JSON preserves the added newline and whitespace, we're wrapping the string representation of JSON values in a `<pre>` tag. Then, we directly return this value to Chaise without going through the markdown renderer.

The markdown renderer always HTML escapes values before processing to ensure the values that look like HTML are not treated as HTML. But since we've been skipping this step for JSON, the HTML tags could be displayed as part of JSON.

For example, a JSON value like `"<a href='example.com'>Click here</a>"` would show up as a link instead of plain text. Fortunately, the more harmful tags like `script` were not being interpreted by React, so this didn't cause any security issues.

In this PR, I made sure to manually HTML-escape the JSON value before wrapping it in a `<pre>` tag.