### PR TITLE
Fix the implementation of not-null for json columns

### DIFF
--- a/test/specs/faceting/conf/faceting_schema/data/path_prefix_o1_o1.json
+++ b/test/specs/faceting/conf/faceting_schema/data/path_prefix_o1_o1.json
@@ -1,5 +1,5 @@
 [
-  {"id": "1", "path_prefix_o1_o1_col": "one_o1_o1", "fk_to_path_prefix_o1_o1_o1": "1"},
-  {"id": "2", "path_prefix_o1_o1_col": "two_o1_o1", "fk_to_path_prefix_o1_o1_o1": "2"},
-  {"id": "3", "path_prefix_o1_o1_col": "three_o1_o1", "fk_to_path_prefix_o1_o1_o1": "1"}
+  {"id": "1", "path_prefix_o1_o1_col": "one_o1_o1", "fk_to_path_prefix_o1_o1_o1": "1", "jsonb_col": {"test": true}},
+  {"id": "2", "path_prefix_o1_o1_col": "two_o1_o1", "fk_to_path_prefix_o1_o1_o1": "2", "jsonb_col": {"test": true}},
+  {"id": "3", "path_prefix_o1_o1_col": "three_o1_o1", "fk_to_path_prefix_o1_o1_o1": "1", "jsonb_col": {"test": true}}
 ]

--- a/test/specs/faceting/conf/faceting_schema/schema.json
+++ b/test/specs/faceting/conf/faceting_schema/schema.json
@@ -1739,6 +1739,10 @@
                 {
                     "name": "path_prefix_o1_o1_col",
                     "type": {"typename": "text"}
+                },
+                {
+                    "name": "jsonb_col",
+                    "type": {"typename": "jsonb"}
                 }
             ],
             "annotations": {

--- a/test/specs/faceting/conf/fast_filter_schema/schema.json
+++ b/test/specs/faceting/conf/fast_filter_schema/schema.json
@@ -37,6 +37,10 @@
         {
           "name": "main_o1_fast_col",
           "type": {"typename": "int4"}
+        },
+        {
+          "name": "jsonb_col",
+          "type": {"typename": "jsonb"}
         }
       ],
       "annotations": {
@@ -111,7 +115,11 @@
                 ]
               },
               {"sourcekey": "facet_with_fast_filter_shared_prefix"},
-              {"sourcekey": "facet_with_fast_filter_and_filter_in_source"}
+              {"sourcekey": "facet_with_fast_filter_and_filter_in_source"},
+              {
+                "source": [{"outbound": ["fast_filter_schema", "main_fk1"]}, "main_o1_jsonb_col"],
+                "fast_filter_source": ["jsonb_col"]
+              }
             ]
           }
         }
@@ -217,6 +225,10 @@
         {
           "name": "fk_to_main_o1_o1",
           "type": {"typename": "int4"}
+        },
+        {
+          "name": "main_o1_jsonb_col",
+          "type": {"typename": "jsonb"}
         }
       ]
     },

--- a/test/specs/faceting/tests/01.faceting.js
+++ b/test/specs/faceting/tests/01.faceting.js
@@ -1881,6 +1881,17 @@ exports.execute = function (options) {
                             });
                         });
 
+                        it ("should properly parse not-null filters.", function () {
+                            newRef = refMain.facetColumns[9].addNotNullFilter();
+
+                            expect(newRef).not.toBe(refMain, "reference didn't change.");
+                            expect(newRef.location.ermrestCompactPath).toBe(
+                                "M:=faceting_schema:main/id=1/$M/int_col::geq::-2/$M/!(jsonb_col::null::;jsonb_col=null)/$M",
+                                "path missmatch."
+                            );
+                            expect(newRef.facetColumns[9].filters.length).toBe(1, "filters length missmatch.");
+                        });
+
                     });
                 });
             });
@@ -2647,6 +2658,7 @@ exports.execute = function (options) {
                     });
 
                     // prefix with different end column
