### PR TITLE
Changes regarding the input required check

### DIFF
--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -63,7 +63,7 @@ here is a quick matrix to locate them.
 | [2016 Visible Foreign Keys](#tag-2016-visible-foreign-keys)              | -       | -      | X     | -      | -   | -   | Foreign key visibility and presentation order                  |
 | [2017 Asset](#tag-2017-asset)                                            | -       | -      | -     | X      | -   | -   | Describes assets                                               |
 | [2018 Citation](#tag-2018-citation)                                      | -       | -      | X     | -      | -   | -   | Describes citation                                             |
-| [2018 Required](#tag-2018-required)                                      | -       | -      | -     | X      | -   | -   | Required model column                                          |
+| [2018 Required](#tag-2018-required)                                      | -       | -      | -     | X      | -   | X   | Required model element                                         |
 | [2018 Indexing Preferences](#tag-2018-indexing-preferences)              | -       | -      | X     | X      | -   | -   | Specify database indexing preferences                          |
 | [2019 Export](#tag-2019-export)                                          | X       | X      | X     | -      | -   | -   | Describes export templates                                     |
 | [2021 Export Fragment Definitions](#tag-2021-export-fragment-definitions)| X       | X      | X     | -      | -   | -   | Describe export fragments that may be used in export anotation |
@@ -809,7 +809,7 @@ At present, the Chaise implementation of the citation annotation has the followi
 `tag:isrd.isi.edu,2018:required`
 
 This key indicates that the values for a given model element will be required by
-the system. This key is allowed on any number of columns. There is no content for this key.
+the system. This key is allowed on any number of columns or foreign keys. There is no content for this key.
 
 ### Tag: 2018 Indexing Preferences
 
@@ -1351,6 +1351,7 @@ The following attributes can be used to manipulate the presentation settings of 
       - `csv` for comma-seperated values.
       - `raw` for space-seperated values.
   - `"selector_ux_mode"`: The display mode for the recordedit input field when this column directive is a foreign key relationship. Supported values are `"facet-search-popup"` and `"simple-search-dropdown"`, with `"facet-search-popup"` being the default. Currently only supported in `entry` contexts.
+  - `"required"`: Use this property to force the required (nullok) check for this visible column. This property is only used in the `entry` contexts. If set to `true`, users cannot leave the input empty. And if set to `false`, the input becomes optional.
   - `"bulk_create_foreign_key"`: Use this property to control the bulk selection of foreign key values in `entry/create` context when there is a prefill query parameter. Supported values are a foreign key `name` in the format of `['schema_name', 'foreign_key_name']` from the schema document, `false`, or `null`. Using a foreign key name will use that foreign key as the one being bulk selected if that foreign key is in the visible columns list. `false` turns off the heuristics that trigger this feature. `null` will override inheritance for this property and use the default heuristics. This will override the `bulk_create_foreign_key` property defined in the display property of the foreign-key annotation. Currently only supported in `entry/create` context.
 - `array_display`: This property is _deprecated_. It is the same as `array_ux_mode` that is defined above under `display` property.
 - `array_options`: Applicaple only to read-only non-filter context of `visible-columns` annotation. This property is meant to be an object of properties that control the display of `array` or `array_d` aggregate column. These options will only affect the display (and templating environment) and have no effect on the generated ERMrest query. The available options are:

--- a/docs/user-docs/column-directive.md
+++ b/docs/user-docs/column-directive.md
@@ -32,6 +32,7 @@ Column directive allows instruction of a data source and modification of its pre
       - [wait\_for](#wait_for)
       - [show\_foreign\_key\_link](#show_foreign_key_link)
       - [selector\_ux\_mode](#selector_ux_mode)
+      - [required](#required)
       - [bulk\_create\_foreign\_key](#bulk_create_foreign_key)
       - [show\_key\_link](#show_key_link)
       - [array\_ux\_mode](#array_ux_mode)
@@ -69,7 +70,8 @@ In this category, you use the [`source`](#source) property to define the data so
       "show_foreign_key_link": <boolean>,
       "show_key_link": <boolean>,
       "array_ux_mode": <csv|ulist|olist|raw>,
-      "selector_ux_mode": <facet-search-popup|simple-search-dropdown>
+      "selector_ux_mode": <facet-search-popup|simple-search-dropdown>,
+      "required": <boolean>
   },
   "array_options": {
     "order": <change the default order>,
@@ -105,7 +107,8 @@ In this category, the [`sourcekey`](#sourcekey) proprety is used to refer to one
       "show_foreign_key_link": <boolean>,
       "show_key_link": <boolean>,
       "array_ux_mode": <csv|ulist|olist|raw>,
-      "selector_ux_mode": <facet-search-popup|simple-search-dropdown>
+      "selector_ux_mode": <facet-search-popup|simple-search-dropdown>,
+      "required": <boolean>
   },
   "array_options":{
     "order": <change the default order>,
@@ -426,6 +429,10 @@ While generating a default presentation for all outbound foreign key paths, ERMr
 ##### selector_ux_mode
 
 While generating a default presentation in `entry` mode for single outbound foreign key paths, Chaise will show a modal popup dialog for selecting rows. Using this attribute, you can modify this behavior. If this attribute is missing, we are going to use the inherited behavior from the [foreign key](annotation.md#tag-2016-foreign-key) annotation defined on the foreign key relationship. If that one is missing too, [table display](annotation.md#tag-2016-table-display) annotation will be applied. Supported values are `"facet-search-popup"` and `"simple-search-dropdown"`, with `"facet-search-popup"` being the default.
+
+##### required
+
+Use this property to force the required (nullok) check for this visible column. This property is only used in the `entry` contexts. If set to `true`, users cannot leave the input empty. And if set to `false`, the input becomes optional.
 
 ##### bulk_create_foreign_key
 

--- a/js/reference.js
+++ b/js/reference.js
@@ -669,6 +669,7 @@ import { getResponseHeader } from '@isrd-isi-edu/ermrestjs/js/http';
 
             var discardedFacets = [], partialyDiscardedFacets = [];
             var addToIssues = function (obj, message, discardedChoices) {
+                // TODO https://github.com/informatics-isi-edu/ermrestjs/issues/940
                 var name = obj.markdown_name;
                 if (!name && obj.sourcekey) {
                     name = obj.sourcekey;

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -13,9 +13,18 @@ export function isObjectAndNotNull(obj: unknown): boolean {
 
 /**
  * Verifies that the object is defined and the containing key/value pair is a non-empty string
+ * NOTE: this doesn't just check that the obj[keyname] is defined, it's also making sure it's a non-empty string.
  */
 export function isObjectAndKeyDefined(obj: any, keyName: string): boolean {
   return obj && typeof obj[keyName] === 'string' && obj[keyName] !== '';
+}
+
+/**
+ * Verifies that the object is defined and the keyName exists in the object.
+ * NOTE: this doesn't check the value of the key, it just checks if the key exists in the object.
+ */
+export function isObjectAndKeyExists(obj: any, keyName: string): boolean {
+  return isObjectAndNotNull(obj) && Object.prototype.hasOwnProperty.call(obj, keyName);
 }
 
 /**

--- a/test/specs/column/conf/columns_schema/schema.json
+++ b/test/specs/column/conf/columns_schema/schema.json
@@ -73,6 +73,7 @@
                         }
                     ],
                     "annotations": {
+                        "tag:isrd.isi.edu,2018:required": true,
                         "tag:isrd.isi.edu,2016:foreign-key": {
                             "to_name": "to_name_value",
                             "display": {
@@ -391,6 +392,7 @@
                     "comment": "is in multiple composite FKRs",
                     "annotations": {
                         "tag:isrd.isi.edu,2016:generated": {},
+                        "tag:isrd.isi.edu,2018:required": true,
                         "tag:isrd.isi.edu,2016:column-display": {
                             "*": {
                                 "column_order": ["columns_schema_outbound_fk_7"]

--- a/test/specs/column/conf/pseudo_column_schema/schema.json
+++ b/test/specs/column/conf/pseudo_column_schema/schema.json
@@ -34,6 +34,7 @@
                         "column_name": "id"
                     }],
                     "annotations": {
+                        "tag:isrd.isi.edu,2018:required": true,
                         "tag:isrd.isi.edu,2016:foreign-key": {
                             "display": {
                                 "entry/edit": {
@@ -53,7 +54,10 @@
                         "schema_name": "pseudo_column_schema",
                         "table_name": "outbound_2",
                         "column_name": "id"
-                    }]
+                    }],
+                    "annotations": {
+                        "tag:isrd.isi.edu,2018:required": true
+                    }
                 }, {
                     "names": [["pseudo_column_schema", "main_fk3"]],
                     "foreign_key_columns": [{
@@ -331,23 +335,35 @@
                     ],
                     "entry/create": "detailed",
                     "entry/edit": [
-                        "main_table_id_col",
+                        {
+                            "source": "main_table_id_col",
+                            "display": {
+                                "required": false
+                            }
+                        },
                         {
                             "source": [{"outbound": ["pseudo_column_schema", "main_fk2"]}, "id"],
                             "markdown_name": "main fk2 dropdown",
-                            "comment": "main fk2 cm dropdown display"
+                            "comment": "main fk2 cm dropdown display",
+                            "display": {
+                                "required": false
+                            }
                         },
                         {
                             "source": [{"outbound": ["pseudo_column_schema", "main_fk1"]}, "id"],
                             "markdown_name": "main fk dropdown",
-                            "comment": "main fk cm dropdown display"
+                            "comment": "main fk cm dropdown display",
+                            "display": {
+                                "required": "invalid-value"
+                            }
                         },
                         {
                             "source": [{"outbound": ["pseudo_column_schema", "main_fk3"]}, "id"],
                             "markdown_name": "main fk3 popup",
                             "comment": "main fk3 cm override popup display",
                             "display": {
-                                "selector_ux_mode": "facet-search-popup"
+                                "selector_ux_mode": "facet-search-popup",
+                                "required": true
                             }
                         },
                         {

--- a/test/specs/column/tests/01.columns_list.js
+++ b/test/specs/column/tests/01.columns_list.js
@@ -164,7 +164,7 @@ exports.execute = function (options) {
      *  columns_schema_outbound_fk_7 -> not part of any fk | has immutable
      *
      * FKRs:
-     *  outbound_fk_1: col_1 -> ref_table (to_name) (column_order: false)
+     *  outbound_fk_1: col_1 -> ref_table (to_name) (column_order: false) (required annot)
      *  outbound_fk_2: col_2 -> ref_table
      *  outbound_fk_3: col_3 -> ref_table
      *  outbound_fk_4: col_3 -> table_w_simple_key_2 | (column_order: [name])
@@ -176,14 +176,14 @@ exports.execute = function (options) {
      *
      * expected output for ref.columns in compact (default heuristics) contexts:
      * 0:   id
-     * 1:   outbound_fk_1 (check to_name)
+     * 1:   outbound_fk_1 (check to_name, nullok has required annotation)
      * 2:   outbound_fk_2  -> is null
      * 3:   outbound_fk_3 (check disambiguation) (check nullok)
      * 4:   outbound_fk_4 (check disambiguation)
      * 5:   col_4
      * 6:   col 5
      * 7:   col_6
-     * 8:   col_7
+     * 8:   col_7 (check nullok has required annotation)
      * 9:   columns_schema_outbound_fk_7
      * 10:  columns_schema_handlebars_col
      * ...: system columns

--- a/test/specs/column/tests/02.reference_column.js
+++ b/test/specs/column/tests/02.reference_column.js
@@ -8,8 +8,8 @@ exports.execute = function (options) {
 
         var catalog_id = process.env.DEFAULT_CATALOG,
             schemaName = "columns_schema",
-            tableName = "columns_table", // the structure of this table is explained in 14.pseudo_columns.js
-            tableWithAsset = "table_w_asset", // the structure of this table is exlpained in 14.pseudo_columns.js
+            tableName = "columns_table", // the structure of this table is explained in 01.columns_list.js
+            tableWithAsset = "table_w_asset", // the structure of this table is exlpained in 01.columns_list.js
             tableWithDiffColTypes = "table_w_diff_col_types",
             tableWSimpleKey = "table_w_simple_key",
             entityId = 1;
@@ -382,28 +382,44 @@ exports.execute = function (options) {
                     }).toThrow("can not use this type of column in entry mode.");
                 });
 
-                it("if any of its columns have nullok=false, should return false.", function () {
+                // display.required column-directive property tests are in 03.pseudo_column.js
+
+                it ('otherwise, if required annotation is present, should honor it.', () => {
+                    // normal column
+                    expect(compactColumns[6].nullok).toBe(false);
+
+                    // outbound fk
+                    expect(compactColumns[1].nullok).toBe(false);
+                });
+
+                it ('otherwise, if any of its columns have nullok=true, should return true.', () => {
+                    // simple fk
+                    expect(compactColumns[2].nullok).toBe(true, 'index=2');
+                    // composite fk, all true
+                    expect(compactColumns[19].nullok).toBe(true, 'index=15');
+                    // composite fk, one true
+                    expect(compactColumns[16].nullok).toBe(true, 'index=16');
+                });
+
+                it ('otherwise should return false.', () => {
                     // simple fk
                     expect(compactColumns[3].nullok).toBe(false);
-                    // composite fk, one false
-                    expect(compactColumns[12].nullok).toBe(false);
                     // composite fk, all false
-                    expect(compactColumns[13].nullok).toBe(false);
+                    expect(compactColumns[17].nullok).toBe(false);
                     // simple key
                     expect(compactColumns[0].nullok).toBe(false);
                 });
-
-                it('otherwise should return true.', function () {
-                    // simple fk
-                    expect(compactColumns[2].nullok).toBe(true);
-                    // composite fk, all true
-                    expect(compactColumns[15].nullok).toBe(true);
-                });
             });
 
-            it('for other columns should return the base column\'s nullok.', function () {
-                expect(compactColumns[4].nullok).toBe(false);
-                expect(compactColumns[8].nullok).toBe(true);
+            describe('for other columns, ', () => {
+                // display.required column-directive property tests are in 03.pseudo_column.js
+
+                it('otherwise should return the base column\'s nullok.', function () {
+                    // nullok is false
+                    expect(compactColumns[7].nullok).toBe(false);
+                    // nullok is true
+                    expect(compactColumns[8].nullok).toBe(true);
+                });
             });
         });
 


### PR DESCRIPTION
`ReferenceColumn.nullok` API is used to mark inputs as required or optional. With the current implementation, as long as any of the columns in a composite foreign key are required (`nullok=false`), we're marking the whole input as required. We did this to ensure data consistency. But now that we've used composite foreign keys in multiple deployments, this is too restrictive. So, with the changes in this PR:

1. We will mark a composite foreign key as optional as long as any of its columns are optional. 
2. If there's a scenario that this heuristic doesn't work for data-modelers, they can use the `2018:required` annotation to mark the foreign key as required.
3. To make manipulating the required check easier, we're also allowing `"required"` to be defined under the `"display"` property of column directives.


To better understand this, let's go through the Facebase example:

- `isa:file` is the main table of interest.
- `isa:biosample` has a foreign key to `isa:dataset`.
- Each file must be part of a dataset, so `isa:file` has a foreign key to `isa:dataset` using the `dataset` column that is `"nullok": false`.
- Each file could be part of a biosample. To make sure the relationship between these three tables is consistent, the foreign key from `isa:file` to `isa:biosample` is composite. The composite foreign key consists of the `dataset` and `biosample` columns. And `biosample` is `"nullok": true`.
- We want to let users pick Dataset and Biosample. So, both of these foreign keys are visible. But since `dataset` is required, Chaise marks both Dataset and Biosample as required. 
- Without the changes in this PR, we would have to modify the foreign key relationships like the following to get the desired behavior from chaise:

  ```sql
  ---- current model:
  -- file table:
  CONSTRAINT fk_file_to_dataset
  FOREIGNKEY (dataset) REFRENCES dataset(RID);

  CONSTRAINT fk_file_to_biosample
  FOREIGNKEY (dataset, biosample) REFRENCES biosample(dataset, RID);

  -- biosample table:
  CONSTRAINT fk_biosample_to_dataset
  FOREIGNKEY (dataset) REFRENCES dataset(RID);

  ---- proposed approach:
  -- file table:
  CONSTRAINT fk_file_to_dataset
  FOREIGNKEY (dataset, dataset_id) REFRENCES dataset(RID, id);

  CONSTRAINT fk_file_to_biosample
  FOREIGNKEY (dataset_id, biosample) REFRENCES biosample(dataset_id, RID);

  -- biosample table:
  CONSTRAINT fk_biosample_to_dataset
  FOREIGNKEY (dataset, dataset_id) REFRENCES dataset(RID, id);
  ```
