### PR TITLE
feat: Conditionally display visible columns and visible foreign keys

### DIFF
--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -932,13 +932,11 @@ Example:
     },
     "conditions": {
         "has_related_data": {
-            "sourcekey": "source-1",
-            "on_empty": "hide"
+            "sourcekey": "source-1"
         },
         "custom_check": {
             "source": [{"inbound": ["schema", "fk3"]}, "RID"],
-            "on_empty": "hide",
-            "condition_pattern": "{{#if $self}}show{{/if}}"
+            "condition_pattern": "{{#each $self}}{{#with this.values}}{{#if (eq _name 'some-value')}}true{{/if}}{{/with}}{{/each}}"
         }
     },
     "search-box": {

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -755,7 +755,7 @@ Supported display _displayoption_ JSON payload patterns:
     - Your desired preview type (`"text"`, `"json"`, `"markdown"`, `"image"`, `"csv"`, `"tsv"`).
     - `"use_ext_mapping"` to let filename extension mapping find the type.
     - `false` to disable the preview for that given content-type.
-    
+
     For instance:
     ```json
     {
@@ -766,7 +766,7 @@ Supported display _displayoption_ JSON payload patterns:
       }
     }
     ```
-  - `{` ... `"filename_ext_mapping": ` _fileextmapping_ ... `}`: Map other filename extensions to the supported preview types. _fileextmapping_ must be an object with the file extension as key and the desired preview type (`"text"`, `"json"`, `"markdown"`, `"image"`, `"csv"`, `"tsv"`) or `false` as its value. By using `false`, file preview will not be presented for that partictular file. 
+  - `{` ... `"filename_ext_mapping": ` _fileextmapping_ ... `}`: Map other filename extensions to the supported preview types. _fileextmapping_ must be an object with the file extension as key and the desired preview type (`"text"`, `"json"`, `"markdown"`, `"image"`, `"csv"`, `"tsv"`) or `false` as its value. By using `false`, file preview will not be presented for that partictular file.
     ```json
     {
       "filename_ext_mapping": {
@@ -783,7 +783,7 @@ Supported display _displayoption_ JSON payload patterns:
     - `"image"`: The size that should be used for image preview.
     - `"csv"`: The size that should be used for CSV preview.
     - `"tsv"`: The size that should be used for CSV preview.
-  - `{` ... `"prefetch_bytes": ` _prefetchbytes_ ... `}`: how many bytes we should fetch for servers that support range requests. _prefetchbytes_ follows the same syntax as _prefetchmaxsize_. By default 524288 or 512 KB will be used. 
+  - `{` ... `"prefetch_bytes": ` _prefetchbytes_ ... `}`: how many bytes we should fetch for servers that support range requests. _prefetchbytes_ follows the same syntax as _prefetchmaxsize_. By default 524288 or 512 KB will be used.
 
 Default heuristics:
 - The `2017 Asset` annotation explicitly indicates that the associated column is the asset location.
@@ -1234,7 +1234,7 @@ Notes:
   4. We continue by looking at the matching `by_name` property of catalog, schema, and table in order. Just like in the previous steps, if the same annotation property is already defined in the created object, it will be overwritten by the new step.
   5. If the column is an asset or is used in another asset column, the annotations under the appropriate `asset` of catalog, schema, and table will be used. Same as above, if the same annotation property is already defined in the created object, it will be overwritten by the new step.
   6. Any annotation defined directly on the column will override the annotations of the previous steps.
-  
+
   For instance, if you have the following column-defaults on the schema
   ```json
   {
@@ -1485,4 +1485,4 @@ The following attributes can be used to manipulate the presentation settings of 
     - `max_length`: `<number>` A number that defines the maximum number of elements that should be displayed.
 - `input_iframe`: Applicaple only to entry contexts. A JSON object that describes the settings for showing "input iframe" in entry apps. Please refer to the [input iframe document](input-iframe.md) for more information about this property.
 - `condition`: Applicable only to `detailed` context. A JSON object that defines a condition controlling whether this column or related entity is displayed. The condition references a data source whose result determines visibility. Please refer to the [condition documentation](column-directive.md#condition) for more information.
-- `condition_key`: Applicable only to `detailed` context. A string that references a reusable condition defined in the [`conditions`](#tag-2019-source-definitions) section of the `source-definitions` annotation. If both `condition` and `condition_key` are defined, `condition` takes precedence.
+- `condition_key`: Applicable only to `detailed` context. A string that references a reusable condition defined in the [`conditions`](#tag-2019-source-definitions) section of the `source-definitions` annotation. If both `condition` and `condition_key` are defined, `condition_key` takes precedence.

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -930,6 +930,17 @@ Example:
             ]
         }
     },
+    "conditions": {
+        "has_related_data": {
+            "sourcekey": "source-1",
+            "on_empty": "hide"
+        },
+        "custom_check": {
+            "source": [{"inbound": ["schema", "fk3"]}, "RID"],
+            "on_empty": "hide",
+            "condition_pattern": "{{#if $self}}show{{/if}}"
+        }
+    },
     "search-box": {
         "or": [
             {"source": "column1", "markdown_name": "another name"},
@@ -945,10 +956,15 @@ Example:
 Supported JSON payload patterns:
 
 - `{` ... `"sources":` _sourcedefinitions_ `,` ... `}`: the source definitions that will allow you to refer to them by just using the defined _sourcekey_.
+- `{` ... `"conditions":` _conditiondefinitions_ `,` ... `}`: reusable condition definitions that can be referenced by column directives via `condition_key`. See [condition and condition_key](column-directive.md#condition) for more information.
 - `{` ... `"search-box": { "or": [` _searchcolumn_ `,` ... `]} }`: Configure list of search columns.
 - `{` ... `"fkeys":` _fkeylist_  `,` ... `}`: Array of foreign key constraints that will be mapped into `$fkey_schema_contraint` key in templating environments.
 - `{` ... `"columns":` _columns_  `,` ... `}`: Array of column names that their data will be available in templating environments.
 
+
+Supported _conditiondefinitions_ patterns:
+
+- `{` ... `"` _conditionkey_ `":` _conditionobject_ ... `}`: where _conditionkey_ is a name that will be used to refer to the defined condition. Each _conditionobject_ must have either `source` or `sourcekey` to identify the data that will be used for evaluating the condition. See the [condition documentation](column-directive.md#condition) for the full list of properties.
 
 Supported _sourcedefinitions_ patterns:
 
@@ -1468,3 +1484,5 @@ The following attributes can be used to manipulate the presentation settings of 
     - `order`: An alternative sort method to apply when a client wants to semantically sort by key values. It follows the same syntax as `column_order`. In scalar array aggregate, you cannot sort based on other columns values, you can only sort based on the scalar value of the column.
     - `max_length`: `<number>` A number that defines the maximum number of elements that should be displayed.
 - `input_iframe`: Applicaple only to entry contexts. A JSON object that describes the settings for showing "input iframe" in entry apps. Please refer to the [input iframe document](input-iframe.md) for more information about this property.
+- `condition`: Applicable only to `detailed` context. A JSON object that defines a condition controlling whether this column or related entity is displayed. The condition references a data source whose result determines visibility. Please refer to the [condition documentation](column-directive.md#condition) for more information.
+- `condition_key`: Applicable only to `detailed` context. A string that references a reusable condition defined in the [`conditions`](#tag-2019-source-definitions) section of the `source-definitions` annotation. If both `condition` and `condition_key` are defined, `condition` takes precedence.

--- a/docs/user-docs/column-directive.md
+++ b/docs/user-docs/column-directive.md
@@ -579,7 +579,7 @@ Conditions are only evaluated in the `detailed` context. In all other contexts, 
 A JSON object that defines an inline condition controlling whether this column or related entity is displayed. The object has the following properties:
 
 - `sourcekey`: A string referencing one of the sources defined in the [`source-definitions`](annotation.md#tag-2019-source-definitions) annotation. The data returned by this source is used to evaluate the condition.
-- `source`: An inline source path (same syntax as the column directive [`source`](#source) property). Use this as an alternative to `sourcekey` when you don't need to reuse the condition source elsewhere. You must provide either `sourcekey` or `source`, but not both.
+- `source`: An inline source path (same syntax as the column directive [`source`](#source) property). Use this as an alternative to `sourcekey` when you don't need to reuse the condition source elsewhere. You must provide at least one of `sourcekey` or `source`. If both are provided, `sourcekey` takes precedence.
 - `on_empty`: _(optional)_ Controls what happens when the condition source returns no data. Accepted values:
   - `"hide"` (default): Hide the column when the condition source is empty.
   - `"show"`: Show the column when the condition source is empty (and hide it when data is present).

--- a/docs/user-docs/column-directive.md
+++ b/docs/user-docs/column-directive.md
@@ -40,6 +40,9 @@ Column directive allows instruction of a data source and modification of its pre
       - [array\_ux\_mode](#array_ux_mode)
     - [array\_options](#array_options)
     - [input\_iframe](#input_iframe)
+  - [3. Condition properties](#3-condition-properties)
+    - [condition](#condition)
+    - [condition\_key](#condition_key)
 - [Shorthand syntax](#shorthand-syntax)
 - [Examples](#examples)
   - [Visible Column List](#visible-column-list)
@@ -83,7 +86,14 @@ In this category, you use the [`source`](#source) property to define the data so
     "url_pattern": <pattern>,
     "field_mapping": <object>,
     "optional_fields": <array of field names>
-  }
+  },
+  "condition": {
+    "sourcekey": <source key for condition data>,
+    "source": <source path for condition data>,
+    "on_empty": <"show" or "hide">,
+    "condition_pattern": <pattern>
+  },
+  "condition_key": <condition key>
 }
 ```
 
@@ -115,7 +125,14 @@ In this category, the [`sourcekey`](#sourcekey) proprety is used to refer to one
   "array_options":{
     "order": <change the default order>,
     "max_lengh": <max length>
-  }
+  },
+  "condition": {
+    "sourcekey": <source key for condition data>,
+    "source": <source path for condition data>,
+    "on_empty": <"show" or "hide">,
+    "condition_pattern": <pattern>
+  },
+  "condition_key": <condition key>
 }
 ```
 
@@ -548,6 +565,79 @@ This property can be used for integrating Chaise's recordedit app with any third
 
 For more information about this property, please refer to [this document](input-iframe.md).
 
+
+### 3. Condition properties
+
+These properties allow you to conditionally show or hide a column or related entity on the record page (`detailed` context). The condition is based on the result of a separate data source. This is useful when you want to display a column only if related data exists (or does not exist).
+
+Conditions are only evaluated in the `detailed` context. In all other contexts, these properties are ignored and the column is displayed normally.
+
+#### condition
+
+A JSON object that defines an inline condition controlling whether this column or related entity is displayed. The object has the following properties:
+
+- `sourcekey`: A string referencing one of the sources defined in the [`source-definitions`](annotation.md#tag-2019-source-definitions) annotation. The data returned by this source is used to evaluate the condition.
+- `source`: An inline source path (same syntax as the column directive [`source`](#source) property). Use this as an alternative to `sourcekey` when you don't need to reuse the condition source elsewhere. You must provide either `sourcekey` or `source`, but not both.
+- `on_empty`: _(optional)_ Controls what happens when the condition source returns no data. Accepted values:
+  - `"hide"` (default): Hide the column when the condition source is empty.
+  - `"show"`: Show the column when the condition source is empty (and hide it when data is present).
+- `condition_pattern`: _(optional)_ A Mustache template that is evaluated using the condition source data. When provided, the condition is based on whether the rendered template produces a non-empty string, rather than whether the condition source returned data. The template has access to `$self` (the condition source value) and the same templating environment as `markdown_pattern`. No markdown rendering is applied to the result; only emptiness is checked.
+
+```json
+{
+  "source": "some_column",
+  "condition": {
+    "sourcekey": "has_related_items",
+    "on_empty": "hide"
+  }
+}
+```
+
+**How conditions are evaluated:**
+
+1. The client sends a request to fetch the condition source data.
+2. If `condition_pattern` is defined, the template is rendered with the condition data. The result is considered "empty" if it renders to an empty or whitespace-only string.
+3. If `condition_pattern` is not defined, the condition is considered "empty" when the source returns no rows (for entity sets) or a null/empty value (for aggregates).
+4. Based on `on_empty`:
+   - `"hide"` (default): the column is shown only when the result is **not** empty.
+   - `"show"`: the column is shown only when the result **is** empty.
+
+**Sync vs. async conditions:**
+
+- If the condition source is all-outbound (no inbound foreign keys or aggregates), the condition is evaluated synchronously using data already available from the main request. No additional request is needed.
+- If the condition source has an inbound path or uses an aggregate, it requires a secondary request. The column value is hidden until the condition is evaluated.
+
+#### condition_key
+
+A string that references a reusable condition defined in the `conditions` section of the [`source-definitions`](annotation.md#tag-2019-source-definitions) annotation. This allows you to define a condition once and apply it to multiple columns or related entities.
+
+If both `condition` and `condition_key` are defined on the same column directive, `condition` takes precedence and `condition_key` is ignored.
+
+```json
+{
+  "source": "some_column",
+  "condition_key": "has_related_data"
+}
+```
+
+Where `has_related_data` is defined in the source-definitions annotation:
+
+```json
+"tag:isrd.isi.edu,2019:source-definitions": {
+  "sources": {
+    "cnt_related": {
+      "source": [{"inbound": ["schema", "fk1"]}, "RID"],
+      "aggregate": "cnt"
+    }
+  },
+  "conditions": {
+    "has_related_data": {
+      "sourcekey": "cnt_related",
+      "on_empty": "hide"
+    }
+  }
+}
+```
 
 
 ## Shorthand syntax

--- a/docs/user-docs/column-directive.md
+++ b/docs/user-docs/column-directive.md
@@ -92,6 +92,7 @@ In this category, you use the [`source`](#source) property to define the data so
     "source": <source path for condition data>,
     "on_empty": <"show" or "hide">,
     "condition_pattern": <pattern>,
+    "template_engine": <handlebars or mustache>,
     "wait_for": <wait_for list>
   },
   "condition_key": <condition key>
@@ -132,6 +133,7 @@ In this category, the [`sourcekey`](#sourcekey) proprety is used to refer to one
     "source": <source path for condition data>,
     "on_empty": <"show" or "hide">,
     "condition_pattern": <pattern>,
+    "template_engine": <handlebars or mustache>,
     "wait_for": <wait_for list>
   },
   "condition_key": <condition key>
@@ -583,7 +585,7 @@ A JSON object that defines an inline condition controlling whether this column o
 - `on_empty`: _(optional)_ Controls what happens when the condition source returns no data. Accepted values:
   - `"hide"` (default): Hide the column when the condition source is empty.
   - `"show"`: Show the column when the condition source is empty (and hide it when data is present).
-- `condition_pattern`: _(optional)_ A Mustache template that is evaluated using the condition source data. When provided, the condition is based on whether the rendered template produces a non-empty string, rather than whether the condition source returned data. The template has access to `$self` (the condition source value) and the same templating environment as `markdown_pattern`. No markdown rendering is applied to the result; only emptiness is checked.
+- `condition_pattern`: _(optional)_ A template that is evaluated using the condition source data. When provided, the condition is based on whether the rendered template produces a non-empty string, rather than whether the condition source returned data. The template has access to `$self` (the condition source value) and the same templating environment as `markdown_pattern`. No markdown rendering is applied to the result; only emptiness is checked.
 - `wait_for`: _(optional)_ An array of source key strings (referencing sources defined in `source-definitions`). These sources are fetched alongside the condition source, and their data is available in the templating environment when `condition_pattern` is evaluated. This allows the condition to reference data from multiple sources. The condition is not evaluated until all `wait_for` sources have completed.
 
 ```json
@@ -628,7 +630,7 @@ A JSON object that defines an inline condition controlling whether this column o
 
 A string that references a reusable condition defined in the `conditions` section of the [`source-definitions`](annotation.md#tag-2019-source-definitions) annotation. This allows you to define a condition once and apply it to multiple columns or related entities.
 
-If both `condition` and `condition_key` are defined on the same column directive, `condition` takes precedence and `condition_key` is ignored.
+If both `condition` and `condition_key` are defined on the same column directive, `condition_key` takes precedence and `condition` is ignored.
 
 ```json
 {

--- a/docs/user-docs/column-directive.md
+++ b/docs/user-docs/column-directive.md
@@ -91,7 +91,8 @@ In this category, you use the [`source`](#source) property to define the data so
     "sourcekey": <source key for condition data>,
     "source": <source path for condition data>,
     "on_empty": <"show" or "hide">,
-    "condition_pattern": <pattern>
+    "condition_pattern": <pattern>,
+    "wait_for": <wait_for list>
   },
   "condition_key": <condition key>
 }
@@ -130,7 +131,8 @@ In this category, the [`sourcekey`](#sourcekey) proprety is used to refer to one
     "sourcekey": <source key for condition data>,
     "source": <source path for condition data>,
     "on_empty": <"show" or "hide">,
-    "condition_pattern": <pattern>
+    "condition_pattern": <pattern>,
+    "wait_for": <wait_for list>
   },
   "condition_key": <condition key>
 }
@@ -582,6 +584,7 @@ A JSON object that defines an inline condition controlling whether this column o
   - `"hide"` (default): Hide the column when the condition source is empty.
   - `"show"`: Show the column when the condition source is empty (and hide it when data is present).
 - `condition_pattern`: _(optional)_ A Mustache template that is evaluated using the condition source data. When provided, the condition is based on whether the rendered template produces a non-empty string, rather than whether the condition source returned data. The template has access to `$self` (the condition source value) and the same templating environment as `markdown_pattern`. No markdown rendering is applied to the result; only emptiness is checked.
+- `wait_for`: _(optional)_ An array of source key strings (referencing sources defined in `source-definitions`). These sources are fetched alongside the condition source, and their data is available in the templating environment when `condition_pattern` is evaluated. This allows the condition to reference data from multiple sources. The condition is not evaluated until all `wait_for` sources have completed.
 
 ```json
 {
@@ -589,6 +592,20 @@ A JSON object that defines an inline condition controlling whether this column o
   "condition": {
     "sourcekey": "has_related_items",
     "on_empty": "hide"
+  }
+}
+```
+
+**Example with `wait_for`:**
+
+```json
+{
+  "source": "some_column",
+  "condition": {
+    "sourcekey": "count_of_items",
+    "wait_for": ["count_of_other_items"],
+    "condition_pattern": "{{#if (and count_of_other_items count_of_items)}}show{{/if}}",
+    "template_engine": "handlebars"
   }
 }
 ```
@@ -632,8 +649,7 @@ Where `has_related_data` is defined in the source-definitions annotation:
   },
   "conditions": {
     "has_related_data": {
-      "sourcekey": "cnt_related",
-      "on_empty": "hide"
+      "sourcekey": "cnt_related"
     }
   }
 }

--- a/js/core.js
+++ b/js/core.js
@@ -1754,7 +1754,8 @@ import {
                         sourcekey: isStringAndNotEmpty(condDef.sourcekey) ? condDef.sourcekey : undefined,
                         source: condDef.source || undefined,
                         on_empty: condDef.on_empty === "show" ? "show" : "hide",
-                        condition_pattern: isStringAndNotEmpty(condDef.condition_pattern) ? condDef.condition_pattern : undefined
+                        condition_pattern: isStringAndNotEmpty(condDef.condition_pattern) ? condDef.condition_pattern : undefined,
+                        template_engine: isStringAndNotEmpty(condDef.template_engine) ? condDef.template_engine : undefined
                     };
                 }
             }

--- a/js/core.js
+++ b/js/core.js
@@ -1549,7 +1549,7 @@ import {
             var self = this;
             var sd = _annotations.SOURCE_DEFINITIONS;
             var hasAnnot = self.annotations.contains(sd);
-            var res = {columns: [], fkeys: [], sources: {}, sourceMapping: {}, sourceDependencies: {}};
+            var res = {columns: [], fkeys: [], sources: {}, sourceMapping: {}, sourceDependencies: {}, conditions: {}};
             var addedCols = {}, addedFks = {}, processedSources = {};
             var allColumns = self.columns.all(),
                 allForeignKeys = self.foreignKeys.all();
@@ -1693,7 +1693,7 @@ import {
             if (!hasAnnot) {
                 res.columns = allColumns;
                 res.fkeys = allForeignKeys;
-                self._sourceDefinitions = new TableSourceDefinitions(this, res.columns, res.fkeys, res.sources, res.sourceMapping, res.sourceDependencies);
+                self._sourceDefinitions = new TableSourceDefinitions(this, res.columns, res.fkeys, res.sources, res.sourceMapping, res.sourceDependencies, res.conditions);
                 return;
             }
 
@@ -1731,7 +1731,35 @@ import {
                 }
             }
 
-            self._sourceDefinitions = new TableSourceDefinitions(this, res.columns, res.fkeys, res.sources, res.sourceMapping, res.sourceDependencies);
+            // conditions
+            if (annot.conditions && typeof annot.conditions === "object") {
+                for (var cKey in annot.conditions) {
+                    if (!Object.prototype.hasOwnProperty.call(annot.conditions, cKey)) continue;
+                    var condDef = annot.conditions[cKey];
+                    if (typeof condDef !== "object" || condDef === null) {
+                        $log.info("source definition, table =" + self.name + ", condition=" + cKey + ": must be an object.");
+                        continue;
+                    }
+                    // must have source or sourcekey
+                    if (!condDef.source && !isStringAndNotEmpty(condDef.sourcekey)) {
+                        $log.info("source definition, table =" + self.name + ", condition=" + cKey + ": must have `source` or `sourcekey`.");
+                        continue;
+                    }
+                    // if sourcekey, it must exist in the sources map
+                    if (isStringAndNotEmpty(condDef.sourcekey) && !(condDef.sourcekey in res.sources)) {
+                        $log.info("source definition, table =" + self.name + ", condition=" + cKey + ": sourcekey `" + condDef.sourcekey + "` not found in sources.");
+                        continue;
+                    }
+                    res.conditions[cKey] = {
+                        sourcekey: isStringAndNotEmpty(condDef.sourcekey) ? condDef.sourcekey : undefined,
+                        source: condDef.source || undefined,
+                        on_empty: condDef.on_empty === "show" ? "show" : "hide",
+                        condition_pattern: isStringAndNotEmpty(condDef.condition_pattern) ? condDef.condition_pattern : undefined
+                    };
+                }
+            }
+
+            self._sourceDefinitions = new TableSourceDefinitions(this, res.columns, res.fkeys, res.sources, res.sourceMapping, res.sourceDependencies, res.conditions);
         },
 
         /**

--- a/js/core.js
+++ b/js/core.js
@@ -1755,7 +1755,8 @@ import {
                         source: condDef.source || undefined,
                         on_empty: condDef.on_empty === "show" ? "show" : "hide",
                         condition_pattern: isStringAndNotEmpty(condDef.condition_pattern) ? condDef.condition_pattern : undefined,
-                        template_engine: isStringAndNotEmpty(condDef.template_engine) ? condDef.template_engine : undefined
+                        template_engine: isStringAndNotEmpty(condDef.template_engine) ? condDef.template_engine : undefined,
+                        wait_for: Array.isArray(condDef.wait_for) ? condDef.wait_for : undefined
                     };
                 }
             }

--- a/js/core.js
+++ b/js/core.js
@@ -1532,6 +1532,7 @@ import {
          * Returns an object with
          * - fkeys: array of ForeignKeyRef objects
          * - columns: Array of columns
+         * - conditions: hash-map of sourcekey to the condition's unprocessed column-directive.
          * - sources: hash-map of name to the SourceObjectWrapper object.
          * - sourceMapping: hashname to all the names
          * - sourceDependencies: for each sourcekey, what are the other sourcekeys that it depends on (includes self as well)
@@ -1737,27 +1738,22 @@ import {
                     if (!Object.prototype.hasOwnProperty.call(annot.conditions, cKey)) continue;
                     var condDef = annot.conditions[cKey];
                     if (typeof condDef !== "object" || condDef === null) {
-                        $log.info("source definition, table =" + self.name + ", condition=" + cKey + ": must be an object.");
+                        $log.info("condition definition, table =" + self.name + ", condition=" + cKey + ": must be an object.");
                         continue;
                     }
                     // must have source or sourcekey
                     if (!condDef.source && !isStringAndNotEmpty(condDef.sourcekey)) {
-                        $log.info("source definition, table =" + self.name + ", condition=" + cKey + ": must have `source` or `sourcekey`.");
+                        $log.info("condition definition, table =" + self.name + ", condition=" + cKey + ": must have `source` or `sourcekey`.");
                         continue;
                     }
                     // if sourcekey, it must exist in the sources map
                     if (isStringAndNotEmpty(condDef.sourcekey) && !(condDef.sourcekey in res.sources)) {
-                        $log.info("source definition, table =" + self.name + ", condition=" + cKey + ": sourcekey `" + condDef.sourcekey + "` not found in sources.");
+                        $log.info("condition definition, table =" + self.name + ", condition=" + cKey + ": sourcekey `" + condDef.sourcekey + "` not found in sources.");
                         continue;
                     }
-                    res.conditions[cKey] = {
-                        sourcekey: isStringAndNotEmpty(condDef.sourcekey) ? condDef.sourcekey : undefined,
-                        source: condDef.source || undefined,
-                        on_empty: condDef.on_empty === "show" ? "show" : "hide",
-                        condition_pattern: isStringAndNotEmpty(condDef.condition_pattern) ? condDef.condition_pattern : undefined,
-                        template_engine: isStringAndNotEmpty(condDef.template_engine) ? condDef.template_engine : undefined,
-                        wait_for: Array.isArray(condDef.wait_for) ? condDef.wait_for : undefined
-                    };
+                    // just capture and don't process
+                    // we have to reprocess these again anyways because they might rely on tuple.
+                    res.conditions[cKey] = condDef;
                 }
             }
 

--- a/js/core.js
+++ b/js/core.js
@@ -81,7 +81,7 @@ import {
      * @memberof ERMrest
      * @function
      * @param {string} uri URI of the ERMrest service.
-     * @param {Object} [contextHeaderParams={cid:'null'}] An optional server header parameters for context logging
+     * @param {any} [contextHeaderParams={cid:'null'}] An optional server header parameters for context logging
      * appended to the end of any request to the server.
      * @return {Server} Returns a server instance.
      * @throws {InvalidInputError} URI is missing

--- a/js/export.js
+++ b/js/export.js
@@ -82,7 +82,7 @@ export const _exportHelpers = {
   /**
    * Return the export fragments that should be used with export annotation.
    * @param {Table} table
-   * @param {Object} defaultExportTemplate
+   * @param {any} defaultExportTemplate
    * @returns An object that can be used in combination with export annotation
    * @private
    * @ignore

--- a/js/utils/pseudocolumn_helpers.js
+++ b/js/utils/pseudocolumn_helpers.js
@@ -691,9 +691,9 @@ import { parse, _convertSearchTermToFilter } from '@isrd-isi-edu/ermrestjs/js/pa
      * - will ignore normal columns.
      * will return an object with the following attributes:
      * - waitForList: an array of pseudo-columns
-     * - hasWaitFor: whether any of the waitFor columns is seconadry
+     * - hasWaitFor: whether any of the waitFor columns is secondary
      * - hasWaitForAggregate: whether any of the waitfor columns are aggregate
-     * @param {Array|String} waitFor - the waitfor definition
+     * @param {unknown} waitFor - the waitfor definition
      * @param {Reference} baseReference - the reference that this waitfor is based on
      * @param {Table} currentTable - the current table.
      * @param {ReferenceColumn=} currentColumn - if this is defined on a column.

--- a/src/models/active-list-condition.ts
+++ b/src/models/active-list-condition.ts
@@ -1,0 +1,135 @@
+// models
+import type { VisibleColumn, Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
+import type { PseudoColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
+
+// legacy
+import { _renderTemplate, _getRowTemplateVariables } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
+
+/**
+ * Encapsulates condition evaluation logic for conditionally visible
+ * columns and related entities in the record page.
+ */
+export default class ActiveListCondition {
+  /** The PseudoColumn for fetching condition data */
+  column: VisibleColumn;
+  /** "show" or "hide" (default "hide") */
+  onEmpty: 'show' | 'hide';
+  /** Optional Mustache template (like url_pattern, no markdown rendering) */
+  conditionPattern?: string;
+
+  constructor(column: VisibleColumn, onEmpty: 'show' | 'hide', conditionPattern?: string) {
+    this.column = column;
+    this.onEmpty = onEmpty;
+    this.conditionPattern = conditionPattern;
+  }
+
+  /**
+   * Evaluate the condition given fetched data.
+   *
+   * @param templateVariables - the accumulated template variables
+   * @param conditionValue - the fetched value (aggregate result or page for entityset)
+   * @param mainTuple - the main record tuple
+   * @returns whether the conditioned content should be shown
+   */
+  evaluateCondition(templateVariables: any, conditionValue: any, mainTuple: Tuple): { shouldShow: boolean } {
+    let isEmpty: boolean;
+
+    if (this.conditionPattern) {
+      // Build $self/$_self based on column type (mirroring sourceFormatPresentation logic)
+      const selfTemplateVariables = this._buildSelfVariables(conditionValue, mainTuple);
+      const keyValues: any = {};
+      Object.assign(keyValues, templateVariables, selfTemplateVariables);
+
+      // Evaluate Mustache template (no markdown rendering)
+      const col = this.column as PseudoColumn;
+      const rendered = _renderTemplate(this.conditionPattern, keyValues, col.table.schema.catalog, {});
+      isEmpty = !rendered || rendered.trim() === '';
+    } else {
+      // No pattern — check if condition source returned data
+      isEmpty = this._isConditionValueEmpty(conditionValue);
+    }
+
+    // on_empty: "hide" (default) → hide when empty → show when NOT empty
+    // on_empty: "show" → show when empty → hide when NOT empty
+    const shouldShow = this.onEmpty === 'show' ? isEmpty : !isEmpty;
+    return { shouldShow };
+  }
+
+  /**
+   * Build $self/$_self template variables based on column type.
+   * Mirrors PseudoColumn.sourceFormatPresentation logic.
+   */
+  private _buildSelfVariables(conditionValue: any, mainTuple: Tuple): any {
+    const col = this.column as PseudoColumn;
+    const context = (col as any)._context;
+
+    // aggregate: use precomputed templateVariables
+    if (col.hasAggregate && conditionValue) {
+      return conditionValue.templateVariables || {};
+    }
+
+    // all-outbound (isUnique): use mainTuple.linkedData
+    if (col.hasPath && col.isUnique) {
+      if (!mainTuple.linkedData[col.name]) {
+        return {};
+      }
+      // scalar
+      if (!col.isEntityMode) {
+        const baseCol = col.baseColumn;
+        return {
+          $self: baseCol.formatvalue(mainTuple.linkedData[col.name][baseCol.name], context),
+          $_self: mainTuple.linkedData[col.name][baseCol.name],
+        };
+      }
+      // entity
+      return {
+        $self: _getRowTemplateVariables(col.table, context, mainTuple.linkedData[col.name]),
+      };
+    }
+
+    // entityset: use conditionValue.templateVariables (page)
+    if (conditionValue && conditionValue.templateVariables) {
+      return conditionValue.templateVariables;
+    }
+
+    // scalar column
+    if (col.baseColumn) {
+      return {
+        $self: col.baseColumn.formatvalue(mainTuple.data[col.baseColumn.name], context),
+        $_self: mainTuple.data[col.baseColumn.name],
+      };
+    }
+
+    return {};
+  }
+
+  /**
+   * Check if the condition value is "empty" (no data returned).
+   */
+  private _isConditionValueEmpty(conditionValue: any): boolean {
+    if (conditionValue === null || conditionValue === undefined) {
+      return true;
+    }
+
+    // aggregate result: check if the value is null/empty
+    if (Array.isArray(conditionValue)) {
+      if (conditionValue.length === 0) return true;
+      const val = conditionValue[0];
+      return val === null || val === undefined || val.value === '' || val.value === null;
+    }
+
+    // page object (entityset): check if length is 0
+    if (typeof conditionValue.length === 'number') {
+      return conditionValue.length === 0;
+    }
+
+    // aggregate single value
+    if (typeof conditionValue === 'object') {
+      if (conditionValue.value === null || conditionValue.value === '' || conditionValue.value === undefined) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/models/active-list-condition.ts
+++ b/src/models/active-list-condition.ts
@@ -14,13 +14,16 @@ export default class ActiveListCondition {
   column: VisibleColumn;
   /** "show" or "hide" (default "hide") */
   onEmpty: 'show' | 'hide';
-  /** Optional Mustache template (like url_pattern, no markdown rendering) */
+  /** Optional template (no markdown rendering) */
   conditionPattern?: string;
+  /** Template engine for condition_pattern: "mustache" (default) or "handlebars" */
+  templateEngine?: string;
 
-  constructor(column: VisibleColumn, onEmpty: 'show' | 'hide', conditionPattern?: string) {
+  constructor(column: VisibleColumn, onEmpty: 'show' | 'hide', conditionPattern?: string, templateEngine?: string) {
     this.column = column;
     this.onEmpty = onEmpty;
     this.conditionPattern = conditionPattern;
+    this.templateEngine = templateEngine;
   }
 
   /**
@@ -40,9 +43,11 @@ export default class ActiveListCondition {
       const keyValues: any = {};
       Object.assign(keyValues, templateVariables, selfTemplateVariables);
 
-      // Evaluate Mustache template (no markdown rendering)
+      // Evaluate template (no markdown rendering)
       const col = this.column as PseudoColumn;
-      const rendered = _renderTemplate(this.conditionPattern, keyValues, col.table.schema.catalog, {});
+      const rendered = _renderTemplate(this.conditionPattern, keyValues, col.table.schema.catalog, {
+        templateEngine: this.templateEngine,
+      });
       isEmpty = !rendered || rendered.trim() === '';
     } else {
       // No pattern — check if condition source returned data

--- a/src/models/active-list-condition.ts
+++ b/src/models/active-list-condition.ts
@@ -1,9 +1,11 @@
 // models
-import type { VisibleColumn, Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
-import type { PseudoColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
+import type { Reference, VisibleColumn, Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
+import type { PseudoColumn, ReferenceColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
+import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
 
 // legacy
 import { _renderTemplate, _getRowTemplateVariables } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
+import { _processWaitForList } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
 
 /**
  * Encapsulates condition evaluation logic for conditionally visible
@@ -19,11 +21,57 @@ export default class ActiveListCondition {
   /** Template engine for condition_pattern: "mustache" (default) or "handlebars" */
   templateEngine?: string;
 
-  constructor(column: VisibleColumn, onEmpty: 'show' | 'hide', conditionPattern?: string, templateEngine?: string) {
+  private _condDef: ConditionDefinition;
+  private _reference: Reference;
+  private _tuple?: Tuple;
+
+  private _waitFor?: ReferenceColumn[];
+  private _hasWaitFor?: boolean;
+  private _hasWaitForAggregate?: boolean;
+
+  constructor(condDef: ConditionDefinition, column: VisibleColumn, reference: Reference, tuple?: Tuple) {
+    this._condDef = condDef;
     this.column = column;
-    this.onEmpty = onEmpty;
-    this.conditionPattern = conditionPattern;
-    this.templateEngine = templateEngine;
+    this._reference = reference;
+    this._tuple = tuple;
+
+    this.onEmpty = condDef.on_empty || 'hide';
+    this.conditionPattern = condDef.condition_pattern;
+    this.templateEngine = condDef.template_engine;
+  }
+
+  /**
+   * Whether there are aggregate or entity set columns in the wait_for list of this condition.
+   */
+  get hasWaitFor(): boolean {
+    if (this._hasWaitFor === undefined) {
+      this.waitFor; // eslint-disable-line @typescript-eslint/no-unused-expressions
+    }
+    return this._hasWaitFor!;
+  }
+
+  /**
+   * Whether there are aggregate columns in the wait_for list of this condition.
+   */
+  get hasWaitForAggregate(): boolean {
+    if (this._hasWaitForAggregate === undefined) {
+      this.waitFor; // eslint-disable-line @typescript-eslint/no-unused-expressions
+    }
+    return this._hasWaitForAggregate!;
+  }
+
+  /**
+   * Array of columns that the condition evaluation depends on.
+   * Follows the same pattern as ReferenceColumn.waitFor.
+   */
+  get waitFor(): ReferenceColumn[] {
+    if (this._waitFor === undefined) {
+      const res = _processWaitForList(this._condDef.wait_for || [], this._reference, this._reference.table, null, this._tuple, 'condition');
+      this._waitFor = res.waitForList;
+      this._hasWaitFor = res.hasWaitFor;
+      this._hasWaitForAggregate = res.hasWaitForAggregate;
+    }
+    return this._waitFor!;
   }
 
   /**
@@ -50,12 +98,12 @@ export default class ActiveListCondition {
       });
       isEmpty = !rendered || rendered.trim() === '';
     } else {
-      // No pattern — check if condition source returned data
+      // No pattern -- check if condition source returned data
       isEmpty = this._isConditionValueEmpty(conditionValue);
     }
 
-    // on_empty: "hide" (default) → hide when empty → show when NOT empty
-    // on_empty: "show" → show when empty → hide when NOT empty
+    // on_empty: "hide" (default) -> hide when empty -> show when NOT empty
+    // on_empty: "show" -> show when empty -> hide when NOT empty
     const shouldShow = this.onEmpty === 'show' ? isEmpty : !isEmpty;
     return { shouldShow };
   }

--- a/src/models/active-list-condition.ts
+++ b/src/models/active-list-condition.ts
@@ -2,9 +2,13 @@
 import type { Reference, VisibleColumn, Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
 import type { ReferenceColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
 import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
+import SourceObjectWrapper from '@isrd-isi-edu/ermrestjs/src/models/source-object-wrapper';
 
 // utils
 import { buildSelfTemplateVariables } from '@isrd-isi-edu/ermrestjs/src/utils/template-utils';
+import { isStringAndNotEmpty } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
+import { _warningMessages } from '@isrd-isi-edu/ermrestjs/src/utils/constants';
+import { createPseudoColumn } from '@isrd-isi-edu/ermrestjs/src/utils/column-utils';
 
 // legacy
 import { _renderTemplate } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
@@ -17,12 +21,21 @@ import { _processWaitForList } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolu
 export default class ActiveListCondition {
   /** The PseudoColumn for fetching condition data */
   column: VisibleColumn;
-  /** "show" or "hide" (default "hide") */
-  onEmpty: 'show' | 'hide';
-  /** Optional template (no markdown rendering) */
-  conditionPattern?: string;
-  /** Template engine for condition_pattern: "mustache" (default) or "handlebars" */
-  templateEngine?: string;
+
+  /** Whether the condition source requires a secondary request (has inbound path or aggregate) */
+  isAsync: boolean;
+
+  /**
+   * For synchronous conditions (all-outbound, no wait_for): whether the condition evaluated to hide.
+   * undefined for async conditions (evaluation happens later on the client).
+   */
+  conditionHide?: boolean;
+
+  /**
+   * if the condition definition is shared across multiple columns/entities,
+   * this key can be used to link them together for efficient evaluation.
+   */
+  conditonKey?: string;
 
   private _condDef: ConditionDefinition;
   private _reference: Reference;
@@ -32,15 +45,46 @@ export default class ActiveListCondition {
   private _hasWaitFor?: boolean;
   private _hasWaitForAggregate?: boolean;
 
-  constructor(condDef: ConditionDefinition, column: VisibleColumn, reference: Reference, tuple?: Tuple) {
+  constructor(condDef: ConditionDefinition, reference: Reference, tuple?: Tuple, conditonKey?: string) {
     this._condDef = condDef;
-    this.column = column;
     this._reference = reference;
     this._tuple = tuple;
+    this.conditonKey = conditonKey;
 
-    this.onEmpty = condDef.on_empty || 'hide';
-    this.conditionPattern = condDef.condition_pattern;
-    this.templateEngine = condDef.template_engine;
+    const wm = _warningMessages;
+
+    if (typeof condDef !== 'object' || (!condDef.source && !isStringAndNotEmpty(condDef.sourcekey))) {
+      throw new Error(wm.CONDITION.INVALID_SOURCE);
+    }
+
+    let condSourceWrapper: SourceObjectWrapper;
+    try {
+      const sds = this._reference.table.sourceDefinitions;
+      if (condDef.sourcekey) {
+        const sd = sds.getSource(condDef.sourcekey as string);
+        if (!sd) {
+          throw new Error('condition sourcekey `' + condDef.sourcekey + '` could not be resolved.');
+        }
+        condSourceWrapper = sd.clone(condDef, this._reference.table, false, this._tuple);
+      } else {
+        condSourceWrapper = new SourceObjectWrapper(condDef, this._reference.table, false, undefined, this._tuple);
+      }
+      this.column = createPseudoColumn(this._reference, condSourceWrapper!, this._tuple);
+    } catch (e: unknown) {
+      throw new Error('failed to create condition column: ' + (e instanceof Error ? e.message : String(e)));
+    }
+
+    const isAsync = condSourceWrapper.hasInbound || condSourceWrapper.hasAggregate;
+
+    // for synchronous conditions, evaluate now and store the result
+    let conditionHide: boolean | undefined;
+    if (!isAsync && this._tuple && !this.hasWaitFor) {
+      const result = this.evaluateCondition(this._tuple.templateVariables, null, this._tuple);
+      conditionHide = !result.shouldShow;
+    }
+
+    this.conditionHide = conditionHide;
+    this.isAsync = isAsync;
   }
 
   /**
@@ -69,7 +113,7 @@ export default class ActiveListCondition {
    */
   get waitFor(): ReferenceColumn[] {
     if (this._waitFor === undefined) {
-      const res = _processWaitForList(this._condDef.wait_for || [], this._reference, this._reference.table, null, this._tuple, 'condition');
+      const res = _processWaitForList(this._condDef.wait_for, this._reference, this._reference.table, null, this._tuple, 'condition');
       this._waitFor = res.waitForList;
       this._hasWaitFor = res.hasWaitFor;
       this._hasWaitForAggregate = res.hasWaitForAggregate;
@@ -87,15 +131,16 @@ export default class ActiveListCondition {
    */
   evaluateCondition(templateVariables: any, conditionValue: any, mainTuple: Tuple): { shouldShow: boolean } {
     let isEmpty: boolean;
+    const condDef = this._condDef;
 
-    if (this.conditionPattern) {
+    if (condDef.condition_pattern) {
       const selfTemplateVariables = buildSelfTemplateVariables(this.column as ReferenceColumn, mainTuple, conditionValue);
       const keyValues: any = {};
       Object.assign(keyValues, templateVariables, selfTemplateVariables);
 
       // evaluate template (no markdown rendering)
-      const rendered = _renderTemplate(this.conditionPattern, keyValues, this.column.table.schema.catalog, {
-        templateEngine: this.templateEngine,
+      const rendered = _renderTemplate(condDef.condition_pattern as string, keyValues, this.column.table.schema.catalog, {
+        templateEngine: condDef.template_engine,
       });
       isEmpty = !rendered || rendered.trim() === '';
     } else {
@@ -105,7 +150,7 @@ export default class ActiveListCondition {
 
     // on_empty: "hide" (default) -> hide when empty -> show when NOT empty
     // on_empty: "show" -> show when empty -> hide when NOT empty
-    const shouldShow = this.onEmpty === 'show' ? isEmpty : !isEmpty;
+    const shouldShow = condDef.on_empty === 'show' ? isEmpty : !isEmpty;
     return { shouldShow };
   }
 

--- a/src/models/active-list-condition.ts
+++ b/src/models/active-list-condition.ts
@@ -26,16 +26,10 @@ export default class ActiveListCondition {
   isAsync: boolean;
 
   /**
-   * For synchronous conditions (all-outbound, no wait_for): whether the condition evaluated to hide.
-   * undefined for async conditions (evaluation happens later on the client).
-   */
-  conditionHide?: boolean;
-
-  /**
    * if the condition definition is shared across multiple columns/entities,
    * this key can be used to link them together for efficient evaluation.
    */
-  conditonKey?: string;
+  conditionKey?: string;
 
   private _condDef: ConditionDefinition;
   private _reference: Reference;
@@ -45,11 +39,11 @@ export default class ActiveListCondition {
   private _hasWaitFor?: boolean;
   private _hasWaitForAggregate?: boolean;
 
-  constructor(condDef: ConditionDefinition, reference: Reference, tuple?: Tuple, conditonKey?: string) {
+  constructor(condDef: ConditionDefinition, reference: Reference, tuple?: Tuple, conditionKey?: string) {
     this._condDef = condDef;
     this._reference = reference;
     this._tuple = tuple;
-    this.conditonKey = conditonKey;
+    this.conditionKey = conditionKey;
 
     const wm = _warningMessages;
 
@@ -65,7 +59,11 @@ export default class ActiveListCondition {
         if (!sd) {
           throw new Error('condition sourcekey `' + condDef.sourcekey + '` could not be resolved.');
         }
-        condSourceWrapper = sd.clone(condDef, this._reference.table, false, this._tuple);
+        // SourceObjectWrapper.clone mutates its first argument (deletes `source`,
+        // copies in keys from the resolved source). condDef may be the shared
+        // object stored in TableSourceDefinitions.conditions (for condition_key
+        // references), so pass a shallow copy to avoid corrupting the shared def.
+        condSourceWrapper = sd.clone({ ...condDef }, this._reference.table, false, this._tuple);
       } else {
         condSourceWrapper = new SourceObjectWrapper(condDef, this._reference.table, false, undefined, this._tuple);
       }
@@ -74,17 +72,7 @@ export default class ActiveListCondition {
       throw new Error('failed to create condition column: ' + (e instanceof Error ? e.message : String(e)));
     }
 
-    const isAsync = condSourceWrapper.hasInbound || condSourceWrapper.hasAggregate;
-
-    // for synchronous conditions, evaluate now and store the result
-    let conditionHide: boolean | undefined;
-    if (!isAsync && this._tuple && !this.hasWaitFor) {
-      const result = this.evaluateCondition(this._tuple.templateVariables, null, this._tuple);
-      conditionHide = !result.shouldShow;
-    }
-
-    this.conditionHide = conditionHide;
-    this.isAsync = isAsync;
+    this.isAsync = condSourceWrapper.hasInbound || condSourceWrapper.hasAggregate;
   }
 
   /**
@@ -122,12 +110,41 @@ export default class ActiveListCondition {
   }
 
   /**
-   * Evaluate the condition given fetched data.
+   * Decide whether the conditioned content should be shown.
    *
-   * @param templateVariables - the accumulated template variables
-   * @param conditionValue - the fetched value (aggregate result or page for entityset)
-   * @param mainTuple - the main record tuple
-   * @returns whether the conditioned content should be shown
+   * Three internal paths, dispatched on `condition_pattern` and `this.isAsync`:
+   *
+   * 1. **`condition_pattern` set.** Render the pattern. `$self` / `$_self` come
+   *    from {@link buildSelfTemplateVariables}, which sources from `mainTuple`
+   *    for sync sources and from `conditionValue` for async sources. Blank
+   *    rendered output ⇒ empty.
+   * 2. **No pattern + `isAsync === true`.** Caller already fetched the data;
+   *    emptiness is computed from `conditionValue` by {@link _isConditionValueEmpty}.
+   * 3. **No pattern + `isAsync === false`.** `conditionValue` is ignored (sync
+   *    sources have no fetched value). The raw value is pulled from `mainTuple`
+   *    via {@link buildSelfTemplateVariables}: scalar sources are empty when
+   *    `$_self` is `null`/`undefined`/`''`; entity-mode sources are empty when
+   *    `$self` is undefined (the joined row didn't load).
+   *
+   * The `on_empty` flag then maps `isEmpty` to "show": `"hide"` (default) shows
+   * when not empty; `"show"` shows when empty.
+   *
+   * @param templateVariables - accumulated `$x`/`$_x` template variables for
+   *   every other source (only consulted by the pattern branch).
+   * @param conditionValue - the fetched value for an async source.
+   *   - **entityset** (Reference.read result): a {@link Page} object — has
+   *     `length` (used by `_isConditionValueEmpty`) and `templateVariables`
+   *     (used by `buildSelfTemplateVariables` when there is a pattern).
+   *   - **aggregate** (column.getAggregatedValue result): the unwrapped first
+   *     element, shaped `{ value, templateVariables }` — `value` is the
+   *     scalar; `templateVariables` carries `$self`/`$_self`.
+   *   - **null** if the request failed or there's no fetched value (treated
+   *     as empty).
+   *   Ignored entirely for sync sources (path 3).
+   * @param mainTuple - the main record tuple. Always required: the pattern
+   *   branch and the sync no-pattern branch both look up `$self`/`$_self`
+   *   from it.
+   * @returns whether the conditioned content should be shown.
    */
   evaluateCondition(templateVariables: any, conditionValue: any, mainTuple: Tuple): { shouldShow: boolean } {
     let isEmpty: boolean;
@@ -143,9 +160,22 @@ export default class ActiveListCondition {
         templateEngine: condDef.template_engine,
       });
       isEmpty = !rendered || rendered.trim() === '';
-    } else {
-      // no pattern: check if condition source returned data
+    } else if (this.isAsync) {
+      // no pattern, async: caller fetched the value
       isEmpty = this._isConditionValueEmpty(conditionValue);
+    } else {
+      // no pattern, sync: derive the raw value from the tuple via the same
+      // helper sourceFormatPresentation uses, then decide emptiness directly.
+      const selfVars = buildSelfTemplateVariables(this.column as ReferenceColumn, mainTuple, null);
+      if ('$_self' in selfVars) {
+        // scalar source (local column or all-outbound scalar)
+        const v = selfVars.$_self;
+        isEmpty = v === null || v === undefined || v === '';
+      } else {
+        // entity-mode source (key, foreign-key, all-outbound entity):
+        // the row exists iff buildSelfTemplateVariables returned a $self.
+        isEmpty = selfVars.$self === undefined;
+      }
     }
 
     // on_empty: "hide" (default) -> hide when empty -> show when NOT empty
@@ -155,30 +185,30 @@ export default class ActiveListCondition {
   }
 
   /**
-   * Check if the condition value is "empty" (no data returned).
+   * Check if a fetched async condition value is "empty".
+   * Only called from the no-pattern async branch of evaluateCondition; expects
+   * one of the shapes produced by Chaise's secondary-fetch:
+   * - page object (entityset)            — empty iff `length === 0`
+   * - `{ value, templateVariables }`     — empty iff `value` is null/''/0
+   * - `null`/`undefined`                 — empty (request failed / missing)
    */
   private _isConditionValueEmpty(conditionValue: any): boolean {
     if (conditionValue === null || conditionValue === undefined) {
       return true;
     }
 
-    // aggregate result: check if the value is null/empty
-    if (Array.isArray(conditionValue)) {
-      if (conditionValue.length === 0) return true;
-      const val = conditionValue[0];
-      return val === null || val === undefined || val.value === '' || val.value === null;
-    }
-
-    // page object (entityset): check if length is 0
+    // page object (entityset)
     if (typeof conditionValue.length === 'number') {
       return conditionValue.length === 0;
     }
 
-    // aggregate single value
+    // aggregate single value: { value, templateVariables }
     if (typeof conditionValue === 'object') {
-      if (conditionValue.value === null || conditionValue.value === '' || conditionValue.value === undefined) {
-        return true;
-      }
+      const inner = (conditionValue as { value?: unknown }).value;
+      if (inner === null || inner === undefined || inner === '') return true;
+      // count-style aggregates may serialize as a numeric string ("0"); coerce.
+      const num = typeof inner === 'number' ? inner : Number(inner);
+      return !isNaN(num) && num === 0;
     }
 
     return false;

--- a/src/models/active-list-condition.ts
+++ b/src/models/active-list-condition.ts
@@ -1,10 +1,13 @@
 // models
 import type { Reference, VisibleColumn, Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
-import type { PseudoColumn, ReferenceColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
+import type { ReferenceColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
 import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
 
+// utils
+import { buildSelfTemplateVariables } from '@isrd-isi-edu/ermrestjs/src/utils/template-utils';
+
 // legacy
-import { _renderTemplate, _getRowTemplateVariables } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
+import { _renderTemplate } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
 import { _processWaitForList } from '@isrd-isi-edu/ermrestjs/js/utils/pseudocolumn_helpers';
 
 /**
@@ -86,19 +89,17 @@ export default class ActiveListCondition {
     let isEmpty: boolean;
 
     if (this.conditionPattern) {
-      // Build $self/$_self based on column type (mirroring sourceFormatPresentation logic)
-      const selfTemplateVariables = this._buildSelfVariables(conditionValue, mainTuple);
+      const selfTemplateVariables = buildSelfTemplateVariables(this.column as ReferenceColumn, mainTuple, conditionValue);
       const keyValues: any = {};
       Object.assign(keyValues, templateVariables, selfTemplateVariables);
 
-      // Evaluate template (no markdown rendering)
-      const col = this.column as PseudoColumn;
-      const rendered = _renderTemplate(this.conditionPattern, keyValues, col.table.schema.catalog, {
+      // evaluate template (no markdown rendering)
+      const rendered = _renderTemplate(this.conditionPattern, keyValues, this.column.table.schema.catalog, {
         templateEngine: this.templateEngine,
       });
       isEmpty = !rendered || rendered.trim() === '';
     } else {
-      // No pattern -- check if condition source returned data
+      // no pattern: check if condition source returned data
       isEmpty = this._isConditionValueEmpty(conditionValue);
     }
 
@@ -106,54 +107,6 @@ export default class ActiveListCondition {
     // on_empty: "show" -> show when empty -> hide when NOT empty
     const shouldShow = this.onEmpty === 'show' ? isEmpty : !isEmpty;
     return { shouldShow };
-  }
-
-  /**
-   * Build $self/$_self template variables based on column type.
-   * Mirrors PseudoColumn.sourceFormatPresentation logic.
-   */
-  private _buildSelfVariables(conditionValue: any, mainTuple: Tuple): any {
-    const col = this.column as PseudoColumn;
-    const context = (col as any)._context;
-
-    // aggregate: use precomputed templateVariables
-    if (col.hasAggregate && conditionValue) {
-      return conditionValue.templateVariables || {};
-    }
-
-    // all-outbound (isUnique): use mainTuple.linkedData
-    if (col.hasPath && col.isUnique) {
-      if (!mainTuple.linkedData[col.name]) {
-        return {};
-      }
-      // scalar
-      if (!col.isEntityMode) {
-        const baseCol = col.baseColumn;
-        return {
-          $self: baseCol.formatvalue(mainTuple.linkedData[col.name][baseCol.name], context),
-          $_self: mainTuple.linkedData[col.name][baseCol.name],
-        };
-      }
-      // entity
-      return {
-        $self: _getRowTemplateVariables(col.table, context, mainTuple.linkedData[col.name]),
-      };
-    }
-
-    // entityset: use conditionValue.templateVariables (page)
-    if (conditionValue && conditionValue.templateVariables) {
-      return conditionValue.templateVariables;
-    }
-
-    // scalar column
-    if (col.baseColumn) {
-      return {
-        $self: col.baseColumn.formatvalue(mainTuple.data[col.baseColumn.name], context),
-        $_self: mainTuple.data[col.baseColumn.name],
-      };
-    }
-
-    return {};
   }
 
   /**

--- a/src/models/reference-column/asset-pseudo-column.ts
+++ b/src/models/reference-column/asset-pseudo-column.ts
@@ -232,7 +232,7 @@ export class AssetPseudoColumn extends ReferenceColumn {
       return { isHTML: false, value: data[this._baseCol.name], unformatted: data[this._baseCol.name] };
     }
 
-    if (this.hasWaitFor && !options.skipWaitFor) {
+    if ((this.hasWaitFor || this.hasCondition) && !options.skipWaitFor) {
       return nullValue;
     }
 

--- a/src/models/reference-column/foreign-key-pseudo-column.ts
+++ b/src/models/reference-column/foreign-key-pseudo-column.ts
@@ -14,6 +14,7 @@ import { isObjectAndNotNull, isStringAndNotEmpty, isObjectAndKeyExists } from '@
 import { fixedEncodeURIComponent } from '@isrd-isi-edu/ermrestjs/src/utils/value-utils';
 import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils';
 import { _annotations, _foreignKeyInputModes } from '@isrd-isi-edu/ermrestjs/src/utils/constants';
+import { buildSelfTemplateVariables } from '@isrd-isi-edu/ermrestjs/src/utils/template-utils';
 import { Reference } from '@isrd-isi-edu/ermrestjs/src/models/reference';
 
 // legacy
@@ -347,12 +348,7 @@ export class ForeignKeyPseudoColumn extends ReferenceColumn {
     const context = this._context;
 
     if (this.display.sourceMarkdownPattern) {
-      let selfTemplateVariables = {};
-      if (mainTuple.linkedData[this.name]) {
-        selfTemplateVariables = {
-          $self: _getRowTemplateVariables(this.table, context, mainTuple.linkedData[this.name]),
-        };
-      }
+      const selfTemplateVariables = buildSelfTemplateVariables(this, mainTuple, columnValue);
 
       const keyValues = {};
       Object.assign(keyValues, templateVariables, selfTemplateVariables);

--- a/src/models/reference-column/foreign-key-pseudo-column.ts
+++ b/src/models/reference-column/foreign-key-pseudo-column.ts
@@ -323,8 +323,8 @@ export class ForeignKeyPseudoColumn extends ReferenceColumn {
       unformatted: this._getNullValue(context!),
     };
 
-    // if there's wait_for, this should return null.
-    if (this.hasWaitFor && !options.skipWaitFor) {
+    // if there's wait_for or async condition, this should return null.
+    if ((this.hasWaitFor || this.hasCondition) && !options.skipWaitFor) {
       return nullValue;
     }
 

--- a/src/models/reference-column/key-pseudo-column.ts
+++ b/src/models/reference-column/key-pseudo-column.ts
@@ -95,7 +95,7 @@ export class KeyPseudoColumn extends ReferenceColumn {
       unformatted: this._getNullValue(context!),
     };
 
-    if (this.hasWaitFor && !options.skipWaitFor) {
+    if ((this.hasWaitFor || this.hasCondition) && !options.skipWaitFor) {
       return nullValue;
     }
 

--- a/src/models/reference-column/key-pseudo-column.ts
+++ b/src/models/reference-column/key-pseudo-column.ts
@@ -8,6 +8,7 @@ import { Reference, Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
 // utils
 import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils';
 import { isStringAndNotEmpty } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
+import { buildSelfTemplateVariables } from '@isrd-isi-edu/ermrestjs/src/utils/template-utils';
 
 // legacy
 import { Key, Table } from '@isrd-isi-edu/ermrestjs/js/core';
@@ -118,9 +119,7 @@ export class KeyPseudoColumn extends ReferenceColumn {
     const context = this._context;
 
     if (this.display.sourceMarkdownPattern) {
-      const selfTemplateVariables = {
-        $self: _getRowTemplateVariables(this.table, context, mainTuple.data),
-      };
+      const selfTemplateVariables = buildSelfTemplateVariables(this, mainTuple, columnValue);
 
       const keyValues = {};
       Object.assign(keyValues, templateVariables, selfTemplateVariables);

--- a/src/models/reference-column/pseudo-column.ts
+++ b/src/models/reference-column/pseudo-column.ts
@@ -15,6 +15,7 @@ import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils
 import { isDefinedAndNotNull, isObject, isObjectAndNotNull, isStringAndNotEmpty, verify } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
 import { fixedEncodeURIComponent } from '@isrd-isi-edu/ermrestjs/src/utils/value-utils';
 import { processAggregateValue } from '@isrd-isi-edu/ermrestjs/src/utils/column-utils';
+import { buildSelfTemplateVariables } from '@isrd-isi-edu/ermrestjs/src/utils/template-utils';
 import {
   _pseudoColAggregateFns,
   _pseudoColEntityAggregateFns,
@@ -193,42 +194,10 @@ export class PseudoColumn extends ReferenceColumn {
   }
 
   sourceFormatPresentation(templateVariables: any, columnValue: any, mainTuple: Tuple) {
-    const baseCol = this.baseColumn;
     const context = this._context;
-    let selfTemplateVariables: any = {};
 
     if (this.display.sourceMarkdownPattern) {
-      // for aggregate, the columnValue has the value precomputed
-      if (this.hasAggregate && columnValue) {
-        selfTemplateVariables = columnValue.templateVariables;
-      }
-      // all-outbound paths
-      else if (this.hasPath && this.isUnique) {
-        // use the linked data if exists
-        if (!mainTuple.linkedData[this.name]) {
-          selfTemplateVariables = {};
-        }
-        // scalar default
-        else if (!this.isEntityMode) {
-          selfTemplateVariables = {
-            $self: baseCol.formatvalue(mainTuple.linkedData[this.name][baseCol.name], context),
-            $_self: mainTuple.linkedData[this.name][baseCol.name],
-          };
-        }
-        // entity default
-        else {
-          selfTemplateVariables = {
-            $self: _getRowTemplateVariables(this.table, context, mainTuple.linkedData[this.name]),
-          };
-        }
-      }
-      // any other paths
-      else if (baseCol) {
-        selfTemplateVariables = {
-          $self: baseCol.formatvalue(mainTuple.data[baseCol.name], context),
-          $_self: mainTuple.data[baseCol.name],
-        };
-      }
+      const selfTemplateVariables = buildSelfTemplateVariables(this, mainTuple, columnValue);
 
       const keyValues = {};
       Object.assign(keyValues, templateVariables, selfTemplateVariables);

--- a/src/models/reference-column/pseudo-column.ts
+++ b/src/models/reference-column/pseudo-column.ts
@@ -148,7 +148,7 @@ export class PseudoColumn extends ReferenceColumn {
       return nullValue;
     }
 
-    if (this.hasWaitFor && !options.skipWaitFor) {
+    if ((this.hasWaitFor || this.hasCondition) && !options.skipWaitFor) {
       return nullValue;
     }
 

--- a/src/models/reference-column/reference-column.ts
+++ b/src/models/reference-column/reference-column.ts
@@ -492,16 +492,25 @@ export class ReferenceColumn {
 
     // get condition def: inline condition or condition_key
     let condDef: ConditionDefinition | undefined;
-    if (this.sourceObjectWrapper.condition) {
-      condDef = this.sourceObjectWrapper.condition;
-    } else {
-      const conditionKey = (this.sourceObjectWrapper as any)._conditionKey;
-      if (conditionKey) {
-        condDef = this._currentTable.sourceDefinitions.getCondition(conditionKey);
-        if (!condDef) {
-          $log.info('condition_key `' + conditionKey + '` not found in source-definitions conditions.');
-          return null;
-        }
+    const sourceObject = this.sourceObjectWrapper.sourceObject;
+    if (isObjectAndNotNull(sourceObject.condition)) {
+      const condObj = sourceObject.condition as Record<string, unknown>;
+      if (condObj.source || isStringAndNotEmpty(condObj.sourcekey)) {
+        condDef = {
+          sourcekey: isStringAndNotEmpty(condObj.sourcekey) ? (condObj.sourcekey as string) : undefined,
+          source: condObj.source || undefined,
+          on_empty: condObj.on_empty === 'show' ? 'show' : 'hide',
+          condition_pattern: isStringAndNotEmpty(condObj.condition_pattern) ? (condObj.condition_pattern as string) : undefined,
+          template_engine: isStringAndNotEmpty(condObj.template_engine) ? (condObj.template_engine as string) : undefined,
+        };
+      } else {
+        $log.info('condition on column `' + this.sourceObjectWrapper.name + '` is missing `source` or `sourcekey`.');
+      }
+    } else if (isStringAndNotEmpty(sourceObject.condition_key)) {
+      condDef = this._currentTable.sourceDefinitions.getCondition(sourceObject.condition_key as string);
+      if (!condDef) {
+        $log.info('condition_key `' + sourceObject.condition_key + '` not found in source-definitions conditions.');
+        return null;
       }
     }
 
@@ -519,7 +528,7 @@ export class ReferenceColumn {
           return null;
         }
       } else if (condDef.source) {
-        sourceWrapper = new SourceObjectWrapper({ source: condDef.source }, this._currentTable, false, undefined);
+        sourceWrapper = new SourceObjectWrapper({ source: condDef.source }, this._currentTable, false, undefined, this._mainTuple);
       }
     } catch (e: unknown) {
       $log.info('failed to resolve condition source: ' + (e instanceof Error ? e.message : String(e)));

--- a/src/models/reference-column/reference-column.ts
+++ b/src/models/reference-column/reference-column.ts
@@ -15,7 +15,6 @@ import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils
 import { isObjectAndKeyExists, isObjectAndNotNull, isStringAndNotEmpty } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
 import { _annotations, _contexts } from '@isrd-isi-edu/ermrestjs/src/utils/constants';
 import { buildSelfTemplateVariables } from '@isrd-isi-edu/ermrestjs/src/utils/template-utils';
-import { createPseudoColumn, isAllOutboundColumn } from '@isrd-isi-edu/ermrestjs/src/utils/column-utils';
 import ActiveListCondition from '@isrd-isi-edu/ermrestjs/src/models/active-list-condition';
 
 // legacy
@@ -48,20 +47,6 @@ export enum ReferenceColumnTypes {
 // function isAggregatePseudoColumn(column: unknown): column is PseudoColumn {
 //   return (column as PseudoColumn).referenceColumnType === ReferenceColumnTypes.PSEUDO && (column as PseudoColumn).hasAggregate;
 // }
-
-export interface ResolvedCondition {
-  /** The resolved condition definition */
-  conditionDef: ConditionDefinition;
-  /** The SourceObjectWrapper for the condition source */
-  sourceWrapper: SourceObjectWrapper;
-  /** Whether the condition source requires a secondary request (has inbound path or aggregate) */
-  isAsync: boolean;
-  /**
-   * For synchronous conditions (all-outbound, no wait_for): whether the condition evaluated to hide.
-   * undefined for async conditions (evaluation happens later on the client).
-   */
-  conditionHide?: boolean;
-}
 
 /**
  * Constructor for ReferenceColumn. This class is a wrapper for Column.
@@ -142,7 +127,7 @@ export class ReferenceColumn {
   protected _hasWaitForAggregate?: boolean;
   protected _waitFor?: ReferenceColumn[];
   protected _hasCondition?: boolean;
-  protected _resolvedCondition?: ResolvedCondition | null;
+  protected _resolvedCondition?: ActiveListCondition | null;
   /**
    * the reference that this column is defined on
    */
@@ -477,7 +462,7 @@ export class ReferenceColumn {
   /**
    * The resolved condition for this column, or null if no condition or not applicable.
    */
-  get resolvedCondition(): ResolvedCondition | null {
+  get resolvedCondition(): ActiveListCondition | null {
     if (this._resolvedCondition === undefined) {
       this._resolvedCondition = this._resolveCondition();
       this._hasCondition = this._resolvedCondition?.isAsync ?? false;
@@ -488,7 +473,7 @@ export class ReferenceColumn {
   /**
    * Resolve the condition definition and source for this column.
    */
-  protected _resolveCondition(): ResolvedCondition | null {
+  protected _resolveCondition(): ActiveListCondition | null {
     // only applicable in detailed context
     if (this._context !== _contexts.DETAILED) {
       return null;
@@ -499,73 +484,30 @@ export class ReferenceColumn {
     }
 
     // get condition def: inline condition or condition_key
-    let condDef: ConditionDefinition | undefined;
+    let condDef: ConditionDefinition | undefined, condKey: string | undefined;
     const sourceObject = this.sourceObjectWrapper.sourceObject;
-    if (isObjectAndNotNull(sourceObject.condition)) {
-      const condObj = sourceObject.condition as Record<string, unknown>;
-      if (condObj.source || isStringAndNotEmpty(condObj.sourcekey)) {
-        condDef = {
-          sourcekey: isStringAndNotEmpty(condObj.sourcekey) ? (condObj.sourcekey as string) : undefined,
-          source: condObj.source || undefined,
-          on_empty: condObj.on_empty === 'show' ? 'show' : 'hide',
-          condition_pattern: isStringAndNotEmpty(condObj.condition_pattern) ? (condObj.condition_pattern as string) : undefined,
-          template_engine: isStringAndNotEmpty(condObj.template_engine) ? (condObj.template_engine as string) : undefined,
-          wait_for: Array.isArray(condObj.wait_for) ? (condObj.wait_for as string[]) : undefined,
-        };
-      } else {
-        $log.info('condition on column `' + this.sourceObjectWrapper.name + '` is missing `source` or `sourcekey`.');
-      }
-    } else if (isStringAndNotEmpty(sourceObject.condition_key)) {
-      condDef = this._currentTable.sourceDefinitions.getCondition(sourceObject.condition_key as string);
+    if (isStringAndNotEmpty(sourceObject.condition_key)) {
+      condKey = sourceObject.condition_key as string;
+      condDef = this._currentTable.sourceDefinitions.getCondition(condKey);
       if (!condDef) {
-        $log.info('condition_key `' + sourceObject.condition_key + '` not found in source-definitions conditions.');
+        $log.info('condition_key `' + condKey + '` not found in source-definitions conditions.');
         return null;
       }
-    }
-
-    if (!condDef) {
+    } else if (isObjectAndNotNull(sourceObject.condition)) {
+      condDef = sourceObject.condition as Record<string, unknown>;
+    } else if (!condDef) {
       return null;
     }
 
-    // resolve the condition source SourceObjectWrapper
-    let sourceWrapper: SourceObjectWrapper | undefined;
+    let condition: ActiveListCondition;
     try {
-      if (condDef.sourcekey) {
-        sourceWrapper = this._currentTable.sourceDefinitions.getSource(condDef.sourcekey, this._mainTuple) ?? undefined;
-        if (!sourceWrapper) {
-          $log.info('condition sourcekey `' + condDef.sourcekey + '` could not be resolved.');
-          return null;
-        }
-      } else if (condDef.source) {
-        sourceWrapper = new SourceObjectWrapper({ source: condDef.source }, this._currentTable, false, undefined, this._mainTuple);
-      }
+      condition = new ActiveListCondition(condDef, this._baseReference, this._mainTuple, condKey);
     } catch (e: unknown) {
-      $log.info('failed to resolve condition source: ' + (e instanceof Error ? e.message : String(e)));
+      $log.warn(e instanceof Error ? e.message : String(e));
       return null;
     }
 
-    if (!sourceWrapper) {
-      return null;
-    }
-
-    const isAsync = sourceWrapper.hasInbound || sourceWrapper.hasAggregate;
-
-    // for synchronous conditions, evaluate now and store the result
-    let conditionHide: boolean | undefined;
-    if (!isAsync && this._mainTuple) {
-      try {
-        const condCol = createPseudoColumn(this._baseReference, sourceWrapper.clone({}, this._currentTable, false, this._mainTuple), this._mainTuple);
-        const condition = new ActiveListCondition(condDef, condCol, this._baseReference, this._mainTuple);
-        if (!condition.hasWaitFor) {
-          const result = condition.evaluateCondition(this._mainTuple.templateVariables, null, this._mainTuple);
-          conditionHide = !result.shouldShow;
-        }
-      } catch (e: unknown) {
-        $log.info('failed to evaluate synchronous condition: ' + (e instanceof Error ? e.message : String(e)));
-      }
-    }
-
-    return { conditionDef: condDef, sourceWrapper, isAsync, conditionHide };
+    return condition;
   }
 
   /**

--- a/src/models/reference-column/reference-column.ts
+++ b/src/models/reference-column/reference-column.ts
@@ -5,8 +5,10 @@ import { CommentType } from '@isrd-isi-edu/ermrestjs/src/models/comment';
 import { DisplayName } from '@isrd-isi-edu/ermrestjs/src/models/display-name';
 import { ColumnAggregateFn, ColumnGroupAggregateFn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
 import { Tuple, Reference } from '@isrd-isi-edu/ermrestjs/src/models/reference';
+import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
 
 // services
+import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
 
 // utils
 import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils';
@@ -43,6 +45,15 @@ export enum ReferenceColumnTypes {
 // function isAggregatePseudoColumn(column: unknown): column is PseudoColumn {
 //   return (column as PseudoColumn).referenceColumnType === ReferenceColumnTypes.PSEUDO && (column as PseudoColumn).hasAggregate;
 // }
+
+export interface ResolvedCondition {
+  /** The resolved condition definition */
+  conditionDef: ConditionDefinition;
+  /** The SourceObjectWrapper for the condition source */
+  sourceWrapper: SourceObjectWrapper;
+  /** Whether the condition source requires a secondary request (has inbound path or aggregate) */
+  isAsync: boolean;
+}
 
 /**
  * Constructor for ReferenceColumn. This class is a wrapper for Column.
@@ -122,6 +133,8 @@ export class ReferenceColumn {
   protected _hasWaitFor?: boolean;
   protected _hasWaitForAggregate?: boolean;
   protected _waitFor?: ReferenceColumn[];
+  protected _hasCondition?: boolean;
+  protected _resolvedCondition?: ResolvedCondition | null;
   /**
    * the reference that this column is defined on
    */
@@ -442,6 +455,87 @@ export class ReferenceColumn {
   }
 
   /**
+   * Whether the column has an async condition that requires a secondary request.
+   * Only true in detailed context for conditions whose source has an inbound path or aggregate.
+   */
+  get hasCondition(): boolean {
+    if (this._hasCondition === undefined) {
+      // triggers resolution
+      void this.resolvedCondition;
+    }
+    return this._hasCondition!;
+  }
+
+  /**
+   * The resolved condition for this column, or null if no condition or not applicable.
+   */
+  get resolvedCondition(): ResolvedCondition | null {
+    if (this._resolvedCondition === undefined) {
+      this._resolvedCondition = this._resolveCondition();
+      this._hasCondition = this._resolvedCondition?.isAsync ?? false;
+    }
+    return this._resolvedCondition;
+  }
+
+  /**
+   * Resolve the condition definition and source for this column.
+   */
+  protected _resolveCondition(): ResolvedCondition | null {
+    // only applicable in detailed context
+    if (this._context !== _contexts.DETAILED) {
+      return null;
+    }
+
+    if (!this.sourceObjectWrapper) {
+      return null;
+    }
+
+    // get condition def: inline condition or condition_key
+    let condDef: ConditionDefinition | undefined;
+    if (this.sourceObjectWrapper.condition) {
+      condDef = this.sourceObjectWrapper.condition;
+    } else {
+      const conditionKey = (this.sourceObjectWrapper as any)._conditionKey;
+      if (conditionKey) {
+        condDef = this._currentTable.sourceDefinitions.getCondition(conditionKey);
+        if (!condDef) {
+          $log.info('condition_key `' + conditionKey + '` not found in source-definitions conditions.');
+          return null;
+        }
+      }
+    }
+
+    if (!condDef) {
+      return null;
+    }
+
+    // resolve the condition source SourceObjectWrapper
+    let sourceWrapper: SourceObjectWrapper | undefined;
+    try {
+      if (condDef.sourcekey) {
+        sourceWrapper = this._currentTable.sourceDefinitions.getSource(condDef.sourcekey) ?? undefined;
+        if (!sourceWrapper) {
+          $log.info('condition sourcekey `' + condDef.sourcekey + '` could not be resolved.');
+          return null;
+        }
+      } else if (condDef.source) {
+        sourceWrapper = new SourceObjectWrapper({ source: condDef.source }, this._currentTable, false, undefined);
+      }
+    } catch (e: unknown) {
+      $log.info('failed to resolve condition source: ' + (e instanceof Error ? e.message : String(e)));
+      return null;
+    }
+
+    if (!sourceWrapper) {
+      return null;
+    }
+
+    const isAsync = sourceWrapper.hasInbound || sourceWrapper.hasAggregate;
+
+    return { conditionDef: condDef, sourceWrapper, isAsync };
+  }
+
+  /**
    * Formats a value corresponding to this reference-column definition.
    */
   formatvalue(data: any, context?: string, options?: any): string | string[] {
@@ -465,8 +559,8 @@ export class ReferenceColumn {
       context = this._context;
     }
 
-    // if there's wait_for, this should return null.
-    if (this.hasWaitFor && !options.skipWaitFor) {
+    // if there's wait_for or async condition, this should return null.
+    if ((this.hasWaitFor || this.hasCondition) && !options.skipWaitFor) {
       return {
         isHTML: false,
         value: this._getNullValue(context!),

--- a/src/models/reference-column/reference-column.ts
+++ b/src/models/reference-column/reference-column.ts
@@ -534,8 +534,14 @@ export class ReferenceColumn {
       context = this._context;
     }
 
-    // if there's wait_for or async condition, this should return null.
-    if ((this.hasWaitFor || this.hasCondition) && !options.skipWaitFor) {
+    // wait_for placeholder: the column depends on data that isn't ready, so
+    // return a null placeholder. Note: hasCondition is intentionally NOT in
+    // this check — the column's value is independent of the condition; the
+    // condition only controls *visibility* (chaise's `conditionHide` flag).
+    // Returning null here for an async-conditioned local column would
+    // permanently blank it, since there's no secondary fetch to flip the
+    // value back in chaise.
+    if (this.hasWaitFor && !options.skipWaitFor) {
       return {
         isHTML: false,
         value: this._getNullValue(context!),

--- a/src/models/reference-column/reference-column.ts
+++ b/src/models/reference-column/reference-column.ts
@@ -14,6 +14,9 @@ import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
 import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils';
 import { isObjectAndKeyExists, isObjectAndNotNull, isStringAndNotEmpty } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
 import { _annotations, _contexts } from '@isrd-isi-edu/ermrestjs/src/utils/constants';
+import { buildSelfTemplateVariables } from '@isrd-isi-edu/ermrestjs/src/utils/template-utils';
+import { createPseudoColumn, isAllOutboundColumn } from '@isrd-isi-edu/ermrestjs/src/utils/column-utils';
+import ActiveListCondition from '@isrd-isi-edu/ermrestjs/src/models/active-list-condition';
 
 // legacy
 import { Column, Table, Type } from '@isrd-isi-edu/ermrestjs/js/core';
@@ -53,6 +56,11 @@ export interface ResolvedCondition {
   sourceWrapper: SourceObjectWrapper;
   /** Whether the condition source requires a secondary request (has inbound path or aggregate) */
   isAsync: boolean;
+  /**
+   * For synchronous conditions (all-outbound, no wait_for): whether the condition evaluated to hide.
+   * undefined for async conditions (evaluation happens later on the client).
+   */
+  conditionHide?: boolean;
 }
 
 /**
@@ -523,7 +531,7 @@ export class ReferenceColumn {
     let sourceWrapper: SourceObjectWrapper | undefined;
     try {
       if (condDef.sourcekey) {
-        sourceWrapper = this._currentTable.sourceDefinitions.getSource(condDef.sourcekey) ?? undefined;
+        sourceWrapper = this._currentTable.sourceDefinitions.getSource(condDef.sourcekey, this._mainTuple) ?? undefined;
         if (!sourceWrapper) {
           $log.info('condition sourcekey `' + condDef.sourcekey + '` could not be resolved.');
           return null;
@@ -542,7 +550,22 @@ export class ReferenceColumn {
 
     const isAsync = sourceWrapper.hasInbound || sourceWrapper.hasAggregate;
 
-    return { conditionDef: condDef, sourceWrapper, isAsync };
+    // for synchronous conditions, evaluate now and store the result
+    let conditionHide: boolean | undefined;
+    if (!isAsync && this._mainTuple) {
+      try {
+        const condCol = createPseudoColumn(this._baseReference, sourceWrapper.clone({}, this._currentTable, false, this._mainTuple), this._mainTuple);
+        const condition = new ActiveListCondition(condDef, condCol, this._baseReference, this._mainTuple);
+        if (!condition.hasWaitFor) {
+          const result = condition.evaluateCondition(this._mainTuple.templateVariables, null, this._mainTuple);
+          conditionHide = !result.shouldShow;
+        }
+      } catch (e: unknown) {
+        $log.info('failed to evaluate synchronous condition: ' + (e instanceof Error ? e.message : String(e)));
+      }
+    }
+
+    return { conditionDef: condDef, sourceWrapper, isAsync, conditionHide };
   }
 
   /**
@@ -712,17 +735,13 @@ export class ReferenceColumn {
   }
 
   sourceFormatPresentation(templateVariables: any, columnValue: any, mainTuple: Tuple): any {
-    const baseCol = this.baseColumns[0];
     const context = this._context;
 
     if (this.display.sourceMarkdownPattern) {
       let selfTemplateVariables = {};
-      // children pseudo-column have already set the $self and $_self
-      if (!this.isPseudo && baseCol) {
-        selfTemplateVariables = {
-          $self: baseCol.formatvalue(mainTuple.data[baseCol.name], context),
-          $_self: mainTuple.data[baseCol.name],
-        };
+      // children pseudo-columns build $self in their own override via buildSelfTemplateVariables
+      if (!this.isPseudo) {
+        selfTemplateVariables = buildSelfTemplateVariables(this, mainTuple, columnValue);
       }
 
       const keyValues = {};

--- a/src/models/reference-column/reference-column.ts
+++ b/src/models/reference-column/reference-column.ts
@@ -502,6 +502,7 @@ export class ReferenceColumn {
           on_empty: condObj.on_empty === 'show' ? 'show' : 'hide',
           condition_pattern: isStringAndNotEmpty(condObj.condition_pattern) ? (condObj.condition_pattern as string) : undefined,
           template_engine: isStringAndNotEmpty(condObj.template_engine) ? (condObj.template_engine as string) : undefined,
+          wait_for: Array.isArray(condObj.wait_for) ? (condObj.wait_for as string[]) : undefined,
         };
       } else {
         $log.info('condition on column `' + this.sourceObjectWrapper.name + '` is missing `source` or `sourcekey`.');

--- a/src/models/reference/reference.ts
+++ b/src/models/reference/reference.ts
@@ -22,7 +22,6 @@ import {
   type PseudoColumn,
   type ColumnAggregateFn,
 } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
-import type { ResolvedCondition } from '@isrd-isi-edu/ermrestjs/src/models/reference-column/reference-column';
 import {
   Citation,
   Page,
@@ -34,6 +33,7 @@ import {
   RelatedReference,
   BulkCreateForeignKeyObject,
 } from '@isrd-isi-edu/ermrestjs/src/models/reference';
+import ActiveListCondition from '@isrd-isi-edu/ermrestjs/src/models/active-list-condition';
 
 // services
 import ConfigService from '@isrd-isi-edu/ermrestjs/src/services/config';
@@ -886,11 +886,11 @@ export class Reference {
      *   so we should just add the column/related directly to the active list.
      */
     const tryCondition = (
-      rc: ResolvedCondition | null | undefined,
+      condition: ActiveListCondition | null | undefined,
       addToDeps: (deps: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => void,
     ): boolean => {
-      if (!isDetailed || !rc) return false;
-      return builder.processConditionedItem(rc, addToDeps);
+      if (!isDetailed || !condition) return false;
+      return builder.processConditionedItem(condition, addToDeps);
     };
 
     const columns = this.generateColumnsList(tuple);
@@ -966,7 +966,7 @@ export class Reference {
   }
 
   /**
-   * Will return the expor templates that are available for this reference.
+   * Will return the export templates that are available for this reference.
    * It will validate the templates that are defined in annotations.
    * If its `detailed` context and annotation was missing,
    * it will return the default export template.

--- a/src/models/reference/reference.ts
+++ b/src/models/reference/reference.ts
@@ -878,19 +878,19 @@ export class Reference {
     const builder = new ActiveListBuilder(this, tuple, isDetailed);
 
     /**
-     * helper for the condition branch shared across columns/related loops
-     * Returns,
-     * - true, if the condition was valid and so we should just capture the dependencies
-     *   and not add them directly to the active list.
-     * - false, if condition missing/invalid/synchronous,
-     *   so we should just add the column/related directly to the active list.
+     * Helper for the condition branch shared across the columns / related loops.
+     * Returns true if the column was routed through a conditional group (so the
+     * caller should NOT add the column directly), false if there was no
+     * applicable condition (caller adds normally).
      */
     const tryCondition = (
       condition: ActiveListCondition | null | undefined,
+      conditionedItem: { column?: boolean; inline?: boolean; related?: boolean; index: number },
       addToDeps: (deps: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => void,
     ): boolean => {
       if (!isDetailed || !condition) return false;
-      return builder.processConditionedItem(condition, addToDeps);
+      builder.processConditionedItem(condition, conditionedItem, addToDeps);
+      return true;
     };
 
     const columns = this.generateColumnsList(tuple);
@@ -906,7 +906,8 @@ export class Reference {
     columns.forEach((col, i: number) => {
       if (builder.hasAggregate(col)) return;
       const rc = col.resolvedCondition;
-      if (tryCondition(rc, (deps) => builder.addInlineToDependent(deps, col, i))) return;
+      const item = isRelatedColumn(col) ? { inline: true, index: i } : { column: true, index: i };
+      if (tryCondition(rc, item, (deps) => builder.addInlineToDependent(deps, col, i))) return;
       builder.addInline(col, i);
     });
 
@@ -914,7 +915,8 @@ export class Reference {
     columns.forEach((col, i: number) => {
       if (!builder.hasAggregate(col)) return;
       const rc = col.resolvedCondition;
-      if (tryCondition(rc, (deps) => builder.addInlineToDependent(deps, col, i))) return;
+      const item = isRelatedColumn(col) ? { inline: true, index: i } : { column: true, index: i };
+      if (tryCondition(rc, item, (deps) => builder.addInlineToDependent(deps, col, i))) return;
       builder.addInline(col, i);
     });
 
@@ -932,7 +934,7 @@ export class Reference {
             builder.addColToDependent(deps, wf, true, ActiveListRequestTypes.RELATED, i);
           });
         };
-        if (tryCondition(rc, addRelatedToDeps)) return;
+        if (tryCondition(rc, { related: true, index: i }, addRelatedToDeps)) return;
         builder.requests.push({ related: true, index: i });
         rel.pseudoColumn?.waitFor.forEach((wf) => {
           builder.addCol(wf, true, ActiveListRequestTypes.RELATED, i);

--- a/src/models/reference/reference.ts
+++ b/src/models/reference/reference.ts
@@ -22,6 +22,7 @@ import {
   type PseudoColumn,
   type ColumnAggregateFn,
 } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
+import type { ResolvedCondition } from '@isrd-isi-edu/ermrestjs/src/models/reference-column/reference-column';
 import {
   Citation,
   Page,
@@ -87,7 +88,7 @@ import {
   type ActiveListRequest,
   type ActiveListRelatedEntityRequest,
 } from '@isrd-isi-edu/ermrestjs/src/services/active-list';
-import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
+
 import { _exportHelpers, _getDefaultExportTemplate, _referenceExportOutput, validateExportTemplate } from '@isrd-isi-edu/ermrestjs/js/export';
 
 /**
@@ -885,11 +886,11 @@ export class Reference {
      *   so we should just add the column/related directly to the active list.
      */
     const tryCondition = (
-      condDef: ConditionDefinition | undefined,
+      rc: ResolvedCondition | null | undefined,
       addToDeps: (deps: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => void,
     ): boolean => {
-      if (!isDetailed || !condDef) return false;
-      return builder.processConditionedItem(condDef, addToDeps);
+      if (!isDetailed || !rc) return false;
+      return builder.processConditionedItem(rc, addToDeps);
     };
 
     const columns = this.generateColumnsList(tuple);
@@ -905,7 +906,7 @@ export class Reference {
     columns.forEach((col, i: number) => {
       if (builder.hasAggregate(col)) return;
       const rc = col.resolvedCondition;
-      if (tryCondition(rc?.conditionDef, (deps) => builder.addInlineToDependent(deps, col, i))) return;
+      if (tryCondition(rc, (deps) => builder.addInlineToDependent(deps, col, i))) return;
       builder.addInline(col, i);
     });
 
@@ -913,7 +914,7 @@ export class Reference {
     columns.forEach((col, i: number) => {
       if (!builder.hasAggregate(col)) return;
       const rc = col.resolvedCondition;
-      if (tryCondition(rc?.conditionDef, (deps) => builder.addInlineToDependent(deps, col, i))) return;
+      if (tryCondition(rc, (deps) => builder.addInlineToDependent(deps, col, i))) return;
       builder.addInline(col, i);
     });
 
@@ -931,7 +932,7 @@ export class Reference {
             builder.addColToDependent(deps, wf, true, ActiveListRequestTypes.RELATED, i);
           });
         };
-        if (tryCondition(rc?.conditionDef, addRelatedToDeps)) return;
+        if (tryCondition(rc, addRelatedToDeps)) return;
         builder.requests.push({ related: true, index: i });
         rel.pseudoColumn?.waitFor.forEach((wf) => {
           builder.addCol(wf, true, ActiveListRequestTypes.RELATED, i);
@@ -941,7 +942,7 @@ export class Reference {
 
     // fkeys
     this.table.sourceDefinitions.fkeys.forEach((fk) => {
-      builder.addFkey(new ForeignKeyPseudoColumn(this, fk));
+      builder.addAllOutBound(new ForeignKeyPseudoColumn(this, fk));
     });
 
     this._activeList = builder.build();

--- a/src/models/reference/reference.ts
+++ b/src/models/reference/reference.ts
@@ -41,7 +41,7 @@ import ErrorService from '@isrd-isi-edu/ermrestjs/src/services/error';
 import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
 
 // utils
-import { createPseudoColumn, isAllOutboundColumn, isRelatedColumn } from '@isrd-isi-edu/ermrestjs/src/utils/column-utils';
+import { createPseudoColumn, isRelatedColumn } from '@isrd-isi-edu/ermrestjs/src/utils/column-utils';
 import {
   computeReadPath,
   generateFacetColumns,
@@ -71,7 +71,6 @@ import { onload } from '@isrd-isi-edu/ermrestjs/js/setup/node';
 import {
   _getPagingValues,
   _getRecursiveAnnotationValue,
-  _isEntryContext,
   _isValidForeignKeyName,
   _isValidSortElement,
   compareColumnPositions,
@@ -81,9 +80,14 @@ import { _compressFacetObject, _sourceColumnHelpers } from '@isrd-isi-edu/ermres
 
 import type { CommentType } from '@isrd-isi-edu/ermrestjs/src/models/comment';
 import type { DisplayName } from '@isrd-isi-edu/ermrestjs/src/models/display-name';
-import ActiveListCondition from '@isrd-isi-edu/ermrestjs/src/models/active-list-condition';
+import {
+  ActiveListBuilder,
+  ActiveListRequestTypes,
+  type ActiveList,
+  type ActiveListRequest,
+  type ActiveListRelatedEntityRequest,
+} from '@isrd-isi-edu/ermrestjs/src/services/active-list';
 import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
-import SourceObjectWrapper from '@isrd-isi-edu/ermrestjs/src/models/source-object-wrapper';
 import { _exportHelpers, _getDefaultExportTemplate, _referenceExportOutput, validateExportTemplate } from '@isrd-isi-edu/ermrestjs/js/export';
 
 /**
@@ -120,7 +124,7 @@ import { _exportHelpers, _getDefaultExportTemplate, _referenceExportOutput, vali
  * @return Promise when resolved passes the
  * {@link Reference} object. If rejected, passes one of the ermrest errors
  */
-export const resolve = async (uri: string, contextHeaderParams?: any): Promise<Reference> => {
+export const resolve = async (uri: string, contextHeaderParams?: unknown): Promise<Reference> => {
   verify(uri, "'uri' must be specified");
   // make sure all the dependencies are loaded
   await onload();
@@ -149,85 +153,6 @@ export const _createReference = (location: Location, catalog: Catalog): Referenc
 // NOTE: This function is only being used in unit tests.
 export const _createPage = (reference: Reference, etag: string, data: any, hasPrevious: boolean, hasNext: boolean): Page => {
   return new Page(reference, etag, data, hasPrevious, hasNext);
-};
-
-type ActiveListRequestObject = {
-  /**
-   * The index of the object in the column's values array
-   */
-  index?: number;
-  /**
-   * whether this is for a visible column
-   */
-  column?: boolean;
-  /**
-   * whether this is for a related entity
-   */
-  related?: boolean;
-  /**
-   * whether this is for an inline related entity
-   */
-  inline?: boolean;
-  /**
-   * whether this is for the citation
-   */
-  citation?: boolean;
-
-  isWaitFor: boolean;
-};
-
-type ActiveListRequest = {
-  column: VisibleColumn;
-
-  /**
-   * whether the request is "first outbound" type.
-   * These booleans are used for figuring out how the data should be fetched.
-   */
-  firstOutbound?: boolean;
-  /**
-   * whether the request is for an aggregate column.
-   * This is used for figuring out how the data should be fetched.
-   */
-  aggregate?: boolean;
-  entity?: boolean;
-  /**
-   * whether the request is an entityset.
-   * This is used for figuring out how the data should be fetched.
-   */
-  entityset?: boolean;
-
-  /**
-   * where this request is needed.
-   */
-  objects: Array<ActiveListRequestObject>;
-};
-
-type ActiveListRelatedEntityRequest = {
-  /**
-   * whether the request is for an inline related entity.
-   * the .index indicated which related entity it is
-   */
-  inline?: boolean;
-  /**
-   * whether the request is for a related entity.
-   * the .index indicated which related entity it is
-   */
-  related?: boolean;
-  index: number;
-};
-
-type ActiveListConditionalGroup = {
-  /** The condition object (class with evaluateCondition method) */
-  condition: ActiveListCondition;
-  /** Requests gated behind this condition (main content + its wait-fors) */
-  dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>;
-};
-
-type ActiveList = {
-  requests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>;
-  conditionalGroups: ActiveListConditionalGroup[];
-  allOutBounds: Array<ForeignKeyPseudoColumn | PseudoColumn>;
-  selfLinks: Array<KeyPseudoColumn>;
 };
 
 export type VisibleColumn =
@@ -295,9 +220,9 @@ export class Reference {
   private _canUseTRS?: boolean;
   private _canUseTCRS?: boolean;
   private _readPath?: string;
-  private _readAttributeGroupPathProps_cached?: any;
+  private _readAttributeGroupPathProps_cached?: unknown;
   private _display?: ReferenceDisplay;
-  private _defaultExportTemplate?: any;
+  private _defaultExportTemplate?: unknown;
   private _csvDownloadLink?: string | null;
   private _searchColumns?: Array<VisibleColumn> | false;
   private _cascadingDeletedItems?: Array<Table | RelatedReference | Reference>;
@@ -394,6 +319,10 @@ export class Reference {
     return this._pseudoColumn;
   }
 
+  /**
+   * The column-directive that is used for creating this reference.
+   * Allows access to props defined on the column-directive (display props, condition, waitFor, etc)
+   */
   setPseudoColumn(value: VisibleColumn) {
     this._pseudoColumn = value;
   }
@@ -670,7 +599,7 @@ export class Reference {
   /**
    * Generate the list of columns for this reference based on context and annotations
    */
-  generateColumnsList(tuple?: Tuple, columnsList?: any[], dontChangeReference?: boolean, skipLog?: boolean): ReferenceColumn[] {
+  generateColumnsList(tuple?: Tuple, columnsList?: Array<unknown>, dontChangeReference?: boolean, skipLog?: boolean): ReferenceColumn[] {
     const resultColumns = generateColumnsList(this, tuple, columnsList, skipLog);
 
     if (!dontChangeReference) {
@@ -944,368 +873,78 @@ export class Reference {
    * @private
    */
   generateActiveList(tuple?: Tuple): ActiveList {
-    // VARIABLES:
-    const allOutBounds: Array<PseudoColumn | ForeignKeyPseudoColumn> = [];
-    const requests: Array<ActiveListRequest | ActiveListRelatedEntityRequest> = [];
-    const selfLinks: Array<KeyPseudoColumn> = [];
-    const conditionalGroups: ActiveListConditionalGroup[] = [];
-    const consideredUniqueFiltered: { [key: string]: number } = {};
-    const consideredSets: { [key: string]: number } = {};
-    const consideredOutbounds: { [key: string]: boolean } = {};
-    const consideredAggregates: { [key: string]: number } = {};
-    const consideredSelfLinks: { [key: string]: boolean } = {};
-    const consideredEntryWaitFors: { [key: string]: number } = {};
-
-    const sds = this.table.sourceDefinitions;
-
-    // in detailed, we want related and citation
     const isDetailed = this._context === _contexts.DETAILED;
-    // in entry, don't include waitfors in the activelist used for loading the page.
-    // the waitfors will be used in chaise instead prior to submission.
-    const isEntry = _isEntryContext(this._context);
-
-    enum ActiveListRequestTypes {
-      COLUMN = 'column',
-      RELATED = 'related',
-      INLINE = 'inline',
-      CITATION = 'citation',
-    }
-
-    // FUNCTIONS:
-    const hasAggregate = (col: VisibleColumn) => {
-      return col.hasWaitForAggregate || ((col as PseudoColumn).isPathColumn && (col as PseudoColumn).hasAggregate);
-    };
-
-    // col: the column that we need its data
-    // isWaitFor: whether it was part of waitFor or just visible
-    // type: where in the page it belongs to
-    // index: the container index (column index, or related index) (optional)
-    const addColToActiveList = (col: VisibleColumn, isWaitFor: boolean, type: ActiveListRequestTypes, index?: number) => {
-      const obj: ActiveListRequestObject = { isWaitFor: isWaitFor };
-
-      // add the type
-      obj[type] = true;
-
-      // add index if available (not available in citation)
-      if (Number.isInteger(index)) {
-        obj.index = index;
-      }
-
-      if (isWaitFor && isEntry) {
-        if (col.name in consideredEntryWaitFors) {
-          (requests[consideredEntryWaitFors[col.name]] as ActiveListRequest).objects.push(obj);
-          return;
-        }
-        consideredEntryWaitFors[col.name] = requests.length;
-        requests.push({ firstOutbound: true, column: col, objects: [obj] });
-        return;
-      }
-
-      // unique filtered
-      // TODO FILTER_IN_SOURCE chaise should use this type of column as well?
-      // TODO FILTER_IN_SOURCE should be added to documentation as well
-      if ((col as PseudoColumn).sourceObjectWrapper?.isUniqueFiltered) {
-        // duplicate
-        if (col.name in consideredUniqueFiltered) {
-          (requests[consideredUniqueFiltered[col.name]] as ActiveListRequest).objects.push(obj);
-          return;
-        }
-
-        // new
-        consideredUniqueFiltered[col.name] = requests.length;
-        requests.push({ entity: true, column: col, objects: [obj] });
-        return;
-      }
-
-      // aggregates
-      if ((col as PseudoColumn).isPathColumn && (col as PseudoColumn).hasAggregate) {
-        // duplicate
-        if (col.name in consideredAggregates) {
-          (requests[consideredAggregates[col.name]] as ActiveListRequest).objects.push(obj);
-          return;
-        }
-
-        // new
-        consideredAggregates[col.name] = requests.length;
-        requests.push({ aggregate: true, column: col, objects: [obj] });
-        return;
-      }
-
-      //entitysets
-      if (isRelatedColumn(col)) {
-        if (!isDetailed) {
-          return; // only acceptable in detailed
-        }
-
-        if (col.name in consideredSets) {
-          (requests[consideredSets[col.name]] as ActiveListRequest).objects.push(obj);
-          return;
-        }
-
-        consideredSets[col.name] = requests.length;
-        requests.push({ entityset: true, column: col, objects: [obj] });
-      }
-
-      // all outbounds
-      if (isAllOutboundColumn(col)) {
-        if (col.name in consideredOutbounds) return;
-        consideredOutbounds[col.name] = true;
-        allOutBounds.push(col as PseudoColumn | ForeignKeyPseudoColumn);
-      }
-
-      // self-links
-      if ((col as KeyPseudoColumn).isKey) {
-        if (col.name in consideredSelfLinks) return;
-        consideredSelfLinks[col.name] = true;
-        selfLinks.push(col as KeyPseudoColumn);
-      }
-    };
+    const builder = new ActiveListBuilder(this, tuple, isDetailed);
 
     /**
-     * Same as addColToActiveList, but adds to a dependent requests array
-     * instead of the main requests array. Used for conditional groups.
+     * helper for the condition branch shared across columns/related loops
+     * Returns,
+     * - true, if the condition was valid and so we should just capture the dependencies
+     *   and not add them directly to the active list.
+     * - false, if condition missing/invalid/synchronous,
+     *   so we should just add the column/related directly to the active list.
      */
-    const addColToDependentList = (
-      dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>,
-      col: VisibleColumn,
-      isWaitFor: boolean,
-      type: ActiveListRequestTypes,
-      index?: number,
-    ) => {
-      const obj: ActiveListRequestObject = { isWaitFor: isWaitFor };
-      obj[type] = true;
-      if (Number.isInteger(index)) {
-        obj.index = index;
-      }
-
-      // aggregates
-      if ((col as PseudoColumn).isPathColumn && (col as PseudoColumn).hasAggregate) {
-        // check if already in dependentRequests
-        const existing = dependentRequests.find((r) => (r as ActiveListRequest).column?.name === col.name && (r as ActiveListRequest).aggregate) as
-          | ActiveListRequest
-          | undefined;
-        if (existing) {
-          existing.objects.push(obj);
-          return;
-        }
-        dependentRequests.push({ aggregate: true, column: col, objects: [obj] });
-        return;
-      }
-
-      // entitysets
-      if (isRelatedColumn(col)) {
-        const existing = dependentRequests.find((r) => (r as ActiveListRequest).column?.name === col.name && (r as ActiveListRequest).entityset) as
-          | ActiveListRequest
-          | undefined;
-        if (existing) {
-          existing.objects.push(obj);
-          return;
-        }
-        dependentRequests.push({ entityset: true, column: col, objects: [obj] });
-        return;
-      }
-
-      // all outbounds — still add to main allOutBounds
-      if (isAllOutboundColumn(col)) {
-        if (!(col.name in consideredOutbounds)) {
-          consideredOutbounds[col.name] = true;
-          allOutBounds.push(col as PseudoColumn | ForeignKeyPseudoColumn);
-        }
-      }
-
-      // self-links — still add to main selfLinks
-      if ((col as KeyPseudoColumn).isKey) {
-        if (!(col.name in consideredSelfLinks)) {
-          consideredSelfLinks[col.name] = true;
-          selfLinks.push(col as KeyPseudoColumn);
-        }
-      }
-    };
-
-    /**
-     * Create a PseudoColumn for a condition source definition.
-     */
-    const createConditionColumn = (condDef: ConditionDefinition): VisibleColumn | undefined => {
-      try {
-        let condSourceWrapper: SourceObjectWrapper;
-        if (condDef.sourcekey) {
-          const sd = sds.getSource(condDef.sourcekey, tuple);
-          if (!sd) {
-            $log.info('condition sourcekey `' + condDef.sourcekey + '` could not be resolved.');
-            return undefined;
-          }
-          condSourceWrapper = sd.clone({}, this.table, false, tuple);
-        } else if (condDef.source) {
-          condSourceWrapper = new SourceObjectWrapper({ source: condDef.source }, this.table, false, undefined, tuple);
-        } else {
-          return undefined;
-        }
-        return createPseudoColumn(this, condSourceWrapper, tuple);
-      } catch (e: unknown) {
-        $log.info('failed to create condition column: ' + (e instanceof Error ? e.message : String(e)));
-        return undefined;
-      }
-    };
-
-    const addInlineColumn = (col: VisibleColumn, i: number) => {
-      if (isRelatedColumn(col)) {
-        requests.push({ inline: true, index: i });
-      } else {
-        addColToActiveList(col, false, ActiveListRequestTypes.COLUMN, i);
-      }
-
-      col.waitFor.forEach((wf: any) => {
-        addColToActiveList(wf, true, isRelatedColumn(col) ? ActiveListRequestTypes.INLINE : ActiveListRequestTypes.COLUMN, i);
-      });
-    };
-
-    /**
-     * Same as addInlineColumn but adds to dependent requests in a conditional group
-     */
-    const addInlineColumnToDependent = (
-      dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>,
-      col: VisibleColumn,
-      i: number,
-    ) => {
-      if (isRelatedColumn(col)) {
-        dependentRequests.push({ inline: true, index: i });
-      } else {
-        addColToDependentList(dependentRequests, col, false, ActiveListRequestTypes.COLUMN, i);
-      }
-
-      col.waitFor.forEach((wf: any) => {
-        addColToDependentList(dependentRequests, wf, true, isRelatedColumn(col) ? ActiveListRequestTypes.INLINE : ActiveListRequestTypes.COLUMN, i);
-      });
-    };
-
-    /**
-     * Process a column or related entity that has a condition.
-     * Returns true if the item was handled (either added to a conditional group or skipped).
-     * Returns false if it should be processed normally (condition evaluated synchronously to show).
-     */
-    const processConditionedItem = (
-      condDef: ConditionDefinition,
-      addToDependent: (dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => void,
+    const tryCondition = (
+      condDef: ConditionDefinition | undefined,
+      addToDeps: (deps: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => void,
     ): boolean => {
-      const condCol = createConditionColumn(condDef);
-      if (!condCol) return false; // invalid condition, process normally
-
-      // if condition source is all-outbound (no secondary request needed), evaluate synchronously
-      if (isAllOutboundColumn(condCol)) {
-        if (tuple) {
-          const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern, condDef.template_engine);
-          const result = condition.evaluateCondition({}, null, tuple);
-          return !result.shouldShow; // return true if we should skip (hide)
-        }
-        return false; // no tuple, can't evaluate — process normally
-      }
-
-      // condition source needs a secondary request
-      const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern, condDef.template_engine);
-
-      // add condition source to main requests (deduplication via consideredSets/consideredAggregates)
-      addColToActiveList(condCol, true, ActiveListRequestTypes.COLUMN);
-
-      // create dependent requests
-      const dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest> = [];
-      addToDependent(dependentRequests);
-
-      // create the conditional group
-      conditionalGroups.push({
-        condition,
-        dependentRequests,
-      });
-
-      return true; // handled
+      if (!isDetailed || !condDef) return false;
+      return builder.processConditionedItem(condDef, addToDeps);
     };
 
-    // THE CODE STARTS HERE:
     const columns = this.generateColumnsList(tuple);
 
     // citation
     if (isDetailed && this.citation) {
       this.citation.waitFor.forEach((col) => {
-        addColToActiveList(col, true, ActiveListRequestTypes.CITATION);
+        builder.addCol(col, true, ActiveListRequestTypes.CITATION);
       });
     }
 
     // columns without aggregate
     columns.forEach((col, i: number) => {
-      if (hasAggregate(col)) return;
-
-      // check for condition (only in detailed context)
-      if (isDetailed) {
-        const rc = (col as ReferenceColumn).resolvedCondition;
-        if (rc) {
-          const handled = processConditionedItem(rc.conditionDef, (depReqs) => {
-            addInlineColumnToDependent(depReqs, col, i);
-          });
-          if (handled) return;
-        }
-      }
-
-      addInlineColumn(col, i);
+      if (builder.hasAggregate(col)) return;
+      const rc = col.resolvedCondition;
+      if (tryCondition(rc?.conditionDef, (deps) => builder.addInlineToDependent(deps, col, i))) return;
+      builder.addInline(col, i);
     });
 
     // columns with aggregate
     columns.forEach((col, i: number) => {
-      if (!hasAggregate(col)) return;
-
-      // check for condition (only in detailed context)
-      if (isDetailed) {
-        const rc = (col as ReferenceColumn).resolvedCondition;
-        if (rc) {
-          const handled = processConditionedItem(rc.conditionDef, (depReqs) => {
-            addInlineColumnToDependent(depReqs, col, i);
-          });
-          if (handled) return;
-        }
-      }
-
-      addInlineColumn(col, i);
+      if (!builder.hasAggregate(col)) return;
+      const rc = col.resolvedCondition;
+      if (tryCondition(rc?.conditionDef, (deps) => builder.addInlineToDependent(deps, col, i))) return;
+      builder.addInline(col, i);
     });
 
     // related tables
     if (isDetailed) {
       this.generateRelatedList(tuple).forEach((rel, i) => {
-        // check for condition on related entity
         const rc = rel.pseudoColumn?.resolvedCondition;
-        if (rc) {
-          const handled = processConditionedItem(rc.conditionDef, (depReqs) => {
-            depReqs.push({ related: true, index: i });
-            if (rel.pseudoColumn) {
-              rel.pseudoColumn.waitFor.forEach((wf: any) => {
-                addColToDependentList(depReqs, wf, true, ActiveListRequestTypes.RELATED, i);
-              });
-            }
+        /**
+         * if there's a condition, we have to capture the requests generated for the related entity as its dependencies.
+         * So when the condition is evaludated, we can decide whether to run those requests or not.
+         */
+        const addRelatedToDeps = (deps: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => {
+          deps.push({ related: true, index: i });
+          rel.pseudoColumn?.waitFor.forEach((wf) => {
+            builder.addColToDependent(deps, wf, true, ActiveListRequestTypes.RELATED, i);
           });
-          if (handled) return;
-        }
-
-        requests.push({ related: true, index: i });
-
-        if (rel.pseudoColumn) {
-          rel.pseudoColumn.waitFor.forEach((wf) => {
-            addColToActiveList(wf, true, ActiveListRequestTypes.RELATED, i);
-          });
-        }
+        };
+        if (tryCondition(rc?.conditionDef, addRelatedToDeps)) return;
+        builder.requests.push({ related: true, index: i });
+        rel.pseudoColumn?.waitFor.forEach((wf) => {
+          builder.addCol(wf, true, ActiveListRequestTypes.RELATED, i);
+        });
       });
     }
 
-    //fkeys
-    sds.fkeys.forEach((fk) => {
-      if (fk.name in consideredOutbounds) return;
-      consideredOutbounds[fk.name] = true;
-      allOutBounds.push(new ForeignKeyPseudoColumn(this, fk));
+    // fkeys
+    this.table.sourceDefinitions.fkeys.forEach((fk) => {
+      builder.addFkey(new ForeignKeyPseudoColumn(this, fk));
     });
 
-    this._activeList = {
-      requests: requests,
-      conditionalGroups: conditionalGroups,
-      allOutBounds: allOutBounds,
-      selfLinks: selfLinks,
-    };
-
+    this._activeList = builder.build();
     return this._activeList;
   }
 
@@ -1340,6 +979,7 @@ export class Reference {
 
     // annotation is missing
     if (!Array.isArray(templates)) {
+      // eslint-disable-next-line eqeqeq
       const canUseDefault = useDefault && this.context === _contexts.DETAILED && this.defaultExportTemplate != null;
 
       return canUseDefault ? [this.defaultExportTemplate] : [];
@@ -1380,7 +1020,7 @@ export class Reference {
    */
   getColumnByName(name: string): VisibleColumn {
     // given an array of columns, find column by name
-    const findCol = (list: any[]): any => {
+    const findCol = (list: Array<VisibleColumn | Column>): VisibleColumn | Column | false => {
       for (let i = 0; i < list.length; i++) {
         if (list[i].name === name) {
           return list[i];
@@ -1392,13 +1032,13 @@ export class Reference {
     // search in visible columns
     let c = findCol(this.columns);
     if (c) {
-      return c;
+      return c as VisibleColumn;
     }
 
     // search in table columns
     c = findCol(this.table.columns.all());
     if (c) {
-      return new ReferenceColumn(this, [c]);
+      return new ReferenceColumn(this, [c as Column]);
     }
 
     // backward compatibility, look at fks and keys using constraint name

--- a/src/models/reference/reference.ts
+++ b/src/models/reference/reference.ts
@@ -148,6 +148,71 @@ export const _createPage = (reference: Reference, etag: string, data: any, hasPr
   return new Page(reference, etag, data, hasPrevious, hasNext);
 };
 
+type ActiveListRequestObject = {
+  /**
+   * The index of the object in the column's values array
+   */
+  index?: number;
+  /**
+   * whether this is for a visible column
+   */
+  column?: boolean;
+  /**
+   * whether this is for a related entity
+   */
+  related?: boolean;
+  /**
+   * whether this is for an inline related entity
+   */
+  inline?: boolean;
+  /**
+   * whether this is for the citation
+   */
+  citation?: boolean;
+
+  isWaitFor: boolean;
+};
+
+type ActiveListRequest = {
+  column: VisibleColumn;
+
+  /**
+   * whether the request is "first outbound" type.
+   * These booleans are used for figuring out how the data should be fetched.
+   */
+  firstOutbound?: boolean;
+  /**
+   * whether the request is for an aggregate column.
+   * This is used for figuring out how the data should be fetched.
+   */
+  aggregate?: boolean;
+  entity?: boolean;
+  /**
+   * whether the request is an entityset.
+   * This is used for figuring out how the data should be fetched.
+   */
+  entityset?: boolean;
+
+  /**
+   * where this request is needed.
+   */
+  objects: Array<ActiveListRequestObject>;
+};
+
+type ActiveListRelatedEntityRequest = {
+  /**
+   * whether the request is for an inline related entity.
+   * the .index indicated which related entity it is
+   */
+  inline?: boolean;
+  /**
+   * whether the request is for a related entity.
+   * the .index indicated which related entity it is
+   */
+  related?: boolean;
+  index: number;
+};
+
 type ActiveList = {
   // TODO
   // requests: {
@@ -159,7 +224,7 @@ type ActiveList = {
   //   related?: boolean;
   //   citation?: boolean;
   // };
-  requests: any[];
+  requests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>;
   allOutBounds: Array<ForeignKeyPseudoColumn | PseudoColumn>;
   selfLinks: Array<KeyPseudoColumn>;
 };
@@ -239,7 +304,7 @@ export class Reference {
   private _related?: Array<RelatedReference>;
   private _facetColumns?: Array<FacetColumn>;
   private _facetColumnsStructure?: Array<number | FacetGroup>;
-  private _activeList?: any;
+  private _activeList?: ActiveList;
   private _citation?: Citation | null;
   private _googleDatasetMetadata?: GoogleDatasetMetadata | null;
 
@@ -849,7 +914,7 @@ export class Reference {
     if (this._activeList === undefined) {
       this.generateActiveList();
     }
-    return this._activeList;
+    return this._activeList!;
   }
 
   /**
@@ -880,7 +945,7 @@ export class Reference {
   generateActiveList(tuple?: Tuple): ActiveList {
     // VARIABLES:
     const allOutBounds: Array<PseudoColumn | ForeignKeyPseudoColumn> = [];
-    const requests: any[] = [];
+    const requests: Array<ActiveListRequest | ActiveListRelatedEntityRequest> = [];
     const selfLinks: Array<KeyPseudoColumn> = [];
     const consideredUniqueFiltered: { [key: string]: number } = {};
     const consideredSets: { [key: string]: number } = {};
@@ -897,10 +962,12 @@ export class Reference {
     // the waitfors will be used in chaise instead prior to submission.
     const isEntry = _isEntryContext(this._context);
 
-    const COLUMN_TYPE = 'column';
-    const RELATED_TYPE = 'related';
-    const CITATION_TYPE = 'citation';
-    const INLINE_TYPE = 'inline';
+    enum ActiveListRequestTypes {
+      COLUMN = 'column',
+      RELATED = 'related',
+      INLINE = 'inline',
+      CITATION = 'citation',
+    }
 
     // FUNCTIONS:
     const hasAggregate = (col: VisibleColumn) => {
@@ -911,8 +978,8 @@ export class Reference {
     // isWaitFor: whether it was part of waitFor or just visible
     // type: where in the page it belongs to
     // index: the container index (column index, or related index) (optional)
-    const addColToActiveList = (col: VisibleColumn, isWaitFor: boolean, type: string, index?: number) => {
-      const obj: any = { isWaitFor: isWaitFor };
+    const addColToActiveList = (col: VisibleColumn, isWaitFor: boolean, type: ActiveListRequestTypes, index?: number) => {
+      const obj: ActiveListRequestObject = { isWaitFor: isWaitFor };
 
       // add the type
       obj[type] = true;
@@ -924,7 +991,7 @@ export class Reference {
 
       if (isWaitFor && isEntry) {
         if (col.name in consideredEntryWaitFors) {
-          requests[consideredEntryWaitFors[col.name]].objects.push(obj);
+          (requests[consideredEntryWaitFors[col.name]] as ActiveListRequest).objects.push(obj);
           return;
         }
         consideredEntryWaitFors[col.name] = requests.length;
@@ -938,7 +1005,7 @@ export class Reference {
       if ((col as PseudoColumn).sourceObjectWrapper?.isUniqueFiltered) {
         // duplicate
         if (col.name in consideredUniqueFiltered) {
-          requests[consideredUniqueFiltered[col.name]].objects.push(obj);
+          (requests[consideredUniqueFiltered[col.name]] as ActiveListRequest).objects.push(obj);
           return;
         }
 
@@ -952,7 +1019,7 @@ export class Reference {
       if ((col as PseudoColumn).isPathColumn && (col as PseudoColumn).hasAggregate) {
         // duplicate
         if (col.name in consideredAggregates) {
-          requests[consideredAggregates[col.name]].objects.push(obj);
+          (requests[consideredAggregates[col.name]] as ActiveListRequest).objects.push(obj);
           return;
         }
 
@@ -969,7 +1036,7 @@ export class Reference {
         }
 
         if (col.name in consideredSets) {
-          requests[consideredSets[col.name]].objects.push(obj);
+          (requests[consideredSets[col.name]] as ActiveListRequest).objects.push(obj);
           return;
         }
 
@@ -996,11 +1063,11 @@ export class Reference {
       if (isRelatedColumn(col)) {
         requests.push({ inline: true, index: i });
       } else {
-        addColToActiveList(col, false, COLUMN_TYPE, i);
+        addColToActiveList(col, false, ActiveListRequestTypes.COLUMN, i);
       }
 
       col.waitFor.forEach((wf: any) => {
-        addColToActiveList(wf, true, isRelatedColumn(col) ? INLINE_TYPE : COLUMN_TYPE, i);
+        addColToActiveList(wf, true, isRelatedColumn(col) ? ActiveListRequestTypes.INLINE : ActiveListRequestTypes.COLUMN, i);
       });
     };
 
@@ -1010,7 +1077,7 @@ export class Reference {
     // citation
     if (isDetailed && this.citation) {
       this.citation.waitFor.forEach((col) => {
-        addColToActiveList(col, true, CITATION_TYPE);
+        addColToActiveList(col, true, ActiveListRequestTypes.CITATION);
       });
     }
 
@@ -1035,7 +1102,7 @@ export class Reference {
 
         if (rel.pseudoColumn) {
           rel.pseudoColumn.waitFor.forEach((wf) => {
-            addColToActiveList(wf, true, RELATED_TYPE, i);
+            addColToActiveList(wf, true, ActiveListRequestTypes.RELATED, i);
           });
         }
       });

--- a/src/models/reference/reference.ts
+++ b/src/models/reference/reference.ts
@@ -81,6 +81,9 @@ import { _compressFacetObject, _sourceColumnHelpers } from '@isrd-isi-edu/ermres
 
 import type { CommentType } from '@isrd-isi-edu/ermrestjs/src/models/comment';
 import type { DisplayName } from '@isrd-isi-edu/ermrestjs/src/models/display-name';
+import ActiveListCondition from '@isrd-isi-edu/ermrestjs/src/models/active-list-condition';
+import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
+import SourceObjectWrapper from '@isrd-isi-edu/ermrestjs/src/models/source-object-wrapper';
 import { _exportHelpers, _getDefaultExportTemplate, _referenceExportOutput, validateExportTemplate } from '@isrd-isi-edu/ermrestjs/js/export';
 
 /**
@@ -213,18 +216,16 @@ type ActiveListRelatedEntityRequest = {
   index: number;
 };
 
+type ActiveListConditionalGroup = {
+  /** The condition object (class with evaluateCondition method) */
+  condition: ActiveListCondition;
+  /** Requests gated behind this condition (main content + its wait-fors) */
+  dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>;
+};
+
 type ActiveList = {
-  // TODO
-  // requests: {
-  //   column: ReferenceColumn;
-  //   objects: Array<{ index: number; column?: boolean; related?: boolean; inline?: boolean; citation?: boolean }>;
-  //   type: 'column' | 'related' | 'inline' | 'citation';
-  //   // TODO backwards compatibility:
-  //   inline?: boolean;
-  //   related?: boolean;
-  //   citation?: boolean;
-  // };
   requests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>;
+  conditionalGroups: ActiveListConditionalGroup[];
   allOutBounds: Array<ForeignKeyPseudoColumn | PseudoColumn>;
   selfLinks: Array<KeyPseudoColumn>;
 };
@@ -947,6 +948,7 @@ export class Reference {
     const allOutBounds: Array<PseudoColumn | ForeignKeyPseudoColumn> = [];
     const requests: Array<ActiveListRequest | ActiveListRelatedEntityRequest> = [];
     const selfLinks: Array<KeyPseudoColumn> = [];
+    const conditionalGroups: ActiveListConditionalGroup[] = [];
     const consideredUniqueFiltered: { [key: string]: number } = {};
     const consideredSets: { [key: string]: number } = {};
     const consideredOutbounds: { [key: string]: boolean } = {};
@@ -1059,6 +1061,92 @@ export class Reference {
       }
     };
 
+    /**
+     * Same as addColToActiveList, but adds to a dependent requests array
+     * instead of the main requests array. Used for conditional groups.
+     */
+    const addColToDependentList = (
+      dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>,
+      col: VisibleColumn,
+      isWaitFor: boolean,
+      type: ActiveListRequestTypes,
+      index?: number,
+    ) => {
+      const obj: ActiveListRequestObject = { isWaitFor: isWaitFor };
+      obj[type] = true;
+      if (Number.isInteger(index)) {
+        obj.index = index;
+      }
+
+      // aggregates
+      if ((col as PseudoColumn).isPathColumn && (col as PseudoColumn).hasAggregate) {
+        // check if already in dependentRequests
+        const existing = dependentRequests.find((r) => (r as ActiveListRequest).column?.name === col.name && (r as ActiveListRequest).aggregate) as
+          | ActiveListRequest
+          | undefined;
+        if (existing) {
+          existing.objects.push(obj);
+          return;
+        }
+        dependentRequests.push({ aggregate: true, column: col, objects: [obj] });
+        return;
+      }
+
+      // entitysets
+      if (isRelatedColumn(col)) {
+        const existing = dependentRequests.find((r) => (r as ActiveListRequest).column?.name === col.name && (r as ActiveListRequest).entityset) as
+          | ActiveListRequest
+          | undefined;
+        if (existing) {
+          existing.objects.push(obj);
+          return;
+        }
+        dependentRequests.push({ entityset: true, column: col, objects: [obj] });
+        return;
+      }
+
+      // all outbounds — still add to main allOutBounds
+      if (isAllOutboundColumn(col)) {
+        if (!(col.name in consideredOutbounds)) {
+          consideredOutbounds[col.name] = true;
+          allOutBounds.push(col as PseudoColumn | ForeignKeyPseudoColumn);
+        }
+      }
+
+      // self-links — still add to main selfLinks
+      if ((col as KeyPseudoColumn).isKey) {
+        if (!(col.name in consideredSelfLinks)) {
+          consideredSelfLinks[col.name] = true;
+          selfLinks.push(col as KeyPseudoColumn);
+        }
+      }
+    };
+
+    /**
+     * Create a PseudoColumn for a condition source definition.
+     */
+    const createConditionColumn = (condDef: ConditionDefinition): VisibleColumn | undefined => {
+      try {
+        let condSourceWrapper: SourceObjectWrapper;
+        if (condDef.sourcekey) {
+          const sd = sds.getSource(condDef.sourcekey, tuple);
+          if (!sd) {
+            $log.info('condition sourcekey `' + condDef.sourcekey + '` could not be resolved.');
+            return undefined;
+          }
+          condSourceWrapper = sd.clone({}, this.table, false, tuple);
+        } else if (condDef.source) {
+          condSourceWrapper = new SourceObjectWrapper({ source: condDef.source }, this.table, false, undefined, tuple);
+        } else {
+          return undefined;
+        }
+        return createPseudoColumn(this, condSourceWrapper, tuple);
+      } catch (e: unknown) {
+        $log.info('failed to create condition column: ' + (e instanceof Error ? e.message : String(e)));
+        return undefined;
+      }
+    };
+
     const addInlineColumn = (col: VisibleColumn, i: number) => {
       if (isRelatedColumn(col)) {
         requests.push({ inline: true, index: i });
@@ -1069,6 +1157,66 @@ export class Reference {
       col.waitFor.forEach((wf: any) => {
         addColToActiveList(wf, true, isRelatedColumn(col) ? ActiveListRequestTypes.INLINE : ActiveListRequestTypes.COLUMN, i);
       });
+    };
+
+    /**
+     * Same as addInlineColumn but adds to dependent requests in a conditional group
+     */
+    const addInlineColumnToDependent = (
+      dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>,
+      col: VisibleColumn,
+      i: number,
+    ) => {
+      if (isRelatedColumn(col)) {
+        dependentRequests.push({ inline: true, index: i });
+      } else {
+        addColToDependentList(dependentRequests, col, false, ActiveListRequestTypes.COLUMN, i);
+      }
+
+      col.waitFor.forEach((wf: any) => {
+        addColToDependentList(dependentRequests, wf, true, isRelatedColumn(col) ? ActiveListRequestTypes.INLINE : ActiveListRequestTypes.COLUMN, i);
+      });
+    };
+
+    /**
+     * Process a column or related entity that has a condition.
+     * Returns true if the item was handled (either added to a conditional group or skipped).
+     * Returns false if it should be processed normally (condition evaluated synchronously to show).
+     */
+    const processConditionedItem = (
+      condDef: ConditionDefinition,
+      addToDependent: (dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => void,
+    ): boolean => {
+      const condCol = createConditionColumn(condDef);
+      if (!condCol) return false; // invalid condition, process normally
+
+      // if condition source is all-outbound (no secondary request needed), evaluate synchronously
+      if (isAllOutboundColumn(condCol)) {
+        if (tuple) {
+          const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern);
+          const result = condition.evaluateCondition({}, null, tuple);
+          return !result.shouldShow; // return true if we should skip (hide)
+        }
+        return false; // no tuple, can't evaluate — process normally
+      }
+
+      // condition source needs a secondary request
+      const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern);
+
+      // add condition source to main requests (deduplication via consideredSets/consideredAggregates)
+      addColToActiveList(condCol, true, ActiveListRequestTypes.COLUMN);
+
+      // create dependent requests
+      const dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest> = [];
+      addToDependent(dependentRequests);
+
+      // create the conditional group
+      conditionalGroups.push({
+        condition,
+        dependentRequests,
+      });
+
+      return true; // handled
     };
 
     // THE CODE STARTS HERE:
@@ -1083,21 +1231,57 @@ export class Reference {
 
     // columns without aggregate
     columns.forEach((col, i: number) => {
-      if (!hasAggregate(col)) {
-        addInlineColumn(col, i);
+      if (hasAggregate(col)) return;
+
+      // check for condition (only in detailed context)
+      if (isDetailed) {
+        const rc = (col as ReferenceColumn).resolvedCondition;
+        if (rc) {
+          const handled = processConditionedItem(rc.conditionDef, (depReqs) => {
+            addInlineColumnToDependent(depReqs, col, i);
+          });
+          if (handled) return;
+        }
       }
+
+      addInlineColumn(col, i);
     });
 
     // columns with aggregate
     columns.forEach((col, i: number) => {
-      if (hasAggregate(col)) {
-        addInlineColumn(col, i);
+      if (!hasAggregate(col)) return;
+
+      // check for condition (only in detailed context)
+      if (isDetailed) {
+        const rc = (col as ReferenceColumn).resolvedCondition;
+        if (rc) {
+          const handled = processConditionedItem(rc.conditionDef, (depReqs) => {
+            addInlineColumnToDependent(depReqs, col, i);
+          });
+          if (handled) return;
+        }
       }
+
+      addInlineColumn(col, i);
     });
 
     // related tables
     if (isDetailed) {
       this.generateRelatedList(tuple).forEach((rel, i) => {
+        // check for condition on related entity
+        const rc = rel.pseudoColumn?.resolvedCondition;
+        if (rc) {
+          const handled = processConditionedItem(rc.conditionDef, (depReqs) => {
+            depReqs.push({ related: true, index: i });
+            if (rel.pseudoColumn) {
+              rel.pseudoColumn.waitFor.forEach((wf: any) => {
+                addColToDependentList(depReqs, wf, true, ActiveListRequestTypes.RELATED, i);
+              });
+            }
+          });
+          if (handled) return;
+        }
+
         requests.push({ related: true, index: i });
 
         if (rel.pseudoColumn) {
@@ -1117,6 +1301,7 @@ export class Reference {
 
     this._activeList = {
       requests: requests,
+      conditionalGroups: conditionalGroups,
       allOutBounds: allOutBounds,
       selfLinks: selfLinks,
     };

--- a/src/models/reference/reference.ts
+++ b/src/models/reference/reference.ts
@@ -1193,7 +1193,7 @@ export class Reference {
       // if condition source is all-outbound (no secondary request needed), evaluate synchronously
       if (isAllOutboundColumn(condCol)) {
         if (tuple) {
-          const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern);
+          const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern, condDef.template_engine);
           const result = condition.evaluateCondition({}, null, tuple);
           return !result.shouldShow; // return true if we should skip (hide)
         }
@@ -1201,7 +1201,7 @@ export class Reference {
       }
 
       // condition source needs a secondary request
-      const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern);
+      const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern, condDef.template_engine);
 
       // add condition source to main requests (deduplication via consideredSets/consideredAggregates)
       addColToActiveList(condCol, true, ActiveListRequestTypes.COLUMN);

--- a/src/models/source-object-wrapper.ts
+++ b/src/models/source-object-wrapper.ts
@@ -386,6 +386,7 @@ export default class SourceObjectWrapper {
           source: condObj.source || undefined,
           on_empty: condObj.on_empty === 'show' ? 'show' : 'hide',
           condition_pattern: isStringAndNotEmpty(condObj.condition_pattern as string) ? (condObj.condition_pattern as string) : undefined,
+          template_engine: isStringAndNotEmpty(condObj.template_engine as string) ? (condObj.template_engine as string) : undefined,
         };
       } else {
         $log.info('condition on column `' + this.name + '` is missing `source` or `sourcekey`.');

--- a/src/models/source-object-wrapper.ts
+++ b/src/models/source-object-wrapper.ts
@@ -77,7 +77,7 @@ export type InputIframePropsType = {
  */
 export default class SourceObjectWrapper {
   /**
-   * the source object
+   * the raw source object (column-directive object)
    */
   public sourceObject: Record<string, unknown>;
   /**

--- a/src/models/source-object-wrapper.ts
+++ b/src/models/source-object-wrapper.ts
@@ -5,6 +5,7 @@ import type SourceObjectNode from '@isrd-isi-edu/ermrestjs/src/models/source-obj
 import type { ReferenceColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
 import type { Tuple, Reference } from '@isrd-isi-edu/ermrestjs/src/models/reference';
 import type { DisplayName } from '@isrd-isi-edu/ermrestjs/src/models/display-name';
+import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
 
 // services
 import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
@@ -144,6 +145,12 @@ export default class SourceObjectWrapper {
   public sourceObjectNodes: SourceObjectNode[] = [];
   public isInputIframe = false;
   public inputIframeProps?: InputIframePropsType;
+
+  /**
+   * the condition definition that controls visibility of this column/related entity.
+   * Only used in detailed context.
+   */
+  public condition?: ConditionDefinition;
 
   /**
    * used for facets
@@ -368,6 +375,27 @@ export default class SourceObjectWrapper {
     }
 
     this.sourceObjectNodes = sourceObjectNodes;
+
+    // parse condition / condition_key
+    if (isObjectAndNotNull(sourceObject.condition)) {
+      const condObj = sourceObject.condition as Record<string, unknown>;
+      // inline condition must have source or sourcekey
+      if (condObj.source || isStringAndNotEmpty(condObj.sourcekey as string)) {
+        this.condition = {
+          sourcekey: isStringAndNotEmpty(condObj.sourcekey as string) ? (condObj.sourcekey as string) : undefined,
+          source: condObj.source || undefined,
+          on_empty: condObj.on_empty === 'show' ? 'show' : 'hide',
+          condition_pattern: isStringAndNotEmpty(condObj.condition_pattern as string) ? (condObj.condition_pattern as string) : undefined,
+        };
+      } else {
+        $log.info('condition on column `' + this.name + '` is missing `source` or `sourcekey`.');
+      }
+    } else if (isStringAndNotEmpty(sourceObject.condition_key as string)) {
+      // condition_key references a reusable condition from source-definitions
+      // resolution happens later when table.sourceDefinitions is available
+      // store it as a marker; generateActiveList will resolve it
+      (this as any)._conditionKey = sourceObject.condition_key;
+    }
 
     return true;
   }

--- a/src/models/source-object-wrapper.ts
+++ b/src/models/source-object-wrapper.ts
@@ -5,7 +5,6 @@ import type SourceObjectNode from '@isrd-isi-edu/ermrestjs/src/models/source-obj
 import type { ReferenceColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
 import type { Tuple, Reference } from '@isrd-isi-edu/ermrestjs/src/models/reference';
 import type { DisplayName } from '@isrd-isi-edu/ermrestjs/src/models/display-name';
-import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
 
 // services
 import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
@@ -145,12 +144,6 @@ export default class SourceObjectWrapper {
   public sourceObjectNodes: SourceObjectNode[] = [];
   public isInputIframe = false;
   public inputIframeProps?: InputIframePropsType;
-
-  /**
-   * the condition definition that controls visibility of this column/related entity.
-   * Only used in detailed context.
-   */
-  public condition?: ConditionDefinition;
 
   /**
    * used for facets
@@ -375,28 +368,6 @@ export default class SourceObjectWrapper {
     }
 
     this.sourceObjectNodes = sourceObjectNodes;
-
-    // parse condition / condition_key
-    if (isObjectAndNotNull(sourceObject.condition)) {
-      const condObj = sourceObject.condition as Record<string, unknown>;
-      // inline condition must have source or sourcekey
-      if (condObj.source || isStringAndNotEmpty(condObj.sourcekey as string)) {
-        this.condition = {
-          sourcekey: isStringAndNotEmpty(condObj.sourcekey as string) ? (condObj.sourcekey as string) : undefined,
-          source: condObj.source || undefined,
-          on_empty: condObj.on_empty === 'show' ? 'show' : 'hide',
-          condition_pattern: isStringAndNotEmpty(condObj.condition_pattern as string) ? (condObj.condition_pattern as string) : undefined,
-          template_engine: isStringAndNotEmpty(condObj.template_engine as string) ? (condObj.template_engine as string) : undefined,
-        };
-      } else {
-        $log.info('condition on column `' + this.name + '` is missing `source` or `sourcekey`.');
-      }
-    } else if (isStringAndNotEmpty(sourceObject.condition_key as string)) {
-      // condition_key references a reusable condition from source-definitions
-      // resolution happens later when table.sourceDefinitions is available
-      // store it as a marker; generateActiveList will resolve it
-      (this as any)._conditionKey = sourceObject.condition_key;
-    }
 
     return true;
   }

--- a/src/models/table-source-definitions.ts
+++ b/src/models/table-source-definitions.ts
@@ -19,7 +19,7 @@ export type ConditionDefinition = {
   /** inline source path (alternative to sourcekey) */
   source?: unknown;
   /** behavior when condition source returns empty: "hide" (default) or "show" */
-  on_empty?: 'show' | 'hide';
+  on_empty: 'show' | 'hide';
   /** optional template evaluated with $self, no markdown rendering */
   condition_pattern?: string;
   /** template engine for condition_pattern: "mustache" (default) or "handlebars" */

--- a/src/models/table-source-definitions.ts
+++ b/src/models/table-source-definitions.ts
@@ -24,6 +24,8 @@ export type ConditionDefinition = {
   condition_pattern?: string;
   /** template engine for condition_pattern: "mustache" (default) or "handlebars" */
   template_engine?: string;
+  /** optional list of sourcekeys whose data should be available when evaluating condition_pattern */
+  wait_for?: string[];
 };
 
 /**

--- a/src/models/table-source-definitions.ts
+++ b/src/models/table-source-definitions.ts
@@ -13,20 +13,21 @@ import { Column, ForeignKeyRef, Table } from '@isrd-isi-edu/ermrestjs/js/core';
  * Used in source-definitions annotation under the `conditions` key, or inline
  * on a column-directive via `condition` / `condition_key`.
  */
-export type ConditionDefinition = {
-  /** reference to an existing sourcekey whose data determines the condition */
-  sourcekey?: string;
-  /** inline source path (alternative to sourcekey) */
-  source?: unknown;
-  /** behavior when condition source returns empty: "hide" (default) or "show" */
-  on_empty: 'show' | 'hide';
-  /** optional template evaluated with $self, no markdown rendering */
-  condition_pattern?: string;
-  /** template engine for condition_pattern: "mustache" (default) or "handlebars" */
-  template_engine?: string;
-  /** optional list of sourcekeys whose data should be available when evaluating condition_pattern */
-  wait_for?: string[];
-};
+// export type ConditionDefinition = {
+//   /** reference to an existing sourcekey whose data determines the condition */
+//   sourcekey?: string;
+//   /** inline source path (alternative to sourcekey) */
+//   source?: unknown;
+//   /** behavior when condition source returns empty: "hide" (default) or "show" */
+//   on_empty: 'show' | 'hide';
+//   /** optional template evaluated with $self, no markdown rendering */
+//   condition_pattern?: string;
+//   /** template engine for condition_pattern: "mustache" (default) or "handlebars" */
+//   template_engine?: string;
+//   /** optional list of sourcekeys whose data should be available when evaluating condition_pattern */
+//   wait_for?: string[];
+// };
+export type ConditionDefinition = Record<string, unknown>;
 
 /**
  * Result of Table.sourceDefinitions

--- a/src/models/table-source-definitions.ts
+++ b/src/models/table-source-definitions.ts
@@ -9,6 +9,22 @@ import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
 import { Column, ForeignKeyRef, Table } from '@isrd-isi-edu/ermrestjs/js/core';
 
 /**
+ * Defines a condition that controls visibility of a column or related entity.
+ * Used in source-definitions annotation under the `conditions` key, or inline
+ * on a column-directive via `condition` / `condition_key`.
+ */
+export type ConditionDefinition = {
+  /** reference to an existing sourcekey whose data determines the condition */
+  sourcekey?: string;
+  /** inline source path (alternative to sourcekey) */
+  source?: unknown;
+  /** behavior when condition source returns empty: "hide" (default) or "show" */
+  on_empty?: 'show' | 'hide';
+  /** optional Mustache template — evaluated with $self, no markdown rendering */
+  condition_pattern?: string;
+};
+
+/**
  * Result of Table.sourceDefinitions
  */
 class TableSourceDefinitions {
@@ -39,6 +55,10 @@ class TableSourceDefinitions {
    * this has been added because of path prefix where a sourcekey might rely on other sourcekeys
    */
   sourceDependencies: Record<string, string[]> = {};
+  /**
+   * reusable condition definitions defined in the source-definitions annotation
+   */
+  private conditions: Record<string, ConditionDefinition> = {};
 
   constructor(
     table: Table,
@@ -47,6 +67,7 @@ class TableSourceDefinitions {
     sources: Record<string, SourceObjectWrapper>,
     sourceMapping: Record<string, string[]>,
     sourceDependencies: Record<string, string[]>,
+    conditions: Record<string, ConditionDefinition> = {},
   ) {
     this.table = table;
     this.columns = columns;
@@ -54,6 +75,16 @@ class TableSourceDefinitions {
     this.sources = sources;
     this.sourceMapping = sourceMapping;
     this.sourceDependencies = sourceDependencies;
+    this.conditions = conditions;
+  }
+
+  /**
+   * Get a condition definition by its key.
+   * @param key The key of the condition definition.
+   * @returns The condition definition or undefined if not found.
+   */
+  getCondition(key: string): ConditionDefinition | undefined {
+    return this.conditions[key];
   }
 
   /**

--- a/src/models/table-source-definitions.ts
+++ b/src/models/table-source-definitions.ts
@@ -84,6 +84,7 @@ class TableSourceDefinitions {
 
   /**
    * Get a condition definition by its key.
+   * NOTE: the returned definition is not processed and might be invalid.
    * @param key The key of the condition definition.
    * @returns The condition definition or undefined if not found.
    */

--- a/src/models/table-source-definitions.ts
+++ b/src/models/table-source-definitions.ts
@@ -20,8 +20,10 @@ export type ConditionDefinition = {
   source?: unknown;
   /** behavior when condition source returns empty: "hide" (default) or "show" */
   on_empty?: 'show' | 'hide';
-  /** optional Mustache template — evaluated with $self, no markdown rendering */
+  /** optional template evaluated with $self, no markdown rendering */
   condition_pattern?: string;
+  /** template engine for condition_pattern: "mustache" (default) or "handlebars" */
+  template_engine?: string;
 };
 
 /**

--- a/src/services/active-list.ts
+++ b/src/services/active-list.ts
@@ -30,6 +30,8 @@ export type ActiveListRequestObject = {
   inline?: boolean;
   /** whether this is for the citation */
   citation?: boolean;
+  /** whether this is for a condition evaluation (index refers to the conditionalGroups index) */
+  condition?: boolean;
 
   isWaitFor: boolean;
 };
@@ -95,6 +97,7 @@ export enum ActiveListRequestTypes {
   RELATED = 'related',
   INLINE = 'inline',
   CITATION = 'citation',
+  CONDITION = 'condition',
 }
 
 // ============================================================================
@@ -359,21 +362,28 @@ export class ActiveListBuilder {
     const condCol = this.createConditionColumn(condDef);
     if (!condCol) return false; // invalid condition, process normally
 
-    // if condition source is all-outbound (no secondary request needed), evaluate synchronously
-    if (isAllOutboundColumn(condCol)) {
+    const condition = new ActiveListCondition(condDef, condCol, this.reference, this.tuple);
+
+    // if condition source is all-outbound (no secondary request needed)
+    // AND there are no async wait_fors, evaluate synchronously
+    if (isAllOutboundColumn(condCol) && !condition.hasWaitFor) {
       if (this.tuple) {
-        const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern, condDef.template_engine);
         const result = condition.evaluateCondition(this.tuple.templateVariables, null, this.tuple);
         return !result.shouldShow; // return true if we should skip (hide)
       }
-      return false; // no tuple, can't evaluate — process normally
+      return false; // no tuple, can't evaluate -- process normally
     }
 
-    // condition source needs a secondary request
-    const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern, condDef.template_engine);
+    // condition source needs a secondary request (or has async wait_fors)
+    const conditionIndex = this.conditionalGroups.length;
 
-    // add condition source to main requests (deduplication via consideredSets/consideredAggregates)
-    this.addCol(condCol, true, ActiveListRequestTypes.COLUMN);
+    // add condition source to main requests
+    this.addCol(condCol, true, ActiveListRequestTypes.CONDITION, conditionIndex);
+
+    // add condition wait_for columns to main requests
+    condition.waitFor.forEach((wf) => {
+      this.addCol(wf, true, ActiveListRequestTypes.CONDITION, conditionIndex);
+    });
 
     // create dependent requests
     const dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest> = [];

--- a/src/services/active-list.ts
+++ b/src/services/active-list.ts
@@ -368,6 +368,10 @@ export class ActiveListBuilder {
     // synchronous condition already evaluated in _resolveCondition
     if (resolvedCondition.conditionHide) return true;
 
+    // synchronous conditions (all-outbound source) without async wait_for
+    // don't need a conditional group — they'll be evaluated when main data arrives
+    if (!resolvedCondition.isAsync && !condition.hasWaitFor) return false;
+
     // condition source needs a secondary request (or has async wait_fors)
     const conditionIndex = this.conditionalGroups.length;
 

--- a/src/services/active-list.ts
+++ b/src/services/active-list.ts
@@ -5,6 +5,7 @@ import type { Reference, VisibleColumn } from '@isrd-isi-edu/ermrestjs/src/model
 import type { Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
 import type { PseudoColumn, ForeignKeyPseudoColumn, KeyPseudoColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
 import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
+import type { ResolvedCondition } from '@isrd-isi-edu/ermrestjs/src/models/reference-column/reference-column';
 
 // services
 import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
@@ -356,23 +357,16 @@ export class ActiveListBuilder {
    * Returns false if it should be processed normally (condition evaluated synchronously to show or no valid condition found).
    */
   processConditionedItem(
-    condDef: ConditionDefinition,
+    resolvedCondition: ResolvedCondition,
     addToDependent: (dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => void,
   ): boolean {
-    const condCol = this.createConditionColumn(condDef);
+    const condCol = this.createConditionColumn(resolvedCondition.conditionDef);
     if (!condCol) return false; // invalid condition, process normally
 
-    const condition = new ActiveListCondition(condDef, condCol, this.reference, this.tuple);
+    const condition = new ActiveListCondition(resolvedCondition.conditionDef, condCol, this.reference, this.tuple);
 
-    // if condition source is all-outbound (no secondary request needed)
-    // AND there are no async wait_fors, evaluate synchronously
-    if (isAllOutboundColumn(condCol) && !condition.hasWaitFor) {
-      if (this.tuple) {
-        const result = condition.evaluateCondition(this.tuple.templateVariables, null, this.tuple);
-        return !result.shouldShow; // return true if we should skip (hide)
-      }
-      return false; // no tuple, can't evaluate -- process normally
-    }
+    // synchronous condition already evaluated in _resolveCondition
+    if (resolvedCondition.conditionHide) return true;
 
     // condition source needs a secondary request (or has async wait_fors)
     const conditionIndex = this.conditionalGroups.length;
@@ -399,7 +393,7 @@ export class ActiveListBuilder {
   }
 
   /** Add a fkey from sourceDefinitions to allOutBounds (with dedup). */
-  addFkey(fkCol: ForeignKeyPseudoColumn): void {
+  addAllOutBound(fkCol: ForeignKeyPseudoColumn): void {
     if (fkCol.name in this.consideredOutbounds) return;
     this.consideredOutbounds[fkCol.name] = true;
     this.allOutBounds.push(fkCol);

--- a/src/services/active-list.ts
+++ b/src/services/active-list.ts
@@ -273,6 +273,17 @@ export class ActiveListBuilder {
       obj.index = index;
     }
 
+    // unique filtered (mirrors addCol branch; dedup is scoped to dependentRequests)
+    if ((col as PseudoColumn).sourceObjectWrapper?.isUniqueFiltered) {
+      const existing = dependentRequests.find((r) => (r as ActiveListRequest).column?.name === col.name);
+      if (existing) {
+        (existing as ActiveListRequest).objects.push(obj);
+        return;
+      }
+      dependentRequests.push({ entity: true, column: col, objects: [obj] });
+      return;
+    }
+
     // aggregates
     if ((col as PseudoColumn).isPathColumn && (col as PseudoColumn).hasAggregate) {
       // check if already in dependentRequests

--- a/src/services/active-list.ts
+++ b/src/services/active-list.ts
@@ -70,9 +70,30 @@ export type ActiveListRelatedEntityRequest = {
   index: number;
 };
 
+/**
+ * Identifies a single conditioned item: the column/inline-related column/related-entity
+ * whose visibility is gated by the group's condition. Multiple items share a group when
+ * they reference the same `condition_key`.
+ */
+export type ActiveListConditionedItem = {
+  column?: boolean;
+  inline?: boolean;
+  related?: boolean;
+  index: number;
+};
+
 export type ActiveListConditionalGroup = {
   /** The condition object (class with evaluateCondition method) */
   condition: ActiveListCondition;
+  /**
+   * The column / inline / related entries gated by this condition. Used by chaise to
+   * mark the user's columns/related-models as conditioned (and to flip their hide flag
+   * when the condition resolves).
+   * Distinct from `dependentRequests`: `conditionedItems` covers EVERY conditioned
+   * item — including sync scalar columns whose `dependentRequests` entry is a no-op —
+   * while `dependentRequests` is just the secondary fetches gated behind the condition.
+   */
+  conditionedItems: ActiveListConditionedItem[];
   /** Requests gated behind this condition (main content + its wait-fors) */
   dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>;
 };
@@ -325,54 +346,58 @@ export class ActiveListBuilder {
   }
 
   /**
-   * Process a column or related entity that has a condition.
-   * Returns true if the item was handled (either added to a conditional group or skipped).
-   * Returns false if it should be processed normally (condition evaluated synchronously to show or no valid condition found).
+   * Add a column / related entity that has a condition into a conditional group.
+   * Always handles the item via the group flow (regardless of whether the
+   * condition source is sync or async). The caller does NOT add the user's
+   * column directly — its identity goes into the group's `conditionedItems` so
+   * chaise knows to gate its visibility, and any secondary fetches go into
+   * `dependentRequests`.
+   *
+   * For sync sources, `addCol` is a no-op on `requests` (sync sources are
+   * not entityset/aggregate by construction), so the source isn't fetched —
+   * but its all-outbound joins / self-link keys still get registered into
+   * `allOutBounds` / `selfLinks`. Chaise evaluates the condition immediately
+   * after the main entity is read.
+   *
+   * For async sources, `addCol` pushes the source (and any async wait-fors)
+   * into `requests`, tagged with `condition: true` so chaise can dispatch
+   * `evaluateCondition` once the data lands.
    */
   processConditionedItem(
     condition: ActiveListCondition,
+    conditionedItem: ActiveListConditionedItem,
     addToDependent: (dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => void,
-  ): boolean {
-    // synchronous condition already evaluated to hide
-    if (condition.conditionHide) return true;
-
-    // synchronous conditions (all-outbound source) without async wait_for
-    // don't need a conditional group — they'll be evaluated when main data arrives
-    // or already handled using the conditionHide above
-    if (!condition.isAsync && !condition.hasWaitFor) return false;
-
-    // if the condition was already evaluated as part of another column/entity's condition group,
-    // we can reuse that group instead of creating a new one
-    if (condition.conditonKey) {
-      const existingGroup = this.conditionalGroups.find((g) => g.condition.conditonKey === condition.conditonKey);
+  ): void {
+    // dedup: if this condition was already grouped (via condition_key), reuse
+    // that group's dependent list and add this item to its conditionedItems list.
+    if (condition.conditionKey) {
+      const existingGroup = this.conditionalGroups.find((g) => g.condition.conditionKey === condition.conditionKey);
       if (existingGroup) {
         addToDependent(existingGroup.dependentRequests);
-        return true;
+        existingGroup.conditionedItems.push(conditionedItem);
+        return;
       }
     }
 
-    // condition source needs a secondary request (or has async wait_fors)
     const conditionIndex = this.conditionalGroups.length;
 
-    // add condition source to main requests
-    this.addCol(condition.column, true, ActiveListRequestTypes.CONDITION, conditionIndex);
-
-    // add condition wait_for columns to main requests
+    // register the condition's own column and its wait-fors. For async sources
+    // this populates `requests` (with `condition: true, index: conditionIndex`
+    // so chaise routes the completion to evaluateCondition); for sync sources
+    // it's a no-op on `requests` but still populates `allOutBounds` / `selfLinks`.
+    this.addCol(condition.column, false, ActiveListRequestTypes.CONDITION, conditionIndex);
     condition.waitFor.forEach((wf) => {
       this.addCol(wf, true, ActiveListRequestTypes.CONDITION, conditionIndex);
     });
 
-    // create dependent requests
+    // build the dependent list and stash the new group.
     const dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest> = [];
     addToDependent(dependentRequests);
-
-    // create the conditional group
     this.conditionalGroups.push({
       condition,
+      conditionedItems: [conditionedItem],
       dependentRequests,
     });
-
-    return true; // handled
   }
 
   /** Add a fkey from sourceDefinitions to allOutBounds (with dedup). */

--- a/src/services/active-list.ts
+++ b/src/services/active-list.ts
@@ -1,17 +1,13 @@
 // models
 import ActiveListCondition from '@isrd-isi-edu/ermrestjs/src/models/active-list-condition';
-import SourceObjectWrapper from '@isrd-isi-edu/ermrestjs/src/models/source-object-wrapper';
 import type { Reference, VisibleColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference/reference';
 import type { Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
 import type { PseudoColumn, ForeignKeyPseudoColumn, KeyPseudoColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
-import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
-import type { ResolvedCondition } from '@isrd-isi-edu/ermrestjs/src/models/reference-column/reference-column';
 
 // services
-import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
 
 // utils
-import { createPseudoColumn, isAllOutboundColumn, isRelatedColumn } from '@isrd-isi-edu/ermrestjs/src/utils/column-utils';
+import { isAllOutboundColumn, isRelatedColumn } from '@isrd-isi-edu/ermrestjs/src/utils/column-utils';
 
 // legacy
 import { _isEntryContext } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
@@ -168,6 +164,7 @@ export class ActiveListBuilder {
       obj.index = index;
     }
 
+    // entry wait_fors (asset wait_for)
     if (isWaitFor && this.isEntry) {
       if (col.name in this.consideredEntryWaitFors) {
         (this.requests[this.consideredEntryWaitFors[col.name]] as ActiveListRequest).objects.push(obj);
@@ -327,56 +324,38 @@ export class ActiveListBuilder {
     });
   }
 
-  /** Create a PseudoColumn for a condition source definition. */
-  private createConditionColumn(condDef: ConditionDefinition): VisibleColumn | undefined {
-    try {
-      const sds = this.reference.table.sourceDefinitions;
-      let condSourceWrapper: SourceObjectWrapper;
-      if (condDef.sourcekey) {
-        const sd = sds.getSource(condDef.sourcekey, this.tuple);
-        if (!sd) {
-          $log.info('condition sourcekey `' + condDef.sourcekey + '` could not be resolved.');
-          return undefined;
-        }
-        condSourceWrapper = sd.clone({}, this.reference.table, false, this.tuple);
-      } else if (condDef.source) {
-        condSourceWrapper = new SourceObjectWrapper({ source: condDef.source }, this.reference.table, false, undefined, this.tuple);
-      } else {
-        return undefined;
-      }
-      return createPseudoColumn(this.reference, condSourceWrapper, this.tuple);
-    } catch (e: unknown) {
-      $log.info('failed to create condition column: ' + (e instanceof Error ? e.message : String(e)));
-      return undefined;
-    }
-  }
-
   /**
    * Process a column or related entity that has a condition.
    * Returns true if the item was handled (either added to a conditional group or skipped).
    * Returns false if it should be processed normally (condition evaluated synchronously to show or no valid condition found).
    */
   processConditionedItem(
-    resolvedCondition: ResolvedCondition,
+    condition: ActiveListCondition,
     addToDependent: (dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => void,
   ): boolean {
-    const condCol = this.createConditionColumn(resolvedCondition.conditionDef);
-    if (!condCol) return false; // invalid condition, process normally
-
-    const condition = new ActiveListCondition(resolvedCondition.conditionDef, condCol, this.reference, this.tuple);
-
-    // synchronous condition already evaluated in _resolveCondition
-    if (resolvedCondition.conditionHide) return true;
+    // synchronous condition already evaluated to hide
+    if (condition.conditionHide) return true;
 
     // synchronous conditions (all-outbound source) without async wait_for
     // don't need a conditional group — they'll be evaluated when main data arrives
-    if (!resolvedCondition.isAsync && !condition.hasWaitFor) return false;
+    // or already handled using the conditionHide above
+    if (!condition.isAsync && !condition.hasWaitFor) return false;
+
+    // if the condition was already evaluated as part of another column/entity's condition group,
+    // we can reuse that group instead of creating a new one
+    if (condition.conditonKey) {
+      const existingGroup = this.conditionalGroups.find((g) => g.condition.conditonKey === condition.conditonKey);
+      if (existingGroup) {
+        addToDependent(existingGroup.dependentRequests);
+        return true;
+      }
+    }
 
     // condition source needs a secondary request (or has async wait_fors)
     const conditionIndex = this.conditionalGroups.length;
 
     // add condition source to main requests
-    this.addCol(condCol, true, ActiveListRequestTypes.CONDITION, conditionIndex);
+    this.addCol(condition.column, true, ActiveListRequestTypes.CONDITION, conditionIndex);
 
     // add condition wait_for columns to main requests
     condition.waitFor.forEach((wf) => {

--- a/src/services/active-list.ts
+++ b/src/services/active-list.ts
@@ -1,0 +1,409 @@
+// models
+import ActiveListCondition from '@isrd-isi-edu/ermrestjs/src/models/active-list-condition';
+import SourceObjectWrapper from '@isrd-isi-edu/ermrestjs/src/models/source-object-wrapper';
+import type { Reference, VisibleColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference/reference';
+import type { Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
+import type { PseudoColumn, ForeignKeyPseudoColumn, KeyPseudoColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
+import type { ConditionDefinition } from '@isrd-isi-edu/ermrestjs/src/models/table-source-definitions';
+
+// services
+import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
+
+// utils
+import { createPseudoColumn, isAllOutboundColumn, isRelatedColumn } from '@isrd-isi-edu/ermrestjs/src/utils/column-utils';
+
+// legacy
+import { _isEntryContext } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type ActiveListRequestObject = {
+  /** The index of the object in the column's values array */
+  index?: number;
+  /** whether this is for a visible column */
+  column?: boolean;
+  /** whether this is for a related entity */
+  related?: boolean;
+  /** whether this is for an inline related entity */
+  inline?: boolean;
+  /** whether this is for the citation */
+  citation?: boolean;
+
+  isWaitFor: boolean;
+};
+
+export type ActiveListRequest = {
+  column: VisibleColumn;
+
+  /**
+   * whether the request is "first outbound" type.
+   * These booleans are used for figuring out how the data should be fetched.
+   */
+  firstOutbound?: boolean;
+  /**
+   * whether the request is for an aggregate column.
+   */
+  aggregate?: boolean;
+  entity?: boolean;
+  /**
+   * whether the request is an entityset.
+   */
+  entityset?: boolean;
+
+  /** where this request is needed. */
+  objects: Array<ActiveListRequestObject>;
+};
+
+export type ActiveListRelatedEntityRequest = {
+  /**
+   * whether the request is for an inline related entity.
+   * the .index indicated which related entity it is
+   */
+  inline?: boolean;
+  /**
+   * whether the request is for a related entity.
+   * the .index indicated which related entity it is
+   */
+  related?: boolean;
+  /** the index of the related entity in the reference.related array */
+  index: number;
+};
+
+export type ActiveListConditionalGroup = {
+  /** The condition object (class with evaluateCondition method) */
+  condition: ActiveListCondition;
+  /** Requests gated behind this condition (main content + its wait-fors) */
+  dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>;
+};
+
+export type ActiveList = {
+  /**
+   * The list of requests that need to be made.
+   * Already ordered based on the priority needed for the page load (top to bottom).
+   */
+  requests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>;
+  /** The list of conditional groups that need to be evaluated. */
+  conditionalGroups: ActiveListConditionalGroup[];
+  allOutBounds: Array<PseudoColumn | ForeignKeyPseudoColumn>;
+  selfLinks: Array<KeyPseudoColumn>;
+};
+
+export enum ActiveListRequestTypes {
+  COLUMN = 'column',
+  RELATED = 'related',
+  INLINE = 'inline',
+  CITATION = 'citation',
+}
+
+// ============================================================================
+// BUILDER
+// ============================================================================
+
+/**
+ * Builds an ActiveList for a Reference. Encapsulates the dedup state and
+ * the various add* helpers that used to live as nested closures inside
+ * Reference.generateActiveList.
+ *
+ * Behavior is intended to be 1:1 with the previous nested implementation.
+ */
+export class ActiveListBuilder {
+  // result buckets (public so the driver in reference.ts can push directly
+  // for the related-entity case, matching the original code).
+  requests: Array<ActiveListRequest | ActiveListRelatedEntityRequest> = [];
+  allOutBounds: Array<PseudoColumn | ForeignKeyPseudoColumn> = [];
+  selfLinks: Array<KeyPseudoColumn> = [];
+  conditionalGroups: ActiveListConditionalGroup[] = [];
+
+  // dedup maps
+  private consideredUniqueFiltered: { [key: string]: number } = {};
+  private consideredSets: { [key: string]: number } = {};
+  private consideredOutbounds: { [key: string]: boolean } = {};
+  private consideredAggregates: { [key: string]: number } = {};
+  private consideredSelfLinks: { [key: string]: boolean } = {};
+  private consideredEntryWaitFors: { [key: string]: number } = {};
+
+  private isEntry: boolean;
+
+  constructor(
+    private reference: Reference,
+    /**
+     * The main request tuple.
+     */
+    private tuple: Tuple | undefined,
+    /**
+     * Whether the active list is being built for detailed context
+     */
+    private isDetailed: boolean,
+  ) {
+    this.isEntry = _isEntryContext(reference.context);
+  }
+
+  /**
+   * Whether the given column is aggregate (either hasWaitForAggregate or is a path column with aggregate)
+   */
+  hasAggregate(col: VisibleColumn): boolean {
+    return col.hasWaitForAggregate || ((col as PseudoColumn).isPathColumn && (col as PseudoColumn).hasAggregate);
+  }
+
+  /**
+   * col: the column that we need its data
+   * isWaitFor: whether it was part of waitFor or just visible
+   * type: where in the page it belongs to
+   * index: the container index (column index, or related index) (optional)
+   */
+  addCol(col: VisibleColumn, isWaitFor: boolean, type: ActiveListRequestTypes, index?: number): void {
+    const obj: ActiveListRequestObject = { isWaitFor: isWaitFor };
+
+    // add the type
+    obj[type] = true;
+
+    // add index if available (not available in citation)
+    if (Number.isInteger(index)) {
+      obj.index = index;
+    }
+
+    if (isWaitFor && this.isEntry) {
+      if (col.name in this.consideredEntryWaitFors) {
+        (this.requests[this.consideredEntryWaitFors[col.name]] as ActiveListRequest).objects.push(obj);
+        return;
+      }
+      this.consideredEntryWaitFors[col.name] = this.requests.length;
+      this.requests.push({ firstOutbound: true, column: col, objects: [obj] });
+      return;
+    }
+
+    // unique filtered
+    // TODO FILTER_IN_SOURCE chaise should use this type of column as well?
+    // TODO FILTER_IN_SOURCE should be added to documentation as well
+    if ((col as PseudoColumn).sourceObjectWrapper?.isUniqueFiltered) {
+      // duplicate
+      if (col.name in this.consideredUniqueFiltered) {
+        (this.requests[this.consideredUniqueFiltered[col.name]] as ActiveListRequest).objects.push(obj);
+        return;
+      }
+
+      // new
+      this.consideredUniqueFiltered[col.name] = this.requests.length;
+      this.requests.push({ entity: true, column: col, objects: [obj] });
+      return;
+    }
+
+    // aggregates
+    if ((col as PseudoColumn).isPathColumn && (col as PseudoColumn).hasAggregate) {
+      // duplicate
+      if (col.name in this.consideredAggregates) {
+        (this.requests[this.consideredAggregates[col.name]] as ActiveListRequest).objects.push(obj);
+        return;
+      }
+
+      // new
+      this.consideredAggregates[col.name] = this.requests.length;
+      this.requests.push({ aggregate: true, column: col, objects: [obj] });
+      return;
+    }
+
+    // entitysets
+    if (isRelatedColumn(col)) {
+      if (!this.isDetailed) {
+        return; // only acceptable in detailed
+      }
+
+      if (col.name in this.consideredSets) {
+        (this.requests[this.consideredSets[col.name]] as ActiveListRequest).objects.push(obj);
+        return;
+      }
+
+      this.consideredSets[col.name] = this.requests.length;
+      this.requests.push({ entityset: true, column: col, objects: [obj] });
+    }
+
+    // all outbounds
+    if (isAllOutboundColumn(col)) {
+      if (col.name in this.consideredOutbounds) return;
+      this.consideredOutbounds[col.name] = true;
+      this.allOutBounds.push(col as PseudoColumn | ForeignKeyPseudoColumn);
+    }
+
+    // self-links
+    if ((col as KeyPseudoColumn).isKey) {
+      if (col.name in this.consideredSelfLinks) return;
+      this.consideredSelfLinks[col.name] = true;
+      this.selfLinks.push(col as KeyPseudoColumn);
+    }
+  }
+
+  /**
+   * Same as addCol, but adds to a dependent requests array
+   * instead of the main requests array. Used for conditional groups.
+   */
+  addColToDependent(
+    dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>,
+    col: VisibleColumn,
+    isWaitFor: boolean,
+    type: ActiveListRequestTypes,
+    index?: number,
+  ): void {
+    const obj: ActiveListRequestObject = { isWaitFor: isWaitFor };
+    obj[type] = true;
+    if (Number.isInteger(index)) {
+      obj.index = index;
+    }
+
+    // aggregates
+    if ((col as PseudoColumn).isPathColumn && (col as PseudoColumn).hasAggregate) {
+      // check if already in dependentRequests
+      const existing = dependentRequests.find((r) => (r as ActiveListRequest).column?.name === col.name && (r as ActiveListRequest).aggregate) as
+        | ActiveListRequest
+        | undefined;
+      if (existing) {
+        existing.objects.push(obj);
+        return;
+      }
+      dependentRequests.push({ aggregate: true, column: col, objects: [obj] });
+      return;
+    }
+
+    // entitysets
+    if (isRelatedColumn(col)) {
+      const existing = dependentRequests.find((r) => (r as ActiveListRequest).column?.name === col.name && (r as ActiveListRequest).entityset) as
+        | ActiveListRequest
+        | undefined;
+      if (existing) {
+        existing.objects.push(obj);
+        return;
+      }
+      dependentRequests.push({ entityset: true, column: col, objects: [obj] });
+      return;
+    }
+
+    // all outbounds — still add to main allOutBounds
+    if (isAllOutboundColumn(col)) {
+      if (!(col.name in this.consideredOutbounds)) {
+        this.consideredOutbounds[col.name] = true;
+        this.allOutBounds.push(col as PseudoColumn | ForeignKeyPseudoColumn);
+      }
+    }
+
+    // self-links — still add to main selfLinks
+    if ((col as KeyPseudoColumn).isKey) {
+      if (!(col.name in this.consideredSelfLinks)) {
+        this.consideredSelfLinks[col.name] = true;
+        this.selfLinks.push(col as KeyPseudoColumn);
+      }
+    }
+  }
+
+  /**
+   * Add a visible column and its waitFors to the active list as inline requests (with deduplication).
+   */
+  addInline(col: VisibleColumn, i: number): void {
+    if (isRelatedColumn(col)) {
+      this.requests.push({ inline: true, index: i });
+    } else {
+      this.addCol(col, false, ActiveListRequestTypes.COLUMN, i);
+    }
+
+    col.waitFor.forEach((wf) => {
+      this.addCol(wf, true, isRelatedColumn(col) ? ActiveListRequestTypes.INLINE : ActiveListRequestTypes.COLUMN, i);
+    });
+  }
+
+  /** Same as addInline but adds to dependent requests in a conditional group */
+  addInlineToDependent(dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>, col: VisibleColumn, i: number): void {
+    if (isRelatedColumn(col)) {
+      dependentRequests.push({ inline: true, index: i });
+    } else {
+      this.addColToDependent(dependentRequests, col, false, ActiveListRequestTypes.COLUMN, i);
+    }
+
+    col.waitFor.forEach((wf) => {
+      this.addColToDependent(dependentRequests, wf, true, isRelatedColumn(col) ? ActiveListRequestTypes.INLINE : ActiveListRequestTypes.COLUMN, i);
+    });
+  }
+
+  /** Create a PseudoColumn for a condition source definition. */
+  private createConditionColumn(condDef: ConditionDefinition): VisibleColumn | undefined {
+    try {
+      const sds = this.reference.table.sourceDefinitions;
+      let condSourceWrapper: SourceObjectWrapper;
+      if (condDef.sourcekey) {
+        const sd = sds.getSource(condDef.sourcekey, this.tuple);
+        if (!sd) {
+          $log.info('condition sourcekey `' + condDef.sourcekey + '` could not be resolved.');
+          return undefined;
+        }
+        condSourceWrapper = sd.clone({}, this.reference.table, false, this.tuple);
+      } else if (condDef.source) {
+        condSourceWrapper = new SourceObjectWrapper({ source: condDef.source }, this.reference.table, false, undefined, this.tuple);
+      } else {
+        return undefined;
+      }
+      return createPseudoColumn(this.reference, condSourceWrapper, this.tuple);
+    } catch (e: unknown) {
+      $log.info('failed to create condition column: ' + (e instanceof Error ? e.message : String(e)));
+      return undefined;
+    }
+  }
+
+  /**
+   * Process a column or related entity that has a condition.
+   * Returns true if the item was handled (either added to a conditional group or skipped).
+   * Returns false if it should be processed normally (condition evaluated synchronously to show or no valid condition found).
+   */
+  processConditionedItem(
+    condDef: ConditionDefinition,
+    addToDependent: (dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => void,
+  ): boolean {
+    const condCol = this.createConditionColumn(condDef);
+    if (!condCol) return false; // invalid condition, process normally
+
+    // if condition source is all-outbound (no secondary request needed), evaluate synchronously
+    if (isAllOutboundColumn(condCol)) {
+      if (this.tuple) {
+        const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern, condDef.template_engine);
+        const result = condition.evaluateCondition(this.tuple.templateVariables, null, this.tuple);
+        return !result.shouldShow; // return true if we should skip (hide)
+      }
+      return false; // no tuple, can't evaluate — process normally
+    }
+
+    // condition source needs a secondary request
+    const condition = new ActiveListCondition(condCol, condDef.on_empty || 'hide', condDef.condition_pattern, condDef.template_engine);
+
+    // add condition source to main requests (deduplication via consideredSets/consideredAggregates)
+    this.addCol(condCol, true, ActiveListRequestTypes.COLUMN);
+
+    // create dependent requests
+    const dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest> = [];
+    addToDependent(dependentRequests);
+
+    // create the conditional group
+    this.conditionalGroups.push({
+      condition,
+      dependentRequests,
+    });
+
+    return true; // handled
+  }
+
+  /** Add a fkey from sourceDefinitions to allOutBounds (with dedup). */
+  addFkey(fkCol: ForeignKeyPseudoColumn): void {
+    if (fkCol.name in this.consideredOutbounds) return;
+    this.consideredOutbounds[fkCol.name] = true;
+    this.allOutBounds.push(fkCol);
+  }
+
+  /**
+   * Return the built ActiveList object. After calling this method, the builder should not be used anymore.
+   */
+  build(): ActiveList {
+    return {
+      requests: this.requests,
+      conditionalGroups: this.conditionalGroups,
+      allOutBounds: this.allOutBounds,
+      selfLinks: this.selfLinks,
+    };
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -405,6 +405,9 @@ export const _warningMessages = Object.freeze({
   FILTER_NOT_ALLOWED: 'filter in source is only supported in `filter` context of visible-columns',
   FILTER_NO_PATH_NOT_ALLOWED: 'filter in source is not supported with local columns or all-outbound paths.',
   USED_IN_IFRAME_INPUT: 'the column already used in another column mapping.',
+  CONDITION: {
+    INVALID_SOURCE: 'condition definition is invalid. `source` or `sourcekey` is required and must be valid.',
+  },
 });
 
 export const _permissionMessages = Object.freeze({

--- a/src/utils/reference-utils.ts
+++ b/src/utils/reference-utils.ts
@@ -507,7 +507,12 @@ export function computeReadPath(
 /**
  * Generate the list of columns for this reference based on context and annotations
  */
-export function generateColumnsList(reference: Reference | RelatedReference, tuple?: Tuple, columnsList?: any[], skipLog?: boolean): VisibleColumn[] {
+export function generateColumnsList(
+  reference: Reference | RelatedReference,
+  tuple?: Tuple,
+  columnsList?: Array<unknown>,
+  skipLog?: boolean,
+): VisibleColumn[] {
   const resultColumns: VisibleColumn[] = [];
   const consideredColumns: { [key: string]: boolean } = {}; // to avoid duplicate pseudo columns
   const tableColumns: { [key: string]: boolean } = {}; // to make sure the hashes we generate are not clashing with table column names

--- a/src/utils/template-utils.ts
+++ b/src/utils/template-utils.ts
@@ -9,16 +9,34 @@ import type { KeyPseudoColumn } from '@isrd-isi-edu/ermrestjs/src/models/referen
 import { _getRowTemplateVariables } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
 
 /**
- * Build the $self and $_self template variables for a given column and tuple.
+ * Build the `$self` (and where applicable `$_self`) template variables for a
+ * given column and tuple. Consolidates the derivation logic that used to be
+ * duplicated across `sourceFormatPresentation` in `ReferenceColumn`,
+ * `PseudoColumn`, `ForeignKeyPseudoColumn`, `KeyPseudoColumn`, and
+ * `ActiveListCondition`.
  *
- * This consolidates the logic that was duplicated across
- * sourceFormatPresentation in ReferenceColumn, PseudoColumn,
- * ForeignKeyPseudoColumn, KeyPseudoColumn, and ActiveListCondition.
+ * The returned shape varies with the column:
+ * - scalar sources (local column, all-outbound scalar) ⇒ `{ $self, $_self }`
+ *   where `$_self` is the raw value and `$self` is `formatvalue(...)`'d.
+ * - entity-mode sources (key, foreign-key, all-outbound entity, entityset) ⇒
+ *   `{ $self }` only, where `$self` is the row template (`{ values, rowName, uri, ... }`).
+ * - aggregates ⇒ `columnValue.templateVariables` directly (already contains
+ *   `$self`/`$_self`).
+ * - missing data (entity row didn't load, etc.) ⇒ `{}`.
  *
- * @param column - the column whose $self we are building
- * @param mainTuple - the main record tuple
- * @param columnValue - the fetched value for async columns (aggregate result or page for entitysets)
- * @returns an object with $self and optionally $_self, suitable for merging into template variables
+ * @param column - the column whose `$self` we are building.
+ * @param mainTuple - the main record tuple. Used to source `$self`/`$_self`
+ *   for any path that doesn't require an async fetch (local columns,
+ *   all-outbound, key, foreign-key).
+ * @param columnValue - the fetched value, only meaningful for async sources:
+ *   - **entityset** (Reference.read result): a {@link Page} — `templateVariables`
+ *     is read from it.
+ *   - **aggregate** (column.getAggregatedValue result, unwrapped first row):
+ *     `{ value, templateVariables }` — `templateVariables` is read from it.
+ *   - **null/undefined** for sync sources, or before the fetch has completed
+ *     (sync paths ignore it; async paths return `{}`).
+ * @returns the `$self`/`$_self` slice ready to be merged into the
+ *   accumulated template variables.
  */
 export function buildSelfTemplateVariables(column: ReferenceColumn, mainTuple: Tuple, columnValue?: any): Record<string, any> {
   const context = (column as any)._context as string;

--- a/src/utils/template-utils.ts
+++ b/src/utils/template-utils.ts
@@ -1,0 +1,99 @@
+// models
+import type { Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
+import type { ReferenceColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column';
+import type { PseudoColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column/pseudo-column';
+import type { ForeignKeyPseudoColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column/foreign-key-pseudo-column';
+import type { KeyPseudoColumn } from '@isrd-isi-edu/ermrestjs/src/models/reference-column/key-pseudo-column';
+
+// legacy
+import { _getRowTemplateVariables } from '@isrd-isi-edu/ermrestjs/js/utils/helpers';
+
+/**
+ * Build the $self and $_self template variables for a given column and tuple.
+ *
+ * This consolidates the logic that was duplicated across
+ * sourceFormatPresentation in ReferenceColumn, PseudoColumn,
+ * ForeignKeyPseudoColumn, KeyPseudoColumn, and ActiveListCondition.
+ *
+ * @param column - the column whose $self we are building
+ * @param mainTuple - the main record tuple
+ * @param columnValue - the fetched value for async columns (aggregate result or page for entitysets)
+ * @returns an object with $self and optionally $_self, suitable for merging into template variables
+ */
+export function buildSelfTemplateVariables(column: ReferenceColumn, mainTuple: Tuple, columnValue?: any): Record<string, any> {
+  const context = (column as any)._context as string;
+
+  // KeyPseudoColumn: $self is row-level template variables from mainTuple.data
+  if ((column as any).isKey) {
+    const keyCol = column as KeyPseudoColumn;
+    return {
+      $self: _getRowTemplateVariables(keyCol.table, context, mainTuple.data),
+    };
+  }
+
+  // ForeignKeyPseudoColumn: $self is row-level template variables from linkedData
+  if ((column as any).isForeignKey) {
+    const fkCol = column as ForeignKeyPseudoColumn;
+    if (!mainTuple.linkedData[fkCol.name]) {
+      return {};
+    }
+    return {
+      $self: _getRowTemplateVariables(fkCol.table, context, mainTuple.linkedData[fkCol.name]),
+    };
+  }
+
+  // PseudoColumn (path-based source column)
+  if ((column as any).isPathColumn) {
+    const pseudoCol = column as PseudoColumn;
+
+    // aggregate: use precomputed templateVariables from the fetched value
+    if (pseudoCol.hasAggregate && columnValue) {
+      return columnValue.templateVariables || {};
+    }
+
+    // all-outbound (isUnique): use mainTuple.linkedData
+    if (pseudoCol.hasPath && pseudoCol.isUnique) {
+      if (!mainTuple.linkedData[pseudoCol.name]) {
+        return {};
+      }
+      // scalar
+      if (!pseudoCol.isEntityMode) {
+        const baseCol = pseudoCol.baseColumn;
+        return {
+          $self: baseCol.formatvalue(mainTuple.linkedData[pseudoCol.name][baseCol.name], context),
+          $_self: mainTuple.linkedData[pseudoCol.name][baseCol.name],
+        };
+      }
+      // entity
+      return {
+        $self: _getRowTemplateVariables(pseudoCol.table, context, mainTuple.linkedData[pseudoCol.name]),
+      };
+    }
+
+    // entityset: use templateVariables from the page result
+    if (columnValue && columnValue.templateVariables) {
+      return columnValue.templateVariables;
+    }
+
+    // other paths with a base column (scalar)
+    if (pseudoCol.baseColumn) {
+      return {
+        $self: pseudoCol.baseColumn.formatvalue(mainTuple.data[pseudoCol.baseColumn.name], context),
+        $_self: mainTuple.data[pseudoCol.baseColumn.name],
+      };
+    }
+
+    return {};
+  }
+
+  // Base ReferenceColumn (non-pseudo, simple column)
+  const baseCol = column.baseColumns[0];
+  if (baseCol) {
+    return {
+      $self: baseCol.formatvalue(mainTuple.data[baseCol.name], context),
+      $_self: mainTuple.data[baseCol.name],
+    };
+  }
+
+  return {};
+}

--- a/test/specs/annotation/conf/source_definitions/schema.json
+++ b/test/specs/annotation/conf/source_definitions/schema.json
@@ -459,6 +459,42 @@
                               "RID"
                           ]
                       }
+                  },
+                  "conditions": {
+                      "cond_local_col":          {"sourcekey": "new_col"},
+                      "cond_outbound_entity":    {"sourcekey": "fk1_col_entity"},
+                      "cond_outbound_scalar":    {"sourcekey": "fk1_col_scalar"},
+                      "cond_all_outbound":       {"sourcekey": "all_outbound_col"},
+                      "cond_inbound_entity":     {"sourcekey": "inbound1_col"},
+                      "cond_agg_cnt":            {"sourcekey": "agg1_cnt"},
+                      "cond_agg_cnt_d":          {"sourcekey": "agg1_cnt_d"},
+                      "cond_agg_min":            {"sourcekey": "agg1_min"},
+                      "cond_agg_max":            {"sourcekey": "agg1_max"},
+                      "cond_agg_array":          {"sourcekey": "agg1_array"},
+                      "cond_agg_array_d":        {"sourcekey": "agg1_array_d"},
+                      "cond_path_w_prefix":      {"sourcekey": "path_to_outbound2_outbound1_inbound1_w_prefix"},
+
+                      "cond_inline_col":         {"source": "col"},
+                      "cond_inline_path":        {"source": [{"outbound": ["source_definitions_schema", "main_fk1"]}, "RID"], "entity": true},
+                      "cond_inline_aggregate":   {"source": [{"inbound": ["source_definitions_schema", "inbound1_fk1"]}, "RID"], "entity": true, "aggregate": "cnt"},
+
+                      "cond_default_on_empty":   {"sourcekey": "agg1_cnt"},
+                      "cond_on_empty_hide":      {"sourcekey": "agg1_cnt", "on_empty": "hide"},
+                      "cond_on_empty_show":      {"sourcekey": "agg1_cnt", "on_empty": "show"},
+
+                      "cond_pattern_default":    {"sourcekey": "agg1_cnt", "condition_pattern": "{{#if $self}}show{{/if}}"},
+                      "cond_pattern_handlebars": {"sourcekey": "agg1_cnt", "condition_pattern": "{{#if $self}}show{{/if}}", "template_engine": "handlebars"},
+
+                      "cond_wait_for_empty":     {"sourcekey": "agg1_cnt", "wait_for": []},
+                      "cond_wait_for_single":    {"sourcekey": "agg1_cnt", "wait_for": ["agg1_cnt_d"]},
+                      "cond_wait_for_multiple":  {"sourcekey": "agg1_cnt", "wait_for": ["agg1_cnt_d", "agg1_min"]},
+
+                      "cond_both_source_and_sourcekey": {"sourcekey": "agg1_cnt", "source": "col"},
+
+                      "cond_invalid_neither":         {"on_empty": "hide"},
+                      "cond_invalid_dangling_key":    {"sourcekey": "does_not_exist"},
+                      "cond_invalid_empty_sourcekey": {"sourcekey": ""},
+                      "cond_invalid_null":            null
                   }
               }
           }

--- a/test/specs/annotation/tests/07.source_definitions.js
+++ b/test/specs/annotation/tests/07.source_definitions.js
@@ -942,5 +942,173 @@ exports.execute = function (options) {
         });
       });
     });
+
+    describe('conditions, ', function () {
+      it('when annotation is missing should return undefined for any key.', function () {
+        expect(tableMainNoAnnot.sourceDefinitions.getCondition('cond_local_col')).toBeUndefined();
+      });
+
+      describe('when annotation is defined, ', function () {
+        var sds;
+        beforeAll(function () {
+          sds = tableMain.sourceDefinitions;
+        });
+
+        describe('valid conditions across source shapes, ', function () {
+          // Each test verifies the condition is parsed (preserved as-is) AND that the
+          // sourcekey resolves to a parsed source — confirming the linkage that the
+          // parser enforces in core.js:1750-1753.
+          var assertSourcekeyCondition = function (key, expectedSourcekey) {
+            var c = sds.getCondition(key);
+            expect(c).toBeDefined('condition `' + key + '` not parsed');
+            expect(c.sourcekey).toBe(expectedSourcekey, 'sourcekey mismatch for `' + key + '`');
+            expect(sds.getSource(expectedSourcekey)).toBeDefined('sourcekey `' + expectedSourcekey + '` does not resolve');
+          };
+
+          it('should accept sourcekey to a local column source.', function () {
+            assertSourcekeyCondition('cond_local_col', 'new_col');
+          });
+
+          it('should accept sourcekey to an outbound entity source.', function () {
+            assertSourcekeyCondition('cond_outbound_entity', 'fk1_col_entity');
+          });
+
+          it('should accept sourcekey to an outbound scalar source.', function () {
+            assertSourcekeyCondition('cond_outbound_scalar', 'fk1_col_scalar');
+          });
+
+          it('should accept sourcekey to a multi-step all-outbound source.', function () {
+            assertSourcekeyCondition('cond_all_outbound', 'all_outbound_col');
+          });
+
+          it('should accept sourcekey to an inbound entityset source.', function () {
+            assertSourcekeyCondition('cond_inbound_entity', 'inbound1_col');
+          });
+
+          it('should accept sourcekey to inbound aggregate sources.', function () {
+            // exercises every aggregate flavor in one test
+            [
+              ['cond_agg_cnt', 'agg1_cnt'],
+              ['cond_agg_cnt_d', 'agg1_cnt_d'],
+              ['cond_agg_min', 'agg1_min'],
+              ['cond_agg_max', 'agg1_max'],
+              ['cond_agg_array', 'agg1_array'],
+              ['cond_agg_array_d', 'agg1_array_d'],
+            ].forEach(function (pair) {
+              assertSourcekeyCondition(pair[0], pair[1]);
+            });
+          });
+
+          it('should accept sourcekey to a path-with-prefix source.', function () {
+            assertSourcekeyCondition('cond_path_w_prefix', 'path_to_outbound2_outbound1_inbound1_w_prefix');
+          });
+        });
+
+        describe('inline source (no sourcekey), ', function () {
+          it('should accept inline source as a bare column name.', function () {
+            var c = sds.getCondition('cond_inline_col');
+            expect(c).toBeDefined();
+            expect(c.source).toBe('col');
+            expect(c.sourcekey).toBeUndefined('inline condition should not have sourcekey');
+          });
+
+          it('should accept inline source as a path array (entity mode).', function () {
+            var c = sds.getCondition('cond_inline_path');
+            expect(c).toBeDefined();
+            expect(Array.isArray(c.source)).toBe(true);
+            expect(c.source.length).toBe(2);
+            expect(c.entity).toBe(true);
+          });
+
+          it('should accept inline source with aggregate.', function () {
+            var c = sds.getCondition('cond_inline_aggregate');
+            expect(c).toBeDefined();
+            expect(Array.isArray(c.source)).toBe(true);
+            expect(c.aggregate).toBe('cnt');
+            expect(c.entity).toBe(true);
+          });
+        });
+
+        describe('on_empty handling, ', function () {
+          it('should preserve on_empty when explicitly "hide".', function () {
+            expect(sds.getCondition('cond_on_empty_hide').on_empty).toBe('hide');
+          });
+
+          it('should preserve on_empty when explicitly "show".', function () {
+            expect(sds.getCondition('cond_on_empty_show').on_empty).toBe('show');
+          });
+
+          it('should leave on_empty undefined when omitted (callers default to "hide").', function () {
+            expect(sds.getCondition('cond_default_on_empty').on_empty).toBeUndefined();
+          });
+        });
+
+        describe('condition_pattern, ', function () {
+          it('should preserve condition_pattern as a string.', function () {
+            var c = sds.getCondition('cond_pattern_default');
+            expect(c.condition_pattern).toBe('{{#if $self}}show{{/if}}');
+            expect(c.template_engine).toBeUndefined('template_engine should default to undefined');
+          });
+
+          it('should preserve template_engine when specified.', function () {
+            var c = sds.getCondition('cond_pattern_handlebars');
+            expect(c.condition_pattern).toBe('{{#if $self}}show{{/if}}');
+            expect(c.template_engine).toBe('handlebars');
+          });
+        });
+
+        describe('wait_for, ', function () {
+          it('should preserve an empty wait_for array.', function () {
+            var c = sds.getCondition('cond_wait_for_empty');
+            expect(Array.isArray(c.wait_for)).toBe(true);
+            expect(c.wait_for.length).toBe(0);
+          });
+
+          it('should preserve wait_for with a single entry.', function () {
+            var c = sds.getCondition('cond_wait_for_single');
+            expect(c.wait_for).toEqual(['agg1_cnt_d']);
+          });
+
+          it('should preserve wait_for with multiple entries.', function () {
+            var c = sds.getCondition('cond_wait_for_multiple');
+            expect(c.wait_for).toEqual(['agg1_cnt_d', 'agg1_min']);
+          });
+        });
+
+        describe('mixed source and sourcekey, ', function () {
+          it('should accept a definition with both source and sourcekey set.', function () {
+            // parser keeps both keys; runtime resolves via sourcekey (ActiveListCondition
+            // checks sourcekey first in active-list-condition.ts:57)
+            var c = sds.getCondition('cond_both_source_and_sourcekey');
+            expect(c).toBeDefined();
+            expect(c.sourcekey).toBe('agg1_cnt');
+            expect(c.source).toBe('col');
+          });
+        });
+
+        describe('invalid conditions, ', function () {
+          // each rejection branch in core.js:1735-1758 gets a dedicated case
+          it('should reject when both source and sourcekey are missing.', function () {
+            expect(sds.getCondition('cond_invalid_neither')).toBeUndefined();
+          });
+
+          it('should reject when sourcekey points to a non-existent source.', function () {
+            expect(sds.getCondition('cond_invalid_dangling_key')).toBeUndefined();
+          });
+
+          it('should reject when sourcekey is an empty string.', function () {
+            expect(sds.getCondition('cond_invalid_empty_sourcekey')).toBeUndefined();
+          });
+
+          it('should reject when the condition value is null.', function () {
+            expect(sds.getCondition('cond_invalid_null')).toBeUndefined();
+          });
+
+          it('should return undefined for non-existent condition keys.', function () {
+            expect(sds.getCondition('does_not_exist_at_all')).toBeUndefined();
+          });
+        });
+      });
+    });
   });
 };

--- a/test/specs/column/conf/active_list_schema/data/main.json
+++ b/test/specs/column/conf/active_list_schema/data/main.json
@@ -1,4 +1,4 @@
 [
-    {"main_id": "01", "rowname_col": "main one", "int_col": 1234501, "int_col_2": 1234511, "int_col_3": 1234521, "fk1_col1": "o011", "fk1_col2": "o012", "fk2_col1": "o111", "fk2_col2": "o112", "fk3_col1": "o111", "fk3_col2": "o112", "fk4_col1": "o21", "col_w_waitfor_in_col_display": "some val"},
+    {"main_id": "01", "rowname_col": "main one", "int_col": 1234501, "int_col_2": 1234511, "int_col_3": 1234521, "int_col_4": 1234531, "fk1_col1": "o011", "fk1_col2": "o012", "fk2_col1": "o111", "fk2_col2": "o112", "fk3_col1": "o111", "fk3_col2": "o112", "fk4_col1": "o21", "col_w_waitfor_in_col_display": "some val"},
     {"main_id": "02", "rowname_col": "main two", "int_col": 1234502, "int_col_2": 1234512, "int_col_3": 1234522}
 ]

--- a/test/specs/column/conf/active_list_schema/schema.json
+++ b/test/specs/column/conf/active_list_schema/schema.json
@@ -437,7 +437,8 @@
                             "condition": {
                                 "sourcekey": "cnt_i1",
                                 "on_empty": "hide",
-                                "condition_pattern": "{{#if $self}}show{{/if}}"
+                                "condition_pattern": "{{#if cnt_i2}}show{{/if}}",
+                                "wait_for": ["cnt_i2"]
                             }
                         },
                         {
@@ -757,7 +758,8 @@
                         },
                         "cond_has_inbound1_show": {
                             "sourcekey": "cnt_i1",
-                            "on_empty": "show"
+                            "on_empty": "show",
+                            "wait_for": ["cnt_i2"]
                         },
                         "cond_with_pattern": {
                             "sourcekey": "cnt_i1",
@@ -766,6 +768,12 @@
                         },
                         "cond_invalid_no_source": {
                             "on_empty": "hide"
+                        },
+                        "cond_with_wait_for": {
+                            "sourcekey": "cnt_i1",
+                            "on_empty": "hide",
+                            "condition_pattern": "{{#if cnt_i2}}show{{/if}}",
+                            "wait_for": ["cnt_i2"]
                         }
                     }
                 }

--- a/test/specs/column/conf/active_list_schema/schema.json
+++ b/test/specs/column/conf/active_list_schema/schema.json
@@ -141,6 +141,10 @@
                     "type": {"typename": "int4"}
                 },
                 {
+                    "name": "int_col_4",
+                    "type": {"typename": "int4"}
+                },
+                {
                     "name": "fk1_col1",
                     "type": {
                         "typename": "text"
@@ -413,6 +417,36 @@
                                 "markdown_pattern": "{{max_i2}}",
                                 "wait_for": ["max_i2", "array_d_entity_i1"]
                             }
+                        },
+                        {
+                            "sourcekey": "min_i3",
+                            "markdown_name": "conditioned_col_inline",
+                            "condition": {
+                                "sourcekey": "cnt_i1",
+                                "on_empty": "hide"
+                            }
+                        },
+                        {
+                            "sourcekey": "min_i4",
+                            "markdown_name": "conditioned_col_key",
+                            "condition_key": "cond_has_inbound1_show"
+                        },
+                        {
+                            "sourcekey": "max_i3",
+                            "markdown_name": "conditioned_col_pattern",
+                            "condition": {
+                                "sourcekey": "cnt_i1",
+                                "on_empty": "hide",
+                                "condition_pattern": "{{#if $self}}show{{/if}}"
+                            }
+                        },
+                        {
+                            "source": "int_col_4",
+                            "markdown_name": "conditioned_col_outbound",
+                            "condition": {
+                                "sourcekey": "outbound_entity_o1",
+                                "on_empty": "hide"
+                            }
                         }
                     ]
                 },
@@ -435,7 +469,11 @@
                                 "wait_for": ["entity_set_i5", "all_outbound_entity_o3_o1_o1"]
                             }
                         },
-                        {"sourcekey": "entity_set_i7"}
+                        {"sourcekey": "entity_set_i7"},
+                        {
+                            "sourcekey": "entity_set_i5",
+                            "condition_key": "cond_has_inbound1"
+                        }
                     ]
                 },
                 "tag:isrd.isi.edu,2018:citation": {
@@ -638,6 +676,18 @@
                             "source": [{"inbound": ["active_list_schema", "inbound2_fk1"]}, "int_col"],
                             "aggregate": "max"
                         },
+                        "min_i3": {
+                            "source": [{"inbound": ["active_list_schema", "inbound3_fk1"]}, "int_col"],
+                            "aggregate": "min"
+                        },
+                        "max_i3": {
+                            "source": [{"inbound": ["active_list_schema", "inbound3_fk1"]}, "int_col"],
+                            "aggregate": "max"
+                        },
+                        "min_i4": {
+                            "source": [{"inbound": ["active_list_schema", "inbound4_fk1"]}, "int_col"],
+                            "aggregate": "min"
+                        },
                         "entity_set_i1": {
                             "source": [{"inbound": ["active_list_schema", "inbound1_fk1"]}, "inbound1_id"]
                         },
@@ -698,6 +748,24 @@
                             ],
                             "entity": true,
                             "aggregate": "array_d"
+                        }
+                    },
+                    "conditions": {
+                        "cond_has_inbound1": {
+                            "sourcekey": "cnt_i1",
+                            "on_empty": "hide"
+                        },
+                        "cond_has_inbound1_show": {
+                            "sourcekey": "cnt_i1",
+                            "on_empty": "show"
+                        },
+                        "cond_with_pattern": {
+                            "sourcekey": "cnt_i1",
+                            "on_empty": "hide",
+                            "condition_pattern": "{{#if $self}}show{{/if}}"
+                        },
+                        "cond_invalid_no_source": {
+                            "on_empty": "hide"
                         }
                     }
                 }

--- a/test/specs/column/conf/active_list_schema/schema.json
+++ b/test/specs/column/conf/active_list_schema/schema.json
@@ -448,6 +448,11 @@
                                 "sourcekey": "outbound_entity_o1",
                                 "on_empty": "hide"
                             }
+                        },
+                        {
+                            "sourcekey": "array_d_entity_i3",
+                            "markdown_name": "conditioned_col_shared_w_fk",
+                            "condition_key": "cond_has_inbound1"
                         }
                     ]
                 },

--- a/test/specs/column/tests/05.active_list.js
+++ b/test/specs/column/tests/05.active_list.js
@@ -367,65 +367,110 @@ exports.execute = function (options) {
 
                 it ("should return the correct number of conditional groups for detailed context.", function () {
                     expect(detailedActiveList.conditionalGroups).toBeDefined("conditionalGroups not defined");
-                    // 3 column groups: conditioned_col_inline, conditioned_col_key (with wait_for),
-                    // conditioned_col_pattern (with wait_for)
-                    // plus 1 related: conditioned entity_set_i5
-                    // conditioned_col_outbound uses all-outbound condition source, so evaluated synchronously — no group
-                    expect(detailedActiveList.conditionalGroups.length).toBe(4,
-                        "should have 4 conditional groups (3 columns + 1 related with async conditions)");
+                    // Option B: every conditioned item gets a group, sync or async.
+                    // 4 conditioned vis-cols (conditioned_col_inline, _key, _pattern, _outbound)
+                    // + 1 conditioned vis-fk (entity_set_i5).
+                    // Iteration order is non-aggregate then aggregate, then related, so:
+                    //   group 0: conditioned_col_outbound (sync, source=outbound_entity_o1, no aggregate)
+                    //   group 1: conditioned_col_inline   (async, source=cnt_i1, no condition_key)
+                    //   group 2: conditioned_col_key      (async, condition_key=cond_has_inbound1_show)
+                    //   group 3: conditioned_col_pattern  (async, source=cnt_i1, inline pattern + wait_for)
+                    //   group 4: entity_set_i5 vis-fk     (async, condition_key=cond_has_inbound1)
+                    expect(detailedActiveList.conditionalGroups.length).toBe(5,
+                        "should have 5 conditional groups (4 columns + 1 related)");
                 });
 
-                it ("each group should have a condition with the correct column.", function () {
+                it ("each group should have a condition with the expected source column.", function () {
                     var groups = detailedActiveList.conditionalGroups;
-                    // all three column conditions use cnt_i1 as condition source
+                    var expectedSources = [
+                        // group 0: sync outbound, source=outbound_entity_o1
+                        columnMapping["outbound_entity_o1"],
+                        // groups 1-4: all use cnt_i1
+                        columnMapping["cnt_i1"],
+                        columnMapping["cnt_i1"],
+                        columnMapping["cnt_i1"],
+                        columnMapping["cnt_i1"]
+                    ];
                     groups.forEach(function (g, i) {
                         expect(g.condition).toBeDefined("condition not defined for group index=" + i);
                         expect(g.condition.column).toBeDefined("condition.column not defined for group index=" + i);
                         expect(g.condition.column.name).toBe(
-                            columnMapping["cnt_i1"],
+                            expectedSources[i],
                             "condition column name missmatch for group index=" + i
                         );
                     });
                 });
 
-                it ("each group should have dependentRequests.", function () {
+                it ("groups should have dependentRequests where applicable.", function () {
                     var groups = detailedActiveList.conditionalGroups;
+                    // group 0 (conditioned_col_outbound on plain int_col_4) has no
+                    // aggregates/entitysets/related items in its dependents — addColToDependent
+                    // only registers those — so deps is legitimately empty. The conditioned item
+                    // identity lives on `conditionedItems` (not dependentRequests), so chaise
+                    // can still gate the column's visibility.
                     groups.forEach(function (g, i) {
                         expect(Array.isArray(g.dependentRequests)).toBe(true,
                             "dependentRequests not an array for group index=" + i);
-                        expect(g.dependentRequests.length).toBeGreaterThan(0,
+                    });
+                    expect(groups[0].dependentRequests.length).toBe(0,
+                        "group 0 (sync outbound on plain column) should have empty deps");
+                    // groups 1-3 wrap aggregate columns, group 4 wraps a related entity, all
+                    // need at least one dependent request to fetch their data.
+                    [1, 2, 3, 4].forEach(function (i) {
+                        expect(groups[i].dependentRequests.length).toBeGreaterThan(0,
                             "dependentRequests should not be empty for group index=" + i);
                     });
                 });
 
+                it ("groups should also track the items they gate via conditionedItems.", function () {
+                    var groups = detailedActiveList.conditionalGroups;
+                    groups.forEach(function (g, i) {
+                        expect(Array.isArray(g.conditionedItems)).toBe(true,
+                            "conditionedItems not an array for group index=" + i);
+                        expect(g.conditionedItems.length).toBeGreaterThan(0,
+                            "conditionedItems should not be empty for group index=" + i);
+                    });
+                    // groups 0-3 are columns. Group 4 (cond_has_inbound1) gates BOTH the
+                    // entity_set_i5 vis-fk AND the dedup-test conditioned_col_shared_w_fk
+                    // — so it has two items, in arrival order: related first, then column.
+                    expect(groups[0].conditionedItems[0].column).toBe(true, "group 0 should be a column item");
+                    expect(groups[4].conditionedItems.length).toBe(2,
+                        "group 4 should hold both the vis-fk and the shared-key column");
+                    var hasRelated = groups[4].conditionedItems.some(function (it) { return it.related === true; });
+                    var hasColumn = groups[4].conditionedItems.some(function (it) { return it.column === true; });
+                    expect(hasRelated).toBe(true, "group 4 should still gate the entity_set_i5 vis-fk");
+                    expect(hasColumn).toBe(true, "group 4 should also gate the conditioned_col_shared_w_fk column");
+                });
+
                 it ("conditions without wait_for should have empty waitFor list.", function () {
                     var groups = detailedActiveList.conditionalGroups;
-                    expect(groups[0].condition.hasWaitFor).toBe(false, "group 0 should not have waitFor");
-                    expect(groups[0].condition.waitFor.length).toBe(0, "group 0 waitFor length");
-                    expect(groups[3].condition.hasWaitFor).toBe(false, "group 3 should not have waitFor");
-                    expect(groups[3].condition.waitFor.length).toBe(0, "group 3 waitFor length");
+                    // groups 0 (sync outbound), 1 (cnt_i1 inline no wait_for), 4 (cond_has_inbound1)
+                    [0, 1, 4].forEach(function (i) {
+                        expect(groups[i].condition.hasWaitFor).toBe(false,
+                            "group " + i + " should not have waitFor");
+                        expect(groups[i].condition.waitFor.length).toBe(0,
+                            "group " + i + " waitFor length");
+                    });
                 });
 
                 it ("conditions with wait_for should have populated waitFor list.", function () {
                     var groups = detailedActiveList.conditionalGroups;
-                    // group 1 (cond_has_inbound1_show with wait_for) and group 2 (conditioned_col_pattern inline with wait_for)
-                    expect(groups[1].condition.hasWaitFor).toBe(true, "group 1 should have waitFor");
-                    expect(groups[1].condition.waitFor.length).toBe(1, "group 1 waitFor length");
-                    expect(groups[1].condition.waitFor[0].name).toBe(
-                        columnMapping["cnt_i2"],
-                        "group 1 waitFor[0] should be cnt_i2"
-                    );
-
-                    expect(groups[2].condition.hasWaitFor).toBe(true, "group 2 should have waitFor");
-                    expect(groups[2].condition.waitFor.length).toBe(1, "group 2 waitFor length");
-                    expect(groups[2].condition.waitFor[0].name).toBe(
-                        columnMapping["cnt_i2"],
-                        "group 2 waitFor[0] should be cnt_i2"
-                    );
+                    // group 2 (cond_has_inbound1_show, wait_for cnt_i2) and
+                    // group 3 (conditioned_col_pattern inline with wait_for cnt_i2)
+                    [2, 3].forEach(function (i) {
+                        expect(groups[i].condition.hasWaitFor).toBe(true,
+                            "group " + i + " should have waitFor");
+                        expect(groups[i].condition.waitFor.length).toBe(1,
+                            "group " + i + " waitFor length");
+                        expect(groups[i].condition.waitFor[0].name).toBe(
+                            columnMapping["cnt_i2"],
+                            "group " + i + " waitFor[0] should be cnt_i2"
+                        );
+                    });
                 });
 
                 it ("condition wait_for columns should appear in main requests with condition objects.", function () {
-                    // cnt_i2 should have condition objects for groups 1 and 2 (wait_for)
+                    // cnt_i2 should have condition objects for groups 2 and 3 (their wait_fors)
                     var cnt_i2_req = detailedActiveList.requests.find(function (r) {
                         return r.column && r.column.name === columnMapping["cnt_i2"];
                     });
@@ -434,8 +479,8 @@ exports.execute = function (options) {
                         return obj.condition;
                     });
                     expect(condObjects.length).toBe(2, "cnt_i2 should have 2 condition objects");
-                    expect(condObjects[0].index).toBe(1, "first condition object should be for group 1");
-                    expect(condObjects[1].index).toBe(2, "second condition object should be for group 2");
+                    expect(condObjects[0].index).toBe(2, "first condition object should be for group 2");
+                    expect(condObjects[1].index).toBe(3, "second condition object should be for group 3");
                 });
             });
         });
@@ -549,37 +594,237 @@ exports.execute = function (options) {
         });
 
         describe("ActiveListCondition.evaluateCondition, ", function () {
+            // Use the async groups for these tests. Group 0 (sync outbound) needs a
+            // real mainTuple to derive emptiness from buildSelfTemplateVariables —
+            // exercising it without one would crash on tuple.linkedData. The async
+            // branch instead consults the conditionValue arg, so we can pass null.
+            //   group 1: inline condition on cnt_i1, on_empty=hide
+            //   group 2: condition_key cond_has_inbound1_show on cnt_i1, on_empty=show
+            //
+            // conditionValue for an aggregate is the unwrapped first row,
+            // shaped {value, templateVariables}. _isConditionValueEmpty treats
+            // null / "" / numeric-zero as empty.
             it ("should return shouldShow=false when condition source is empty and on_empty='hide'.", function () {
                 var groups = detailedActiveList.conditionalGroups;
-                // group 0: condition source=cnt_i1, on_empty=hide
-                var condition = groups[0].condition;
+                var condition = groups[1].condition;
                 var result = condition.evaluateCondition({}, null, null);
                 expect(result.shouldShow).toBe(false, "should hide when empty and on_empty=hide");
             });
 
             it ("should return shouldShow=true when condition source is empty and on_empty='show'.", function () {
                 var groups = detailedActiveList.conditionalGroups;
-                // group 1: condition source=cnt_i1, on_empty=show
-                var condition = groups[1].condition;
+                var condition = groups[2].condition;
                 var result = condition.evaluateCondition({}, null, null);
                 expect(result.shouldShow).toBe(true, "should show when empty and on_empty=show");
             });
 
             it ("should return shouldShow=true when condition source has data and on_empty='hide'.", function () {
                 var groups = detailedActiveList.conditionalGroups;
-                // group 0: on_empty=hide → show when NOT empty
-                var condition = groups[0].condition;
-                // simulate aggregate result with value
-                var result = condition.evaluateCondition({}, [{value: "5", isHTML: false, templateVariables: {$self: "5"}}], null);
+                var condition = groups[1].condition;
+                var result = condition.evaluateCondition({}, {value: "5", templateVariables: {$self: "5"}}, null);
                 expect(result.shouldShow).toBe(true, "should show when has data and on_empty=hide");
             });
 
             it ("should return shouldShow=false when condition source has data and on_empty='show'.", function () {
                 var groups = detailedActiveList.conditionalGroups;
-                // group 1: on_empty=show → hide when NOT empty
-                var condition = groups[1].condition;
-                var result = condition.evaluateCondition({}, [{value: "5", isHTML: false, templateVariables: {$self: "5"}}], null);
+                var condition = groups[2].condition;
+                var result = condition.evaluateCondition({}, {value: "5", templateVariables: {$self: "5"}}, null);
                 expect(result.shouldShow).toBe(false, "should hide when has data and on_empty=show");
+            });
+        });
+
+        describe("ActiveListCondition.conditionKey, ", function () {
+            it ("should be undefined for inline conditions (no condition_key reference).", function () {
+                var groups = detailedActiveList.conditionalGroups;
+                // group 0: conditioned_col_outbound (inline)
+                // group 1: conditioned_col_inline   (inline)
+                // group 3: conditioned_col_pattern  (inline w/ pattern)
+                [0, 1, 3].forEach(function (i) {
+                    expect(groups[i].condition.conditionKey).toBeUndefined(
+                        "group " + i + " conditionKey should be undefined for inline conditions");
+                });
+            });
+
+            it ("should be set to the key for condition_key references.", function () {
+                var groups = detailedActiveList.conditionalGroups;
+                // group 2: conditioned_col_key uses condition_key=cond_has_inbound1_show
+                expect(groups[2].condition.conditionKey).toBe("cond_has_inbound1_show");
+                // group 4: entity_set_i5 vis-fk + conditioned_col_shared_w_fk both use cond_has_inbound1
+                expect(groups[4].condition.conditionKey).toBe("cond_has_inbound1");
+            });
+        });
+
+        describe("ActiveListCondition.isAsync, ", function () {
+            it ("should be false for sync condition sources (all-outbound entity).", function () {
+                // group 0: condition source = outbound_entity_o1 (all-outbound, no inbound, no aggregate)
+                expect(detailedActiveList.conditionalGroups[0].condition.isAsync).toBe(false,
+                    "group 0 (outbound_entity_o1) should be sync");
+            });
+
+            it ("should be true for async condition sources (inbound aggregate).", function () {
+                // groups 1-4 all use cnt_i1 (inbound + cnt aggregate → async)
+                [1, 2, 3, 4].forEach(function (i) {
+                    expect(detailedActiveList.conditionalGroups[i].condition.isAsync).toBe(true,
+                        "group " + i + " (cnt_i1 source) should be async");
+                });
+            });
+        });
+
+        describe("ActiveListCondition.evaluateCondition (sync source), ", function () {
+            // group 0: condition source = outbound_entity_o1 (all-outbound entity, sync), on_empty=hide.
+            // Sync entity-mode emptiness comes from buildSelfTemplateVariables — empty when
+            // mainTuple.linkedData[outbound_entity_o1.name] is missing/null.
+            //   row 1 ("01") has fk1_col1/fk1_col2 → outbound row exists → not empty → show
+            //   row 2 ("02") has no fk1 cols      → outbound row missing → empty   → hide
+            it ("should show when sync FK is populated and on_empty=hide.", function (done) {
+                mainRefDetailed.read(2).then(function (page) {
+                    var condition = detailedActiveList.conditionalGroups[0].condition;
+                    var result = condition.evaluateCondition({}, null, page.tuples[0]);
+                    expect(result.shouldShow).toBe(true, "row 1 (FK populated) should show");
+                    done();
+                }).catch(catchError(done));
+            });
+
+            it ("should hide when sync FK is empty and on_empty=hide.", function (done) {
+                mainRefDetailed.read(2).then(function (page) {
+                    var condition = detailedActiveList.conditionalGroups[0].condition;
+                    var result = condition.evaluateCondition({}, null, page.tuples[1]);
+                    expect(result.shouldShow).toBe(false, "row 2 (FK empty) should hide");
+                    done();
+                }).catch(catchError(done));
+            });
+        });
+
+        describe("ActiveListCondition.evaluateCondition (pattern source), ", function () {
+            // group 3: conditioned_col_pattern. Inline condition with
+            //   condition_pattern: "{{#if cnt_i2}}show{{/if}}", wait_for: ["cnt_i2"]
+            // Renders to "show" if cnt_i2 truthy in templateVariables, else empty.
+            // on_empty=hide → show iff render is non-empty.
+            // Handlebars is the active engine (set via setClientConfig in beforeAll).
+            //
+            // The pattern path always calls buildSelfTemplateVariables, which for an
+            // aggregate path column (cnt_i1) reads templateVariables off the conditionValue.
+            // We pass a stub aggregate value with empty templateVariables — the pattern
+            // doesn't reference $self / $_self anyway, only cnt_i2 from the outer map.
+            var aggValueStub = {value: 5, templateVariables: {}};
+
+            it ("should show when condition_pattern renders non-empty.", function () {
+                var condition = detailedActiveList.conditionalGroups[3].condition;
+                var result = condition.evaluateCondition({cnt_i2: 5}, aggValueStub, null);
+                expect(result.shouldShow).toBe(true, "pattern rendered \"show\" → shouldShow=true");
+            });
+
+            it ("should hide when condition_pattern renders to empty string.", function () {
+                var condition = detailedActiveList.conditionalGroups[3].condition;
+                // 0 is falsy in handlebars #if → render is "" → empty → hide
+                var result = condition.evaluateCondition({cnt_i2: 0}, aggValueStub, null);
+                expect(result.shouldShow).toBe(false, "pattern rendered \"\" → shouldShow=false");
+            });
+
+            it ("should hide when wait_for variable is missing from templateVariables.", function () {
+                var condition = detailedActiveList.conditionalGroups[3].condition;
+                var result = condition.evaluateCondition({}, aggValueStub, null);
+                expect(result.shouldShow).toBe(false, "cnt_i2 missing → render empty → hide");
+            });
+        });
+
+        describe("ActiveListCondition.evaluateCondition (async value shapes), ", function () {
+            // group 1: cnt_i1 inline, async, no pattern, on_empty=hide.
+            // shouldShow == !isEmpty (empty values hide; non-empty values show).
+            var condition;
+            beforeAll(function () {
+                condition = detailedActiveList.conditionalGroups[1].condition;
+            });
+
+            it ("should treat null/undefined conditionValue as empty.", function () {
+                expect(condition.evaluateCondition({}, null, null).shouldShow).toBe(false,
+                    "null conditionValue → empty → hide");
+                expect(condition.evaluateCondition({}, undefined, null).shouldShow).toBe(false,
+                    "undefined conditionValue → empty → hide");
+            });
+
+            it ("should treat page-shape with length=0 as empty (entityset).", function () {
+                var result = condition.evaluateCondition({}, {length: 0, tuples: []}, null);
+                expect(result.shouldShow).toBe(false, "empty page → hide");
+            });
+
+            it ("should treat page-shape with length>0 as non-empty (entityset).", function () {
+                var result = condition.evaluateCondition({}, {length: 3, tuples: [{}, {}, {}]}, null);
+                expect(result.shouldShow).toBe(true, "non-empty page → show");
+            });
+
+            it ("should treat aggregate value=0 (number) as empty.", function () {
+                var result = condition.evaluateCondition({}, {value: 0, templateVariables: {}}, null);
+                expect(result.shouldShow).toBe(false, "value=0 (count-style) → empty");
+            });
+
+            it ("should treat aggregate value='0' (numeric string) as empty (count-style coercion).", function () {
+                // covers the Number() coercion branch — count aggregates often serialize as "0"
+                var result = condition.evaluateCondition({}, {value: "0", templateVariables: {}}, null);
+                expect(result.shouldShow).toBe(false, "value='0' should coerce to 0 → empty");
+            });
+
+            it ("should treat aggregate value='' (empty string) as empty.", function () {
+                var result = condition.evaluateCondition({}, {value: "", templateVariables: {}}, null);
+                expect(result.shouldShow).toBe(false, "value='' → empty");
+            });
+
+            it ("should treat aggregate value=5 (non-zero number) as non-empty.", function () {
+                var result = condition.evaluateCondition({}, {value: 5, templateVariables: {$self: "5"}}, null);
+                expect(result.shouldShow).toBe(true, "value=5 → not empty");
+            });
+
+            it ("should treat aggregate value='abc' (non-numeric string) as non-empty.", function () {
+                // Number("abc") = NaN → !isNaN check fails → falls through to "not empty"
+                var result = condition.evaluateCondition({}, {value: "abc", templateVariables: {}}, null);
+                expect(result.shouldShow).toBe(true, "value='abc' → !isNaN(NaN)=false → not empty");
+            });
+        });
+
+        describe("processConditionedItem dedup (shared condition_key), ", function () {
+            it ("should NOT create a separate group when two items share the same condition_key.", function () {
+                // 4 conditioned vis-cols + 1 conditioned vis-fk + 1 NEW conditioned vis-col sharing
+                // cond_has_inbound1 with the vis-fk = 6 conditioned items but only 5 groups (dedup).
+                expect(detailedActiveList.conditionalGroups.length).toBe(5,
+                    "should still be 5 groups even with 6 conditioned items");
+            });
+
+            it ("should add both items to the same group's conditionedItems list.", function () {
+                var group = detailedActiveList.conditionalGroups[4];
+                expect(group.condition.conditionKey).toBe("cond_has_inbound1",
+                    "group 4 should be the cond_has_inbound1 group");
+                expect(group.conditionedItems.length).toBe(2,
+                    "should hold both the vis-fk and the new column");
+
+                var byType = group.conditionedItems.reduce(function (acc, it) {
+                    if (it.related) acc.related = it;
+                    if (it.column) acc.column = it;
+                    return acc;
+                }, {});
+                expect(byType.related).toBeDefined("vis-fk item should still be present");
+                expect(byType.column).toBeDefined("new column item should be added");
+            });
+
+            it ("should add the new column's secondary fetch to the group dependentRequests, not main requests.", function () {
+                var group = detailedActiveList.conditionalGroups[4];
+                // the new column's source is array_d_entity_i3 (an aggregate) — it should land
+                // in the group's deps so chaise only fires it after the condition resolves true.
+                var depForNewCol = group.dependentRequests.find(function (r) {
+                    return r.column && r.column.name === columnMapping["array_d_entity_i3"] && r.aggregate;
+                });
+                expect(depForNewCol).toBeDefined("group 4 deps should include array_d_entity_i3");
+
+                // and the main detailed requests for array_d_entity_i3 should NOT have a new
+                // top-level entry from the conditioned column (only the existing wait_for entry)
+                var mainReq = detailedActiveList.requests.find(function (r) {
+                    return r.column && r.column.name === columnMapping["array_d_entity_i3"] && r.aggregate;
+                });
+                expect(mainReq).toBeDefined("array_d_entity_i3 should still be in main requests (used as wait_for of cnt_i2)");
+                var fromConditionedCol = mainReq.objects.filter(function (obj) {
+                    return obj.column && !obj.isWaitFor && obj.index >= 35;
+                });
+                expect(fromConditionedCol.length).toBe(0,
+                    "main detailed requests should NOT pick up the conditioned column directly");
             });
         });
 
@@ -851,6 +1096,17 @@ exports.execute = function (options) {
                 "hasWaitFor": false,
                 "hasCondition": false,
                 "value": "1,234,531"
+            },
+            {
+                // Added for the dedup test (#6) — shares condition_key cond_has_inbound1
+                // with the entity_set_i5 vis-fk. In compact context the condition is stripped
+                // (hasCondition=false); the column itself is an array_d aggregate so value stays
+                // empty until the secondary fetch resolves.
+                "title": "conditioned_col_shared_w_fk",
+                "waitFor": [],
+                "hasWaitFor": false,
+                "hasCondition": false,
+                "value": ""
             }
         ];
 
@@ -1068,6 +1324,15 @@ exports.execute = function (options) {
                 "hasWaitFor": false,
                 "hasCondition": false,
                 "value": "1,234,531"
+            },
+            {
+                // Detailed twin of the compact entry above — shares condition_key
+                // cond_has_inbound1 with the entity_set_i5 vis-fk (group 4 dedup target).
+                "title": "conditioned_col_shared_w_fk",
+                "waitFor": [],
+                "hasWaitFor": false,
+                "hasCondition": true,
+                "value": ""
             }
         ];
 
@@ -1165,7 +1430,10 @@ exports.execute = function (options) {
                     "column": "array_d_entity_i3",
                     "aggregate": true,
                     "objects": [
-                        {"index": 18, "isWaitFor": true, "column": true}
+                        {"index": 18, "isWaitFor": true, "column": true},
+                        // dedup-test column (#6) lands at compact index 32 — its source IS array_d_entity_i3.
+                        // In compact, conditions are stripped, so the column is registered normally.
+                        {"index": 32, "isWaitFor": false, "column": true}
                     ]
                 },
                 {
@@ -1293,10 +1561,15 @@ exports.execute = function (options) {
                         {"index": 20, "isWaitFor": false, "column": true},
                         {"index": 21, "isWaitFor": true, "column": true},
                         {"index": 23, "isWaitFor": true, "column": true},
-                        {"isWaitFor": true, "condition": true, "index": 0},
-                        {"isWaitFor": true, "condition": true, "index": 1},
-                        {"isWaitFor": true, "condition": true, "index": 2},
-                        {"isWaitFor": true, "condition": true, "index": 3}
+                        // condition source for groups 1, 2, 3, 4. group 0 belongs to the
+                        // sync outbound_entity_o1 condition on conditioned_col_outbound,
+                        // which is processed first (non-aggregate pass) and doesn't fetch
+                        // anything. condition sources are isWaitFor:false (they ARE the
+                        // condition, not a prerequisite of it).
+                        {"isWaitFor": false, "condition": true, "index": 1},
+                        {"isWaitFor": false, "condition": true, "index": 2},
+                        {"isWaitFor": false, "condition": true, "index": 3},
+                        {"isWaitFor": false, "condition": true, "index": 4}
                     ]
                 },
                 {
@@ -1358,8 +1631,11 @@ exports.execute = function (options) {
                         {"index": 21, "isWaitFor": false,"column": true},
                         {"index": 23, "isWaitFor": true, "column": true},
                         {"index": 25, "isWaitFor": true, "column": true},
-                        {"isWaitFor": true, "condition": true, "index": 1},
-                        {"isWaitFor": true, "condition": true, "index": 2}
+                        // wait_for of conditions on groups 2 (cond_has_inbound1_show on col 32)
+                        // and 3 (inline cnt_i1 + condition_pattern on col 33). still isWaitFor:true
+                        // — wait_fors of conditions ARE prerequisites.
+                        {"isWaitFor": true, "condition": true, "index": 2},
+                        {"isWaitFor": true, "condition": true, "index": 3}
                     ]
                 },
                 {

--- a/test/specs/column/tests/05.active_list.js
+++ b/test/specs/column/tests/05.active_list.js
@@ -103,6 +103,9 @@ exports.execute = function (options) {
         "entity_set_i7": "VEu1Crxy0bkExWQzrm6vvA",
         "all_outbound_entity_o1_o1_o1": "nTVhVgmnwDAdAScCUP5qwA",
         "path_to_outbound1_inbound1_array_d": "foYSV-qV86Kqb62X9sZlbQ",
+        "min_i3": "cVT7HCiuMShqBDIm54k-JA",
+        "max_i3": "8JxsvVi1yPJXQHDsoyPrHw",
+        "min_i4": "JXPgemxZLAlobnG6xDvLHQ",
     };
     var reverseColumnMapping = Object.keys(columnMapping).reduce(function (ret, key) {
         ret[columnMapping[key]] = key;
@@ -157,7 +160,7 @@ exports.execute = function (options) {
 
             // TODO add a test case for this too
             it ("should return the proper wait_fors (entry).", function () {
-                const expectedCreateColumns = Array.from({length: 9}, (_, i) => {
+                const expectedCreateColumns = Array.from({length: 10}, (_, i) => {
                     let waitFor = [];
 
                     if (i === 7) { // asset_col_1
@@ -202,11 +205,82 @@ exports.execute = function (options) {
             // more in depth test can be found in citation spec and chaise
         });
 
+        describe("Table.sourceDefinitions.conditions, ", function () {
+            var sds;
+            beforeAll(function () {
+                sds = mainRef.table.sourceDefinitions;
+            });
+
+            it ("should parse valid conditions from the annotation.", function () {
+                var cond = sds.getCondition("cond_has_inbound1");
+                expect(cond).toBeDefined("cond_has_inbound1 not found");
+                expect(cond.sourcekey).toBe("cnt_i1", "sourcekey missmatch");
+                expect(cond.on_empty).toBe("hide", "on_empty missmatch");
+                expect(cond.condition_pattern).toBeUndefined("condition_pattern should be undefined");
+            });
+
+            it ("should parse on_empty='show' correctly.", function () {
+                var cond = sds.getCondition("cond_has_inbound1_show");
+                expect(cond).toBeDefined("cond_has_inbound1_show not found");
+                expect(cond.sourcekey).toBe("cnt_i1", "sourcekey missmatch");
+                expect(cond.on_empty).toBe("show", "on_empty missmatch");
+            });
+
+            it ("should parse condition_pattern correctly.", function () {
+                var cond = sds.getCondition("cond_with_pattern");
+                expect(cond).toBeDefined("cond_with_pattern not found");
+                expect(cond.condition_pattern).toBe("{{#if $self}}show{{/if}}", "condition_pattern missmatch");
+            });
+
+            it ("should not parse invalid conditions (missing source/sourcekey).", function () {
+                var cond = sds.getCondition("cond_invalid_no_source");
+                expect(cond).toBeUndefined("invalid condition should not be parsed");
+            });
+
+            it ("should return undefined for non-existent condition keys.", function () {
+                var cond = sds.getCondition("non_existent_condition");
+                expect(cond).toBeUndefined("non-existent condition should return undefined");
+            });
+        });
+
+        describe("SourceObjectWrapper.condition, ", function () {
+            it ("should parse inline condition on a column.", function () {
+                // conditioned_col_inline in detailed context
+                var col = detailedColumns[31];
+                expect(col.displayname.value).toContain("conditioned_col_inline", "wrong column at index 31");
+                var sow = col.sourceObjectWrapper;
+                expect(sow).toBeDefined("sourceObjectWrapper not defined");
+                expect(sow.condition).toBeDefined("condition not defined");
+                expect(sow.condition.sourcekey).toBe("cnt_i1", "sourcekey missmatch");
+                expect(sow.condition.on_empty).toBe("hide", "on_empty missmatch");
+            });
+
+            it ("should resolve condition_key on a column.", function () {
+                // conditioned_col_key in detailed context
+                var col = detailedColumns[32];
+                expect(col.displayname.value).toContain("conditioned_col_key", "wrong column at index 32");
+                // condition_key is resolved in generateActiveList, but the _conditionKey marker should be set
+                var sow = col.sourceObjectWrapper;
+                expect(sow).toBeDefined("sourceObjectWrapper not defined");
+            });
+
+            it ("should parse condition on columns in non-detailed context too.", function () {
+                // conditions are parsed on the sourceObjectWrapper regardless of context
+                var col = compactColumns[28];
+                expect(col.displayname.value).toContain("conditioned_col_inline", "wrong column at index 28");
+                var sow = col.sourceObjectWrapper;
+                if (sow) {
+                    expect(sow.condition).toBeDefined("condition should still be parsed on sourceObjectWrapper");
+                }
+            });
+        });
+
         describe("Reference.sourceWaitFor", function () {
             it ("should be properly defined on related entities.", function () {
                 var expectedRelatedEntitiesWaitFor = [
                     {"waitFor": ["array_d_entity_i4", "array_d_entity_i5"], "hasWaitFor": true},
                     {"waitFor": ["entity_set_i5", "all_outbound_entity_o3_o1_o1"], "hasWaitFor": true},
+                    {"waitFor": [], "hasWaitFor": false},
                     {"waitFor": [], "hasWaitFor": false}
                 ];
                 var related = mainRefDetailed.related;
@@ -269,6 +343,68 @@ exports.execute = function (options) {
 
                 it ("should return the selfLinks properly.", function () {
                     testNameList(createActiveList.selfLinks, expectedCreateActiveList.selfLinks);
+                });
+            });
+
+            describe("conditionalGroups, ", function () {
+                it ("should be empty for compact (non-detailed) context.", function () {
+                    expect(compactActiveList.conditionalGroups).toBeDefined("conditionalGroups not defined");
+                    expect(compactActiveList.conditionalGroups.length).toBe(0, "should be empty for compact");
+                });
+
+                it ("should be empty for entry/create context.", function () {
+                    expect(createActiveList.conditionalGroups).toBeDefined("conditionalGroups not defined");
+                    expect(createActiveList.conditionalGroups.length).toBe(0, "should be empty for create");
+                });
+
+                it ("should return the correct number of conditional groups for detailed context.", function () {
+                    expect(detailedActiveList.conditionalGroups).toBeDefined("conditionalGroups not defined");
+                    // 3 groups: conditioned_col_inline (inline condition), conditioned_col_key (condition_key),
+                    // conditioned_col_pattern (inline w/ pattern), plus conditioned related entity_set_i5
+                    // conditioned_col_outbound uses all-outbound condition source, so evaluated synchronously — no group
+                    expect(detailedActiveList.conditionalGroups.length).toBe(4,
+                        "should have 4 conditional groups (3 columns + 1 related with async conditions)");
+                });
+
+                it ("each group should have a condition with the correct column.", function () {
+                    var groups = detailedActiveList.conditionalGroups;
+                    // all three column conditions use cnt_i1 as condition source
+                    groups.forEach(function (g, i) {
+                        expect(g.condition).toBeDefined("condition not defined for group index=" + i);
+                        expect(g.condition.column).toBeDefined("condition.column not defined for group index=" + i);
+                        expect(g.condition.column.name).toBe(
+                            columnMapping["cnt_i1"],
+                            "condition column name missmatch for group index=" + i
+                        );
+                    });
+                });
+
+                it ("each group should have the correct onEmpty value.", function () {
+                    var groups = detailedActiveList.conditionalGroups;
+                    expect(groups[0].condition.onEmpty).toBe("hide", "group 0 onEmpty");
+                    expect(groups[1].condition.onEmpty).toBe("show", "group 1 onEmpty (condition_key cond_has_inbound1_show)");
+                    expect(groups[2].condition.onEmpty).toBe("hide", "group 2 onEmpty");
+                    expect(groups[3].condition.onEmpty).toBe("hide", "group 3 onEmpty (related)");
+                });
+
+                it ("should have conditionPattern when specified.", function () {
+                    var groups = detailedActiveList.conditionalGroups;
+                    expect(groups[0].conditionPattern).toBeUndefined("group 0 should not have conditionPattern");
+                    expect(groups[1].conditionPattern).toBeUndefined("group 1 should not have conditionPattern");
+                    expect(groups[2].condition.conditionPattern).toBe(
+                        "{{#if $self}}show{{/if}}",
+                        "group 2 conditionPattern missmatch"
+                    );
+                });
+
+                it ("each group should have dependentRequests.", function () {
+                    var groups = detailedActiveList.conditionalGroups;
+                    groups.forEach(function (g, i) {
+                        expect(Array.isArray(g.dependentRequests)).toBe(true,
+                            "dependentRequests not an array for group index=" + i);
+                        expect(g.dependentRequests.length).toBeGreaterThan(0,
+                            "dependentRequests should not be empty for group index=" + i);
+                    });
                 });
             });
         });
@@ -381,6 +517,41 @@ exports.execute = function (options) {
             });
         });
 
+        describe("ActiveListCondition.evaluateCondition, ", function () {
+            it ("should return shouldShow=false when condition source is empty and on_empty='hide'.", function () {
+                var groups = detailedActiveList.conditionalGroups;
+                // group 0: condition source=cnt_i1, on_empty=hide
+                var condition = groups[0].condition;
+                var result = condition.evaluateCondition({}, null, null);
+                expect(result.shouldShow).toBe(false, "should hide when empty and on_empty=hide");
+            });
+
+            it ("should return shouldShow=true when condition source is empty and on_empty='show'.", function () {
+                var groups = detailedActiveList.conditionalGroups;
+                // group 1: condition source=cnt_i1, on_empty=show
+                var condition = groups[1].condition;
+                var result = condition.evaluateCondition({}, null, null);
+                expect(result.shouldShow).toBe(true, "should show when empty and on_empty=show");
+            });
+
+            it ("should return shouldShow=true when condition source has data and on_empty='hide'.", function () {
+                var groups = detailedActiveList.conditionalGroups;
+                // group 0: on_empty=hide → show when NOT empty
+                var condition = groups[0].condition;
+                // simulate aggregate result with value
+                var result = condition.evaluateCondition({}, [{value: "5", isHTML: false, templateVariables: {$self: "5"}}], null);
+                expect(result.shouldShow).toBe(true, "should show when has data and on_empty=hide");
+            });
+
+            it ("should return shouldShow=false when condition source has data and on_empty='show'.", function () {
+                var groups = detailedActiveList.conditionalGroups;
+                // group 1: on_empty=show → hide when NOT empty
+                var condition = groups[1].condition;
+                var result = condition.evaluateCondition({}, [{value: "5", isHTML: false, templateVariables: {$self: "5"}}], null);
+                expect(result.shouldShow).toBe(false, "should hide when has data and on_empty=show");
+            });
+        });
+
         afterAll(function () {
             options.ermRest.setClientConfig({});
         });
@@ -400,6 +571,9 @@ exports.execute = function (options) {
                 })), "wait_for missmatch" + message);
             }
             expect(list[index].hasWaitFor).toBe(col.hasWaitFor, "hasWaitFor missmatch" + message);
+            if (col.hasCondition !== undefined) {
+                expect(list[index].hasCondition).toBe(col.hasCondition, "hasCondition missmatch" + message);
+            }
         });
     }
 
@@ -617,6 +791,34 @@ exports.execute = function (options) {
                 "waitFor": ["max_i2", "array_d_entity_i1"],
                 "hasWaitFor": true,
                 "value": ""
+            },
+            {
+                "title": "conditioned_col_inline",
+                "waitFor": [],
+                "hasWaitFor": false,
+                "hasCondition": false,
+                "value": ""
+            },
+            {
+                "title": "conditioned_col_key",
+                "waitFor": [],
+                "hasWaitFor": false,
+                "hasCondition": false,
+                "value": ""
+            },
+            {
+                "title": "conditioned_col_pattern",
+                "waitFor": [],
+                "hasWaitFor": false,
+                "hasCondition": false,
+                "value": ""
+            },
+            {
+                "title": "conditioned_col_outbound",
+                "waitFor": [],
+                "hasWaitFor": false,
+                "hasCondition": false,
+                "value": "1,234,531"
             }
         ];
 
@@ -806,6 +1008,34 @@ exports.execute = function (options) {
                 "waitFor": ["max_i2", "array_d_entity_i1"],
                 "hasWaitFor": true,
                 "value": ""
+            },
+            {
+                "title": "conditioned_col_inline",
+                "waitFor": [],
+                "hasWaitFor": false,
+                "hasCondition": true,
+                "value": ""
+            },
+            {
+                "title": "conditioned_col_key",
+                "waitFor": [],
+                "hasWaitFor": false,
+                "hasCondition": true,
+                "value": ""
+            },
+            {
+                "title": "conditioned_col_pattern",
+                "waitFor": [],
+                "hasWaitFor": false,
+                "hasCondition": true,
+                "value": ""
+            },
+            {
+                "title": "conditioned_col_outbound",
+                "waitFor": [],
+                "hasWaitFor": false,
+                "hasCondition": false,
+                "value": "1,234,531"
             }
         ];
 
@@ -934,6 +1164,27 @@ exports.execute = function (options) {
                     "objects": [
                         {"index": 22, "isWaitFor": false, "column": true}
                     ]
+                },
+                {
+                    "column": "min_i3",
+                    "aggregate": true,
+                    "objects": [
+                        {"index": 28, "isWaitFor": false, "column": true}
+                    ]
+                },
+                {
+                    "column": "min_i4",
+                    "aggregate": true,
+                    "objects": [
+                        {"index": 29, "isWaitFor": false, "column": true}
+                    ]
+                },
+                {
+                    "column": "max_i3",
+                    "aggregate": true,
+                    "objects": [
+                        {"index": 30, "isWaitFor": false, "column": true}
+                    ]
                 }
             ],
             allOutBounds: [
@@ -1009,7 +1260,11 @@ exports.execute = function (options) {
                         {"index": 7, "isWaitFor": true, "column": true},
                         {"index": 20, "isWaitFor": false, "column": true},
                         {"index": 21, "isWaitFor": true, "column": true},
-                        {"index": 23, "isWaitFor": true, "column": true}
+                        {"index": 23, "isWaitFor": true, "column": true},
+                        {"isWaitFor": true, "column": true},
+                        {"isWaitFor": true, "column": true},
+                        {"isWaitFor": true, "column": true},
+                        {"isWaitFor": true, "column": true}
                     ]
                 },
                 {

--- a/test/specs/column/tests/05.active_list.js
+++ b/test/specs/column/tests/05.active_list.js
@@ -388,25 +388,6 @@ exports.execute = function (options) {
                     });
                 });
 
-                it ("each group should have the correct onEmpty value.", function () {
-                    var groups = detailedActiveList.conditionalGroups;
-                    expect(groups[0].condition.onEmpty).toBe("hide", "group 0 onEmpty");
-                    expect(groups[1].condition.onEmpty).toBe("show", "group 1 onEmpty (condition_key cond_has_inbound1_show)");
-                    expect(groups[2].condition.onEmpty).toBe("hide", "group 2 onEmpty");
-                    expect(groups[3].condition.onEmpty).toBe("hide", "group 3 onEmpty (related)");
-                });
-
-                it ("should have conditionPattern when specified.", function () {
-                    var groups = detailedActiveList.conditionalGroups;
-                    expect(groups[0].condition.conditionPattern).toBeUndefined("group 0 should not have conditionPattern");
-                    expect(groups[1].condition.conditionPattern).toBeUndefined("group 1 should not have conditionPattern");
-                    expect(groups[2].condition.conditionPattern).toBe(
-                        "{{#if cnt_i2}}show{{/if}}",
-                        "group 2 conditionPattern missmatch"
-                    );
-                    expect(groups[3].condition.conditionPattern).toBeUndefined("group 3 should not have conditionPattern (related)");
-                });
-
                 it ("each group should have dependentRequests.", function () {
                     var groups = detailedActiveList.conditionalGroups;
                     groups.forEach(function (g, i) {

--- a/test/specs/column/tests/05.active_list.js
+++ b/test/specs/column/tests/05.active_list.js
@@ -243,34 +243,32 @@ exports.execute = function (options) {
             });
         });
 
-        describe("SourceObjectWrapper.condition, ", function () {
-            it ("should parse inline condition on a column.", function () {
+        describe("SourceObjectWrapper condition sourceObject, ", function () {
+            it ("should have inline condition on the sourceObject.", function () {
                 // conditioned_col_inline in detailed context
                 var col = detailedColumns[31];
                 expect(col.displayname.value).toContain("conditioned_col_inline", "wrong column at index 31");
                 var sow = col.sourceObjectWrapper;
                 expect(sow).toBeDefined("sourceObjectWrapper not defined");
-                expect(sow.condition).toBeDefined("condition not defined");
-                expect(sow.condition.sourcekey).toBe("cnt_i1", "sourcekey missmatch");
-                expect(sow.condition.on_empty).toBe("hide", "on_empty missmatch");
+                expect(sow.sourceObject.condition).toBeDefined("condition not defined on sourceObject");
+                expect(sow.sourceObject.condition.sourcekey).toBe("cnt_i1", "sourcekey missmatch");
             });
 
-            it ("should resolve condition_key on a column.", function () {
+            it ("should have condition_key on the sourceObject.", function () {
                 // conditioned_col_key in detailed context
                 var col = detailedColumns[32];
                 expect(col.displayname.value).toContain("conditioned_col_key", "wrong column at index 32");
-                // condition_key is resolved in generateActiveList, but the _conditionKey marker should be set
                 var sow = col.sourceObjectWrapper;
                 expect(sow).toBeDefined("sourceObjectWrapper not defined");
+                expect(sow.sourceObject.condition_key).toBeDefined("condition_key not defined on sourceObject");
             });
 
-            it ("should parse condition on columns in non-detailed context too.", function () {
-                // conditions are parsed on the sourceObjectWrapper regardless of context
+            it ("should have condition on sourceObject in non-detailed context too.", function () {
                 var col = compactColumns[28];
                 expect(col.displayname.value).toContain("conditioned_col_inline", "wrong column at index 28");
                 var sow = col.sourceObjectWrapper;
                 if (sow) {
-                    expect(sow.condition).toBeDefined("condition should still be parsed on sourceObjectWrapper");
+                    expect(sow.sourceObject.condition).toBeDefined("condition should be on sourceObject");
                 }
             });
         });

--- a/test/specs/column/tests/05.active_list.js
+++ b/test/specs/column/tests/05.active_list.js
@@ -241,6 +241,16 @@ exports.execute = function (options) {
                 var cond = sds.getCondition("non_existent_condition");
                 expect(cond).toBeUndefined("non-existent condition should return undefined");
             });
+
+            it ("should parse wait_for in condition definitions.", function () {
+                var cond = sds.getCondition("cond_with_wait_for");
+                expect(cond).toBeDefined("cond_with_wait_for not found");
+                expect(cond.sourcekey).toBe("cnt_i1", "sourcekey missmatch");
+                expect(cond.condition_pattern).toBe("{{#if cnt_i2}}show{{/if}}", "condition_pattern missmatch");
+                expect(Array.isArray(cond.wait_for)).toBe(true, "wait_for should be an array");
+                expect(cond.wait_for.length).toBe(1, "wait_for length missmatch");
+                expect(cond.wait_for[0]).toBe("cnt_i2", "wait_for[0] missmatch");
+            });
         });
 
         describe("SourceObjectWrapper condition sourceObject, ", function () {
@@ -357,8 +367,9 @@ exports.execute = function (options) {
 
                 it ("should return the correct number of conditional groups for detailed context.", function () {
                     expect(detailedActiveList.conditionalGroups).toBeDefined("conditionalGroups not defined");
-                    // 3 groups: conditioned_col_inline (inline condition), conditioned_col_key (condition_key),
-                    // conditioned_col_pattern (inline w/ pattern), plus conditioned related entity_set_i5
+                    // 3 column groups: conditioned_col_inline, conditioned_col_key (with wait_for),
+                    // conditioned_col_pattern (with wait_for)
+                    // plus 1 related: conditioned entity_set_i5
                     // conditioned_col_outbound uses all-outbound condition source, so evaluated synchronously — no group
                     expect(detailedActiveList.conditionalGroups.length).toBe(4,
                         "should have 4 conditional groups (3 columns + 1 related with async conditions)");
@@ -387,12 +398,13 @@ exports.execute = function (options) {
 
                 it ("should have conditionPattern when specified.", function () {
                     var groups = detailedActiveList.conditionalGroups;
-                    expect(groups[0].conditionPattern).toBeUndefined("group 0 should not have conditionPattern");
-                    expect(groups[1].conditionPattern).toBeUndefined("group 1 should not have conditionPattern");
+                    expect(groups[0].condition.conditionPattern).toBeUndefined("group 0 should not have conditionPattern");
+                    expect(groups[1].condition.conditionPattern).toBeUndefined("group 1 should not have conditionPattern");
                     expect(groups[2].condition.conditionPattern).toBe(
-                        "{{#if $self}}show{{/if}}",
+                        "{{#if cnt_i2}}show{{/if}}",
                         "group 2 conditionPattern missmatch"
                     );
+                    expect(groups[3].condition.conditionPattern).toBeUndefined("group 3 should not have conditionPattern (related)");
                 });
 
                 it ("each group should have dependentRequests.", function () {
@@ -403,6 +415,46 @@ exports.execute = function (options) {
                         expect(g.dependentRequests.length).toBeGreaterThan(0,
                             "dependentRequests should not be empty for group index=" + i);
                     });
+                });
+
+                it ("conditions without wait_for should have empty waitFor list.", function () {
+                    var groups = detailedActiveList.conditionalGroups;
+                    expect(groups[0].condition.hasWaitFor).toBe(false, "group 0 should not have waitFor");
+                    expect(groups[0].condition.waitFor.length).toBe(0, "group 0 waitFor length");
+                    expect(groups[3].condition.hasWaitFor).toBe(false, "group 3 should not have waitFor");
+                    expect(groups[3].condition.waitFor.length).toBe(0, "group 3 waitFor length");
+                });
+
+                it ("conditions with wait_for should have populated waitFor list.", function () {
+                    var groups = detailedActiveList.conditionalGroups;
+                    // group 1 (cond_has_inbound1_show with wait_for) and group 2 (conditioned_col_pattern inline with wait_for)
+                    expect(groups[1].condition.hasWaitFor).toBe(true, "group 1 should have waitFor");
+                    expect(groups[1].condition.waitFor.length).toBe(1, "group 1 waitFor length");
+                    expect(groups[1].condition.waitFor[0].name).toBe(
+                        columnMapping["cnt_i2"],
+                        "group 1 waitFor[0] should be cnt_i2"
+                    );
+
+                    expect(groups[2].condition.hasWaitFor).toBe(true, "group 2 should have waitFor");
+                    expect(groups[2].condition.waitFor.length).toBe(1, "group 2 waitFor length");
+                    expect(groups[2].condition.waitFor[0].name).toBe(
+                        columnMapping["cnt_i2"],
+                        "group 2 waitFor[0] should be cnt_i2"
+                    );
+                });
+
+                it ("condition wait_for columns should appear in main requests with condition objects.", function () {
+                    // cnt_i2 should have condition objects for groups 1 and 2 (wait_for)
+                    var cnt_i2_req = detailedActiveList.requests.find(function (r) {
+                        return r.column && r.column.name === columnMapping["cnt_i2"];
+                    });
+                    expect(cnt_i2_req).toBeDefined("cnt_i2 should be in requests");
+                    var condObjects = cnt_i2_req.objects.filter(function (obj) {
+                        return obj.condition;
+                    });
+                    expect(condObjects.length).toBe(2, "cnt_i2 should have 2 condition objects");
+                    expect(condObjects[0].index).toBe(1, "first condition object should be for group 1");
+                    expect(condObjects[1].index).toBe(2, "second condition object should be for group 2");
                 });
             });
         });
@@ -599,6 +651,7 @@ exports.execute = function (options) {
                     expect(obj.index).toBe(expObj.index, "index missmatch" + message + " obj index=" + objIndex);
                     expect(obj.isWaitFor).toBe(expObj.isWaitFor, "isWaitFor missmatch" + message + " obj index=" + objIndex);
                     expect(obj.column).toBe(expObj.column, "column missmatch" + message + " obj index=" + objIndex);
+                    expect(obj.condition).toBe(expObj.condition, "condition missmatch" + message + " obj index=" + objIndex);
                 });
             }
 
@@ -1259,10 +1312,10 @@ exports.execute = function (options) {
                         {"index": 20, "isWaitFor": false, "column": true},
                         {"index": 21, "isWaitFor": true, "column": true},
                         {"index": 23, "isWaitFor": true, "column": true},
-                        {"isWaitFor": true, "column": true},
-                        {"isWaitFor": true, "column": true},
-                        {"isWaitFor": true, "column": true},
-                        {"isWaitFor": true, "column": true}
+                        {"isWaitFor": true, "condition": true, "index": 0},
+                        {"isWaitFor": true, "condition": true, "index": 1},
+                        {"isWaitFor": true, "condition": true, "index": 2},
+                        {"isWaitFor": true, "condition": true, "index": 3}
                     ]
                 },
                 {
@@ -1323,7 +1376,9 @@ exports.execute = function (options) {
                     "objects": [
                         {"index": 21, "isWaitFor": false,"column": true},
                         {"index": 23, "isWaitFor": true, "column": true},
-                        {"index": 25, "isWaitFor": true, "column": true}
+                        {"index": 25, "isWaitFor": true, "column": true},
+                        {"isWaitFor": true, "condition": true, "index": 1},
+                        {"isWaitFor": true, "condition": true, "index": 2}
                     ]
                 },
                 {


### PR DESCRIPTION
### Summary

Adds the `condition` block (and the reusable `condition_key` reference) to column-directives in `tag:isrd.isi.edu,2016:visible-columns` and `tag:isrd.isi.edu,2016:visible-foreign-keys`. When a condition is set, ERMrestJS exposes it through a new `Reference.activeList.conditionalGroups` structure plus an `ActiveListCondition.evaluateCondition()` entry point. Consumers (Chaise) gate the column / related-entity's visibility on the result.

For more information about the annotation syntax and the new props, refer to #1098.

### Changes

#### Annotation parsing — `js/core.js`
- `_populateSourceDefinitions()` parses a new `conditions` map under `tag:isrd.isi.edu,2019:source-definitions` (~lines 1735–1758).
- Each entry must be a non-null object with `source` or `sourcekey`. If `sourcekey` is given, it must resolve to an already-parsed source. Bad entries are dropped with a `$log.info`.
- Stored unprocessed; consumers re-resolve per use because resolution can depend on the tuple.

#### `TableSourceDefinitions` — `src/models/table-source-definitions.ts`
- Holds `conditions: Record<string, ConditionDefinition>`.
- Adds `getCondition(key)` — returns the raw condition def or `undefined`.

#### `ActiveListCondition` — `src/models/active-list-condition.ts` (new)
- Encapsulates a condition's lifecycle. Stores:
  - `column` — the `PseudoColumn` for the condition source.
  - `isAsync` — `true` if the source has an inbound or aggregate (so the source needs a secondary fetch).
  - `conditionKey` — the original `condition_key`, used by the active-list builder for cross-item dedup.
- Constructor passes a **shallow copy** of the raw condition def to `SourceObjectWrapper.clone(...)` because `clone` mutates its input and the raw def is shared across every column referencing the same `condition_key`.
- `evaluateCondition(templateVariables, conditionValue, mainTuple)` is the single dispatch point. Three internal branches keyed on the presence of `condition_pattern` and on `isAsync`:
  - **Pattern**: renders via `_renderTemplate` against `templateVariables` merged with the `$self` / `$_self` slice from `buildSelfTemplateVariables`. Blank output ⇒ empty.
  - **No pattern, async**: caller-supplied `conditionValue` (the `Page` for entitysets, `{value, templateVariables}` for aggregates) is checked by `_isConditionValueEmpty` — handles length-zero pages and `value` of `null`/`undefined`/`""`/`0`/`"0"` (count-style aggregates may serialize as numeric strings, hence the `Number()` coercion).
  - **No pattern, sync**: derives the raw value from `mainTuple` via `buildSelfTemplateVariables` (the same util `sourceFormatPresentation` uses). Scalar empty when `$_self` is `null`/`undefined`/`""`; entity-mode empty when no `$self` came back.
- `on_empty: "hide"` (default) → show when not-empty; `on_empty: "show"` → show when empty.
- `waitFor`, `hasWaitFor`, `hasWaitForAggregate` reuse `_processWaitForList`, tagged with `'condition'` so error messages locate the failure.

#### Resolution on a column directive — `src/models/reference-column/reference-column.ts`
- New `resolvedCondition` getter — checks `sourceObject.condition_key` first (looks it up in `sourceDefinitions.conditions`); falls back to inline `sourceObject.condition`. If both are set, **`condition_key` wins**. Active only in `detailed` context. Cached.
- `hasCondition` is true when `resolvedCondition.isAsync` — drives `formatPresentation` to return null while Chaise's evaluation is pending. (Sync-conditioned columns format normally; visibility is gated separately.)

#### `Reference.activeList` — `src/models/reference/reference.ts` + `src/services/active-list.ts`
- `ActiveList` returns a new `conditionalGroups: ActiveListConditionalGroup[]`. Each group has:
  - `condition` — the `ActiveListCondition`.
  - `conditionedItems` — list of `{column?, inline?, related?, index}` for items the group gates.
  - `dependentRequests` — secondary fetches that should only run after the condition resolves to "show".
- `ActiveListBuilder.processConditionedItem(condition, conditionedItem, addToDeps)` is the single intake point for any conditioned item:
  1. If a previous group already exists with the same `conditionKey`, push `conditionedItem` into its `conditionedItems` and add the caller's deps into its `dependentRequests` (dedup) and return.
  2. Otherwise create a new group at index `conditionalGroups.length`. Register the condition's source + wait-fors via `addCol(..., CONDITION, conditionIndex)`. For async sources this puts the source / wait-fors into `requests` tagged with `condition: true, index: conditionIndex` so Chaise can dispatch evaluation when the fetch lands; for sync sources `addCol` is a no-op on `requests` but still populates `allOutBounds` / `selfLinks` so any required joins / self-link keys end up in the main read URL.
- Sync and async conditions go through the same flow. Internally `evaluateCondition` picks the right branch.
- Conditions are honored only when `isDetailed` is true.

### Test coverage

#### Parsing — `test/specs/annotation/tests/07.source_definitions.js`
New `describe('conditions, ', ...)` block with **24 cases** mirroring the existing `sources` coverage:
- 7 sourcekey shapes (local column, outbound entity, outbound scalar, multi-step all-outbound, inbound entityset, all aggregate flavors, path-with-prefix).
- 3 inline source shapes (bare column, path array entity, path with aggregate).
- `on_empty` handling — explicit `"hide"`, explicit `"show"`, omitted (left undefined for callers to default).
- `condition_pattern` preserved as string; `template_engine` round-tripped when set.
- `wait_for` — empty array, single entry, multiple entries.
- Mixed `source` AND `sourcekey` — parser keeps both keys (sourcekey wins at runtime).
- All four rejection branches in `core.js`: neither set, dangling sourcekey, empty-string sourcekey, JSON `null`.

#### Runtime — `test/specs/column/tests/05.active_list.js`
Six new describe sub-blocks covering every `ActiveListCondition` branch:
- **`conditionKey` field** — `undefined` for inline conditions, set to the key for `condition_key` references.
- **`isAsync` field** — `false` for sync sources (all-outbound entity), `true` for inbound / aggregate.
- **`evaluateCondition` (sync source)** — exercises the sync branch with real tuples from `mainRefDetailed.read(2)`. Row with FK populated → show; row without → hide.
- **`evaluateCondition` (pattern source)** — renders `{{#if cnt_i2}}show{{/if}}` via handlebars. Asserts show / hide based on whether `cnt_i2` is truthy / falsy / missing in the supplied template variables.
- **`evaluateCondition` (async value shapes)** — every shape branch in `_isConditionValueEmpty`: null, page-shape with length 0, page-shape with length > 0, aggregate value `0` (number), `"0"` (numeric string — count-style coercion), `""`, non-zero number, non-numeric string.
- **`processConditionedItem` dedup** — adds a second column reusing an existing `condition_key`. Asserts the group accepts both items into `conditionedItems` instead of creating a new group, and the new column's secondary fetch lands in the group's `dependentRequests` rather than the top-level `requests` list.