+                    // also checking that not-null json is properly handled
                     describe("case 3", function () {
                         testReadAndReadPath(
                             {
@@ -2665,6 +2677,13 @@ exports.execute = function (options) {
                                             "path_prefix_o1_o1_i1_col"
                                         ],
                                         "choices": ["one_o1_o1_i1"]
+                                    },
+                                    {
+                                        "source": [
+                                            { "sourcekey": "path_to_path_prefix_o1_o1" },
+                                            "jsonb_col"
+                                        ],
+                                        "not_null": true
                                     }
                                 ]
                             },
@@ -2672,6 +2691,7 @@ exports.execute = function (options) {
                                 "M:=faceting_schema:main",
                                 "M_P2:=(fk_to_path_prefix_o1)=(faceting_schema:path_prefix_o1:id)/M_P1:=(fk_to_path_prefix_o1_o1)=(faceting_schema:path_prefix_o1_o1:id)/id=2/$M",
                                 "$M_P1/(id)=(faceting_schema:path_prefix_o1_o1_i1:fk_to_path_prefix_o1_o1)/path_prefix_o1_o1_i1_col=one_o1_o1_i1/$M",
+                                "$M_P1/!(jsonb_col::null::;jsonb_col=null)/$M",
                                 "$M_P1/F3:=left(fk_to_path_prefix_o1_o1_o1)=(faceting_schema:path_prefix_o1_o1_o1:id)/$M",
                                 "RID;M:=array_d(M:*),F3:=F3:path_prefix_o1_o1_o1_col,F2:=M_P1:path_prefix_o1_o1_col,F1:=M_P2:path_prefix_o1_col@sort(RID)"
                             ].join("/"),
@@ -2683,6 +2703,7 @@ exports.execute = function (options) {
                                         "T:=faceting_schema:main",
                                         "T_P1:=(fk_to_path_prefix_o1)=(faceting_schema:path_prefix_o1:id)/M:=(fk_to_path_prefix_o1_o1)=(faceting_schema:path_prefix_o1_o1:id)",
                                         "(id)=(faceting_schema:path_prefix_o1_o1_i1:fk_to_path_prefix_o1_o1)/path_prefix_o1_o1_i1_col=one_o1_o1_i1/$T/$M/id=2/$T",
+                                        "$M/!(jsonb_col::null::;jsonb_col=null)/$T",
                                         "$M/F1:=left(fk_to_path_prefix_o1_o1_o1)=(faceting_schema:path_prefix_o1_o1_o1:id)/$M/RID;M:=array_d(M:*),F1:=array_d(F1:*)@sort(RID)"
                                     ].join("/"),
                                     read: {
@@ -2696,6 +2717,7 @@ exports.execute = function (options) {
                                         "T:=faceting_schema:main",
                                         // NOTE T_P2 is not needed but code doesn't handle it
                                         "T_P2:=(fk_to_path_prefix_o1)=(faceting_schema:path_prefix_o1:id)/T_P1:=(fk_to_path_prefix_o1_o1)=(faceting_schema:path_prefix_o1_o1:id)/id=2/$T",
+                                        "$T_P1/!(jsonb_col::null::;jsonb_col=null)/$T",
                                         "$T_P1/M:=(id)=(faceting_schema:path_prefix_o1_o1_i1:fk_to_path_prefix_o1_o1)",
                                         "F1:=left(fk_to_path_prefix_o1_o1)=(faceting_schema:path_prefix_o1_o1:id)/$M/RID;M:=array_d(M:*),F1:=array_d(F1:*)@sort(RID)"
                                     ].join("/"),
@@ -3004,6 +3026,7 @@ exports.execute = function (options) {
                 });
 
                 // prefix with different end column
+                // also checking that not-null json is properly handled
                 describe("case 3", function () {
                     testReadAndReadPath(
                         {
@@ -3022,6 +3045,13 @@ exports.execute = function (options) {
                                         "path_prefix_o1_o1_i1_col"
                                     ],
                                     "choices": ["one_o1_o1_i1"]
+                                },
+                                {
+                                    "source": [
+                                        { "sourcekey": "path_to_path_prefix_o1_o1_w_filter" },
+                                        "jsonb_col"
+                                    ],
+                                    "not_null": true
                                 }
                             ]
                         },
@@ -3032,6 +3062,7 @@ exports.execute = function (options) {
                             "!(date_col::gt::" + currentDateString + "&path_prefix_o1_col=some_non_used_value)",
                             "M_P1:=(fk_to_path_prefix_o1_o1)=(faceting_schema:path_prefix_o1_o1:id)/id=2/$M",
                             "$M_P1/(id)=(faceting_schema:path_prefix_o1_o1_i1:fk_to_path_prefix_o1_o1)/path_prefix_o1_o1_i1_col=one_o1_o1_i1/$M",
+                            "$M_P1/!(jsonb_col::null::;jsonb_col=null)/$M",
                             "F1:=left(fk_to_f1)=(faceting_schema:f1:id)/$M",
                             "RID;M:=array_d(M:*),F1:=array_d(F1:*)@sort(RID)"
                         ].join("/")

--- a/test/specs/faceting/tests/02.fast_filter.js
+++ b/test/specs/faceting/tests/02.fast_filter.js
@@ -197,6 +197,10 @@ exports.execute = (options) => {
               source: [{ sourcekey: 'path_to_main_o1_RID' }, { inbound: ['fast_filter_schema', 'main_o1_i2_fk1'] }, 'RID'],
               choices: ['1'],
             },
+            {
+              source: [{ outbound: ['fast_filter_schema', 'main_fk1'] }, 'main_o1_jsonb_col'],
+              not_null: true,
+            },
           ],
         };
 
