### PR TITLE
Fix issues in the json facet support

### DIFF
--- a/js/ag_reference.js
+++ b/js/ag_reference.js
@@ -825,7 +825,10 @@ AttributeGroupTuple.prototype = {
             var data = this._data, hasNull, self = this;
             this._uniqueId = self._page.reference.shortestKey.reduce(function (res, c, index) {
                 hasNull = hasNull || data[c.name] == null;
-                return res + (index > 0 ? "_" : "") + data[c.name];
+                const isJSON = c.type.name === 'json' || c.type.name === 'jsonb';
+                // if the column is JSON, we need to stringify it otherwise it will print [object Object]
+                const value = isJSON ? JSON.stringify(data[c.name]) : data[c.name];
+                return res + (index > 0 ? "_" : "") + value;
             }, "");
 
             //TODO should be evaluated for composite keys

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -861,20 +861,23 @@ import HandlebarsService from '@isrd-isi-edu/ermrestjs/src/services/handlebars';
      * Given the available linked data, generate the uniqueId for the row this data represents given the shortest key of the table
      *
      * @param {ERMrest.Key[]} tableShortestKey shortest key from the table the linkedData is for
-     * @param {Object} linkedData data to use to generate the unique id
+     * @param {Object} data data to use to generate the unique id
      * @returns string | null - unique id for the row the linkedData represents
      */
-    export function _generateTupleUniqueId(tableShortestKey, linkedData) {
-        var keyName, hasNull = false, _uniqueId = "";
+    export function _generateTupleUniqueId(tableShortestKey, data) {
+        let hasNull = false, _uniqueId = "";
 
         for (var i = 0; i < tableShortestKey.length; i++) {
-            keyName = tableShortestKey[i].name;
-            if (linkedData[keyName] == null) {
+            const col = tableShortestKey[i];
+            const keyName = col.name;
+            if (data[keyName] == null) {
                 hasNull = true;
                 break;
             }
             if (i !== 0) _uniqueId += "_";
-            _uniqueId += linkedData[keyName];
+            const isJSON = col.type.name === 'json' || col.type.name === 'jsonb';
+            // if the column is JSON, we need to stringify it otherwise it will print [object Object]
+            _uniqueId += isJSON ? JSON.stringify(data[keyName], undefined, 0) : data[keyName];
         }
 
         if (hasNull) {

--- a/test/specs/faceting/tests/01.faceting.js
+++ b/test/specs/faceting/tests/01.faceting.js
@@ -1910,8 +1910,6 @@ exports.execute = function (options) {
                 });
             });
 
-            return;
-
             describe("sourceReference and column APIs, ", function () {
                 it("should have filters of other facet columns, and not filters of itself.", function () {
                     checkSourceReference(
@@ -2381,8 +2379,6 @@ exports.execute = function (options) {
                 });
             });
         });
-
-        return;
 
         describe("should be able to handle facets with long paths.", function () {
             var ref;

--- a/test/specs/faceting/tests/01.faceting.js
+++ b/test/specs/faceting/tests/01.faceting.js
@@ -1829,8 +1829,18 @@ exports.execute = function (options) {
                                 testJSONFilter({ "key": "one" }, "%7B%22key%22%3A%22one%22%7D");
                             });
 
+                            it("Having string representation of object as the value.", function () {
+                                // this is how chaise uses it
+                                testJSONFilter('{"key":"one"}', "%7B%22key%22%3A%22one%22%7D");
+                            });
+
                             it("Having array as the value.", function () {
                                 testJSONFilter(["key", "one"], "%5B%22key%22%2C%22one%22%5D");
+                            });
+
+                            it("Having string representation of array as the value.", function () {
+                                // this is how chaise uses it
+                                testJSONFilter('["key","one"]', "%5B%22key%22%2C%22one%22%5D");
                             });
 
                             it("Having number as the value.", function () {
@@ -1838,11 +1848,15 @@ exports.execute = function (options) {
                             });
 
                             it("having string literal of integer as value.", function () {
-                                testJSONFilter("1234", "%221234%22");
+                                testJSONFilter("1234", "1234");
                             });
 
                             it("Having string literal as the value.", function () {
                                 testJSONFilter("value", "%22value%22");
+                            });
+
+                            it("Having string representation of string as the value.", function () {
+                                testJSONFilter('"value"', "%22value%22");
                             });
 
                             it("Having boolean as the value.", function () {
@@ -1895,6 +1909,8 @@ exports.execute = function (options) {
                     });
                 });
             });
+
+            return;
 
             describe("sourceReference and column APIs, ", function () {
                 it("should have filters of other facet columns, and not filters of itself.", function () {
@@ -2365,6 +2381,8 @@ exports.execute = function (options) {
                 });
             });
         });
+
+        return;
 
         describe("should be able to handle facets with long paths.", function () {
             var ref;


### PR DESCRIPTION
When I initially implemented facets, I assumed we would pass the raw JSON objects to the `addChoiceFilters` API. But in some cases, the Chaise doesn't have access to the raw object and passes the string representation instead.

To ensure that both Chaise and ermrestjs consistently handle JSON facets, I ensured that we could pass string representation of facets in this PR. As part of this I also ensured that we're not applying `stringified` on an already JSON-stringified object. Because of this, refreshing the page in Chaise would keep changing the given filter.

I also fixed the `Tuple.uniqueID` API to handle JSON columns properly. This API is supposed to return a string, but we were concatenating the raw values to generate it. In the case of `json`/`jsonb` types, it would return `[object Object]`, which is obviously not what we want.

