### PR TITLE
Allow accessing main data in filter of column-directives

### DIFF
--- a/js/ag_reference.js
+++ b/js/ag_reference.js
@@ -59,7 +59,7 @@ export function AttributeGroupReference(keyColumns, aggregateColumns, location, 
 
     /**
      * Array of AttributeGroupColumn that will be used as the key columns
-     * @type {ERMrest.AttributeGroupColumn[]}
+     * @type {AttributeGroupColumn[]}
      */
     this._keyColumns = keyColumns;
 
@@ -80,7 +80,7 @@ export function AttributeGroupReference(keyColumns, aggregateColumns, location, 
     this.table = sourceTable;
 
     /**
-     * @type {ERMrest.ReferenceAggregateFn}
+     * @type {ReferenceAggregateFn}
      */
     this.aggregate = new AttributeGroupReferenceAggregateFn(this);
 
@@ -124,7 +124,7 @@ AttributeGroupReference.prototype = {
 
     /**
      * Returns the visible key columns
-     * @type {ERMrest.AttributeGroupColumn[]}
+     * @type {AttributeGroupColumn[]}
      */
     get shortestKey() {
         return this._keyColumns.filter(function (kc) {
@@ -181,7 +181,7 @@ AttributeGroupReference.prototype = {
       * This will generate a new unfiltered reference each time.
       * Returns a reference that points to all entities of current table
       *
-      * @type {ERMrest.Reference}
+      * @type {Reference}
       */
      get unfilteredReference() {
          verify(this.table, "table is not defined for current reference");
@@ -512,7 +512,7 @@ AttributeGroupReference.prototype = {
     /**
      * Find a column in list of key and aggregate columns.
      * @param  {string} name the column name
-     * @return {ERMrest.AttributeGroupColumn}
+     * @return {AttributeGroupColumn}
      */
     getColumnByName: function (name) {
 
@@ -608,7 +608,7 @@ AttributeGroupReference.prototype = {
 export function AttributeGroupPage(reference, data, hasPrevious, hasNext) {
     /**
      * The page's associated reference.
-     * @type {ERMrest.AttributeGroupReference}
+     * @type {AttributeGroupReference}
      */
     this.reference = reference;
 
@@ -639,7 +639,7 @@ AttributeGroupPage.prototype = {
      *   console.log("Tuple:", tuple.displayname.value, "has values:", tuple.values);
      * }
      * ```
-     * @type {ERMrest.AttributeGroupTuple[]}
+     * @type {AttributeGroupTuple[]}
      */
     get tuples () {
         if (this._tuples === undefined) {
@@ -675,7 +675,7 @@ AttributeGroupPage.prototype = {
      *   );
      * }
      * ```
-     * @type {ERMrest.AttributeGroupReference|null}
+     * @type {AttributeGroupReference|null}
      */
     get next() {
         if (this.hasNext) {
@@ -696,7 +696,7 @@ AttributeGroupPage.prototype = {
      *   );
      * }
      * ```
-     * @type {ERMrest.AttributeGroupReference|null}
+     * @type {AttributeGroupReference|null}
      */
     get previous() {
         if (this.hasPrevious) {
@@ -892,7 +892,7 @@ AttributeGroupTuple.prototype = {
  *
  * @param       {string} alias the alias that we want to use. If alias exist we will use the alias=term for creating url.
  * @param       {string} term  the term string, e.g., cnt(*) or col1.
- * @param       {ERMrest.Column} baseColumn the database column that this is based on
+ * @param       {Column} baseColumn the database column that this is based on
  * @param       {Object|string} displayname displayname of column, if it's an object it will have `value`, `unformatted`, and `isHTML`
  * @param       {ERMrset.Type} colType    type of column
  * @param       {string} comment     The string for comment (tooltip)
@@ -927,7 +927,7 @@ export function AttributeGroupColumn(alias, term, baseColumn, displayname, colTy
 
     /**
      * The database column that this is based on. It might not be defined.
-     * @type {ERMrest.Column}
+     * @type {Column}
      */
     this.baseColumn = baseColumn;
 
@@ -949,7 +949,7 @@ export function AttributeGroupColumn(alias, term, baseColumn, displayname, colTy
 
         /**
         * Type object
-        * @type {ERMrest.Type}
+        * @type {Type}
         */
         this.type = colType;
     }
@@ -1104,7 +1104,7 @@ AttributeGroupColumn.prototype = {
  * Constructor for creating location object for creating a {@link ERMrest.AttributeGroupReference}
 
  * @param       {string} service      the service part of url
- * @param       {ERMrest.catalog} catalog      the catalog object
+ * @param       {catalog} catalog      the catalog object
  * @param       {String} path         the whole path string
  * @param       {Object} searchObject search obect, it should have `term`, and `column`.
  * @param       {Object[]} sortObject sort object, An array of objects with `column`, and `descending` as attribute.
@@ -1122,7 +1122,7 @@ export function AttributeGroupLocation(service, catalog, path, searchObject, sor
     /**
      * catalog object
      *
-     * @type {ERMrest.Catalog}
+     * @type {Catalog}
      */
     this.catalog = catalog;
 
@@ -1249,7 +1249,7 @@ AttributeGroupLocation.prototype = {
  *  will access this constructor for purposes of fetching grouped aggregate data
  *  for a specific column
  *
- * @param {ERMrest.AttributeGroupReference} reference The reference that this aggregate function belongs to
+ * @param {AttributeGroupReference} reference The reference that this aggregate function belongs to
  * @memberof ERMrest
  * @constructor
  */
@@ -1286,8 +1286,8 @@ AttributeGroupReferenceAggregateFn.prototype = {
  *  - This will currently be used by the aggregateGroup histogram function to return a
  *    BucketAttributeGroupReference rather than a {@link ERMrest.Reference}
  *
- * @param       {ERMrest.ReferenceColumn} baseColumn The column that is used for creating grouped aggregate
- * @param       {ERMrest.Reference} baseRef The reference representing the column
+ * @param       {ReferenceColumn} baseColumn The column that is used for creating grouped aggregate
+ * @param       {Reference} baseRef The reference representing the column
  * @param       {String} min The min value for the key column request
  * @param       {String} max The max value for the key column request
  * @param       {Integer} numberOfBuckets  The number of buckets for the request

--- a/js/column.js
+++ b/js/column.js
@@ -39,7 +39,7 @@ import {
 
 // legacy
 import { parse } from '@isrd-isi-edu/ermrestjs/js/parser';
-import { Type } from '@isrd-isi-edu/ermrestjs/js/core';
+import { Column, Type, ForeignKeyRef } from '@isrd-isi-edu/ermrestjs/js/core';
 import { Page, Reference, Tuple, _referenceCopy } from '@isrd-isi-edu/ermrestjs/js/reference';
 import {
   AttributeGroupColumn,
@@ -91,8 +91,8 @@ import {
  * - Otherwise: PseudoColumn
  *
  * @private
- * @param  {ERMrest.Reference}  reference    the parent reference
- * @param  {ERMrest.Column}  column       the underlying column object
+ * @param  {Reference}  reference    the parent reference
+ * @param  {Column}  column       the underlying column object
  * @param  {ERMrest.SourceObjectWrapper}  sourceObjectWrapper the column definition
  * @param  {ERMrest.Tuple=}  mainTuple    the main tuple
  * @param  {String=}  name         the name to avoid computing it again.
@@ -159,13 +159,13 @@ export const _createPseudoColumn = function (reference, sourceObjectWrapper, mai
 /**
  * @memberof ERMrest
  * @constructor
- * @param {ERMrest.Reference} reference column's reference
- * @param {ERMrest.Column[]} baseCols List of columns that this reference-column will be created based on.
- * @param {ERMrest.SourceObjectWrapper} sourceObjectWrapper the sourceObjectWrapper object (might be undefined)
+ * @param {Reference} reference column's reference
+ * @param {Column[]} cols List of columns that this reference-column will be created based on.
+ * @param {SourceObjectWrapper} sourceObjectWrapper the sourceObjectWrapper object (might be undefined)
  * @param {string} name        to avoid processing the name again, this might be undefined.
- * @param {ERMrest.Tuple} mainTuple   if the reference is referring to just one tuple, this is defined.
+ * @param {Tuple} mainTuple   if the reference is referring to just one tuple, this is defined.
  * @desc
- * Constructor for ReferenceColumn. This class is a wrapper for {@link ERMrest.Column}.
+ * Constructor for ReferenceColumn. This class is a wrapper for {@link Column}.
  */
 export function ReferenceColumn(reference, cols, sourceObjectWrapper, name, mainTuple) {
     this._baseReference = reference;
@@ -1657,8 +1657,8 @@ Object.defineProperty(PseudoColumn.prototype, "canUseScalarProjection", {
  * @memberof ERMrest
  * @constructor
  * @class
- * @param {ERMrest.Reference} reference column's reference
- * @param {ERMrest.ForeignKeyRef} fk the foreignkey
+ * @param {Reference} reference column's reference
+ * @param {ForeignKeyRef} fk the foreignkey
  * @desc
  * Constructor for ForeignKeyPseudoColumn. This class is a wrapper for {@link ERMrest.ForeignKeyRef}.
  * This class extends the {@link ERMrest.ReferenceColumn}
@@ -1702,7 +1702,7 @@ export function ForeignKeyPseudoColumn (reference, fk, sourceObjectWrapper, name
     // NOTE added for compatibility
     // I cannot simply create a sourceObjectWrapper because it needs a shortestkey of length one.
     if (!isObjectAndNotNull(sourceObjectWrapper)) {
-        this.lastForeignKeyNode = new SourceObjectNode(fk, false, true);
+        this.lastForeignKeyNode = new SourceObjectNode(fk, false, true, false, false, undefined, undefined, fk.table);
         this.firstForeignKeyNode = this.lastForeignKeyNode;
         this.sourceObjectNodes = [this.lastForeignKeyNode];
         this.foreignKeyPathLength = 1;

--- a/js/column.js
+++ b/js/column.js
@@ -93,10 +93,10 @@ import {
  * @private
  * @param  {Reference}  reference    the parent reference
  * @param  {Column}  column       the underlying column object
- * @param  {ERMrest.SourceObjectWrapper}  sourceObjectWrapper the column definition
- * @param  {ERMrest.Tuple=}  mainTuple    the main tuple
+ * @param  {SourceObjectWrapper}  sourceObjectWrapper the column definition
+ * @param  {Tuple=}  mainTuple    the main tuple
  * @param  {String=}  name         the name to avoid computing it again.
- * @return {ERMrest.ReferenceColumn}
+ * @return {ReferenceColumn}
  */
 export const _createPseudoColumn = function (reference, sourceObjectWrapper, mainTuple) {
     var sourceObject = sourceObjectWrapper.sourceObject,
@@ -222,7 +222,7 @@ export function ReferenceColumn(reference, cols, sourceObjectWrapper, name, main
     this.isPseudo = false;
 
     /**
-     * @type {ERMrest.Table}
+     * @type {Table}
      */
     this.table = this._baseCols.length > 0 ? this._baseCols[0].table : reference.table;
 
@@ -313,7 +313,7 @@ ReferenceColumn.prototype = {
     },
     /**
      *
-     * @type {ERMrest.Type}
+     * @type {Type}
      */
     get type() {
         if (this._type === undefined) {
@@ -353,7 +353,7 @@ ReferenceColumn.prototype = {
 
     /**
      * @desc Returns the aggregate function object
-     * @type {ERMrest.ColumnAggregateFn}
+     * @type {ColumnAggregateFn}
      */
     get aggregate() {
         if (this._aggregate === undefined) {
@@ -364,7 +364,7 @@ ReferenceColumn.prototype = {
 
     /**
      * @desc Returns the aggregate group object
-     * @type {ERMrest.ColumnGroupAggregateFn}
+     * @type {ColumnGroupAggregateFn}
      */
     get groupAggregate() {
         if (this._groupAggregate === undefined) {
@@ -732,7 +732,7 @@ ReferenceColumn.prototype = {
      * Array of columns that the current column value depends on. It will get the list from:
      * - source display.wait_for, or
      * - column-display.wait_for or key-display.wait_for (depending on the type of column)
-     * @type {ERMrest.ReferenceColumn[]}
+     * @type {ReferenceColumn[]}
      */
     get waitFor() {
         if (this._waitFor === undefined) {
@@ -757,7 +757,7 @@ ReferenceColumn.prototype = {
      * Should be called once every value is retrieved
      * @param  {Object} templateVariables     [description]
      * @param  {Object} columnValue the value of aggregate column (if it's aggregate)
-     * @param  {ERMrest.Tuple} mainTuple             [description]
+     * @param  {Tuple} mainTuple             [description]
      * @return {Object}                       [description]
      */
     sourceFormatPresentation: function (templateVariables, columnValue, mainTuple) {
@@ -876,11 +876,11 @@ ReferenceColumn.prototype = {
  * it will append "-<integer>" to it.
  *
  * @memberof ERMrest
- * @param {ERMrest.Reference} reference  column's reference
- * @param {ERMrest.Column} column      the column that this pseudo-column is representing
- * @param {ERMrest.SourceObjectWrapper} sourceObjectWrapper the sourceObjectWrapper object (might be undefined)
+ * @param {Reference} reference  column's reference
+ * @param {Column} column      the column that this pseudo-column is representing
+ * @param {SourceObjectWrapper} sourceObjectWrapper the sourceObjectWrapper object (might be undefined)
  * @param {string} name        to avoid processing the name again, this might be undefined.
- * @param {ERMrest.Tuple} mainTuple   if the reference is referring to just one tuple, this is defined.
+ * @param {Tuple} mainTuple   if the reference is referring to just one tuple, this is defined.
  * @constructor
  * @class
  */
@@ -905,11 +905,11 @@ _extends(VirtualColumn, ReferenceColumn);
  * entity (inbound or p&b association)
  *
  * @memberof ERMrest
- * @param {ERMrest.Reference} reference  column's reference
- * @param {ERMrest.Column} column      the column that this pseudo-column is representing
- * @param {ERMrest.SourceObjectWrapper} sourceObjectWrapper the sourceObjectWrapper object (might be undefined)
+ * @param {Reference} reference  column's reference
+ * @param {Column} column      the column that this pseudo-column is representing
+ * @param {SourceObjectWrapper} sourceObjectWrapper the sourceObjectWrapper object (might be undefined)
  * @param {string} name        to avoid processing the name again, this might be undefined.
- * @param {ERMrest.Tuple} mainTuple   if the reference is referring to just one tuple, this is defined.
+ * @param {Tuple} mainTuple   if the reference is referring to just one tuple, this is defined.
  * @constructor
  * @class
  */
@@ -1061,7 +1061,7 @@ PseudoColumn.prototype.formatPresentation = function(data, context, templateVari
  *          3.1.3.2. In entity mode, we are going to return list of row_names derived from `row_name/compact`.
  *  3.2. Otherwise we will only apply the pre_format annotation for the column.
  *
- * @param  {ERMrest.Page} page               the page object of main (current) refernece
+ * @param  {Page} page               the page object of main (current) refernece
  * @param {Object} contextHeaderParams the object that we want to log.
  * @return {Promise}
  */
@@ -1549,7 +1549,7 @@ Object.defineProperty(PseudoColumn.prototype, "aggregateFn", {
  * 3. if mainTuple is available, create the reference based on this path:
  *      <pseudoColumnSchema:PseudoColumnTable>/<path from pseudo-column to main table>/<facets based on value of shortestkey of main table>
  * 4. Otherwise create the path by traversing the path
- * @member {ERMrest.Reference} reference
+ * @member {Reference} reference
  * @memberof ERMrest.PseudoColumn#
  */
 Object.defineProperty(PseudoColumn.prototype, "reference", {
@@ -1688,13 +1688,13 @@ export function ForeignKeyPseudoColumn (reference, fk, sourceObjectWrapper, name
     ].join("/");
 
     /**
-     * @type {ERMrest.Reference}
+     * @type {Reference}
      * @desc The reference object that represents the table of this PseudoColumn
      */
     this.reference =  new Reference(parse(ermrestURI), table.schema.catalog);
 
     /**
-     * @type {ERMrest.ForeignKeyRef}
+     * @type {ForeignKeyRef}
      * @desc The Foreign key object that this PseudoColumn is created based on
      */
     this.foreignKey = fk;
@@ -1730,9 +1730,9 @@ ForeignKeyPseudoColumn.prototype.generateUniqueId = function (linkedData) {
  * constrained based on the domain_filter_pattern annotation. If thisx
  * annotation doesn't exist, it returns this (reference)
  * `this` is the same as column.reference
- * @param {ERMrest.ReferenceColumn} column - column that `this` is based on
+ * @param {ReferenceColumn} column - column that `this` is based on
  * @param {Object} data - tuple data with potential constraints
- * @returns {ERMrest.Reference} the constrained reference
+ * @returns {Reference} the constrained reference
  */
 ForeignKeyPseudoColumn.prototype.filteredRef = function(data, linkedData) {
     var getFilteredRef = function (self) {
@@ -2028,7 +2028,7 @@ Object.defineProperty(ForeignKeyPseudoColumn.prototype, "hasDomainFilter", {
 });
 /**
  * The visible columns that are used as part of the domain-filter
- * @member {ERMrest.ReferenceColumn[]} domainFilterUsedColumns
+ * @member {ReferenceColumn[]} domainFilterUsedColumns
  * @memberof ERMrest.ForeignKeyPseudoColumn#
  */
 Object.defineProperty(ForeignKeyPseudoColumn.prototype, 'domainFilterUsedColumns', {
@@ -2072,7 +2072,7 @@ Object.defineProperty(ForeignKeyPseudoColumn.prototype, "defaultValues", {
 
 /**
  * returns a reference using raw default values of the constituent columns.
- * @member {ERMrest.Refernece} defaultReference
+ * @member {Refernece} defaultReference
  * @memberof ERMrest.ForeignKeyPseudoColumn#
  */
 Object.defineProperty(ForeignKeyPseudoColumn.prototype, "defaultReference", {
@@ -2277,8 +2277,8 @@ Object.defineProperty(ForeignKeyPseudoColumn.prototype, "nullok", {
  * @memberof ERMrest
  * @constructor
  * @class
- * @param {ERMrest.Reference} reference column's reference
- * @param {ERMrest.Key} key the key
+ * @param {Reference} reference column's reference
+ * @param {Key} key the key
  * @desc
  * Constructor for KeyPseudoColumn. This class is a wrapper for {@link ERMrest.Key}.
  * This class extends the {@link ERMrest.ReferenceColumn}
@@ -2300,7 +2300,7 @@ export function KeyPseudoColumn (reference, key, sourceObjectWrapper, name) {
     this.isKey = true;
 
     /**
-     * @type {ERMrest.ForeignKeyRef}
+     * @type {ForeignKeyRef}
      * @desc The Foreign key object that this PseudoColumn is created based on
      */
     this.key = key;
@@ -2467,8 +2467,8 @@ Object.defineProperty(KeyPseudoColumn.prototype, "display", {
  * @memberof ERMrest
  * @constructor
  * @class
- * @param {ERMrest.Reference} reference column's reference
- * @param {ERMrest.Column} column the asset column
+ * @param {Reference} reference column's reference
+ * @param {Column} column the asset column
  *
  * @property {string} urlPattern  A desired upload location can be derived by Pattern Expansion on pattern.
  * @property {(ERMrest.Column|null)} filenameColumn if it's string, then it is the name of column we want to store filename inside of it.
@@ -2728,7 +2728,7 @@ AssetPseudoColumn.prototype._determineSortable = function () {
 
 /**
  * Returns the template_engine defined in the annotation
- * @member {ERMrest.Refernece} template_engine
+ * @member {Refernece} template_engine
  * @memberof ERMrest.AssetPseudoColumn#
  */
 Object.defineProperty(AssetPseudoColumn.prototype, "templateEngine", {
@@ -2742,7 +2742,7 @@ Object.defineProperty(AssetPseudoColumn.prototype, "templateEngine", {
 
 /**
  * Returns the url_pattern defined in the annotation (the raw value and not computed).
- * @member {ERMrest.Refernece} urlPattern
+ * @member {Refernece} urlPattern
  * @memberof ERMrest.AssetPseudoColumn#
  */
 Object.defineProperty(AssetPseudoColumn.prototype, "urlPattern", {
@@ -2756,7 +2756,7 @@ Object.defineProperty(AssetPseudoColumn.prototype, "urlPattern", {
 
 /**
  * The column object that filename is stored in.
- * @member {ERMrest.Column} filenameColumn
+ * @member {Column} filenameColumn
  * @memberof ERMrest.AssetPseudoColumn#
  */
 Object.defineProperty(AssetPseudoColumn.prototype, "filenameColumn", {
@@ -2775,7 +2775,7 @@ Object.defineProperty(AssetPseudoColumn.prototype, "filenameColumn", {
 
 /**
  * The column object that filename is stored in.
- * @member {ERMrest.Column} filenameColumn
+ * @member {Column} filenameColumn
  * @memberof ERMrest.AssetPseudoColumn#
  */
 Object.defineProperty(AssetPseudoColumn.prototype, "byteCountColumn", {
@@ -2794,7 +2794,7 @@ Object.defineProperty(AssetPseudoColumn.prototype, "byteCountColumn", {
 
 /**
  * The column object that md5 hash is stored in.
- * @member {ERMrest.Column} md5
+ * @member {Column} md5
  * @memberof ERMrest.AssetPseudoColumn#
  */
 Object.defineProperty(AssetPseudoColumn.prototype, "md5", {
@@ -2818,7 +2818,7 @@ Object.defineProperty(AssetPseudoColumn.prototype, "md5", {
 
 /**
  * The column object that sha256 hash is stored in.
- * @member {ERMrest.Column} sha256
+ * @member {Column} sha256
  * @memberof ERMrest.AssetPseudoColumn#
  */
 Object.defineProperty(AssetPseudoColumn.prototype, "sha256", {
@@ -2912,7 +2912,7 @@ Object.defineProperty(AssetPseudoColumn.prototype, "displayImagePreview", {
 
 /**
  * Returns the wait for list for this column.
- * @member {ERMrest.Refernece} waitFor
+ * @member {Refernece} waitFor
  * @memberof ERMrest.AssetPseudoColumn#
  */
 Object.defineProperty(AssetPseudoColumn.prototype, "waitFor", {
@@ -2939,8 +2939,8 @@ Object.defineProperty(AssetPseudoColumn.prototype, "waitFor", {
  * @memberof ERMrest
  * @constructor
  * @class
- * @param {ERMrest.Reference} reference column's reference
- * @param {ERMrest.Reference} fk the foreignkey
+ * @param {Reference} reference column's reference
+ * @param {Reference} fk the foreignkey
  * @desc
  * Constructor for InboundForeignKeyPseudoColumn. This class is a wrapper for {@link ERMrest.ForeignKeyRef}.
  * This is a bit different than the {@link ERMrest.ForeignKeyPseudoColumn}, as that was for foreign keys
@@ -2959,7 +2959,7 @@ export function InboundForeignKeyPseudoColumn (reference, relatedReference, sour
 
     /**
      * The reference that can be used to get the data for this pseudo-column
-     * @type {ERMrest.Reference}
+     * @type {Reference}
      */
     this.reference = relatedReference;
 
@@ -2967,13 +2967,13 @@ export function InboundForeignKeyPseudoColumn (reference, relatedReference, sour
 
     /**
      * The table that this pseudo-column represents
-     * @type {ERMrest.Table}
+     * @type {Table}
      */
     this.table = relatedReference.table;
 
     /**
      * The {@link ERMrest.ForeignKeyRef} that this pseudo-column is based on.
-     * @type {ERMrest.ForeignKeyRef}
+     * @type {ForeignKeyRef}
      */
     this.foreignKey = fk;
 
@@ -3073,9 +3073,9 @@ Object.defineProperty(InboundForeignKeyPseudoColumn.prototype, "compressedDataSo
  *
  * If the ReferenceColumn is not provided, then the FacetColumn is for reference
  *
- * @param {ERMrest.Reference} reference the reference that this FacetColumn blongs to.
+ * @param {Reference} reference the reference that this FacetColumn blongs to.
  * @param {int} index The index of this FacetColumn in the list of facetColumns
- * @param {ERMrest.SourceObjectWrapper} facetObjectWrapper The filter object that this FacetColumn will be created based on
+ * @param {SourceObjectWrapper} facetObjectWrapper The filter object that this FacetColumn will be created based on
  * @param {?ERMrest.FacetFilter[]} filters Array of filters
  * @memberof ERMrest
  * @constructor
@@ -3084,13 +3084,13 @@ export function FacetColumn (reference, index, facetObjectWrapper, filters) {
 
     /**
      * The column object that the filters are based on
-     * @type {ERMrest.Column}
+     * @type {Column}
      */
     this._column = facetObjectWrapper.column;
 
     /**
      * The reference that this facet blongs to
-     * @type {ERMrest.Reference}
+     * @type {Reference}
      */
     this.reference = reference;
 
@@ -3279,7 +3279,7 @@ FacetColumn.prototype = {
 
     /**
      * ReferenceColumn that this facetColumn is based on
-     * @type {ERMrest.ReferenceColumn}
+     * @type {ReferenceColumn}
      */
     get column () {
         if (this._referenceColumn === undefined) {
@@ -3313,7 +3313,7 @@ FacetColumn.prototype = {
      *   parse it.
      *
      *
-     * @type {ERMrest.Reference}
+     * @type {Reference}
      */
     get sourceReference () {
         if (this._sourceReference === undefined) {
@@ -3676,7 +3676,7 @@ FacetColumn.prototype = {
      * An {@link ERMrest.AttributeGroupReference} object that can be used to get
      * the available scalar values of this facet. This will use the sortColumns, and hideNumOccurrences APIs.
      * It will throw an error if it's used in entity-mode.
-     * @type {ERMrest.AttributeGroupReference}
+     * @type {AttributeGroupReference}
      */
     get scalarValuesReference() {
         verify(!this.isEntityMode, "this API cannot be used in entity-mode");
@@ -4089,7 +4089,7 @@ FacetColumn.prototype = {
     /**
      * Create a new Reference with appending a new Search filter to current FacetColumn
      * @param  {String} term the term for search
-     * @return {ERMrest.Reference} the Reference with the new filter
+     * @return {Reference} the Reference with the new filter
      */
     addSearchFilter: function (term) {
         verify (isDefinedAndNotNull(term), "`term` is required.");
@@ -4102,7 +4102,7 @@ FacetColumn.prototype = {
 
     /**
      * Create a new Reference with appending a list of choice filters to current FacetColumn
-     * @return {ERMrest.Reference} the reference with the new filter
+     * @return {Reference} the reference with the new filter
      */
     addChoiceFilters: function (values) {
         verify(Array.isArray(values), "given argument must be an array");
@@ -4118,7 +4118,7 @@ FacetColumn.prototype = {
     /**
      * Create a new Reference with replacing choice facet filters by the given input
      * This will also remove NotNullFacetFilter
-     * @return {ERMrest.Reference} the reference with the new filter
+     * @return {Reference} the reference with the new filter
      */
     replaceAllChoiceFilters: function (values) {
         verify(Array.isArray(values), "given argument must be an array");
@@ -4136,7 +4136,7 @@ FacetColumn.prototype = {
     /**
      * Given a term, it will remove any choice filter with that term (if any).
      * @param  {Array<any>} terms array of terms
-     * @return {ERMrest.Reference} the reference with the new filter
+     * @return {Reference} the reference with the new filter
      */
     removeChoiceFilters: function (terms) {
         verify(Array.isArray(terms), "given argument must be an array");
@@ -4152,7 +4152,7 @@ FacetColumn.prototype = {
      * @param  {boolean=} minExclusive whether the minimum boundary is exclusive or not.
      * @param  {String|int=} max maximum value. Can be null or undefined.
      * @param  {boolean=} maxExclusive whether the maximum boundary is exclusive or not.
-     * @return {ERMrest.Reference} the reference with the new filter
+     * @return {Reference} the reference with the new filter
      */
     addRangeFilter: function (min, minExclusive, max, maxExclusive) {
         verify (isDefinedAndNotNull(min) || isDefinedAndNotNull(max), "One of min and max must be defined.");
@@ -4181,7 +4181,7 @@ FacetColumn.prototype = {
      * @param  {boolean=} minExclusive whether the minimum boundary is exclusive or not.
      * @param  {String|int=} max maximum value. Can be null or undefined.
      * @param  {boolean=} maxExclusive whether the maximum boundary is exclusive or not.
-     * @return {ERMrest.Reference} the reference with the new filter
+     * @return {Reference} the reference with the new filter
      */
     removeRangeFilter: function (min, minExclusive, max, maxExclusive) {
         //TODO needs refactoring
@@ -4201,7 +4201,7 @@ FacetColumn.prototype = {
      * this function to only add the filter, and then in the client first remove all and thenadd
      * addNotNullFilter, but since the code is not very optimized that would result on a heavy
      * operation.
-     * @return {ERMrest.Reference}
+     * @return {Reference}
      */
     addNotNullFilter: function () {
         return this._applyFilters([new NotNullFacetFilter()]);
@@ -4209,7 +4209,7 @@ FacetColumn.prototype = {
 
     /**
      * Create a new Reference without any filters.
-     * @return {ERMrest.Reference}
+     * @return {Reference}
      */
     removeNotNullFilter: function () {
         var filters = this.filters.filter(function (f) {
@@ -4220,7 +4220,7 @@ FacetColumn.prototype = {
 
     /**
      * Create a new Reference by removing all the filters from current facet.
-     * @return {ERMrest.Reference} the reference with the new filter
+     * @return {Reference} the reference with the new filter
      */
     removeAllFilters: function() {
         return this._applyFilters([]);
@@ -4229,7 +4229,7 @@ FacetColumn.prototype = {
     /**
      * Create a new Reference by removing a filter from current facet.
      * @param  {int} index index of element that we want to remove from list
-     * @return {ERMrest.Reference} the reference with the new filter
+     * @return {Reference} the reference with the new filter
      */
     removeFilter: function (index) {
         var filters = this.filters.slice();
@@ -4243,8 +4243,8 @@ FacetColumn.prototype = {
      * Given an array of {@link ERMrest.FacetFilter}, will return a new
      * {@link ERMrest.Reference} with the applied filters to the current FacetColumn
      * @private
-     * @param  {ERMrest.FacetFilter[]} filters array of filters
-     * @return {ERMrest.Reference} the reference with the new filter
+     * @param  {FacetFilter[]} filters array of filters
+     * @return {Reference} the reference with the new filter
      */
     _applyFilters: function (filters) {
         var self = this, loc = this.reference.location;
@@ -4378,7 +4378,7 @@ _extends(ChoiceFacetFilter, FacetFilter);
  * @param       {boolean=} minExclusive whether the min filter is exclusive or not
  * @param       {String|int=} max
  * @param       {boolean=} maxExclusive whether the max filter is exclusive or not
- * @param       {ERMrest.Type}
+ * @param       {Type}
  * @constructor
  * @memberof ERMrest
  */
@@ -4465,7 +4465,7 @@ function NotNullFacetFilter () {
  *  for a specific column
  * @memberof ERMrest
  * @class
- * @param {ERMrest.ReferenceColumn} column - the column that is used for creating column aggregates
+ * @param {ReferenceColumn} column - the column that is used for creating column aggregates
  */
 export function ColumnAggregateFn (column) {
     this.column = column;
@@ -4512,7 +4512,7 @@ ColumnAggregateFn.prototype = {
  *  will access this constructor for purposes of fetching grouped aggregate data
  *  for a specific column
  *
- * @param {ERMrest.ReferenceColumn} column The column that is used for creating grouped aggregate
+ * @param {ReferenceColumn} column The column that is used for creating grouped aggregate
  * @memberof ERMrest
  * @constructor
  */
@@ -4532,7 +4532,7 @@ ColumnGroupAggregateFn.prototype = {
      * @param {Object=} sortColumns the sort column object that you want to pass
      * @param {Boolean=} hideNumOccurrences whether we should add number of Occurrences or not.
      * @param {Boolean=} dontAllowNull whether the null value should be returned for the facet or not.
-     * @returns {ERMrest.AttributeGroupReference}
+     * @returns {AttributeGroupReference}
      */
     entityCounts: function(columnDisplayname, sortColumns, hideNumOccurrences, dontAllowNull) {
         if (this.column.isPseudo) {
@@ -4633,7 +4633,7 @@ ColumnGroupAggregateFn.prototype = {
      * @param  {int} bucketCount number of buckets
      * @param  {int} min         minimum value
      * @param  {int} max         maximum value
-     * @return {ERMrest.BucketAttributeGroupReference}
+     * @return {BucketAttributeGroupReference}
      */
     histogram: function (bucketCount, min, max) {
         verify(typeof bucketCount === "number", "Invalid bucket count type.");

--- a/js/column.js
+++ b/js/column.js
@@ -6,6 +6,8 @@ import moment from 'moment-timezone';
 
 // models
 // import DeferredPromise from '@isrd-isi-edu/ermrestjs/src/models/deferred-promise';
+import SourceObjectNode from '@isrd-isi-edu/ermrestjs/src/models/source-object-node';
+import SourceObjectWrapper from '@isrd-isi-edu/ermrestjs/src/models/source-object-wrapper';
 
 // services
 import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
@@ -73,8 +75,6 @@ import {
 import {
   _compressSource,
   _sourceColumnHelpers,
-  SourceObjectNode,
-  SourceObjectWrapper,
   _processWaitForList,
 } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
 
@@ -1702,7 +1702,7 @@ export function ForeignKeyPseudoColumn (reference, fk, sourceObjectWrapper, name
     // NOTE added for compatibility
     // I cannot simply create a sourceObjectWrapper because it needs a shortestkey of length one.
     if (!isObjectAndNotNull(sourceObjectWrapper)) {
-        this.lastForeignKeyNode = new SourceObjectNode(fk, false, true, false, false, undefined, undefined, fk.table);
+        this.lastForeignKeyNode = new SourceObjectNode(fk, fk.table, false, true, false, false, undefined, undefined, false);
         this.firstForeignKeyNode = this.lastForeignKeyNode;
         this.sourceObjectNodes = [this.lastForeignKeyNode];
         this.foreignKeyPathLength = 1;

--- a/js/core.js
+++ b/js/core.js
@@ -8,6 +8,8 @@ import { contextHeaderName, _ERMrestFeatures } from '@isrd-isi-edu/ermrestjs/src
 
 // models
 import { InvalidInputError, MalformedURIError, NotFoundError } from '@isrd-isi-edu/ermrestjs/src/models/errors';
+import TableSourceDefinitions from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
+
 // import DeferredPromise from '@isrd-isi-edu/ermrestjs/src/models/deferred-promise';
 
 // services
@@ -80,8 +82,8 @@ import {
      * @param {string} uri URI of the ERMrest service.
      * @param {Object} [contextHeaderParams={cid:'null'}] An optional server header parameters for context logging
      * appended to the end of any request to the server.
-     * @return {ERMrest.Server} Returns a server instance.
-     * @throws {ERMrest.InvalidInputError} URI is missing
+     * @return {Server} Returns a server instance.
+     * @throws {InvalidInputError} URI is missing
      * @desc
      * ERMrest server factory creates or reuses ERMrest.Server instances. The
      * URI should be to the ERMrest _service_. For example,
@@ -139,8 +141,6 @@ import {
 
         /**
          * The wrapped http service for this server instance.
-         * @private
-         * @type {Object}
          */
         this.http = HTTPService.wrapHTTP(ConfigService.http);
         this.http.contextHeaderParams = contextHeaderParams;
@@ -159,7 +159,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Catalogs}
+         * @type {Catalogs}
          */
         this.catalogs = null;
 
@@ -198,7 +198,7 @@ import {
     /**
      * @memberof ERMrest
      * @constructor
-     * @param {ERMrest.Server} server the server object.
+     * @param {Server} server the server object.
      * @desc
      * Constructor for the Catalogs.
      */
@@ -268,16 +268,16 @@ import {
     /**
      * @memberof ERMrest
      * @constructor
-     * @param {ERMrest.Server} server the server object.
+     * @param {Server} server the server object.
      * @param {string} id the catalog id.
      * @desc
      * Constructor for the Catalog.
      */
-    function Catalog(server, id) {
+    export function Catalog(server, id) {
 
         /**
          * For internal use only. A reference to the server instance.
-         * @type {ERMrest.Server}
+         * @type {Server}
          * @private
          */
         this.server = server;
@@ -297,7 +297,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Schemas}
+         * @type {Schemas}
          */
         this.schemas = new Schemas();
 
@@ -530,7 +530,7 @@ import {
          * @desc returns the constraint object for the pair.
          * @param {Array.<string>} pair constraint name array. Its length must be two.
          * @param {?string} subject the retuned must have the same object, otherwise return null.
-         * @throws {ERMrest.NotFoundError} constraint not found
+         * @throws {NotFoundError} constraint not found
          * @returns {Object|null} the constraint object. Null means the constraint name is not valid.
          */
         constraintByNamePair: function (pair, subject) {
@@ -547,7 +547,7 @@ import {
          * Given tableName, and schemaName find the table
          * @param  {string} tableName  name of the table
          * @param  {string} schemaName name of the schema. Can be undefined.
-         * @return {ERMrest.Table}
+         * @return {Table}
          */
         getTable: function (tableName, schemaName) {
             var schema;
@@ -642,8 +642,8 @@ import {
 
         /**
          * @param {string} name schema name
-         * @returns {ERMrest.Schema} schema object
-         * @throws {ERMrest.NotFoundError} schema not found
+         * @returns {Schema} schema object
+         * @throws {NotFoundError} schema not found
          * @desc get schema by schema name
          */
         get: function (name) {
@@ -666,9 +666,9 @@ import {
         /**
          * @param  {string} tableName  the name of table
          * @param  {string=} schemaName the name of schema (optional)
-         * @return {ERMrest.Table}
-         * @throws {ERMrest.MalformedURIError}
-         * @throws  {ERMrest.NotFoundError}
+         * @return {Table}
+         * @throws {MalformedURIError}
+         * @throws  {NotFoundError}
          * Given table name and schema will find the table object.
          * If schema name is not given, it will still try to find the table.
          * If the table name exists in multiple schemas or it doesn't exist,
@@ -701,7 +701,7 @@ import {
     /**
      * @memberof ERMrest
      * @constructor
-     * @param {ERMrest.Catalog} catalog the catalog object.
+     * @param {Catalog} catalog the catalog object.
      * @param {string} jsonSchema json of the schema.
      * @desc
      * Constructor for the Catalog.
@@ -710,7 +710,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Catalog}
+         * @type {Catalog}
          */
         this.catalog = catalog;
 
@@ -736,7 +736,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Annotations}
+         * @type {Annotations}
          */
         this.annotations = new Annotations();
         for (var uri in jsonSchema.annotations) {
@@ -795,7 +795,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Tables}
+         * @type {Tables}
          */
         this.tables = new Tables();
         for (var key in jsonSchema.tables) {
@@ -903,8 +903,8 @@ import {
         /**
          *
          * @param {string} name name of table
-         * @returns {ERMrest.Table} table
-         * @throws {ERMrest.NotFoundError} table not found
+         * @returns {Table} table
+         * @throws {NotFoundError} table not found
          * @desc get table by table name
          */
         get: function (name) {
@@ -930,16 +930,16 @@ import {
     /**
      * @memberof ERMrest
      * @constructor
-     * @param {ERMrest.Schema} schema the schema object.
+     * @param {Schema} schema the schema object.
      * @param {string} jsonTable the json of the table.
      * @desc
      * Constructor for Table.
      */
-    function Table(schema, jsonTable) {
+    export function Table(schema, jsonTable) {
 
         /**
          *
-         * @type {ERMrest.Schema}
+         * @type {Schema}
          */
         this.schema = schema;
 
@@ -963,7 +963,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Table.Entity}
+         * @type {Table.Entity}
          */
         this.entity = new Entity(this.schema.catalog.server, this);
 
@@ -976,13 +976,13 @@ import {
         /**
          * this defaults to itself on the first pass of introspection
          * then might be changed on the second pass if this is an alternative table
-         * @type {ERMrest.Table}
+         * @type {Table}
          */
         this._baseTable = this;
 
         /**
          *
-         * @type {ERMrest.Annotations}
+         * @type {Annotations}
          */
         this.annotations = new Annotations();
         for (var uri in jsonTable.annotations) {
@@ -1037,7 +1037,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Columns}
+         * @type {Columns}
          */
         this.columns = new Columns(this);
 
@@ -1049,7 +1049,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Keys}
+         * @type {Keys}
          */
         this.keys = new Keys();
         for (i = 0; i < jsonTable.keys.length; i++) {
@@ -1065,13 +1065,13 @@ import {
 
         /**
          *
-         * @type {ERMrest.ForeignKeys}
+         * @type {ForeignKeys}
          */
         this.foreignKeys = new ForeignKeys(this);
 
         /**
          * All the FKRs to this table.
-         * @type {ERMrest.ForeignKeys}
+         * @type {ForeignKeys}
          */
         this.referredBy = new InboundForeignKeys(this);
 
@@ -1290,7 +1290,7 @@ import {
          * 4. has more text
          * 5. made of columns defined earlier (column position)
          *
-         * @type {ERMrest.Column[]}
+         * @type {Column[]}
          */
         get displayKey () {
             if (this._displayKey === undefined) {
@@ -1357,7 +1357,7 @@ import {
          * The columns that create the stable key
          * NOTE doesn't support composite keys for now
          *
-         * @type {ERMrest.Column[]}
+         * @type {Column[]}
          */
         get stableKey() {
             if (this._stabelKey === undefined) {
@@ -1510,7 +1510,7 @@ import {
          * - sourceMapping: hashname to all the names
          * - sourceDependencies: for each sourcekey, what are the other sourcekeys that it depends on (includes self as well)
          *                       this has been added because of path prefix where a sourcekey might rely on other sourcekeys
-         * @type {Object}
+         * @type {TableSourceDefinitions}
          */
         get sourceDefinitions() {
             if (this._sourceDefinitions === undefined) {
@@ -1667,7 +1667,7 @@ import {
             if (!hasAnnot) {
                 res.columns = allColumns;
                 res.fkeys = allForeignKeys;
-                self._sourceDefinitions = res;
+                self._sourceDefinitions = new TableSourceDefinitions(this, res.columns, res.fkeys, res.sources, res.sourceMapping, res.sourceDependencies);
                 return;
             }
 
@@ -1705,7 +1705,7 @@ import {
                 }
             }
 
-            self._sourceDefinitions = res;
+            self._sourceDefinitions = new TableSourceDefinitions(this, res.columns, res.fkeys, res.sources, res.sourceMapping, res.sourceDependencies);
         },
 
         /**
@@ -1773,7 +1773,7 @@ import {
 
                         // sourcekey has priority over source. if both used, ignore source and only honor source.
                         if (src.sourcekey) {
-                            sd = self.sourceDefinitions.sources[src.sourcekey];
+                            sd = self.sourceDefinitions.getSource(src.sourcekey);
                             if (!sd) {
                                 $log.info(message + ", index=" + index + ": given sourcekey `" + src.sourcekey + "` is not valid.");
                                 continue; // ignore the faulty ones
@@ -2098,7 +2098,7 @@ import {
 
         /**
          * if the table is pure and binary, will return the two foreignkeys that create it
-         * @type {ERMrest.ForeignKeyRef[]}
+         * @type {ForeignKeyRef[]}
          */
         get pureBinaryForeignKeys () {
             if(this._pureBinaryForeignKeys_cached === undefined) {
@@ -2392,8 +2392,8 @@ import {
     /**
      * @memberof ERMrest.Table
      * @constructor
-     * @param {ERMrest.Server} server
-     * @param {ERMrest.Table} table
+     * @param {Server} server
+     * @param {Table} table
      * @desc
      * Constructor for Entity. This is a container in Table
      */
@@ -2420,8 +2420,8 @@ import {
 
         /**
          *
-         * @param {ERMrest.Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} [filter]
-         * @param {ERMrest.Column[] | String[]} [output] selected columns
+         * @param {Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} [filter]
+         * @param {Column[] | String[]} [output] selected columns
          * @param {Object[]} [sortby] columns to sort in order, required is paging is specified.
          * The format of object is {"column": ERMREST.Column | String, "order": asc | desc}
          * This should be a list of columns in order of sort, followed by all the key columns
@@ -2511,7 +2511,7 @@ import {
 
         /**
          *
-         * @param {ERMrest.Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} [filter]
+         * @param {Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} [filter]
          * @returns {Promise} promise returning number of count if resolved or
          *     {@link ERMrest.TimedOutError}, {@link ERMrest.InternalServerError}, {@link ERMrest.ServiceUnavailableError},
          *     {@link ERMrest.ConflictError}, {@link ERMrest.ForbiddenError} or {@link ERMrest.UnauthorizedError} if rejected
@@ -2540,9 +2540,9 @@ import {
 
         /**
          *
-         * @param {ERMrest.Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} [filter]
+         * @param {Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} [filter]
          * @param {Number} [limit] Number of rows
-         * @param {ERMrest.Column[] | string[]} [columns] Array of column names or Column objects output
+         * @param {Column[] | string[]} [columns] Array of column names or Column objects output
          * @param {Object[]} [sortby] An ordered array of {column, order} where column is column name or Column object, order is null (default), 'asc' or 'desc'
          * @returns {Promise} promise returning rowset if resolved or
          *     {@link ERMrest.TimedOutError}, {@link ERMrest.InternalServerError}, {@link ERMrest.ServiceUnavailableError},
@@ -2567,9 +2567,9 @@ import {
 
         /**
          *
-         * @param {ERMrest.Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate | null} filter null if not being used
+         * @param {Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate | null} filter null if not being used
          * @param {Number} limit Required. Number of rows
-         * @param {ERMrest.Column[] | String[]} [columns] Array of column names or Column objects output
+         * @param {Column[] | String[]} [columns] Array of column names or Column objects output
          * @param {Object[]} [sortby]An ordered array of {column, order} where column is column name or Column object, order is null (default), 'asc' or 'desc'
          * @param {Object} row json row data used to getBefore
          * @returns {Promise} promise returning rowset if resolved or
@@ -2596,9 +2596,9 @@ import {
 
         /**
          *
-         * @param {ERMrest.Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate | null} filter null is not being used
+         * @param {Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate | null} filter null is not being used
          * @param {Number} limit Required. Number of rows
-         * @param {ERMrest.Column[] | String[]} [columns] Array of column names or Column objects output
+         * @param {Column[] | String[]} [columns] Array of column names or Column objects output
          * @param {Object[]} [sortby]An ordered array of {column, order} where column is column name or Column object, order is null (default), 'asc' or 'desc'
          * @param {Object} row json row data used to getAfter
          * @returns {Promise} promise returning rowset if resolved or
@@ -2623,7 +2623,7 @@ import {
 
         /**
          *
-         * @param {ERMrest.Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} filter
+         * @param {Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} filter
          * @returns {Promise} Promise that returns the json row data deleted if resolved or
          *     {@link ERMrest.TimedOutError}, {@link ERMrest.InternalServerError}, {@link ERMrest.ServiceUnavailableError},
          *     {@link ERMrest.ConflictError}, {@link ERMrest.ForbiddenError} or {@link ERMrest.UnauthorizedError} if rejected
@@ -2700,11 +2700,11 @@ import {
     /**
      *
      * @memberof ERMrest
-     * @param {ERMrest.Table} table
+     * @param {Table} table
      * @param {Object} jsonRows
-     * @param {ERMrest.Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate | null} filter null if not being used
+     * @param {Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate | null} filter null if not being used
      * @param {Number} limit Number of rows
-     * @param {ERMrest.Column[] | String[]} columns Array of column names or Column objects output
+     * @param {Column[] | String[]} columns Array of column names or Column objects output
      * @param {Object[]} [sortby] An ordered array of {column, order} where column is column name or Column object, order is null/'' (default), 'asc' or 'desc'
      * @constructor
      */
@@ -2871,7 +2871,7 @@ import {
         /**
          *
          * @param {string} name name of column
-         * @returns {ERMrest.Column} column
+         * @returns {Column} column
          */
         get: function (name) {
             var result = this._columns.filter(function (column) {
@@ -2887,7 +2887,7 @@ import {
         /**
          *
          * @param {int} pos
-         * @returns {ERMrest.Column}
+         * @returns {Column}
          */
         getByPosition: function (pos) {
             return this._columns[pos];
@@ -2900,7 +2900,7 @@ import {
      *
      * @memberof ERMrest
      * @constructor
-     * @param {ERMrest.Table} table the table object.
+     * @param {Table} table the table object.
      * @param {string} jsonColumn the json column.
      * @param {Object?} assetCategoryInfo if the column is an asset, this must be an object with categroy and URLColumn properties
      */
@@ -3084,7 +3084,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Table}
+         * @type {Table}
          */
         this.table = table;
 
@@ -3133,7 +3133,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Type}
+         * @type {Type}
          */
         this.type = new Type(jsonColumn.type);
 
@@ -3200,7 +3200,7 @@ import {
 
         /**
          *
-         * @type {ERMrest.Annotations}
+         * @type {Annotations}
          */
         this.annotations = new Annotations();
 
@@ -3299,14 +3299,14 @@ import {
 
         /**
          * Member of Keys
-         * @type {ERMrest.Key[]}
+         * @type {Key[]}
          * @desc keys that this column is a member of
          */
         this.memberOfKeys = [];
 
         /**
          * Member of ForeignKeys
-         * @type {ERMrest.ForeignKeyRef[]}
+         * @type {ForeignKeyRef[]}
          * @desc foreign key that this column is a member of
          */
         this.memberOfForeignKeys = [];
@@ -3626,7 +3626,7 @@ import {
         /**
          * If the column is unique and not-null, will return the simple key
          * that is made of this column. Otherwise it will return `null`
-         * @type {ERMrest.Key}
+         * @type {Key}
          */
         get uniqueNotNullKey () {
             if (this._uniqueNotNullKey === undefined) {
@@ -3668,7 +3668,7 @@ import {
 
         /**
          *
-         * @returns {ERMrest.Annotation[]} list of all annotations
+         * @returns {Annotation[]} list of all annotations
          */
         all: function () {
             if (!this._all) {
@@ -3703,8 +3703,8 @@ import {
         /**
          *
          * @param {string} uri uri of annotation
-         * @returns {ERMrest.Annotation} annotation
-         * @throws {ERMrest.NotFoundError} annotation not found
+         * @returns {Annotation} annotation
+         * @throws {NotFoundError} annotation not found
          * @desc get annotation by URI
          */
         get: function (uri) {
@@ -3807,7 +3807,7 @@ import {
 
         /**
          *
-         * @returns {ERMrest.ColSet[]} array of colsets
+         * @returns {ColSet[]} array of colsets
          */
         colsets: function () {
             var sets = [];
@@ -3819,9 +3819,9 @@ import {
 
         /**
          *
-         * @param {ERMrest.ColSet} colset
-         * @returns {ERMrest.Key} key of the colset
-         * @throws {ERMrest.NotFoundError} Key not found
+         * @param {ColSet} colset
+         * @returns {Key} key of the colset
+         * @throws {NotFoundError} Key not found
          * @desc get the key by the column set
          */
         get: function (colset) {
@@ -3841,7 +3841,7 @@ import {
     /**
      * @memberof ERMrest
      * @constructor
-     * @param {ERMrest.Table} table the table object.
+     * @param {Table} table the table object.
      * @param {string} jsonKey json key.
      * @desc
      * Constructor for Key.
@@ -3879,12 +3879,12 @@ import {
         });
 
         /**
-         * @type {ERMrest.ColSet}
+         * @type {ColSet}
          */
         this.colset = new ColSet(uniqueColumns);
 
         /**
-         * @type {ERMrest.Annotations}
+         * @type {Annotations}
          */
         this.annotations = new Annotations();
         for (var uri in jsonKey.annotations) {
@@ -3983,7 +3983,7 @@ import {
 
         /**
          * whether key has a column
-         * @param {ERMrest.Column} column
+         * @param {Column} column
          * @returns {boolean}
          */
         containsColumn: function (column) {
@@ -4188,8 +4188,8 @@ import {
     /**
      *
      * @memberof ERMrest
-     * @param {ERMrest.Column[]} from array of from Columns
-     * @param {ERMrest.Column[]} to array of to Columns
+     * @param {Column[]} from array of from Columns
+     * @param {Column[]} to array of to Columns
      * @constructor
      */
     function Mapping(from, to) { // both array of 'Column' objects
@@ -4226,7 +4226,7 @@ import {
 
         /**
          *
-         * @returns {ERMrest.Column[]} the from columns
+         * @returns {Column[]} the from columns
          */
         domain: function () {
             return this._from;
@@ -4234,9 +4234,9 @@ import {
 
         /**
          *
-         * @param {ERMrest.Column} fromCol
-         * @returns {ERMrest.Column} mapping column
-         * @throws {ERMrest.NotFoundError} no mapping column found
+         * @param {Column} fromCol
+         * @returns {Column} mapping column
+         * @throws {NotFoundError} no mapping column found
          * @desc get the mapping column given the from column
          */
         get: function (fromCol) {
@@ -4251,9 +4251,9 @@ import {
 
         /**
          *
-         * @param {ERMrest.Column} toCol
-         * @returns {ERMrest.Column} mapping column
-         * @throws {ERMrest.NotFoundError} no mapping column found
+         * @param {Column} toCol
+         * @returns {Column} mapping column
+         * @throws {NotFoundError} no mapping column found
          * @desc get the mapping column given the to column
          */
         getFromColumn: function (toCol) {
@@ -4269,7 +4269,7 @@ import {
 
     /**
      * @desc holds inbound foreignkeys of a table.
-     * @param {ERMrest.Table} table the table that this object is for
+     * @param {Table} table the table that this object is for
      * @memberof ERMrest
      * @constructor
      */
@@ -4304,7 +4304,7 @@ import {
          * - name: the pseudo column name
          * @private
          * @param  {String} context
-         * @param  {ERMrest.Tuple} mainTuple the main table data
+         * @param  {Tuple} mainTuple the main table data
          * @return {Object}
          */
         _contextualize: function (context, mainTuple) {
@@ -4357,12 +4357,12 @@ import {
                 }
                 // path
                 else if (typeof orders[i] === "object") {
-                    var wrapper;
+                    let wrapper;
                     if (orders[i].source || orders[i].sourcekey) {
                         try {
                             // if both source and sourcekey are defined, ignore the source and use sourcekey
                             if (orders[i].sourcekey) {
-                                var def = definitions.sources[orders[i].sourcekey];
+                                const def = definitions.getSource(orders[i].sourcekey);
                                 if (def) {
                                     wrapper = def.clone(orders[i], this._table, false, mainTuple);
                                 }
@@ -4424,7 +4424,7 @@ import {
 
         /**
          *
-         * @returns {ERMrest.ForeignKeyRef[]} an array of all foreign key references
+         * @returns {ForeignKeyRef[]} an array of all foreign key references
          */
         all: function () {
             return this._foreignKeys;
@@ -4432,7 +4432,7 @@ import {
 
         /**
          *
-         * @returns {ERMrest.ColSet[]} an array of the foreign keys' colsets
+         * @returns {ColSet[]} an array of the foreign keys' colsets
          */
         colsets: function () {
             var sets = [];
@@ -4456,7 +4456,7 @@ import {
 
         /**
          *
-         * @returns {ERMrest.Mapping[]} mappings
+         * @returns {Mapping[]} mappings
          */
         mappings: function () {
             return this._mappings;
@@ -4464,9 +4464,9 @@ import {
 
         /**
          *
-         * @param {ERMrest.ColSet} colset
-         * @throws {ERMrest.NotFoundError} foreign key not found
-         * @returns {ERMrest.ForeignKeyRef[]} foreign key reference of the colset
+         * @param {ColSet} colset
+         * @throws {NotFoundError} foreign key not found
+         * @returns {ForeignKeyRef[]} foreign key reference of the colset
          * @desc get the foreign key of the given column set
          */
         get: function (colset) {
@@ -4490,7 +4490,7 @@ import {
     /**
      *
      * @memberof ERMrest
-     * @param {ERMrest.Table} table
+     * @param {Table} table
      * @param {Object} jsonFKR
      * @constructor
      */
@@ -4506,7 +4506,7 @@ import {
 
         /**
          * @desc The table that this foreignkey is defined on (from table)
-         * @type {ERMrest.Table}
+         * @type {Table}
          */
         this.table = table;
 
@@ -4528,7 +4528,7 @@ import {
         }
 
         /**
-         * @type {ERMrest.ColSet}
+         * @type {ColSet}
          */
         this.colset = new ColSet(foreignKeyCols);
 
@@ -4545,7 +4545,7 @@ import {
         /**
          * find key from referencedCols
          * use index 0 since all refCols should be of the same schema:table
-         * @type {ERMrest.Key}
+         * @type {Key}
          */
         this.key = refTable.keys.get(new ColSet(referencedCols));
 
@@ -4556,7 +4556,7 @@ import {
         this.rights = jsonFKR.rights;
 
         /**
-         * @type {ERMrest.Mapping}
+         * @type {Mapping}
          */
         this.mapping = new Mapping(foreignKeyCols, referencedCols);
 
@@ -4587,7 +4587,7 @@ import {
         this.ignore = false;
 
         /**
-         * @type {ERMrest.Annotations}
+         * @type {Annotations}
          */
         this.annotations = new Annotations();
         for (var uri in jsonFKR.annotations) {
@@ -4903,7 +4903,7 @@ import {
 
         if (jsonType.base_type !== undefined) {
             /**
-             * @type {ERMrest.Type}
+             * @type {Type}
              */
             this.baseType = new Type(jsonType.base_type);
         }
@@ -4927,8 +4927,3 @@ import {
             return this._rootName;
         }
     };
-
-    function SourceDefinition(key, obj) {
-        this.key = key;
-        this.sourceObject = obj;
-    }

--- a/js/core.js
+++ b/js/core.js
@@ -42,7 +42,8 @@ import {
 import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils';
 
 // legacy
-import { _sourceColumnHelpers, _compressSource, SourceObjectWrapper } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
+import { _sourceColumnHelpers, _compressSource } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
+import SourceObjectWrapper from '@isrd-isi-edu/ermrestjs/src/models/source-object-wrapper';
 import { _createReference } from '@isrd-isi-edu/ermrestjs/js/reference';
 import { parse } from '@isrd-isi-edu/ermrestjs/js/parser';
 import {
@@ -1714,7 +1715,7 @@ import {
         * - columns: the search columns
         * - allSamePathPrefix: if all using the same path prefix
         *
-        * @type {false|Object}
+        * @type {false|{columns: SourceObjectWrapper[], allSamePathPrefix: boolean}}
         */
         get searchSourceDefinition() {
             if (this._searchSourceDefinition === undefined) {

--- a/js/datapath.js
+++ b/js/datapath.js
@@ -15,7 +15,7 @@ import { _nextChar } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
 
 /**
  * @memberof ERMrest.Datapath
- * @param {ERMrest.Table} table
+ * @param {Table} table
  * @constructor
  */
 export function DataPath(table) {
@@ -23,13 +23,13 @@ export function DataPath(table) {
 
   /**
    *
-   * @type {ERMrest.Catalog}
+   * @type {Catalog}
    */
   this.catalog = table.schema.catalog;
 
   /**
    *
-   * @type {ERMrest.Datapath.PathTable}
+   * @type {Datapath.PathTable}
    */
   this.context = new PathTable(table, this, this._nextAlias);
 
@@ -63,8 +63,8 @@ DataPath.prototype = {
 
   /**
    *
-   * @param {ERMrest.Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} filter
-   * @returns {ERMrest.Datapath.DataPath} a shallow copy of this datapath with filter
+   * @param {Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} filter
+   * @returns {Datapath.DataPath} a shallow copy of this datapath with filter
    * @desc
    * this datapath is not modified
    */
@@ -76,10 +76,10 @@ DataPath.prototype = {
 
   /**
    *
-   * @param {ERMrest.Table} table
+   * @param {Table} table
    * @param context
    * @param link
-   * @returns {ERMrest.Datapath.PathTable}
+   * @returns {Datapath.PathTable}
    * @desc extend the Datapath with table
    */
   extend: function (table, context, link) {
@@ -152,7 +152,7 @@ DataPath.prototype = {
 
     /**
      *
-     * @param {ERMrest.Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} filter
+     * @param {Filters.Negation | ERMrest.Filters.Conjunction | ERMrest.Filters.Disjunction | ERMrest.Filters.UnaryPredicate | ERMrest.Filters.BinaryPredicate} filter
      * @desc delete entities
      * @returns {Promise} promise that returns deleted entities if resolved or
      *     {@link ERMrest.Errors.TimedOutError}, {@link ERMrest.Errors.InternalServerError}, {@link ERMrest.Errors.ServiceUnavailableError},
@@ -184,21 +184,21 @@ DataPath.prototype = {
 /**
  *
  * @memberof ERMrest.Datapath
- * @param {ERMrest.Table} table
- * @param {ERMrest.Datapath.DataPath} datapath
+ * @param {Table} table
+ * @param {Datapath.DataPath} datapath
  * @param {string} alias
  * @constructor
  */
 function PathTable(table, datapath, alias) {
   /**
    *
-   * @type {ERMrest.Datapath.DataPath}
+   * @type {Datapath.DataPath}
    */
   this.datapath = datapath;
 
   /**
    *
-   * @type {ERMrest.Table}
+   * @type {Table}
    */
   this.table = table;
 
@@ -210,7 +210,7 @@ function PathTable(table, datapath, alias) {
 
   /**
    *
-   * @type {ERMrest.Datapath.PathColumns}
+   * @type {Datapath.PathColumns}
    */
   this.columns = new PathColumns(table, this); // pathcolumns
 }
@@ -230,8 +230,8 @@ PathTable.prototype = {
 /**
  *
  * @memberof ERMrest.Datapath
- * @param {ERMrest.Table} table
- * @param {ERMrest.Datapath.PathTable} pathtable
+ * @param {Table} table
+ * @param {Datapath.PathTable} pathtable
  */
 function PathColumns(table, pathtable) {
   this._table = table;
@@ -266,8 +266,8 @@ PathColumns.prototype = {
   /**
    *
    * @param {string} colName column name
-   * @returns {ERMrest.Datapath.PathColumn} returns the PathColumn
-   * @throws {ERMrest.Errors.NotFoundError} column not found
+   * @returns {Datapath.PathColumn} returns the PathColumn
+   * @throws {Errors.NotFoundError} column not found
    * @desc get PathColumn object by column name
    */
   get: function (colName) {
@@ -289,20 +289,20 @@ PathColumns.prototype = {
 
 /**
  * @memberof ERMrest.Datapath
- * @param {ERMrest.Column} column
- * @param {ERMrest.Datapath.PathTable} pathtable
+ * @param {Column} column
+ * @param {Datapath.PathTable} pathtable
  * @constructor
  */
 function PathColumn(column, pathtable) {
   /**
    *
-   * @type {ERMrest.Datapath.PathTable}
+   * @type {Datapath.PathTable}
    */
   this.pathtable = pathtable;
 
   /**
    *
-   * @type {ERMrest.Column}
+   * @type {Column}
    */
   this.column = column;
 

--- a/js/export.js
+++ b/js/export.js
@@ -28,7 +28,7 @@ export const _exportHelpers = {
    * Returns the export templates that are defined on this table.
    * NOTE If this returns `null`, then the exportTemplates is not defined on the table or schema
    * NOTE The returned array should not be directly used as it might be using fragments
-   * @param {ERMrest.Table} table
+   * @param {Table} table
    * @param {string} context
    * @private
    * @ignore
@@ -81,7 +81,7 @@ export const _exportHelpers = {
 
   /**
    * Return the export fragments that should be used with export annotation.
-   * @param {ERMrest.Table} table
+   * @param {Table} table
    * @param {Object} defaultExportTemplate
    * @returns An object that can be used in combination with export annotation
    * @private
@@ -286,7 +286,7 @@ export const validateExportTemplate = function (template) {
  *
  * @memberof ERMrest
  * @class
- * @param {ERMrest.Reference} reference
+ * @param {Reference} reference
  * @param {String} bagName the name that will be used for the bag
  * @param {Object} template the tempalte must be in the valid format.
  * @param {String} servicePath the path to the service, i.e. "/deriva/export/"
@@ -506,7 +506,7 @@ Exporter.prototype = {
 
 /**
  * Try export/<context> then export then 'detailed'
- * @param {ERMrest.reference} ref
+ * @param {reference} ref
  * @param {Boolean} useCompact - whether the current context is compact or not
  */
 export const _getExportReference = function (ref, useCompact) {
@@ -575,12 +575,12 @@ export const _getExportReference = function (ref, useCompact) {
  * These are the same column names that we are using for row-name generation.
  *
  * @private
- * @param  {ERMrest.reference} ref       the reference that we want the output for
+ * @param  {reference} ref       the reference that we want the output for
  * @param  {String} tableAlias          the alias that is used for projecting table (last table in path)
  * @param  {String=} path               the string that will be prepended to the path
  * @param  {String=} addMainKey         whether we want to add the key of the main table.
  *                                      if this is true, the next parameter is required.
- * @param  {ERMrest.Reference=} mainRef The main reference
+ * @param  {Reference=} mainRef The main reference
  * @return {Object}                     the output object
  */
 export const _referenceExportOutput = function (ref, tableAlias, path, addMainKey, mainRef, useCompact) {
@@ -767,7 +767,7 @@ export const _referenceExportOutput = function (ref, tableAlias, path, addMainKe
 /**
  * Given a reference object, will return the appropriate output object using entity api
  * @private
- * @param  {ERMrest.Reference} ref  the reference object
+ * @param  {Reference} ref  the reference object
  * @param  {String} path the string that will be prepended to the path
  * @return {Object} the output object
  */
@@ -793,7 +793,7 @@ export const _referenceExportEntityOutput = function (ref, path) {
  * Given a column will return the appropriate output object for asset.
  * It will return null if column is not an asset.
  * @private
- * @param  {ERMrest.Column} col the column object
+ * @param  {Column} col the column object
  * @param  {String} destinationPath the string that will be prepended to destination path
  * @param  {String} sourcePath      the string that will be prepended to source path
  * @return {Object}

--- a/js/filters.js
+++ b/js/filters.js
@@ -127,9 +127,9 @@ Disjunction.prototype = {
 /**
  *
  * @memberof ERMrest.Filters
- * @param {ERMrest.Column} column
- * @param {ERMrest.Filters.OPERATOR} operator
- * @throws {ERMrest.Errors.InvalidFilterOperatorError} invalid filter operator
+ * @param {Column} column
+ * @param {Filters.OPERATOR} operator
+ * @throws {Errors.InvalidFilterOperatorError} invalid filter operator
  * @constructor
  */
 export function UnaryPredicate(column, operator) {
@@ -159,10 +159,10 @@ UnaryPredicate.prototype = {
 
 /**
  * @memberof ERMrest.Filters
- * @param {ERMrest.Column} column
- * @param {ERMrest.Filters.OPERATOR} operator
+ * @param {Column} column
+ * @param {Filters.OPERATOR} operator
  * @param {String | Number} rvalue
- * @throws {ERMrest.Errors.InvalidFilterOperatorError} invalid filter operator
+ * @throws {Errors.InvalidFilterOperatorError} invalid filter operator
  * @constructor
  */
 export function BinaryPredicate(column, operator, rvalue) {

--- a/js/parser.js
+++ b/js/parser.js
@@ -27,7 +27,8 @@ import {
 
   // legacy
   import { decodeFacet, encodeFacet, _encodeRegexp, versionDecodeBase32 } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
-  import { PathPrefixAliasMapping, _renderFacet, _sourceColumnHelpers } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
+  import { _renderFacet, _sourceColumnHelpers } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
+  import PathPrefixAliasMapping from '@isrd-isi-edu/ermrestjs/src/models/path-prefix-alias-mapping';
 
     /**
      * The ERMrest service name. Internal use only.

--- a/js/parser.js
+++ b/js/parser.js
@@ -11,7 +11,7 @@ import {
     InvalidFacetOperatorError,
     InvalidFilterOperatorError,
   } from '@isrd-isi-edu/ermrestjs/src/models/errors';
-  
+
   // utils
   import {
     _ERMrestFeatures,
@@ -24,7 +24,7 @@ import {
   import { isObjectAndNotNull, isStringAndNotEmpty, verify } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
   import { fixedEncodeURIComponent, simpleDeepCopy, stripTrailingSlash, trimSlashes } from '@isrd-isi-edu/ermrestjs/src/utils/value-utils';
   import { _facetingErrors, _FacetsLogicalOperators, _specialSourceDefinitions, _parserAliases } from '@isrd-isi-edu/ermrestjs/src/utils/constants';
-  
+
   // legacy
   import { decodeFacet, encodeFacet, _encodeRegexp, versionDecodeBase32 } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
   import { PathPrefixAliasMapping, _renderFacet, _sourceColumnHelpers } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
@@ -41,9 +41,9 @@ import {
      * @memberof ERMrest
      * @function parse
      * @param {String} uri An ERMrest resource URI to be parsed.
-     * @param {ERMrest.Catalog?} catalogObject the catalog object that the uri is based on
+     * @param {Catalog?} catalogObject the catalog object that the uri is based on
      * @returns {ERMrest.Location} Location object created from the URI.
-     * @throws {ERMrest.InvalidInputError} If the URI does not contain the
+     * @throws {InvalidInputError} If the URI does not contain the
      * service name.
      */
     export const parse = function (uri, catalogObject) {
@@ -143,7 +143,7 @@ import {
      * @param  {string} tableName  Name of table
      * @param  {object} facets     an object
      * @param  {object} cfacets    an object
-     * @param  {ERMrest.Catalog} [catalogObject] the catalog object (optional)
+     * @param  {Catalog} [catalogObject] the catalog object (optional)
      * @return {string}            a path that ERMrestJS understands and can parse, can be undefined
      */
     export const createLocation = function (service, catalogId, schemaName, tableName, facets, cfacets, catalogObject) {
@@ -191,7 +191,7 @@ import {
      * NOTE: For parsing the facet, Location object needs the catalog object.
      *       it should either be passed while creating the location object, or set after.
      * @param {String} uri full path
-     * @param {ERMrest.Catalog} the catalog object for parsing some parts of url might be needed.
+     * @param {Catalog} the catalog object for parsing some parts of url might be needed.
      * @constructor
      */
     export function Location(uri, catalogObject) {
@@ -1403,7 +1403,7 @@ import {
         },
 
         /**
-         * @type {ERMrest.catalog}
+         * @type {catalog}
          */
         get catalogObject() {
             return this._catalogObject;
@@ -1418,7 +1418,7 @@ import {
 
         /**
          * The reference object that this Location object belongs to
-         * @type {ERMrest.Reference}
+         * @type {Reference}
          */
         get referenceObject() {
             return this._referenceObject;
@@ -2178,7 +2178,7 @@ import {
      * https://github.com/informatics-isi-edu/ermrestjs/issues/447
      *
      * @param       {String|Object} str Can be blob or json (object).
-     * @param       {String} path to generate rediretUrl in error 
+     * @param       {String} path to generate rediretUrl in error
      * @constructor
      */
     function ParsedFacets (str, path) {
@@ -2237,7 +2237,7 @@ import {
      *
      *
      * @param       {String|Object} str Can be blob or json (object).
-     * @param       {String} path to generate rediretUrl in error 
+     * @param       {String} path to generate rediretUrl in error
      * @constructor
      */
     function CustomFacets (str, path) {

--- a/js/reference.js
+++ b/js/reference.js
@@ -100,9 +100,9 @@ import {
   _compressFacetObject,
   _compressSource,
   _sourceColumnHelpers,
-  SourceObjectWrapper,
   _processWaitForList,
 } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
+import SourceObjectWrapper from '@isrd-isi-edu/ermrestjs/src/models/source-object-wrapper';
 
     /**
      * This function resolves a URI reference to a {@link ERMrest.Reference}
@@ -5981,7 +5981,7 @@ import {
          * and both the old and new value for the modified key are submitted together
          * for proper updating.
          *
-         * @type {Object}
+         * @type {any}
          */
         get data() {
             if (this._oldData === undefined) {

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -384,7 +384,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
     /**
      * @function
      * @param {string} context the context that we want the value of.
-     * @param {ERMrest.Annotation} annotation the annotation object.
+     * @param {Annotation} annotation the annotation object.
      * @param {Boolean} dontUseDefaultContext Whether we should use the default (*) context
      * @desc This function returns the list that should be used for the given context.
      * Used for visible columns and visible foreign keys.
@@ -439,7 +439,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
     /**
      * retun the value that should be used for the display setting. If missing, it will return "-1".
      *
-    * @param {ERMrest.Table|ERMrest.Column|ERMrest.ForeignKeyRef} obj either table object, or an object that has `.table`
+    * @param {Table|ERMrest.Column|ERMrest.ForeignKeyRef} obj either table object, or an object that has `.table`
     * @param {String} context the context string
     * @param {String} annotKey the annotation key that you want the annotation value for
     * @param {Boolean} isTable if the first parameter is table, you should pass `true` for this parameter
@@ -505,7 +505,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
     };
 
     /**
-     * @param {ERMrest.Annotations} annotations - the defined annotation on the model
+     * @param {Annotations} annotations - the defined annotation on the model
      * @param {String} key - the annotation key
      * @param {Boolean|null} defaultValue - the value that should be used if annotation is missing.
      *                                      (parent value or null)
@@ -582,7 +582,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
      * - `descending`: The boolean that Indicates whether we should reverse sort order or not.
      *
      * @param  {string} columnOrder The object that defines the column/row order
-     * @param  {ERMrest.Table} table
+     * @param  {Table} table
      * @param  {Object=} options the extra options:
      *                  - allowNumOccurrences: to allow the specific frequency column_order
      * @return {Array=} If it's undefined, the column_order that is defined is not valid
@@ -727,7 +727,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
 
     /**
      * @function
-     * @param {ERMrest.Table} table The object that we want the formatted values for.
+     * @param {Table} table The object that we want the formatted values for.
      * @param {String} context the context that we want the formatted values for.
      * @param {object} data The object which contains key value pairs of data to be transformed
      * @param {object} linkedData The object which contains key value paris of foreign key data.
@@ -838,11 +838,11 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
      *  - rowName: a rowname object.
      *  - uri.detailed: applink to detailed for the row
      * @private
-     * @param  {ERMrest.Table} table  the table object
+     * @param  {Table} table  the table object
      * @param  {string} context    current context
      * @param  {Object} data       the raw data
      * @param  {Object=} linkedData the raw data of foreignkeys
-     * @param  {ERMrest.Reference=} key the alternate key to use
+     * @param  {Reference=} key the alternate key to use
      * @return {Object}
      */
     export function _getRowTemplateVariables(table, context, data, linkedData, key) {
@@ -861,7 +861,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
     /**
      * Given the available linked data, generate the uniqueId for the row this data represents given the shortest key of the table
      *
-     * @param {ERMrest.Key[]} tableShortestKey shortest key from the table the linkedData is for
+     * @param {Key[]} tableShortestKey shortest key from the table the linkedData is for
      * @param {Object} data data to use to generate the unique id
      * @returns string | null - unique id for the row the linkedData represents
      */
@@ -890,7 +890,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
 
     /**
      * @function
-     * @param {ERMrest.Table} table The table that we want the row name for.
+     * @param {Table} table The table that we want the row name for.
      * @param {String} context Current context.
      * @param {object} data The object which contains key value pairs of data.
      * @param {Object} linkedData The object which contains key value pairs of foreign key data.
@@ -995,7 +995,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
     /**
      * @function
      * @desc Given a key object, will return the presentation object that can bse used for it
-     * @param  {ERMrest.Key} key    the key object
+     * @param  {Key} key    the key object
      * @param  {object} data        the data for the table that key is from
      * @param  {string} context     the context string
      * @param  {object=} templateVariables
@@ -1077,7 +1077,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
      * @private
      * @desc Given the key of a table, and data for one row will return the
      * presentation object for the row.
-     * @param  {ERMrest.Key} key   the key of the table
+     * @param  {Key} key   the key of the table
      * @param  {String} context    Current context
      * @param  {object} data       Data for the table that this key is referring to.
      * @param  {boolean} addLink   whether the function should attach link or just the rowname.
@@ -1108,9 +1108,9 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
 
     /**
      * Given a table object and raw data for a row, return a uri to that row with fitlers.
-     * @param  {ERMrest.Table} table the table object
+     * @param  {Table} table the table object
      * @param  {Object} raw data for the row
-     * @param  {ERMrest.Key=} key if we want the link based on a specific key
+     * @param  {Key=} key if we want the link based on a specific key
      * @return {String|null} filter that represents the current row. If row data
      * is missing, it will return null.
      */
@@ -1133,7 +1133,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
     /**
      * @function
      * @private
-     * @param  {ERMrest.Key} key     key of the table
+     * @param  {Key} key     key of the table
      * @param  {string} context current context
      * @param  {object} data    data for the table that this key is referring to
      * @return {object} an object with the following attributes:
@@ -1206,9 +1206,9 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
      *  - filters: If successful, it will be an array of {path, keyData}
      *  - hasNull: If failed, it will signal that the issue was related to null value
      *             for a column. `column` property will return the column name that had null value.
-     * @param {ERMrest.Column[]} keyColumns
+     * @param {Column[]} keyColumns
      * @param {Object} data
-     * @param {ERMrest.Catalog} catalogObject
+     * @param {Catalog} catalogObject
      * @param {number} pathOffsetLength the length of offset that should be considered for length limitation logic.
      *                                  if the given value is negative, we will not check the url length limitation.
      * @param {string} displayname the displayname of reference, used for error message
@@ -1741,7 +1741,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
 
     /**
      * format the raw value based on the column definition type, heuristics, annotations, etc.
-     * @param {ERMrest.Type} type - the type object of the column
+     * @param {Type} type - the type object of the column
      * @param {Object} data - the 'raw' data value.
      * @returns {string} The formatted value.
      */
@@ -2166,7 +2166,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
     };
 
     /**
-     * A wrapper for {ERMrest.renderMustacheTemplate}
+     * A wrapper for {renderMustacheTemplate}
      * acceptable options:
      * - templateEngine: "mustache" or "handlbars"
      * - avoidValidation: to avoid validation of the template
@@ -2175,7 +2175,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
      *
      * @param  {string} template - template to be rendered
      * @param  {object} keyValues - formatted key value pairs needed for the template
-     * @param  {ERMrest.Catalog} catalog - the catalog that this value is for
+     * @param  {Catalog} catalog - the catalog that this value is for
      * @param  {any=} options optioanl parameters
      * @return {string} Returns a string produced as a result of templating using options.templateEngine or `Mustache` by default.
      */
@@ -2210,12 +2210,12 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
     };
 
     /**
-     * A wrapper for {ERMrest._validateMustacheTemplate}
+     * A wrapper for {_validateMustacheTemplate}
      * it will take care of adding formmatted and unformatted values.
      * options.ignoredColumns: list of columns that you want validator to ignore
      * options.templateEngine: "mustache" or "handlbars"
      *
-     * @param  {ERMrest.Table} table
+     * @param  {Table} table
      * @param  {object} data
      * @param  {string} template
      * @param  {Catalog} catalog
@@ -2244,7 +2244,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
      *
      * @param  {String} template the handlebars/mustache template
      * @param  {Object} data     the key-value pair of data
-     * @param  {ERMrest.Table} table    the table object
+     * @param  {Table} table    the table object
      * @param  {String} context  context string
      * @param  {Object} options
      * @return {Object}          An object with `isHTML` and `value` attributes.

--- a/js/utils/pseudocolumn_helpers.js
+++ b/js/utils/pseudocolumn_helpers.js
@@ -5,6 +5,9 @@ import { hash as sparkMD5Hash } from 'spark-md5';
 
 // models
 // import DeferredPromise from '@isrd-isi-edu/ermrestjs/src/models/deferred-promise';
+import SourceObjectNode from '@isrd-isi-edu/ermrestjs/src/models/source-object-node';
+import SourceObjectWrapper from '@isrd-isi-edu/ermrestjs/src/models/source-object-wrapper';
+import PathPrefixAliasMapping from '@isrd-isi-edu/ermrestjs/src/models/path-prefix-alias-mapping';
 
 // services
 import CatalogService from '@isrd-isi-edu/ermrestjs/src/services/catalog';
@@ -631,7 +634,10 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
         for (var i = 0; i < res.length; i++) {
             ["and", "or"].forEach(shortenAndOr(res[i]));
 
-            ["alias", "sourcekey", "inbound", "outbound", "filter", "operand_pattern", "operator", "negate"].forEach(shorten(res[i]));
+            [
+                "alias", "sourcekey", "inbound", "outbound",
+                "filter", "operand_pattern", "operand_pattern_processed", "operator", "negate"
+            ].forEach(shorten(res[i]));
         }
         return res;
     };
@@ -1277,483 +1283,7 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
         }
     };
 
-    /**
-     *
-     * @param {Object} sourceObject the column directive object
-     * @param {Table} table the root (starting) table
-     * @param {boolean} isFacet whether this is a facet or not
-     * @param {Object=} sources already generated source (only useful for source-def generation)
-     * @param {Tuple=} mainTuple the main tuple that is used for filters
-     * @param {boolean=} skipProcessingFilters whether we should skip processing filters or not
-     * @desc Represents a column-directive
-     */
-    export function SourceObjectWrapper (sourceObject, table, isFacet, sources, mainTuple, skipProcessingFilters) {
-        this.sourceObject = sourceObject;
 
-        // if the extra objects are not passed, we cannot process
-        if (isObjectAndNotNull(table)) {
-            var res = this._process(table, isFacet, sources, mainTuple, skipProcessingFilters);
-            if (res.error) {
-                throw new Error(res.message);
-            }
-        }
-    }
-
-    SourceObjectWrapper.prototype = {
-
-        /**
-         * return a new sourceObjectWrapper that is created by merging the given sourceObject and existing object.
-         *
-         * Useful when we have an object with sourcekey and want to find the actual definition. You can then call
-         * clone on the source-def and pass the object.
-         *
-         * const myCol = {"sourcekey": "some_key"};
-         * const sd = table.sourceDefinitions.getSource(myCol.sourcekey);
-         * if (sd) {
-         *   const wrapper = sd.clone(myCol, table);
-         * }
-         *
-         * - attributes in sourceObject will override the similar ones in the current object.
-         * - "source" of sourceObject will be ignored. so "sourcekey" always has priority over "source".
-         * - mainTuple should be passed in detailed context so we can use it for filters.
-         *
-         * @param {Object} sourceObject the source object
-         * @param {Table} table the table that these sources belong to.
-         * @param {boolean} isFacet whether this is for a facet or not
-         */
-        clone: function (sourceObject, table, isFacet, mainTuple) {
-            let key;
-            const self = this;
-
-            // remove the definition attributes
-            _sourceDefinitionAttributes.forEach(function (attr) {
-                delete sourceObject[attr];
-            });
-
-            for (key in self.sourceObject) {
-                if (!Object.prototype.hasOwnProperty.call(self.sourceObject, key)) continue;
-
-                // only add the attributes that are not defined again
-                if (!Object.prototype.hasOwnProperty.call(sourceObject, key)) {
-                    sourceObject[key] = self.sourceObject[key];
-                }
-            }
-
-            return new SourceObjectWrapper(sourceObject, table, isFacet, undefined, mainTuple);
-        },
-
-        /**
-         * Parse the given sourceobject and create the attributes
-         * @param {Table} table
-         * @param {boolean} isFacet  -- validation is differrent if it's a facet
-         * @param {Object=} sources already generated source (only useful for source-def generation)
-         * @param {Tuple=} mainTuple the main tuple that is used for filters
-         * @param {boolean=} skipProcessingFilters whether we should skip processing filters or not
-         * @returns  {Object}
-         */
-        _process: function (table, isFacet, sources, mainTuple, skipProcessingFilters) {
-            var self = this, sourceObject = this.sourceObject, wm = _warningMessages;
-
-            var returnError = function (message) {
-                return {error: true, message: message};
-            };
-
-            if (typeof sourceObject !== "object" || !sourceObject.source) {
-                return returnError(wm.INVALID_SOURCE);
-            }
-
-            var colName, col, colTable = table, source = sourceObject.source, sourceObjectNodes = [];
-            var hasPath = false, hasInbound = false, hasPrefix = false, isAllOutboundNotNull = false, isAllOutboundNotNullPerModel = false;
-            let lastForeignKeyNode, firstForeignKeyNode, foreignKeyPathLength = 0;
-            let isFiltered = false, filterProps = {};
-
-            // just the column name
-            if (isStringAndNotEmpty(source)){
-                colName = source;
-            }
-            // from 0 to source.length-1 we have paths
-            else if (Array.isArray(source) && source.length === 1 && isStringAndNotEmpty(source[0])) {
-                colName = source[0];
-            }
-            else if (Array.isArray(source) && source.length > 1) {
-                var res = _sourceColumnHelpers.processDataSourcePath(source, table, table.name, table.schema.catalog.id, sources, mainTuple, skipProcessingFilters);
-                if (res.error) {
-                    return res;
-                }
-
-                hasPath = res.foreignKeyPathLength > 0;
-                hasInbound = res.hasInbound;
-                hasPrefix = res.hasPrefix;
-                firstForeignKeyNode = res.firstForeignKeyNode;
-                lastForeignKeyNode = res.lastForeignKeyNode;
-                colTable = res.column.table;
-                foreignKeyPathLength = res.foreignKeyPathLength;
-                sourceObjectNodes = res.sourceObjectNodes;
-                colName = res.column.name;
-                isFiltered = res.isFiltered;
-                filterProps = res.filterProps;
-                isAllOutboundNotNull =  res.isAllOutboundNotNull;
-                isAllOutboundNotNullPerModel = res.isAllOutboundNotNullPerModel;
-
-            }  else {
-                return returnError("Invalid source definition");
-            }
-
-            // we need this check here to make sure the column is in the table
-            try {
-                col = colTable.columns.get(colName);
-            } catch (exp) {
-                return returnError(wm.INVALID_COLUMN_IN_SOURCE_PATH);
-            }
-            var isEntity = hasPath && (sourceObject.entity !== false) && col.isUniqueNotNull;
-
-            // validate aggregate fn
-            if (isFacet !== true && sourceObject.aggregate && _pseudoColAggregateFns.indexOf(sourceObject.aggregate) === -1) {
-                return returnError(wm.INVALID_AGG);
-            }
-
-            self.column = col;
-
-            self.hasPrefix = hasPrefix;
-            // NOTE hasPath only means foreign key path and not filter
-            self.hasPath = hasPath;
-            self.foreignKeyPathLength = foreignKeyPathLength;
-            self.hasInbound = hasInbound;
-            self.hasAggregate = typeof sourceObject.aggregate === "string";
-            self.isFiltered = isFiltered;
-            self.filterProps = filterProps;
-            self.isEntityMode = isEntity;
-            self.isUnique = !self.hasAggregate && !self.isFiltered && (!hasPath || !hasInbound);
-
-            // TODO FILTER_IN_SOURCE better name...
-            /**
-             * these type of columns would be very similiar to aggregate columns.
-             * but it requires more changes in both chaise and ermrestjs
-             * (most probably a new column type or at least more api to fetch their values is needed)
-             * (in chaise we would have to add a new type of secondary requests to active list)
-             * (not sure if these type of pseudo-columns are even useful or not)
-             * so for now we're not going to allow these type of pseudo-columns in visible-columns
-             */
-            self.isUniqueFiltered = !self.hasAggregate && self.isFiltered && (!hasPath || !hasInbound);
-
-            self.isAllOutboundNotNullPerModel = isAllOutboundNotNullPerModel;
-            self.isAllOutboundNotNull = isAllOutboundNotNull;
-
-            // attach last fk
-            if (lastForeignKeyNode != null) {
-                self.lastForeignKeyNode = lastForeignKeyNode;
-            }
-
-            // attach first fk
-            if (firstForeignKeyNode != null) {
-                self.firstForeignKeyNode = firstForeignKeyNode;
-            }
-
-            // generate name:
-            // TODO maybe we shouldn't even allow aggregate in faceting (for now we're ignoring it)
-            if ((sourceObject.self_link === true) || self.isFiltered || self.hasPath || self.isEntityMode || (isFacet !== true && self.hasAggregate)) {
-                self.name = _sourceColumnHelpers.generateSourceObjectHashName(sourceObject, isFacet, sourceObjectNodes);
-                self.isHash = true;
-
-                if (table.columns.has(self.name)) {
-                    return returnError("Generated Hash `" + self.name + "` for pseudo-column exists in table `" + table.name +"`.");
-                }
-            }else {
-                self.name = col.name;
-                self.isHash = false;
-            }
-
-            self.sourceObjectNodes = sourceObjectNodes;
-
-            return self;
-        },
-
-        /**
-         * Return the string representation of this foreignkey path
-         * returned format:
-         * if not isLeft and outAlias is not passed: ()=()/.../()=()
-         * if isLeft: left()=()/.../left()=()
-         * if outAlias defined: ()=()/.../outAlias:=()/()
-         * used in:
-         *   - export default
-         *   - column.getAggregate
-         *   - reference.read
-         * @param {Boolean} reverse whether we want the reverse path
-         * @param {Boolean} isLeft use left join
-         * @param {String=} outAlias the alias that should be added to the output
-         */
-        toString: function (reverse, isLeft, outAlias, isReverseRightJoin) {
-            var self = this;
-            return self.sourceObjectNodes.reduce(function (prev, sn, i) {
-                if (sn.isFilter) {
-                    if (reverse) {
-                        return sn.toString() + (i > 0 ? "/" : "") + prev;
-                    } else {
-                        return prev + (i > 0 ? "/" : "") + sn.toString();
-                    }
-                }
-
-                // it will always be the first one
-                if (sn.isPathPrefix) {
-                    // if we're reversing, we have to add alias to the first one,
-                    // otherwise we only need to add alias if this object only has a prefix and nothing else
-                    if (reverse) {
-                        return sn.toString(reverse, isLeft, outAlias, isReverseRightJoin);
-                    } else {
-                        return sn.toString(reverse, isLeft, self.foreignKeyPathLength == sn.nodeObject.foreignKeyPathLength ? outAlias : null, isReverseRightJoin);
-                    }
-                }
-
-                var fkStr = sn.toString(reverse, isLeft);
-                var addAlias = outAlias &&
-                               (reverse && sn === self.firstForeignKeyNode ||
-                               !reverse && sn === self.lastForeignKeyNode );
-
-                // NOTE alias on each node is ignored!
-                // currently we've added alias only for the association and
-                // therefore it's not really needed here anyways
-                var res = "";
-                if (reverse) {
-                    if (i > 0) {
-                        res += fkStr + "/";
-                    } else {
-                        if (addAlias) {
-                            res += outAlias + ":=";
-                            if (isReverseRightJoin) {
-                                res += "right";
-                            }
-                        }
-                        res += fkStr;
-                    }
-
-                    res += prev;
-                    return res;
-                } else {
-                    return prev + (i > 0 ? "/" : "") + (addAlias ? outAlias + ":=" : "") + fkStr;
-                }
-
-            }, "");
-
-        },
-
-        /**
-         * Turn this into a raw source path without any path prefix
-         * NOTE the returned array is not a complete path as it
-         *      doesn't include the last column
-         * currently used in two places:
-         *   - generating hashname for a sourcedef that uses path prefix
-         *   - generating the reverse path for a related entitty
-         * @param {Boolean} reverse
-         * @param {String=} outAlias alias that will be added to the last fk
-         *                     regardless of reversing or not
-         */
-        getRawSourcePath: function (reverse, outAlias) {
-            var path = [], self = this, obj;
-            var len = self.sourceObjectNodes.length;
-            var isLast = function (index) {
-                return reverse ? (index >= 0) : (index < len);
-            };
-
-            var i = reverse ? (len-1) : 0;
-            while (isLast(i)) {
-                let sn = self.sourceObjectNodes[i];
-                if (sn.isPathPrefix) {
-                    // if this is the last element, we have to add the alias to this
-                    path = path.concat(sn.nodeObject.getRawSourcePath(reverse, self.foreignKeyPathLength == sn.nodeObject.foreignKeyPathLength ? outAlias : null));
-                }
-                else if (sn.isFilter) {
-                    path.push(sn.nodeObject);
-                }  else {
-                    if ((reverse && sn.isInbound) || (!reverse && !sn.isInbound)) {
-                        obj = {"outbound": sn.nodeObject.constraint_names[0]};
-                    } else {
-                        obj = {"inbound": sn.nodeObject.constraint_names[0]};
-                    }
-
-                    // add alias to the last element
-                    if (isStringAndNotEmpty(outAlias) && sn == self.lastForeignKeyNode){
-                        obj.alias = outAlias;
-                    }
-
-                    path.push(obj);
-                }
-
-                i = i + (reverse ? -1 : 1);
-            }
-            return path;
-        },
-
-        /**
-         * Return the reverse path as facet with the value of shortestkey
-         * currently used in two places:
-         *   - column.refernece
-         *   - reference.generateRelatedReference
-         * both are for generating the reverse related entity path
-         * @param {Tuple} tuple
-         * @param {Table} rootTable
-         * @param {String=} outAlias
-         */
-        getReverseAsFacet: function (tuple, rootTable, outAlias) {
-            if (!isObjectAndNotNull(tuple)) return null;
-            var i, col, filters = [], filterSource = [];
-
-            // create the reverse path
-            filterSource = this.getRawSourcePath(true, outAlias);
-
-            // add the filter data
-            for (i = 0; i < rootTable.shortestKey.length; i++) {
-                col = rootTable.shortestKey[i];
-                if (!tuple.data || !tuple.data[col.name]) {
-                    return null;
-                }
-                const filter = {
-                    source: filterSource.concat(col.name)
-                };
-                filter[_facetFilterTypes.CHOICE] = [tuple.data[col.name]];
-                filters.push(filter);
-            }
-
-            if (filters.length == 0) {
-                return null;
-            }
-
-            return {"and": filters};
-        },
-
-        /**
-         * if sourceObject has the required input_iframe properties, will attach `inputIframeProps` and `isInputIframe`
-         * to the sourceObject.
-         * The returned value of this function summarizes whether processing was successful or not.
-         *
-         * var res = processInputIframe(reference, tuple, usedColumnMapping);
-         * if (res.error) {
-         *   console.log(res.message);
-         * } else {
-         *  // success
-         * }
-         *
-         * @param {*} reference the reference object of the parent
-         * @param {*} tuple the tuple object
-         * @param {*} usedIframeInputMappings an object capturing columns used in other mappings. used to avoid overlapping
-         */
-        processInputIframe: function (reference, tuple, usedIframeInputMappings) {
-            var self = this;
-            var context = reference._context;
-            var annot = this.sourceObject.input_iframe;
-            if (!isObjectAndNotNull(annot) || !isStringAndNotEmpty(annot.url_pattern)) {
-                return { error: true, message: 'url_pattern not defined.' };
-            }
-
-            if (!isObjectAndNotNull(annot.field_mapping)) {
-                return { erorr: true, message: 'field_mapping not defined.' };
-            }
-
-            var optionalFieldNames = [];
-            if (Array.isArray(annot.optional_fields)) {
-                annot.optional_fields.forEach(function (f) {
-                    if (isStringAndNotEmpty(f)) optionalFieldNames.push(f);
-                });
-            }
-
-            var emptyFieldConfirmMessage = '';
-            if (isStringAndNotEmpty(annot.empty_field_confirm_message_markdown)) {
-                emptyFieldConfirmMessage = renderMarkdown(annot.empty_field_confirm_message_markdown);
-            }
-
-            var columns = [], fieldMapping = {};
-            for (var f in annot.field_mapping) {
-                var colName = annot.field_mapping[f];
-
-                // column already used in another mapping
-                if (colName in usedIframeInputMappings) {
-                    return { error: true, message: 'column `' + colName + '` already used in another field_mapping.' };
-                }
-
-                try {
-                    var c = self.column.table.columns.get(colName);
-                    var isSerial = (c.type.name.indexOf('serial') === 0);
-
-                    // we cannot use getInputDisabled since we just want to do this based on ACLs
-                    if (context === _contexts.CREATE && (c.isSystemColumn || c.isGeneratedPerACLs || isSerial)) {
-                        if (colName in optionalFieldNames) continue;
-                        return { error: true, message: 'column `' + colName + '` cannot be modified by this user.'};
-                    }
-                    if ((context == _contexts.EDIT || context == _contexts.ENTRY) && (c.isSystemColumn || c.isImmutablePerACLs || isSerial)) {
-                        if (colName in optionalFieldNames) continue;
-                        return { error: true, message: 'column `' + colName + '` cannot be modified by this user.'};
-                    }
-
-                    // create a pseudo-column will make sure we're also handling assets
-                    var wrapper = new SourceObjectWrapper({'source': colName}, reference.table);
-                    var refCol = _createPseudoColumn(reference, wrapper, tuple);
-
-                    fieldMapping[f] = refCol;
-                    columns.push(refCol);
-                } catch (exp) {
-                    if (colName in optionalFieldNames) continue;
-                    return { error: true, message: 'column `' + colName + '` not found.'};
-                }
-            }
-
-            self.isInputIframe = true;
-            self.inputIframeProps = {
-                /**
-                 * can be used for finding the location of iframe
-                 */
-                urlPattern: annot.url_pattern,
-                urlTemplateEngine: annot.template_engine,
-                /**
-                 * the columns used in the mapping
-                 */
-                columns: columns,
-                /**
-                 * an object from field name to column.
-                 */
-                fieldMapping: fieldMapping,
-                /**
-                 * name of optional fields
-                 */
-                optionalFieldNames: optionalFieldNames,
-                /**
-                 * the message that we should show when user wants to submit empty.
-                 */
-                emptyFieldConfirmMessage: emptyFieldConfirmMessage
-            };
-
-            return {success: true, columns: columns};
-        },
-
-        /**
-         * @param {Table} table
-         * @param {Tuple=} mainTuple
-         * @param {boolean=} dontThrowError if set to true, will not throw an error if the filters are not valid
-         */
-        processFilterNodes: function (mainTuple, dontThrowError) {
-            if (!this.filterProps || this.filterProps.isFilterProcessed) {
-                return { success: true };
-            }
-
-            try {
-                for (const sn of this.sourceObjectNodes) {
-                    if (sn.isPathPrefix) {
-                        sn.nodeObject.processFilterNodes(mainTuple);
-                    } else if (sn.isFilter) {
-                        sn.processFilter(mainTuple);
-                    }
-                }
-
-                this.filterProps.isFilterProcessed = true;
-
-                return { success: true };
-            } catch (exp) {
-                if (dontThrowError) {
-                    return { success: false, error: true, message: exp.message };
-                } else {
-                    throw exp;
-                }
-            }
-        }
-    };
 
     /**
      * Helper functions related to source syntax
@@ -1810,7 +1340,6 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
                         prefix = rootTable.sourceDefinitions.getSource(source[i].sourcekey);
                     }
 
-                    // TODO filter-in-source should it process filters?
                     if (!prefix) {
                         return returnError("sourcekey is invalid.");
                     }
@@ -1828,7 +1357,7 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
                     if (!prefix.hasPath) {
                         return returnError("referrred `sourcekey` must be a foreign key path.");
                     }
-                    sourceObjectNodes.push(new SourceObjectNode(prefix, false, false, false, true, source[i].sourcekey, undefined, colTable));
+                    sourceObjectNodes.push(new SourceObjectNode(prefix, colTable, false, false, false, true, source[i].sourcekey, undefined, false));
 
                     firstForeignKeyNode = prefix.firstForeignKeyNode;
                     lastForeignKeyNode = prefix.lastForeignKeyNode;
@@ -1837,7 +1366,6 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
                     tableName = prefix.column.table.name;
                     hasInbound = hasInbound || prefix.hasInbound;
                     isFiltered = isFiltered || prefix.isFiltered;
-                    // TODO filter-in-source these should get it from prefix.filterProps
                     filterProps.hasRootFilter = prefix.hasRootFilter;
                     filterProps.hasFilterInBetween = prefix.hasFilterInBetween;
                     filterProps.leafFilterString = prefix.leafFilterString;
@@ -1852,7 +1380,7 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
 
                     var snf;
                     try {
-                        snf = new SourceObjectNode(source[i], true, false, false, false, undefined, undefined, colTable, undefined, mainTuple, skipProcessingFilters);
+                        snf = new SourceObjectNode(source[i], colTable, true, false, false, false, undefined, undefined, false, skipProcessingFilters, mainTuple);
                     } catch (exp) {
                         return returnError(exp.message);
                     }
@@ -1866,7 +1394,7 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
                     // create the string filter string, if this is not the last, then it will be emptied out
                     // for now we just want the string, later we could improve this implementation
                     // (for recordedit the whole object would be needed and not just string)
-                    // TODO filter-in-source toString is problematic here
+                    // NOTE filter-in-source toString is problematic here
                     filterProps.leafFilterString = filterProps.leafFilterString ?  [filterProps.leafFilterString, snf.toString()].join('/') : snf.toString();
 
                     // add the node to the list
@@ -1939,7 +1467,7 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
 
                     tableName = colTable.name;
 
-                    var sn = new SourceObjectNode(fk, false, true, isInbound, false, null, fkAlias, colTable, isAlternativeJoin);
+                    var sn = new SourceObjectNode(fk, colTable, false, true, isInbound, false, null, fkAlias, isAlternativeJoin);
                     sourceObjectNodes.push(sn);
 
                     if (firstForeignKeyNode == null) {
@@ -2258,9 +1786,9 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
          * parse the given source object node.
          * - this will mutate the given nodeObject and replaces the `operand_pattern` with the processed value
          *   and also set `operand_pattern_processed` to true
-         * @param {Object} nodeObject
-         * @param {Object} keyValues
-         * @param {Table} table
+         * @param {Object} nodeObject the source object node that should be parsed
+         * @param {Object} keyValues the key values that should be used for rendering the template
+         * @param {Table} table the table that this node refers to (the leaf table)
          * @returns
          */
         parseSourceObjectNodeFilter: function (nodeObject, keyValues, table) {
@@ -2499,7 +2027,7 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
             var stringifyAndOr = function (arr) {
                 // TODO we might want to sort this to make sure the order
                 // of elements doesn't matter
-                return "[" + arr.sort(helpers._sortFilterInSource).map(helpers._stringifyFilterInSource).join(",") + "]";
+                return "[" + arr.slice().sort(helpers._sortFilterInSource).map(helpers._stringifyFilterInSource).join(",") + "]";
             };
 
             var res = [];
@@ -2665,237 +2193,5 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
             }
 
             return _sourceColumnHelpers.generateSourceObjectHashName({source: source}, false);
-        }
-    };
-
-    /**
-     *
-     * @param {Object} nodeObject
-     * @param {boolean} isFilter
-     * @param {boolean} isForeignKey
-     * @param {boolean} isInbound
-     * @param {boolean} isPathPrefix
-     * @param {string=} pathPrefixSourcekey
-     * @param {string=} alias
-     * @param {Table} table the table that this node belongs to
-     * @param {boolean=} isAlternativeJoin
-     * @param {Object=} mainTuple
-     * @param {boolean=} skipProcessingFilters while parsing the sources for the first time, we don't have access to data
-     * so we cannot parse the filters. This is used to skip the filter parsing
-     * @desc This is the source object node that is used to represent a source object.
-     * It can be a filter, foreign key, inbound, outbound, or path prefix.
-     * - If it's a filter, it will parse the filter and store the parsed version in
-     *   `parsedFilterNode` and `nodeObject` will be modified to ensure the
-     *   `operand_pattern` is processed.
-     */
-    export function SourceObjectNode (
-        nodeObject, isFilter, isForeignKey, isInbound, isPathPrefix, pathPrefixSourcekey,
-        alias, table, isAlternativeJoin, mainTuple, skipProcessingFilters
-    ) {
-        this.nodeObject = nodeObject;
-
-        this.table = table;
-
-        this.isFilter = isFilter;
-        if (isFilter) {
-            if (!skipProcessingFilters) {
-                this.isFilterProcessed = true;
-                this.processFilter(mainTuple);
-            } else {
-                this.isFilterProcessed = false;
-            }
-        }
-
-        this.isForeignKey = isForeignKey;
-        this.isInbound = isInbound;
-
-        this.isPathPrefix = isPathPrefix;
-        this.pathPrefixSourcekey = pathPrefixSourcekey;
-
-        this.isAlternativeJoin = isAlternativeJoin;
-
-        this.alias = alias;
-    }
-
-    SourceObjectNode.prototype = {
-        /**
-         * Return the string representation of this node
-         * @param {boolean=} reverse - whether we should reverse the order (applicable to fk)
-         * @param {boolean=} isLeft  - whether we want to use left outer join (applicable to fk)
-         * @returns {String}
-         */
-        toString: function (reverse, isLeft, outAlias, isReverseRightJoin) {
-            var self = this;
-
-            if (self.isForeignKey) {
-                var rev = ( (reverse && self.isInbound) || (!reverse && !self.isInbound) );
-                return self.nodeObject.toString(rev, isLeft);
-            }
-
-            if (self.isPathPrefix) {
-                return self.nodeObject.toString(reverse, isLeft, outAlias, isReverseRightJoin);
-            }
-
-            return this.parsedFilterNode;
-        },
-
-        // TOOD what's the point of this???
-        // TODO FILTER_IN_SOURCE better name
-        get simpleConjunction () {
-            if (this._simpleConjunction === undefined) {
-
-                // TODO
-                var computeValue = function (self) {
-                    if (!self.isFilter) return null;
-
-                    var no = self.nodeObject;
-
-                    if ("or" in no) return null;
-
-                    // if ("")
-
-                };
-
-                this._simpleConjunction = computeValue(this);
-            }
-            return this._simpleConjunction;
-        },
-
-        processFilter: function (mainTuple) {
-            if (!this.isFilter) return;
-
-            let keyValues = {};
-            if (mainTuple && this.table) {
-                // get the key values from the main tuple
-                // this will be used to process the operand_pattern
-                keyValues = _getFormattedKeyValues(this.table, mainTuple.reference.context, mainTuple.data, mainTuple.linkedData);
-            }
-
-            // this will parse the filter and throw errors if it's invalid
-            this.parsedFilterNode = _sourceColumnHelpers.parseSourceObjectNodeFilter(this.nodeObject, keyValues, this.table);
-        }
-    };
-
-    /**
-     * This prototype is used for the shared prefix logic.
-     *
-     * @param {Object} forcedAliases        The aliases that must be used for the given sourcekeys
-     * @param {Object[]?} usedSourceObjects The source objects that are used in the url
-     *                                      (used for populating usedSourceKeys)
-     * @param {Table?} rootTable    The table that the source objects start from
-     *                                      (used for populating usedSourceKeys)
-     * @ignore
-     */
-    export function PathPrefixAliasMapping (forcedAliases, usedSourceObjects, rootTable) {
-        /**
-         * Aliases that already mapped to a join statement
-         * <sourcekey> -> <alias>
-         * @type {Object}
-         */
-        this.aliases = {};
-
-        /**
-         * sourcekeys that are used more than once and require alias
-         * <sourcekey> -> value is not important
-         * @type {Object}
-         */
-        this.usedSourceKeys = {};
-
-        /**
-         * The index of last added alias
-         * @type {number}
-         */
-        this.lastIndex = 0;
-
-        /**
-         * The aliases that must be used for the given sourcekeys
-         * <sourcekey> -> <alias>
-         * @type {Object}
-         */
-        this.forcedAliases = {};
-        if (isObjectAndNotNull(forcedAliases)) {
-            this.forcedAliases = forcedAliases;
-        }
-
-        // populate the this.usedSourceKeys based on the given objects
-        this._populateUsedSourceKeys(usedSourceObjects, rootTable);
-    }
-
-    PathPrefixAliasMapping.prototype = {
-        /**
-         * Given an array of source objects will populate the used source keys
-         * in the given first parameter.
-         * NOTE: this function doesn't account for cases where a recursive path
-         * is used twice. for example assume the following scenario:
-         * {
-         *   "key1": {
-         *     "source": [{"inbound": ["s", "const"]}, "RID"]
-         *   },
-         *   "key1_i1": {
-         *     "source": [{"sourcekey": "key1"}, {"inbound": ["s", "const2"]}, "RID"]
-         *   },
-             "key1_key1_i1": {
-         *     "source": [{"sourcekey": "key1_i1"}, {"inbound": ["s", "const3"]}, "RID"]
-         *   }
-         * }
-         * if "key1_i1" and "key1_key1_i1" are used in multiple sources, then it will include "key1" as well as
-         * "key1_i1" as part of usedSourcekeys even though adding alias for "key1_i1" is enough and
-         * we don't need any for "key1".
-         *
-         * @param {Object[]} sources the source objects that are used in the url
-         * @param {Table} rootTable the table that the source objects start from
-         * @private
-         */
-        _populateUsedSourceKeys: function (sources, rootTable) {
-            if (!Array.isArray(sources) || sources.length == 0 || !rootTable) return;
-            var self = this;
-            var addToSourceKey = function (key) {
-                if (!(key in rootTable.sourceDefinitions.sourceDependencies)) return;
-
-                rootTable.sourceDefinitions.sourceDependencies[key].forEach(function (dep) {
-                    if (dep in self.usedSourceKeys) {
-                        self.usedSourceKeys[dep]++;
-                    } else {
-                        self.usedSourceKeys[dep] = 1;
-                    }
-                });
-            };
-            sources.forEach(function (srcObj) {
-                if (!isObjectAndNotNull(srcObj)) return;
-
-                if (typeof srcObj.sourcekey === "string") {
-                    if (srcObj.sourcekey === _specialSourceDefinitions.SEARCH_BOX) {
-                        // add the search columns as well
-                        if (rootTable.searchSourceDefinition && Array.isArray(rootTable.searchSourceDefinition.columns)) {
-                            rootTable.searchSourceDefinition.columns.forEach(function (col, index) {
-                                // if the all are coming from the same path prefix, just look at the first one
-                                if (index > 0 && rootTable.searchSourceDefinition.allSamePathPrefix) {
-                                    return;
-                                }
-                                if (col.sourceObject && col.sourceObject.sourcekey) {
-                                    addToSourceKey(col.sourceObject.sourcekey);
-                                } else if (col.sourceObjectNodes.length > 0 && col.sourceObjectNodes[0].isPathPrefix) {
-                                    addToSourceKey(col.sourceObjectNodes[0].pathPrefixSourcekey);
-                                }
-                            });
-                        }
-                        return;
-                    }
-                    addToSourceKey (srcObj.sourcekey);
-                    return;
-                }
-
-                if (!Array.isArray(srcObj.source) || !isStringAndNotEmpty(srcObj.source[0].sourcekey)) {
-                    return;
-                }
-                // if this is the case, then it's an invalid url that will throw error later
-                if (srcObj.source[0].sourcekey === _specialSourceDefinitions.SEARCH_BOX) {
-                    return;
-                }
-                addToSourceKey(srcObj.source[0].sourcekey);
-            });
-            for (var k in self.usedSourceKeys) {
-                if (self.usedSourceKeys[k] < 2) delete self.usedSourceKeys[k];
-            }
         }
     };

--- a/src/models/path-prefix-alias-mapping.ts
+++ b/src/models/path-prefix-alias-mapping.ts
@@ -1,0 +1,130 @@
+import { isObjectAndNotNull, isStringAndNotEmpty } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
+import { _specialSourceDefinitions } from '@isrd-isi-edu/ermrestjs/src/utils/constants';
+import { Table } from '@isrd-isi-edu/ermrestjs/js/core';
+
+/**
+ * This class is used for the shared prefix logic.
+ */
+class PathPrefixAliasMapping {
+  /**
+   * Aliases that already mapped to a join statement
+   * <sourcekey> -> <alias>
+   */
+  public aliases: Record<string, string> = {};
+
+  /**
+   * sourcekeys that are used more than once and require alias
+   * <sourcekey> -> value is not important
+   */
+  public usedSourceKeys: Record<string, number> = {};
+
+  /**
+   * The index of last added alias
+   */
+  public lastIndex: number = 0;
+
+  /**
+   * The aliases that must be used for the given sourcekeys
+   * <sourcekey> -> <alias>
+   */
+  public forcedAliases: Record<string, string> = {};
+
+  /**
+   * @param forcedAliases        The aliases that must be used for the given sourcekeys
+   * @param usedSourceObjects The source objects that are used in the url
+   *                                      (used for populating usedSourceKeys)
+   * @param rootTable    The table that the source objects start from
+   *                                      (used for populating usedSourceKeys)
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(forcedAliases?: Record<string, string>, usedSourceObjects?: any[], rootTable?: Table) {
+    if (isObjectAndNotNull(forcedAliases)) {
+      this.forcedAliases = forcedAliases!;
+    }
+
+    // populate the this.usedSourceKeys based on the given objects
+    this._populateUsedSourceKeys(usedSourceObjects, rootTable);
+  }
+
+  private _addToSourceKey(key: string, rootTable: Table): void {
+    if (!(key in rootTable.sourceDefinitions.sourceDependencies)) return;
+
+    rootTable.sourceDefinitions.sourceDependencies[key].forEach((dep: string) => {
+      if (dep in this.usedSourceKeys) {
+        this.usedSourceKeys[dep]++;
+      } else {
+        this.usedSourceKeys[dep] = 1;
+      }
+    });
+  }
+
+  /**
+   * Given an array of source objects will populate the used source keys
+   * in the given first parameter.
+   * NOTE: this function doesn't account for cases where a recursive path
+   * is used twice. for example assume the following scenario:
+   * {
+   *   "key1": {
+   *     "source": [{"inbound": ["s", "const"]}, "RID"]
+   *   },
+   *   "key1_i1": {
+   *     "source": [{"sourcekey": "key1"}, {"inbound": ["s", "const2"]}, "RID"]
+   *   },
+       "key1_key1_i1": {
+   *     "source": [{"sourcekey": "key1_i1"}, {"inbound": ["s", "const3"]}, "RID"]
+   *   }
+   * }
+   * if "key1_i1" and "key1_key1_i1" are used in multiple sources, then it will include "key1" as well as
+   * "key1_i1" as part of usedSourcekeys even though adding alias for "key1_i1" is enough and
+   * we don't need any for "key1".
+   *
+   * @param sources the source objects that are used in the url
+   * @param rootTable the table that the source objects start from
+   * @private
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _populateUsedSourceKeys(sources?: any[], rootTable?: Table): void {
+    if (!Array.isArray(sources) || sources.length === 0 || !rootTable) return;
+
+    sources.forEach((srcObj) => {
+      if (!isObjectAndNotNull(srcObj)) return;
+
+      if (typeof srcObj.sourcekey === 'string') {
+        if (srcObj.sourcekey === _specialSourceDefinitions.SEARCH_BOX) {
+          // add the search columns as well
+          if (rootTable.searchSourceDefinition && Array.isArray(rootTable.searchSourceDefinition.columns)) {
+            rootTable.searchSourceDefinition.columns.forEach((col: any, index: number) => {
+              // if the all are coming from the same path prefix, just look at the first one
+              if (index > 0 && rootTable.searchSourceDefinition && rootTable.searchSourceDefinition.allSamePathPrefix) {
+                return;
+              }
+              if (col.sourceObject && col.sourceObject.sourcekey) {
+                this._addToSourceKey(col.sourceObject.sourcekey, rootTable);
+              } else if (col.sourceObjectNodes.length > 0 && col.sourceObjectNodes[0].isPathPrefix) {
+                this._addToSourceKey(col.sourceObjectNodes[0].pathPrefixSourcekey, rootTable);
+              }
+            });
+          }
+          return;
+        }
+        this._addToSourceKey(srcObj.sourcekey, rootTable);
+        return;
+      }
+
+      if (!Array.isArray(srcObj.source) || !isStringAndNotEmpty(srcObj.source[0].sourcekey)) {
+        return;
+      }
+      // if this is the case, then it's an invalid url that will throw error later
+      if (srcObj.source[0].sourcekey === _specialSourceDefinitions.SEARCH_BOX) {
+        return;
+      }
+      this._addToSourceKey(srcObj.source[0].sourcekey, rootTable);
+    });
+
+    for (const k in this.usedSourceKeys) {
+      if (this.usedSourceKeys[k] < 2) delete this.usedSourceKeys[k];
+    }
+  }
+}
+
+export default PathPrefixAliasMapping;

--- a/src/models/source-object-node.ts
+++ b/src/models/source-object-node.ts
@@ -1,0 +1,156 @@
+// utils
+import { _getFormattedKeyValues } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
+
+// legacy
+import { Table } from '@isrd-isi-edu/ermrestjs/js/core';
+import { Tuple } from '@isrd-isi-edu/ermrestjs/js/reference';
+import { _sourceColumnHelpers } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
+
+/**
+ * This is the source object node that is used to represent a source object.
+ * It can be a filter, foreign key, inbound, outbound, or path prefix.
+ */
+class SourceObjectNode {
+  /**
+   * the object that represents this node
+   * - if this is a filter, it will be the parsed filter node (Object)
+   * - if this is a foreign key, it will be the foreign key object (ForeignKeyRef)
+   * - if this is a path prefix, it will be the path prefix object (SourceObjectWrapper)
+   */
+  public nodeObject: any;
+
+  /**
+   * the table that this node belongs to (the table that the previous node points to)
+   */
+  public table: Table;
+
+  /**
+   * whether this node is a filter
+   */
+  public isFilter: boolean;
+  /**
+   * whether the filter has been processed
+   * - if true, the `parsedFilterNode` will be set to the parsed filter
+   * - if false, the `parsedFilterNode` will be undefined
+   */
+  public isFilterProcessed: boolean = false;
+  /**
+   * whether this node is a foreign key
+   */
+  public isForeignKey: boolean;
+  /**
+   * whether the foreign key is inbound or outbound
+   */
+  public isInbound: boolean;
+  /**
+   * whether this node is a path prefix
+   */
+  public isPathPrefix: boolean;
+  /**
+   * the source key for the path prefix
+   */
+  public pathPrefixSourcekey?: string;
+  /**
+   * whether this node is an alternative join
+   */
+  public isAlternativeJoin: boolean;
+  /**
+   * the alias for this node
+   */
+  public alias?: string;
+
+  /**
+   * the parsed filter node
+   */
+  private parsedFilterNode?: string;
+
+  constructor(
+    nodeObject: any,
+    /**
+     * the table that this node belongs to (the table that the previous node points to)
+     */
+    table: Table,
+    isFilter: boolean,
+    isForeignKey: boolean,
+    isInbound: boolean,
+    isPathPrefix: boolean,
+    pathPrefixSourcekey: string | undefined,
+    alias: string | undefined,
+    /**
+     * whether this node is an alternative join
+     */
+    isAlternativeJoin: boolean,
+    /**
+     * if set to true, the filter will not be processed
+     * this is used by Table.sourceDefinitions to skip processing filters since we still don't have the main tuple
+     */
+    skipProcessingFilters?: boolean,
+    /**
+     * the main tuple that this node is associated with
+     * this is used to process the filter if this is a filter node
+     */
+    mainTuple?: Tuple,
+  ) {
+    this.nodeObject = nodeObject;
+    this.table = table;
+    this.isFilter = isFilter;
+
+    if (isFilter) {
+      if (!skipProcessingFilters) {
+        this.isFilterProcessed = true;
+        this.processFilter(mainTuple);
+      } else {
+        this.isFilterProcessed = false;
+      }
+    }
+
+    this.isForeignKey = isForeignKey;
+    this.isInbound = isInbound;
+    this.isPathPrefix = isPathPrefix;
+    this.pathPrefixSourcekey = pathPrefixSourcekey;
+    this.isAlternativeJoin = isAlternativeJoin;
+    this.alias = alias;
+  }
+
+  /**
+   * Return the string representation of this node
+   * @param reverse - whether we should reverse the order (applicable to fk)
+   * @param isLeft  - whether we want to use left outer join (applicable to fk)
+   * @param outAlias - output alias
+   * @param isReverseRightJoin - whether this is a reverse right join
+   * @returns string representation
+   */
+  toString(reverse?: boolean, isLeft?: boolean, outAlias?: string, isReverseRightJoin?: boolean): string {
+    if (this.isForeignKey) {
+      const rev = (reverse && this.isInbound) || (!reverse && !this.isInbound);
+      return this.nodeObject.toString(rev, isLeft);
+    }
+
+    if (this.isPathPrefix) {
+      return this.nodeObject.toString(reverse, isLeft, outAlias, isReverseRightJoin);
+    }
+
+    return this.parsedFilterNode || '';
+  }
+
+  /**
+   * Process the filter for this node
+   * @param mainTuple - the main tuple to extract key values from
+   */
+  processFilter(mainTuple?: Tuple): void {
+    if (!this.isFilter) return;
+
+    let keyValues: Record<string, unknown> = {};
+    if (mainTuple && this.table) {
+      // get the key values from the main tuple
+      // this will be used to process the operand_pattern
+      const ref = mainTuple.reference;
+      keyValues = _getFormattedKeyValues(ref.table, ref.context, mainTuple.data, mainTuple.linkedData) as Record<string, unknown>;
+    }
+
+    // this will parse the filter and throw errors if it's invalid
+    this.parsedFilterNode = _sourceColumnHelpers.parseSourceObjectNodeFilter(this.nodeObject, keyValues, this.table);
+  }
+}
+
+export default SourceObjectNode;

--- a/src/models/source-object-wrapper.ts
+++ b/src/models/source-object-wrapper.ts
@@ -1,0 +1,684 @@
+/* eslint-disable prettier/prettier */
+
+// models
+import SourceObjectNode from '@isrd-isi-edu/ermrestjs/src/models/source-object-node';
+
+// services
+// import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
+
+// utils
+import { isObjectAndNotNull, isStringAndNotEmpty } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
+import { _contexts, _facetFilterTypes, _pseudoColAggregateFns, _sourceDefinitionAttributes, _warningMessages } from '@isrd-isi-edu/ermrestjs/src/utils/constants';
+import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils';
+
+// legacy imports that need to be accessed
+import { _sourceColumnHelpers } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
+import { _createPseudoColumn, ReferenceColumn } from '@isrd-isi-edu/ermrestjs/js/column';
+import { Column, Table } from '@isrd-isi-edu/ermrestjs/js/core';
+import { Reference, Tuple } from '@isrd-isi-edu/ermrestjs/js/reference';
+
+type FilterPropsType = {
+  /**
+   * whether the filter is processed or not
+   */
+  isFilterProcessed: boolean;
+  /**
+   * whether there's any filter applied to the root (the first node)
+   */
+  hasRootFilter: boolean;
+  /**
+   * whether there's any filter applied to the nodes in between
+   * (i.e. not the root and not the leaf)
+   */
+  hasFilterInBetween: boolean;
+  /**
+   * the leaf filter string
+   */
+  leafFilterString: string;
+}
+
+/**
+ * Represents a column-directive
+ */
+class SourceObjectWrapper {
+  /**
+   * the source object
+   */
+  public sourceObject: Record<string, unknown>;
+  /**
+   * the column that this source object refers to
+   * undefined if it's a virtual column
+   */
+  public column?: Column;
+  /**
+   * whether the source object has a prefix or not
+   */
+  public hasPrefix = false;
+  /**
+   * whether the source object has a foreign key path or not
+   */
+  public hasPath = false;
+  /**
+   * the length of the foreign key path
+   * this is the number of foreign key nodes in the path
+   */
+  public foreignKeyPathLength = 0;
+  /**
+   * whether the source object has an inbound foreign key path or not
+   */
+  public hasInbound = false;
+  /**
+   * whether the source object has an aggregate function or not
+   */
+  public hasAggregate = false;
+  /**
+   * whether any of the source object nodes is filtered or not
+   */
+  public isFiltered = false;
+  public filterProps?: FilterPropsType = {
+    isFilterProcessed: true,
+    hasRootFilter: false,
+    hasFilterInBetween: false,
+    leafFilterString: ''
+  };
+
+  /**
+   * whether this is an entity mode or not
+   */
+  public isEntityMode = false;
+  /**
+   * whether this represents a unique row or not
+   */
+  public isUnique = false;
+  /**
+   * whether this is unique and filtered
+   */
+  public isUniqueFiltered = false;
+  /**
+   * returns true if all foreign keys are outbound and all the columns involved are not null.
+   */
+  public isAllOutboundNotNullPerModel = false;
+  /**
+   *
+   */
+  public isAllOutboundNotNull = false;
+  public lastForeignKeyNode?: SourceObjectNode;
+  public firstForeignKeyNode?: SourceObjectNode;
+  public name = '';
+  public isHash = false;
+  public sourceObjectNodes: SourceObjectNode[] = [];
+  public isInputIframe = false;
+  public inputIframeProps?: {
+    /**
+     * the url pattern that should be used to generate the iframe url
+     */
+    urlPattern: string;
+    /**
+     * the template engine that should be used to generate the url
+     */
+    urlTemplateEngine?: string;
+    /**
+     * the columns used in the mapping
+     */
+    columns: ReferenceColumn[];
+    /**
+     * an object from field name to column.
+     */
+    fieldMapping: Record<string, ReferenceColumn>;
+    /**
+     * name of optional fields
+     */
+    optionalFieldNames: string[];
+    /**
+     * the message that we should show when user wants to submit empty.
+     */
+    emptyFieldConfirmMessage: string;
+  };
+
+  /**
+   * @param sourceObject the column directive object
+   * @param table the root (starting) table
+   * @param isFacet whether this is a facet or not
+   * @param sources already generated source (only useful for source-def generation)
+   * @param mainTuple the main tuple that is used for filters
+   * @param skipProcessingFilters whether we should skip processing filters or not
+   */
+  constructor(
+    sourceObject: Record<string, unknown>,
+    table?: Table,
+    isFacet?: boolean,
+    sources?: unknown,
+    mainTuple?: Tuple,
+    skipProcessingFilters?: boolean,
+  ) {
+    this.sourceObject = sourceObject;
+
+    // if the extra objects are not passed, we cannot process
+    if (isObjectAndNotNull(table)) {
+      const res = this._process(table!, isFacet, sources, mainTuple, skipProcessingFilters);
+      if (typeof res === 'object' && res.error) {
+        throw new Error(res.message);
+      }
+    }
+  }
+
+  /**
+   * return a new sourceObjectWrapper that is created by merging the given sourceObject and existing object.
+   *
+   * Useful when we have an object with sourcekey and want to find the actual definition. You can then call
+   * clone on the source-def and pass the object.
+   *
+   * const myCol = {"sourcekey": "some_key"};
+   * const sd = table.sourceDefinitions.getSource(myCol.sourcekey);
+   * if (sd) {
+   *   const wrapper = sd.clone(myCol, table);
+   * }
+   *
+   * - attributes in sourceObject will override the similar ones in the current object.
+   * - "source" of sourceObject will be ignored. so "sourcekey" always has priority over "source".
+   * - mainTuple should be passed in detailed context so we can use it for filters.
+   *
+   * @param sourceObject the source object
+   * @param table the table that these sources belong to.
+   * @param isFacet whether this is for a facet or not
+   */
+  clone(sourceObject: Record<string, unknown>, table: Table, isFacet?: boolean, mainTuple?: Tuple): SourceObjectWrapper {
+    let key: string;
+
+    // remove the definition attributes
+    _sourceDefinitionAttributes.forEach(function (attr: string) {
+      delete sourceObject[attr];
+    });
+
+    for (key in this.sourceObject) {
+      if (!Object.prototype.hasOwnProperty.call(this.sourceObject, key)) continue;
+
+      // only add the attributes that are not defined again
+      if (!Object.prototype.hasOwnProperty.call(sourceObject, key)) {
+        sourceObject[key] = this.sourceObject[key];
+      }
+    }
+
+    return new SourceObjectWrapper(sourceObject, table, isFacet, undefined, mainTuple);
+  }
+
+  /**
+   * Parse the given sourceobject and create the attributes
+   * @param table
+   * @param isFacet  -- validation is differrent if it's a facet
+   * @param sources already generated source (only useful for source-def generation)
+   * @param mainTuple the main tuple that is used for filters
+   * @param skipProcessingFilters whether we should skip processing filters or not
+   * @returns
+   */
+  private _process(
+    table: Table,
+    isFacet?: boolean,
+    sources?: any,
+    mainTuple?: Tuple,
+    skipProcessingFilters?: boolean
+  ): true | { error: boolean; message: string } {
+    const sourceObject = this.sourceObject;
+    const wm = _warningMessages;
+
+    const returnError = (message: string) => {
+      return { error: true, message: message };
+    };
+
+    if (typeof sourceObject !== 'object' || !sourceObject.source) {
+      return returnError(wm.INVALID_SOURCE);
+    }
+
+    let colName: string;
+    let col: Column | undefined = undefined;
+    let colTable = table;
+    const source = sourceObject.source;
+    let sourceObjectNodes: SourceObjectNode[] = [];
+    let hasPath = false;
+    let hasInbound = false;
+    let hasPrefix = false;
+    let isAllOutboundNotNull = false;
+    let isAllOutboundNotNullPerModel = false;
+    let lastForeignKeyNode: SourceObjectNode | undefined = undefined;
+    let firstForeignKeyNode: SourceObjectNode | undefined = undefined;
+    let foreignKeyPathLength = 0;
+    let isFiltered = false;
+    let filterProps: FilterPropsType | undefined = undefined;
+
+    // just the column name
+    if (isStringAndNotEmpty(source) && typeof source === 'string') {
+      colName = source;
+    }
+    // from 0 to source.length-1 we have paths
+    else if (Array.isArray(source) && source.length === 1 && isStringAndNotEmpty(source[0])) {
+      colName = source[0];
+    } else if (Array.isArray(source) && source.length > 1) {
+      const res = _sourceColumnHelpers.processDataSourcePath(
+        source,
+        table,
+        table.name,
+        table.schema.catalog.id,
+        sources,
+        mainTuple,
+        skipProcessingFilters
+      ) as any;
+
+      if (res.error) {
+        return res;
+      }
+
+      hasPath = res.foreignKeyPathLength > 0;
+      hasInbound = res.hasInbound;
+      hasPrefix = res.hasPrefix;
+      firstForeignKeyNode = res.firstForeignKeyNode;
+      lastForeignKeyNode = res.lastForeignKeyNode;
+      colTable = res.column.table;
+      foreignKeyPathLength = res.foreignKeyPathLength;
+      sourceObjectNodes = res.sourceObjectNodes;
+      colName = res.column.name;
+      isFiltered = res.isFiltered;
+      filterProps = res.filterProps;
+      isAllOutboundNotNull = res.isAllOutboundNotNull;
+      isAllOutboundNotNullPerModel = res.isAllOutboundNotNullPerModel;
+    } else {
+      return returnError('Invalid source definition');
+    }
+
+    // we need this check here to make sure the column is in the table
+    try {
+      col = colTable.columns.get(colName);
+    } catch {
+      return returnError(wm.INVALID_COLUMN_IN_SOURCE_PATH);
+    }
+    const isEntity = hasPath && sourceObject.entity !== false && col.isUniqueNotNull;
+
+    // validate aggregate fn
+    if (isFacet !== true && typeof sourceObject.aggregate === 'string' && _pseudoColAggregateFns.indexOf(sourceObject.aggregate) === -1) {
+      return returnError(wm.INVALID_AGG);
+    }
+
+    this.column = col;
+
+    this.hasPrefix = hasPrefix;
+    // NOTE hasPath only means foreign key path and not filter
+    this.hasPath = hasPath;
+    this.foreignKeyPathLength = foreignKeyPathLength;
+    this.hasInbound = hasInbound;
+    this.hasAggregate = typeof sourceObject.aggregate === 'string';
+    this.isFiltered = isFiltered;
+    this.filterProps = filterProps;
+    this.isEntityMode = isEntity;
+    this.isUnique = !this.hasAggregate && !this.isFiltered && (!hasPath || !hasInbound);
+
+    // TODO FILTER_IN_SOURCE better name...
+    /**
+     * these type of columns would be very similiar to aggregate columns.
+     * but it requires more changes in both chaise and ermrestjs
+     * (most probably a new column type or at least more api to fetch their values is needed)
+     * (in chaise we would have to add a new type of secondary requests to active list)
+     * (not sure if these type of pseudo-columns are even useful or not)
+     * so for now we're not going to allow these type of pseudo-columns in visible-columns
+     */
+    this.isUniqueFiltered = !this.hasAggregate && this.isFiltered && (!hasPath || !hasInbound);
+
+    this.isAllOutboundNotNullPerModel = isAllOutboundNotNullPerModel;
+    this.isAllOutboundNotNull = isAllOutboundNotNull;
+
+    // attach last fk
+    if (lastForeignKeyNode !== undefined && lastForeignKeyNode !== null) {
+      this.lastForeignKeyNode = lastForeignKeyNode;
+    }
+
+    // attach first fk
+    if (firstForeignKeyNode !== undefined && firstForeignKeyNode !== null) {
+      this.firstForeignKeyNode = firstForeignKeyNode;
+    }
+
+    // generate name:
+    // TODO maybe we shouldn't even allow aggregate in faceting (for now we're ignoring it)
+    if (
+      sourceObject.self_link === true ||
+      this.isFiltered ||
+      this.hasPath ||
+      this.isEntityMode ||
+      (isFacet !== true && this.hasAggregate)
+    ) {
+      this.name = _sourceColumnHelpers.generateSourceObjectHashName(sourceObject, !!isFacet, sourceObjectNodes) as string;
+
+      this.isHash = true;
+
+      if (table.columns.has(this.name)) {
+        return returnError(
+          'Generated Hash `' + this.name + '` for pseudo-column exists in table `' + table.name + '`.'
+        );
+      }
+    } else {
+      this.name = col.name;
+      this.isHash = false;
+    }
+
+    this.sourceObjectNodes = sourceObjectNodes;
+
+    return true;
+  }
+
+  /**
+   * Return the string representation of this foreignkey path
+   * returned format:
+   * if not isLeft and outAlias is not passed: ()=()/.../()=()
+   * if isLeft: left()=()/.../left()=()
+   * if outAlias defined: ()=()/.../outAlias:=()/()
+   * used in:
+   *   - export default
+   *   - column.getAggregate
+   *   - reference.read
+   * @param reverse whether we want the reverse path
+   * @param isLeft use left join
+   * @param outAlias the alias that should be added to the output
+   */
+  toString(reverse?: boolean, isLeft?: boolean, outAlias?: string, isReverseRightJoin?: boolean): string {
+    return this.sourceObjectNodes.reduce((prev: string, sn: any, i: number) => {
+      if (sn.isFilter) {
+        if (reverse) {
+          return sn.toString() + (i > 0 ? '/' : '') + prev;
+        } else {
+          return prev + (i > 0 ? '/' : '') + sn.toString();
+        }
+      }
+
+      // it will always be the first one
+      if (sn.isPathPrefix) {
+        // if we're reversing, we have to add alias to the first one,
+        // otherwise we only need to add alias if this object only has a prefix and nothing else
+        if (reverse) {
+          return sn.toString(reverse, isLeft, outAlias, isReverseRightJoin);
+        } else {
+          return sn.toString(
+            reverse,
+            isLeft,
+            this.foreignKeyPathLength === sn.nodeObject.foreignKeyPathLength ? outAlias : null,
+            isReverseRightJoin
+          );
+        }
+      }
+
+      const fkStr = sn.toString(reverse, isLeft);
+      const addAlias =
+        outAlias &&
+        ((reverse && sn === this.firstForeignKeyNode) || (!reverse && sn === this.lastForeignKeyNode));
+
+      // NOTE alias on each node is ignored!
+      // currently we've added alias only for the association and
+      // therefore it's not really needed here anyways
+      let res = '';
+      if (reverse) {
+        if (i > 0) {
+          res += fkStr + '/';
+        } else {
+          if (addAlias) {
+            res += outAlias + ':=';
+            if (isReverseRightJoin) {
+              res += 'right';
+            }
+          }
+          res += fkStr;
+        }
+
+        res += prev;
+        return res;
+      } else {
+        return prev + (i > 0 ? '/' : '') + (addAlias ? outAlias + ':=' : '') + fkStr;
+      }
+    }, '');
+  }
+
+  /**
+   * Turn this into a raw source path without any path prefix
+   * NOTE the returned array is not a complete path as it
+   *      doesn't include the last column
+   * currently used in two places:
+   *   - generating hashname for a sourcedef that uses path prefix
+   *   - generating the reverse path for a related entitty
+   * @param reverse
+   * @param outAlias alias that will be added to the last fk
+   *                     regardless of reversing or not
+   */
+  getRawSourcePath(reverse?: boolean, outAlias?: string): any[] {
+    const path: any[] = [];
+    const len = this.sourceObjectNodes.length;
+    const isLast = (index: number) => {
+      return reverse ? index >= 0 : index < len;
+    };
+
+    let i = reverse ? len - 1 : 0;
+    while (isLast(i)) {
+      const sn = this.sourceObjectNodes[i];
+      if (sn.isPathPrefix) {
+        // if this is the last element, we have to add the alias to this
+        path.push(
+          ...sn.nodeObject.getRawSourcePath(
+            reverse,
+            this.foreignKeyPathLength == sn.nodeObject.foreignKeyPathLength ? outAlias : null
+          )
+        );
+      } else if (sn.isFilter) {
+        path.push(sn.nodeObject);
+      } else {
+        let obj: any;
+        if ((reverse && sn.isInbound) || (!reverse && !sn.isInbound)) {
+          obj = { outbound: sn.nodeObject.constraint_names[0] };
+        } else {
+          obj = { inbound: sn.nodeObject.constraint_names[0] };
+        }
+
+        // add alias to the last element
+        if (isStringAndNotEmpty(outAlias) && sn == this.lastForeignKeyNode) {
+          obj.alias = outAlias;
+        }
+
+        path.push(obj);
+      }
+
+      i = i + (reverse ? -1 : 1);
+    }
+    return path;
+  }
+
+  /**
+   * Return the reverse path as facet with the value of shortestkey
+   * currently used in two places:
+   *   - column.refernece
+   *   - reference.generateRelatedReference
+   * both are for generating the reverse related entity path
+   * @param tuple
+   * @param rootTable
+   * @param outAlias
+   */
+  getReverseAsFacet(tuple: Tuple, rootTable: Table, outAlias?: string): any {
+    if (!isObjectAndNotNull(tuple)) return null;
+    let i: number;
+    const filters: any[] = [];
+    let filterSource: any[] = [];
+
+    // create the reverse path
+    filterSource = this.getRawSourcePath(true, outAlias);
+
+    // add the filter data
+    for (i = 0; i < rootTable.shortestKey.length; i++) {
+      const col: Column = rootTable.shortestKey[i];
+      if (!tuple.data || !tuple.data[col.name]) {
+        return null;
+      }
+      const filter: any = {
+        source: filterSource.concat(col.name),
+      };
+      filter[_facetFilterTypes.CHOICE] = [tuple.data[col.name]];
+      filters.push(filter);
+    }
+
+    if (filters.length == 0) {
+      return null;
+    }
+
+    return { and: filters };
+  }
+
+  /**
+   * if sourceObject has the required input_iframe properties, will attach `inputIframeProps` and `isInputIframe`
+   * to the sourceObject.
+   * The returned value of this function summarizes whether processing was successful or not.
+   *
+   * var res = processInputIframe(reference, tuple, usedColumnMapping);
+   * if (res.error) {
+   *   console.log(res.message);
+   * } else {
+   *  // success
+   * }
+   *
+   * @param reference the reference object of the parent
+   * @param tuple the tuple object
+   * @param usedIframeInputMappings an object capturing columns used in other mappings. used to avoid overlapping
+   */
+  processInputIframe(reference: Reference, tuple: Tuple, usedIframeInputMappings: any): {
+    success?: boolean;
+    error?: boolean;
+    message?: string;
+    columns?: ReferenceColumn[];
+  } {
+    const context = reference._context;
+    const annot: any = this.sourceObject.input_iframe;
+    if (!isObjectAndNotNull(annot) || !isStringAndNotEmpty(annot.url_pattern)) {
+      return { error: true, message: 'url_pattern not defined.' };
+    }
+
+    if (!isObjectAndNotNull(annot.field_mapping)) {
+      return { error: true, message: 'field_mapping not defined.' };
+    }
+
+    const optionalFieldNames: string[] = [];
+    if (Array.isArray(annot.optional_fields)) {
+      annot.optional_fields.forEach(function (f: unknown) {
+        if (isStringAndNotEmpty(f) && typeof f === 'string') optionalFieldNames.push(f);
+      });
+    }
+
+    let emptyFieldConfirmMessage = '';
+    if (isStringAndNotEmpty(annot.empty_field_confirm_message_markdown)) {
+      emptyFieldConfirmMessage = renderMarkdown(annot.empty_field_confirm_message_markdown);
+    }
+
+    const columns: ReferenceColumn[] = [];
+    const fieldMapping: Record<string, ReferenceColumn> = {};
+    for (const f in annot.field_mapping) {
+      const colName = annot.field_mapping[f];
+
+      // column already used in another mapping
+      if (colName in usedIframeInputMappings) {
+        return {
+          error: true,
+          message: 'column `' + colName + '` already used in another field_mapping.',
+        };
+      }
+
+      try {
+        const c = this.column!.table.columns.get(colName);
+        const isSerial = c.type.name.indexOf('serial') === 0;
+
+        // we cannot use getInputDisabled since we just want to do this based on ACLs
+        if (
+          context === _contexts.CREATE &&
+          (c.isSystemColumn || c.isGeneratedPerACLs || isSerial)
+        ) {
+          if (colName in optionalFieldNames) continue;
+          return {
+            error: true,
+            message: 'column `' + colName + '` cannot be modified by this user.',
+          };
+        }
+        if (
+          (context === _contexts.EDIT || context === _contexts.ENTRY) &&
+          (c.isSystemColumn || c.isImmutablePerACLs || isSerial)
+        ) {
+          if (colName in optionalFieldNames) continue;
+          return {
+            error: true,
+            message: 'column `' + colName + '` cannot be modified by this user.',
+          };
+        }
+
+        // create a pseudo-column will make sure we're also handling assets
+        const wrapper = new SourceObjectWrapper({ source: colName }, reference.table);
+        const refCol = _createPseudoColumn(reference, wrapper, tuple);
+
+        fieldMapping[f] = refCol;
+        columns.push(refCol);
+      } catch {
+        if (colName in optionalFieldNames) continue;
+        return { error: true, message: 'column `' + colName + '` not found.' };
+      }
+    }
+
+    this.isInputIframe = true;
+    this.inputIframeProps = {
+      /**
+       * can be used for finding the location of iframe
+       */
+      urlPattern: annot.url_pattern,
+      urlTemplateEngine: annot.template_engine,
+      /**
+       * the columns used in the mapping
+       */
+      columns: columns,
+      /**
+       * an object from field name to column.
+       */
+      fieldMapping: fieldMapping,
+      /**
+       * name of optional fields
+       */
+      optionalFieldNames: optionalFieldNames,
+      /**
+       * the message that we should show when user wants to submit empty.
+       */
+      emptyFieldConfirmMessage: emptyFieldConfirmMessage,
+    };
+
+    return { success: true, columns: columns };
+  }
+
+  /**
+   * @param mainTuple
+   * @param dontThrowError if set to true, will not throw an error if the filters are not valid
+   */
+  processFilterNodes(mainTuple?: Tuple, dontThrowError?: boolean): {
+    success: boolean;
+    error?: boolean;
+    message?: string;
+  } {
+    if (!this.filterProps || this.filterProps.isFilterProcessed) {
+      return { success: true };
+    }
+
+    try {
+      for (const sn of this.sourceObjectNodes) {
+        if (sn.isPathPrefix) {
+          sn.nodeObject.processFilterNodes(mainTuple);
+        } else if (sn.isFilter) {
+          sn.processFilter(mainTuple);
+        }
+      }
+
+      this.filterProps.isFilterProcessed = true;
+
+      return { success: true };
+    } catch (exp: unknown) {
+      if (dontThrowError) {
+        return { success: false, error: true, message: (exp as Error).message };
+      } else {
+        throw exp;
+      }
+    }
+  }
+}
+
+export default SourceObjectWrapper;

--- a/src/models/table-source-definitions.ts
+++ b/src/models/table-source-definitions.ts
@@ -4,7 +4,7 @@ import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
 // legacy
 import { Column, ForeignKeyRef, Table } from '@isrd-isi-edu/ermrestjs/js/core';
 import { Tuple } from '@isrd-isi-edu/ermrestjs/js/reference';
-import { SourceObjectWrapper } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
+import SourceObjectWrapper from '@isrd-isi-edu/ermrestjs/src/models/source-object-wrapper';
 
 /**
  * Result of Table.sourceDefinitions

--- a/src/models/table-source-definitions.ts
+++ b/src/models/table-source-definitions.ts
@@ -1,0 +1,96 @@
+// services
+import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
+
+// legacy
+import { Column, ForeignKeyRef, Table } from '@isrd-isi-edu/ermrestjs/js/core';
+import { Tuple } from '@isrd-isi-edu/ermrestjs/js/reference';
+import { SourceObjectWrapper } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
+
+/**
+ * Result of Table.sourceDefinitions
+ */
+class TableSourceDefinitions {
+  /**
+   * the table that these source definitions are for
+   */
+  private table: Table;
+  /**
+   * columns that will be available in the templating environment
+   */
+  columns: Column[] = [];
+  /**
+   * foreign keys that will be available in the templating environment
+   */
+  fkeys: ForeignKeyRef[] = [];
+  /**
+   * valid source-definitions
+   * NOTE: if the source has a filter, this will not validate it and so should not be
+   * used directly.
+   */
+  private sources: Record<string, SourceObjectWrapper> = {};
+  /**
+   * mapping of hash to the defined source names.
+   */
+  sourceMapping: Record<string, string[]> = {};
+  /**
+   * for each sourcekey, what are the other sourcekeys that it depends on (includes self as well)
+   * this has been added because of path prefix where a sourcekey might rely on other sourcekeys
+   */
+  sourceDependencies: Record<string, string[]> = {};
+
+  constructor(
+    table: Table,
+    columns: Column[],
+    fkeys: ForeignKeyRef[],
+    sources: Record<string, SourceObjectWrapper>,
+    sourceMapping: Record<string, string[]>,
+    sourceDependencies: Record<string, string[]>,
+  ) {
+    this.table = table;
+    this.columns = columns;
+    this.fkeys = fkeys;
+    this.sources = sources;
+    this.sourceMapping = sourceMapping;
+    this.sourceDependencies = sourceDependencies;
+  }
+
+  /**
+   * Get all valid source definitions for the table.
+   * This will process the filter nodes of each source definition and return only those that do not
+   * throw an error when processing the filter nodes.
+   * @param mainTuple The main tuple to use for processing the filter nodes.
+   * @returns the valid source definitions.
+   */
+  getSources(mainTuple?: Tuple): Record<string, SourceObjectWrapper> {
+    const validSources: Record<string, SourceObjectWrapper> = {};
+    for (const sourcekey in this.sources) {
+      const sd = this.sources[sourcekey];
+      try {
+        void sd.processFilterNodes(mainTuple);
+        validSources[sourcekey] = sd;
+      } catch (exp: unknown) {
+        // if the source definition has a filter, it will throw an error if the filter is
+        const message = `source definition, table =${this.table.name}, name=${sourcekey}`;
+        $log.info(`${message}: ${exp instanceof Error ? exp.message : String(exp)}`);
+      }
+    }
+    return validSources;
+  }
+
+  /**
+   * Get a source definition by its key.
+   * @param sourcekey The key of the source definition.
+   * @returns The source definition or undefined if not found.
+   */
+  getSource(sourcekey: string, mainTuple?: Tuple): SourceObjectWrapper | undefined {
+    const sd = this.sources[sourcekey];
+
+    if (!sd || !sd.processFilterNodes(mainTuple, true).success) {
+      return undefined;
+    }
+
+    return sd;
+  }
+}
+
+export default TableSourceDefinitions;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -484,6 +484,7 @@ export const _shorterVersion = Object.freeze({
   and: 'and',
   or: 'or',
   operand_pattern: 'opd',
+  operand_pattern_processed: 'opd_p',
   operator: 'opr',
   negate: 'n',
 });

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -79,7 +79,7 @@ export function isInteger(value: unknown) {
  * @function verify
  * @param {boolean} test The test
  * @param {string} message The message
- * @throws {ERMrest.InvalidInputError} If test is not true.
+ * @throws {InvalidInputError} If test is not true.
  * @private
  */
 export function verify(test: any, message: string) {

--- a/test/specs/annotation/tests/07.source_definitions.js
+++ b/test/specs/annotation/tests/07.source_definitions.js
@@ -31,11 +31,7 @@ exports.execute = function (options) {
 
   var testSourceWrapperAPIs = function (obj, reverse, isLeft, outAlias, expectedString, expectedRawSource, message) {
     var addedMessage = message ? message : '';
-
-    // TODO fiter-in-source
-    if (expectedString) {
-      expect(obj.toString(reverse, isLeft, outAlias)).toEqual(expectedString, 'toString missmatch ' + addedMessage);
-    }
+    expect(obj.toString(reverse, isLeft, outAlias)).toEqual(expectedString, 'toString missmatch ' + addedMessage);
 
     if (expectedRawSource) {
       var src = obj.getRawSourcePath(reverse, outAlias);
@@ -747,11 +743,10 @@ exports.execute = function (options) {
                   false,
                   true,
                   'alias',
-                  // TODO filter-in-source why is the order getting changed?
-                  // [
-                  //   '((id=' + moment().format('YYYY') + '&!(col%20w%20space::null::));col::ts::some%20val;!(RMB::null::;id::null::))',
-                  //   'alias:=left(id)=(source_definitions_schema:outbound1:id)',
-                  // ].join('/'),
+                  [
+                    '((id=' + moment().format('YYYY') + '&!(col%20w%20space::null::));col::ts::some%20val;!(RMB::null::;id::null::))',
+                    'alias:=left(id)=(source_definitions_schema:outbound1:id)',
+                  ].join('/'),
                   '',
                   null, // it's a big object that we cannot easily test and there's no point in testing as well
                   'case 3',

--- a/test/specs/column/conf/pseudo_column_schema/schema.json
+++ b/test/specs/column/conf/pseudo_column_schema/schema.json
@@ -331,6 +331,17 @@
                                 "id"
                             ],
                             "aggregate": "min"
+                        },
+                        {
+                            "source": [
+                                {"filter": "main_table_id_col", "operand_pattern": "{{{main_table_id_col}}}"},
+                                {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
+                                {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
+                                {"outbound": ["pseudo_column_schema", "inbound_2_fk1"]},
+                                {"filter": "id", "operand_pattern": "{{{$fkey_pseudo_column_schema_main_fk1.rowName}}}"},
+                                "id"
+                            ],
+                            "markdown_name": "col with filter using data"
                         }
                     ],
                     "entry/create": "detailed",

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -1,5 +1,7 @@
 const utils = require('./../../../utils/utilities.js');
 
+const moment = require('moment-timezone');
+
 /**
  * The structure of table and contexts used:
  * main -> f1 -> f2
@@ -166,7 +168,7 @@ exports.execute = function (options) {
       '$virtual-column-1',
       '$virtual-column-1-1',
       'rxU1VoEIaH0rnNoNVr0fwA',
-      'up2zcsXMZsWvCSiWNXt2Kg',
+      'DwJz2eQLrN4DpJfEbeYT6g',
       'u2ZKnWX7hWq_KuPYF53ZhQ',
     ];
 
@@ -451,7 +453,7 @@ exports.execute = function (options) {
                 { outbound: ['pseudo_column_schema', 'main_inbound_2_association_fk2'] },
                 {
                   or: [
-                    { filter: 'RCT', operand_pattern: '{{{$moment.year}}}-{{{$moment.month}}}-{{{$moment.date}}}', operator: '::gt::' },
+                    { filter: 'RCT', operand_pattern: moment().format('YYYY-M-DD'), operator: '::gt::', operand_pattern_processed: true },
                     { filter: 'RID', operator: '::null::', negate: true },
                   ],
                 },
@@ -1060,7 +1062,7 @@ exports.execute = function (options) {
             { o: ['pseudo_column_schema', 'main_inbound_2_association_fk2'] },
             {
               or: [
-                { f: 'RCT', opd: '{{{$moment.year}}}-{{{$moment.month}}}-{{{$moment.date}}}', opr: '::gt::' },
+                { f: 'RCT', opd: moment().format('YYYY-M-DD'), opr: '::gt::', opd_p: true },
                 { f: 'RID', opr: '::null::', n: true },
               ],
             },

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -168,11 +168,12 @@ exports.execute = function (options) {
       '$virtual-column-1',
       '$virtual-column-1-1',
       'rxU1VoEIaH0rnNoNVr0fwA',
-      'DwJz2eQLrN4DpJfEbeYT6g',
+      'JzpcyAVsEw4hj5XQ2RSAjA',
       'u2ZKnWX7hWq_KuPYF53ZhQ',
+      '70d05Zq4WBgu95blBsBAtg',
     ];
 
-    var detailedPseudoColumnIndices = [4, 5, 6, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 24, 25, 28, 29, 30];
+    var detailedPseudoColumnIndices = [4, 5, 6, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 24, 25, 28, 29, 30, 31];
 
     var detailedColumnTypes = [
       '',
@@ -203,6 +204,7 @@ exports.execute = function (options) {
       'isPathColumn',
       'isVirtualColumn',
       'isVirtualColumn',
+      'isPathColumn',
       'isPathColumn',
       'isPathColumn',
     ];
@@ -560,9 +562,23 @@ exports.execute = function (options) {
         it('other attributes must be as expected.', function () {});
       });
 
-      it('generateColumnsList, passing tuple should not change the column list.', function () {
+      it('generateColumnsList, passing tuple should parse the filters.', function () {
         detailedColsWTuple = mainRefDetailed.generateColumnsList(mainTuple);
-        areSameColumnList(detailedColsWTuple, detailedCols);
+        expect(detailedColsWTuple.length).toBe(32, 'length missmatch');
+        areSameColumnList(detailedColsWTuple.slice(0, detailedColsWTuple.length - 1), detailedCols);
+        const lastCol = detailedColsWTuple[detailedColsWTuple.length - 1];
+        utils.checkColumnList(
+          [lastCol],
+          [[
+            {filter: 'main_table_id_col', operand_pattern: '01', operand_pattern_processed: true},
+            { inbound: ['pseudo_column_schema', 'main_inbound_2_association_fk1'] },
+            { outbound: ['pseudo_column_schema', 'main_inbound_2_association_fk2'] },
+            { outbound: ['pseudo_column_schema', 'inbound_2_fk1'] },
+            {filter: 'id', operand_pattern: '01', operand_pattern_processed: true},
+            'id'
+          ]],
+          'PseudoColumn with filter missmatch.',
+        );
       });
 
       it('faceting should be able to handle these new type of columns.', function (done) {
@@ -979,7 +995,8 @@ exports.execute = function (options) {
             'main',
             'inbound_1_outbound_1_outbound_1',
             'inbound_2',
-            'outbound_2_inbound_1'
+            'outbound_2_inbound_1',
+            'inbound_2_outbound_1',
           ]);
         });
       });
@@ -1068,7 +1085,15 @@ exports.execute = function (options) {
             },
             'id',
           ], // 29
-          [{ o: ['pseudo_column_schema', 'main_fk2'] }, { i: ['pseudo_column_schema', 'outbound_2_inbound_1_fk1'] }, 'id'] // 30
+          [{ o: ['pseudo_column_schema', 'main_fk2'] }, { i: ['pseudo_column_schema', 'outbound_2_inbound_1_fk1'] }, 'id'], // 30
+          [
+            {f: 'main_table_id_col', opd: '01', opd_p: true},
+            { i: ['pseudo_column_schema', 'main_inbound_2_association_fk1'] },
+            { o: ['pseudo_column_schema', 'main_inbound_2_association_fk2'] },
+            { o: ['pseudo_column_schema', 'inbound_2_fk1'] },
+            { f: 'id', opd: '01', opd_p: true },
+            'id',
+          ], // 31
         ];
         it('should return the data source of the pseudo-column.', function () {
           detailedColsWTuple.forEach(function (col, index) {
@@ -1574,8 +1599,8 @@ exports.execute = function (options) {
     }
   }
 
-  function checkReferenceColumns(tesCases) {
-    tesCases.forEach(function (test) {
+  function checkReferenceColumns(testCases) {
+    testCases.forEach(function (test) {
       utils.checkColumnList(test.ref.columns, test.expected, test.message ? test.message : 'checkReferenceColumns');
     });
   }

--- a/test/specs/reference/tests/02.related_reference.js
+++ b/test/specs/reference/tests/02.related_reference.js
@@ -410,7 +410,7 @@ exports.execute = function(options) {
                                 {"f": "RID", "opr": "::null::"}
                             ]},
                             {"i": ["reference_schema", "fk_inbound_related_to_reference"]},
-                            {"f": "id", "opd": "-1", "n": true},
+                            {"f": "id", "opd": "-1", "n": true, "opd_p": true},
                             "id"
                         ], false, false
                     ];


### PR DESCRIPTION
This PR will allow us to use the main entity data as part of the `operand_pattern` in filters defined in the column-directive.