@@ -207,6 +211,7 @@ exports.execute = (options) => {
           '(fk_to_main_o1)=(fast_filter_schema:main_o1:id)/(fk_to_main_o1_o1)=(fast_filter_schema:main_o1_o1:id)/other_col=any(1,2,3)/$M',
           'M_P1:=(fk_to_main_o1)=(fast_filter_schema:main_o1:id)/(id)=(fast_filter_schema:main_o1_i2:fk_to_main_o1)/id=any(1,2,3)/$M',
           '$M_P1/id::gt::2/(id)=(fast_filter_schema:main_o1_i2:fk_to_main_o1)/id=1/$M',
+          '!(jsonb_col::null::;jsonb_col=null)/$M'
         ].join('/');
 
         const testReadAndReadPath = (context) => {
@@ -258,6 +263,7 @@ exports.execute = (options) => {
                   '(fk_to_main_o1_o1)=(fast_filter_schema:main_o1_o1:id)/other_col=any(1,2,3)/$T',
                   'T_P1:=(fk_to_main_o1)=(fast_filter_schema:main_o1:id)/id::gt::2',
                   '(id)=(fast_filter_schema:main_o1_i2:fk_to_main_o1)/id=1/$T',
+                  '!(jsonb_col::null::;jsonb_col=null)/$T',
                   '$T_P1/M:=(id)=(fast_filter_schema:main_o1_i1:fk_to_main_o1)',
                   'F1:=left(fk_to_main_o1)=(fast_filter_schema:main_o1:id)/$M/RID;M:=array_d(M:*),F1:=array_d(F1:*)@sort(RID)',
                 ].join('/'),


### PR DESCRIPTION
When users click on the "no value" filter in recordset, we're interpreting it as the following:

```
json_col::null::;json_col=null
```

This way, we're handling the database value missing (`json_col::null::`) as well as the JSON value being `null.` But for "All records with value" (not-null), we've only used the `!(json_col::null::)` filter.

In this PR, I changed the implementation of not-null to `!(json_col::null::;json_col=null)` so it's aligned with the "no value" filter.