### PR TITLE
feat: Add `visible_cell_height` to the display annotation

### DIFF
--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -175,8 +175,8 @@ Supported JSON _maxfacetdepth_ patterns:
 
 Supported JSON _visiblecellheight_ patterns:
 
-- Any positive number.
-- `false`: Disable the feature and show all the contents. If this property is missing, this is the default behavior.
+- Any positive number: The cell values in the record page will be limited to the given height.
+- `false`: Disable the feature and show all the contents. If this property is missing or is invalid, this is the default behavior.
 
 Supported JSON _context_ patterns:
 - See [Context Names](#context-names) section for the list of supported JSON _context_ patterns.

--- a/docs/user-docs/annotation.md
+++ b/docs/user-docs/annotation.md
@@ -102,6 +102,7 @@ Supported JSON payload patterns:
 - `{`... `"max_facet_depth":` `{` _context_ `:` _maxfacetdepth_ `,`  ...`}`: How many levels of facet popups we should allow.
 - `{`... `"show_saved_query":` _savedquery_ ...`}`: Whether we want to display the saved query UI features or not. By default, this feature is turned off (set to false).
 - `{`... `"bulk_create_foreign_key"`: _bulkfk_ ... `}`: Use this property to control the bulk selection of foreign key values in `entry/create` context when there is a prefill query parameter. By default, the heuristics will be used to determine if this feature will be used. This can be defined on each of the catalog, schema, and table model elements.
+- `{`... `"visible_cell_height":` `{` _context_ `:` _visiblecellheight_ `,` ... `}`: Limit the height of displayed cells. Currently only supported in the `detailed` context (record page).
 
 Supported JSON _ccomment_ patterns:
 
@@ -170,6 +171,12 @@ Supported JSON _maxfacetdepth_ patterns:
 - `1`: Facet panel is only displayed for one level. The facet panel is not displayed as part of the facet popups.
 - `2`: Facet panel is displayed for two levels. Both once the main table is opened and when the facet popup is opened for any of the facets.
 - Any number bigger than 2 will be treated the same as defining `2`.
+
+
+Supported JSON _visiblecellheight_ patterns:
+
+- Any positive number.
+- `false`: Disable the feature and show all the contents. If this property is missing, this is the default behavior.
 
 Supported JSON _context_ patterns:
 - See [Context Names](#context-names) section for the list of supported JSON _context_ patterns.

--- a/docs/user-docs/column-directive.md
+++ b/docs/user-docs/column-directive.md
@@ -67,7 +67,8 @@ In this category, you use the [`source`](#source) property to define the data so
   "comment": <tooltip message>,
   "comment_display": <inline|tooltip>,
   "comment_render_markdown": <boolean>,
-  "hide_column_header": <boolean>
+  "hide_column_header": <boolean>,
+  "visible_cell_height": <number or false>,
   "display": {
       "markdown_pattern": <pattern>,
       "template_engine": <handlebars or mustache>,
@@ -113,7 +114,8 @@ In this category, the [`sourcekey`](#sourcekey) proprety is used to refer to one
   "comment": <tooltip message>,
   "comment_display": <inline|tooltip>,
   "comment_render_markdown": <boolean>,
-  "hide_column_header": <boolean>
+  "hide_column_header": <boolean>,
+  "visible_cell_height": <number or false>,
   "display": {
       "markdown_pattern": <pattern>,
       "template_engine": <handlebars or mustache>,
@@ -162,7 +164,8 @@ The following is an overview of such column directive with all the available pro
   "markdown_name": <display name>,
   "comment": <tooltip message>,
   "comment_display": <inline|tooltip>,
-  "hide_column_header": <boolean>
+  "hide_column_header": <boolean>,
+  "visible_cell_height": <number or false>,
   "display": {
       "markdown_pattern": <pattern>,
       "template_engine": <handlebars or mustache>,
@@ -413,6 +416,14 @@ By default Chaise will display `comment` as a tooltip. Set this value to `inline
 #### hide_column_header
 
 By setting this to `true`, chaise will hide the column header (and still show the value). This is only supported in `detailed` context. If this attribute is missing, we are going to use the inherited behavior from the [column display](annotation.md#tag-2016-column-display) annotation. If that one is missing too, [display annotation](annotation.md#tag-2015-display) will be used.
+
+#### visible_cell_height
+
+Limit the height of displayed cells. Currently only supported in the `detailed` context (record page). The acceptable values are,
+
+- Any positive number: The cell values in the record page will be limited to the given height.
+- `false`: Disable the feature and show all the contents. If this property is missing or is invalid, this is the default behavior.
+
 
 #### self-link
 If you want to show a self-link to the current row, you need to make sure the source is based on a not-null unique column of the current table and add the `"self_link": true` to the definition.

--- a/js/core.js
+++ b/js/core.js
@@ -21,7 +21,7 @@ import HTTPService from '@isrd-isi-edu/ermrestjs/src/services/http';
 import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
 
 // utils
-import { isObjectAndNotNull, isEmptyArray, isStringAndNotEmpty, isValidColorRGBHex } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
+import { isObjectAndNotNull, isEmptyArray, isStringAndNotEmpty, isValidColorRGBHex, isValidVisibleCellHeight } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
 import { fixedEncodeURIComponent, escapeHTML, updateObject } from '@isrd-isi-edu/ermrestjs/src/utils/value-utils';
 import {
   _annotations,
@@ -3570,6 +3570,8 @@ import {
                     }
                 }
 
+                const visibleCellHeight = _getHierarchicalDisplayAnnotationValue(this, context, "visible_cell_height", false);
+
                 this._display[context] = {
                     "hideColumnHeader": annotation.hide_column_header || false, // only hide if the annotation value is true
                     "isPreformat": hasPreformat,
@@ -3582,7 +3584,8 @@ import {
                     "columnOrder": columnOrder,
                     "comment": _processModelComment(comment, commentRenderMarkdown, columnCommentDisplayMode),
                     "commentRenderMarkdown": commentRenderMarkdown,
-                    "commentDisplayMode": columnCommentDisplayMode
+                    "commentDisplayMode": columnCommentDisplayMode,
+                    "visibleCellHeight": isValidVisibleCellHeight(visibleCellHeight) ? visibleCellHeight : undefined
                 };
             }
             return this._display[context];
@@ -4079,9 +4082,7 @@ import {
                 columnOrder = _processColumnOrderList(annotation.column_order, this.table);
                 showKeyLink = annotation.show_key_link;
                 if (typeof showFKLink !== "boolean") {
-                    showKeyLink = _getHierarchicalDisplayAnnotationValue(
-                        self, context, "show_key_link"
-                    );
+                    showKeyLink = _getHierarchicalDisplayAnnotationValue(self, context, "show_key_link", false);
 
                     // default:
                     //   compact/select: false
@@ -4108,16 +4109,18 @@ import {
                     comment = annotComment;
                 }
 
-                var displayProps = _getHierarchicalDisplayAnnotationValue(this, context, "comment_display", false);
-                var commentDisplay = _commentDisplayModes.tooltip, commentRenderMarkdown;
-                if (isObjectAndNotNull(displayProps)) {
-                    if (_isValidModelCommentDisplay(displayProps.column_comment_display)) {
-                        commentDisplay = displayProps.column_comment_display;
+                const commentProps = _getHierarchicalDisplayAnnotationValue(this, context, "comment_display", false);
+                let commentDisplay = _commentDisplayModes.tooltip, commentRenderMarkdown;
+                if (isObjectAndNotNull(commentProps)) {
+                    if (_isValidModelCommentDisplay(commentProps.column_comment_display)) {
+                        commentDisplay = commentProps.column_comment_display;
                     }
-                    if (typeof displayProps.comment_render_markdown === 'boolean') {
-                        commentRenderMarkdown = displayProps.comment_render_markdown;
+                    if (typeof commentProps.comment_render_markdown === 'boolean') {
+                        commentRenderMarkdown = commentProps.comment_render_markdown;
                     }
                 }
+
+                const visibleCellHeight = _getHierarchicalDisplayAnnotationValue(this, context, "visible_cell_height", false);
 
                 this._display[context] = {
                     "columnOrder": columnOrder,
@@ -4125,7 +4128,8 @@ import {
                     "templateEngine": annotation.template_engine,
                     "markdownPattern": annotation.markdown_pattern,
                     "showKeyLink": showKeyLink,
-                    "comment": _processModelComment(comment, commentRenderMarkdown, commentDisplay)
+                    "comment": _processModelComment(comment, commentRenderMarkdown, commentDisplay),
+                    "visibleCellHeight": isValidVisibleCellHeight(visibleCellHeight) ? visibleCellHeight : undefined
                 };
             }
 

--- a/js/core.js
+++ b/js/core.js
@@ -4081,7 +4081,7 @@ import {
 
                 columnOrder = _processColumnOrderList(annotation.column_order, this.table);
                 showKeyLink = annotation.show_key_link;
-                if (typeof showFKLink !== "boolean") {
+                if (typeof showKeyLink !== "boolean") {
                     showKeyLink = _getHierarchicalDisplayAnnotationValue(self, context, "show_key_link", false);
 
                     // default:

--- a/src/models/reference-column/foreign-key-pseudo-column.ts
+++ b/src/models/reference-column/foreign-key-pseudo-column.ts
@@ -10,7 +10,12 @@ import { Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
 import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
 
 // utils
-import { isObjectAndNotNull, isStringAndNotEmpty, isObjectAndKeyExists } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
+import {
+  isObjectAndNotNull,
+  isStringAndNotEmpty,
+  isObjectAndKeyExists,
+  isValidVisibleCellHeight,
+} from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
 import { fixedEncodeURIComponent } from '@isrd-isi-edu/ermrestjs/src/utils/value-utils';
 import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils';
 import { _annotations, _foreignKeyInputModes } from '@isrd-isi-edu/ermrestjs/src/utils/constants';
@@ -578,6 +583,10 @@ export class ForeignKeyPseudoColumn extends ReferenceColumn {
 
       if (this.sourceObject && typeof this.sourceObject.hide_column_header === 'boolean') {
         sourceDisplay.hideColumnHeader = this.sourceObject.hide_column_header;
+      }
+
+      if (this.sourceObject && isValidVisibleCellHeight(this.sourceObject.visible_cell_height)) {
+        sourceDisplay.visibleCellHeight = this.sourceObject.visible_cell_height;
       }
 
       Object.assign(res, fkDisplay, sourceDisplay);

--- a/src/models/reference-column/key-pseudo-column.ts
+++ b/src/models/reference-column/key-pseudo-column.ts
@@ -7,7 +7,7 @@ import { Reference, Tuple } from '@isrd-isi-edu/ermrestjs/src/models/reference';
 
 // utils
 import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils';
-import { isStringAndNotEmpty } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
+import { isValidVisibleCellHeight, isStringAndNotEmpty } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
 import { buildSelfTemplateVariables } from '@isrd-isi-edu/ermrestjs/src/utils/template-utils';
 
 // legacy
@@ -225,6 +225,10 @@ export class KeyPseudoColumn extends ReferenceColumn {
 
       if (this.sourceObject && typeof this.sourceObject.hide_column_header === 'boolean') {
         sourceDisplay.hideColumnHeader = this.sourceObject.hide_column_header;
+      }
+
+      if (this.sourceObject && isValidVisibleCellHeight(this.sourceObject.visible_cell_height)) {
+        sourceDisplay.visibleCellHeight = this.sourceObject.visible_cell_height;
       }
 
       Object.assign(res, keyDisplay, sourceDisplay);

--- a/src/models/reference-column/reference-column.ts
+++ b/src/models/reference-column/reference-column.ts
@@ -12,7 +12,12 @@ import $log from '@isrd-isi-edu/ermrestjs/src/services/logger';
 
 // utils
 import { renderMarkdown } from '@isrd-isi-edu/ermrestjs/src/utils/markdown-utils';
-import { isObjectAndKeyExists, isObjectAndNotNull, isStringAndNotEmpty } from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
+import {
+  isValidVisibleCellHeight,
+  isObjectAndKeyExists,
+  isObjectAndNotNull,
+  isStringAndNotEmpty,
+} from '@isrd-isi-edu/ermrestjs/src/utils/type-utils';
 import { _annotations, _contexts } from '@isrd-isi-edu/ermrestjs/src/utils/constants';
 import { buildSelfTemplateVariables } from '@isrd-isi-edu/ermrestjs/src/utils/template-utils';
 import ActiveListCondition from '@isrd-isi-edu/ermrestjs/src/models/active-list-condition';
@@ -383,6 +388,10 @@ export class ReferenceColumn {
 
       if (this.sourceObject && typeof this.sourceObject.hide_column_header === 'boolean') {
         sourceDisplay.hideColumnHeader = this.sourceObject.hide_column_header;
+      }
+
+      if (this.sourceObject && isValidVisibleCellHeight(this.sourceObject.visible_cell_height)) {
+        sourceDisplay.visibleCellHeight = this.sourceObject.visible_cell_height;
       }
 
       // Using assign to avoid changing the original colDisplay

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -87,3 +87,12 @@ export function verify(test: any, message: string) {
     throw new InvalidInputError(message);
   }
 }
+
+/**
+ * check if the value is a valid visible cell height
+ * @param value The value to check
+ * @returns True if the value is a positive number or false, false otherwise
+ */
+export function isValidVisibleCellHeight(value: unknown) {
+  return (typeof value === 'number' && value > 0) || value === false;
+}

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -89,9 +89,7 @@ export function verify(test: any, message: string) {
 }
 
 /**
- * check if the value is a valid visible cell height
- * @param value The value to check
- * @returns True if the value is a positive number or false, false otherwise
+ * check if the value is a valid visible cell height (i.e. a positive number or false)
  */
 export function isValidVisibleCellHeight(value: unknown) {
   return (typeof value === 'number' && value > 0) || value === false;

--- a/test/specs/column/conf/pseudo_column_schema/schema.json
+++ b/test/specs/column/conf/pseudo_column_schema/schema.json
@@ -10,7 +10,10 @@
                 "unique_columns": ["main_table_id_col"],
                 "annotations": {
                     "tag:misd.isi.edu,2015:display": {
-                        "markdown_name": "**key name**"
+                        "markdown_name": "**key name**",
+                        "visible_cell_height": {
+                            "detailed": 400
+                        }
                     },
                     "tag:isrd.isi.edu,2017:key-display": {
                         "*": {
@@ -182,7 +185,8 @@
                             "source": "col",
                             "markdown_name": "new name",
                             "comment": "new comment",
-                            "hide_column_header": false
+                            "hide_column_header": false,
+                            "visible_cell_height": 300
                         },
                         {
                             "source": "main_table_id_col",
@@ -194,7 +198,12 @@
                             },
                             "hide_column_header": true
                         },
-                        {"source": [{"outbound": ["pseudo_column_schema", "main_fk1"]}, "id"], "markdown_name": "main fk", "comment": "main fk cm"},
+                        {
+                            "source": [{"outbound": ["pseudo_column_schema", "main_fk1"]}, "id"],
+                            "markdown_name": "main fk",
+                            "comment": "main fk cm",
+                            "visible_cell_height": 2500
+                        },
                         {"source": [{"outbound": ["pseudo_column_schema", "main_fk1"]}, "id"], "entity": false},
                         {"source": [
                             {"outbound": ["pseudo_column_schema", "main_fk1"]},
@@ -206,12 +215,12 @@
                             {"outbound": ["pseudo_column_schema", "outbound_1_fk1"]},
                             "id"
                         ], "entity": false, "markdown_name": "**Outbound Len 2**", "comment": "outbound len 2 cm"},
-                        {"source": [{"inbound": ["pseudo_column_schema", "inbound_1_fk1"]}, "id"], "markdown_name": "inbound", "comment": "inbound cm"},
+                        {"source": [{"inbound": ["pseudo_column_schema", "inbound_1_fk1"]}, "id"], "markdown_name": "inbound", "comment": "inbound cm", "visible_cell_height": 450},
                         {"source": [
                             {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
                             {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
                             "id"
-                        ], "markdown_name": "**association table**", "comment": false},
+                        ], "markdown_name": "**association table**", "comment": false, "visible_cell_height": 550},
                         {"sourcekey": "path_to_inbound_2_outbound_1", "source": "RID", "comment": "make sure sourcekey is used and source is ignored"},
                         {"source": [{"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]}, "id"]},
                         {"source": [
@@ -231,7 +240,7 @@
                             {"inbound": ["pseudo_column_schema", "main_inbound_2_association_fk1"]},
                             {"outbound": ["pseudo_column_schema", "main_inbound_2_association_fk2"]},
                             "id"
-                        ], "aggregate": "array", "entity": false},
+                        ], "aggregate": "array", "entity": false, "visible_cell_height": 650},
                         {"sourcekey": "path_to_inbound_2", "aggregate": "array", "array_display": "csv"},
                         {
                             "sourcekey": "main_inbound_2_association_fk1_fk2_path_id_cnt_d",

--- a/test/specs/column/tests/03.pseudo_column.js
+++ b/test/specs/column/tests/03.pseudo_column.js
@@ -943,6 +943,27 @@ exports.execute = function (options) {
         // the rest of tests are in 02.referenced_column.js
       });
 
+      describe('.display.visibleCellHeight', function () {
+        var visibleCellHeightIndices = { 1: 300, 3: 2500, 7: 450, 8: 550, 15: 650 };
+
+        it('should return the `visible_cell_height` defined on the source', function () {
+          Object.keys(visibleCellHeightIndices).forEach(function (i) {
+            expect(detailedColsWTuple[i].display.visibleCellHeight).toBe(visibleCellHeightIndices[i], 'missmatch for index=' + i);
+          });
+        });
+
+        it('for key pseudo-columns, should return the `visible_cell_height` defined on the key display annotation', function () {
+          expect(detailedColsWTuple[2].display.visibleCellHeight).toBe(400, 'missmatch for index=2');
+        });
+
+        it('otherwise should return a falsy value', function () {
+          detailedColsWTuple.forEach(function (col, i) {
+            if (i === 2 || i in visibleCellHeightIndices) return;
+            expect(col.display.visibleCellHeight).toBeFalsy('missmatch for index=' + i);
+          });
+        });
+      });
+
       describe('.inputDisplayMode', function () {
         it('should return the `selector_ux_mode` defined on the table-display annotation', function () {
           // table-display on outbound_2 says 'simple-search-dropdown' that overrides default ('facet-search-popup')

--- a/test/specs/common/conf/common_schema_2/schema.json
+++ b/test/specs/common/conf/common_schema_2/schema.json
@@ -32,11 +32,25 @@
                 },
                 {
                     "name": "table_1_text",
-                    "type": { "typename": "text" }
+                    "type": { "typename": "text" },
+                    "annotations": {
+                        "tag:misd.isi.edu,2015:display": {
+                            "visible_cell_height": {
+                                "detailed": 300
+                            }
+                        }
+                    }
                 },
                 {
                     "name": "table_1_longtext",
-                    "type": { "typename": "longtext" }
+                    "type": { "typename": "longtext" },
+                    "annotations": {
+                        "tag:misd.isi.edu,2015:display": {
+                            "visible_cell_height": {
+                                "detailed": false
+                            }
+                        }
+                    }
                 },
                 {
                     "name": "table_1_date",
@@ -76,7 +90,14 @@
                 },
                 {
                     "name": "table_1_markdown",
-                    "type": { "typename": "markdown" }
+                    "type": { "typename": "markdown" },
+                    "annotations": {
+                        "tag:misd.isi.edu,2015:display": {
+                            "visible_cell_height": {
+                                "detailed": "300"
+                            }
+                        }
+                    }
                 },
                 {
                     "name": "table_1_show_null_annotation",
@@ -244,6 +265,10 @@
                 "tag:misd.isi.edu,2015:display": {
                     "show_null": {
                         "entry/create": "table"
+                    },
+                    "visible_cell_height": {
+                        "detailed": 2000,
+                        "compact": 500
                     }
                 }
             }
@@ -868,6 +893,9 @@
             },
             "show_foreign_key_link": {
                 "compact/brief": false
+            },
+            "visible_cell_height": {
+                "detailed": 800
             }
         }
     }

--- a/test/specs/common/spec.js
+++ b/test/specs/common/spec.js
@@ -5,6 +5,7 @@ require('./../../utils/starter.spec.js').runTests({
         "/common/tests/02.column.js",
         "/common/tests/03.table.js",
         "/common/tests/04.catalog.js",
+        "/common/tests/05.visible_cell_height.js",
     ],
     schemaConfigurations: [
         "/common/conf/common_schema_2.conf.json", //this should come first since schema_1 has fk to it.

--- a/test/specs/common/tests/05.visible_cell_height.js
+++ b/test/specs/common/tests/05.visible_cell_height.js
@@ -1,0 +1,104 @@
+const utils = require('../../../utils/utilities.js');
+
+exports.execute = function (options) {
+
+  describe('For determining the visible_cell_height display annotation, ', function () {
+    var catalogId;
+
+    /**
+     * returns display.visibleCellHeight of the given column on the table's reference
+     * in the given context.
+     */
+    var fetchVisibleCellHeight = function (schemaName, tableName, columnName, context, done, cb) {
+      var uri = options.url + '/catalog/' + catalogId + '/entity/' + schemaName + ':' + tableName;
+      options.ermRest.resolve(uri, { cid: 'test' }).then(function (reference) {
+        var cols = reference.contextualize[context].columns.filter(function (col) {
+          return col.name === columnName;
+        });
+        expect(cols.length).toBe(1, 'could not find column `' + columnName + '`');
+        cb(cols[0].display.visibleCellHeight);
+        done();
+      }).catch(function (err) {
+        done.fail(err);
+      });
+    };
+
+    beforeAll(function () {
+      catalogId = process.env.DEFAULT_CATALOG;
+    });
+
+    describe('regarding the default behavior, ', function () {
+      it('should return a falsy value when the annotation is not defined on any level.', function (done) {
+        fetchVisibleCellHeight('common_schema_1', 'table_1_schema_1', 'table_1_key', 'detailed', done, function (val) {
+          expect(val).toBeFalsy();
+        });
+      });
+    });
+
+    describe('regarding the annotation hierarchy, ', function () {
+      beforeAll(function (done) {
+        // catalog-level annotation. removed in afterAll
+        utils.setCatalogAnnotations(options, {
+          'tag:misd.isi.edu,2015:display': {
+            'visible_cell_height': { 'detailed': 1000 }
+          }
+        }).then(function () {
+          done();
+        }).catch(function (err) {
+          done.fail(err);
+        });
+      });
+
+      it('should honor the annotation defined on the catalog level.', function (done) {
+        fetchVisibleCellHeight('common_schema_1', 'table_1_schema_1', 'table_1_key', 'detailed', done, function (val) {
+          expect(val).toBe(1000);
+        });
+      });
+
+      it('should honor the annotation defined on the schema level and ignore the catalog.', function (done) {
+        fetchVisibleCellHeight('common_schema_2', 'table_w_defaults', 'key', 'detailed', done, function (val) {
+          expect(val).toBe(800);
+        });
+      });
+
+      it('should honor the annotation defined on the table level and ignore the schema.', function (done) {
+        fetchVisibleCellHeight('common_schema_2', 'table_1_schema_2', 'table_1_date', 'detailed', done, function (val) {
+          expect(val).toBe(2000);
+        });
+      });
+
+      it('should honor the context defined in the annotation.', function (done) {
+        fetchVisibleCellHeight('common_schema_2', 'table_1_schema_2', 'table_1_date', 'compact', done, function (val) {
+          expect(val).toBe(500);
+        });
+      });
+
+      it('should honor the annotation defined on the column level and ignore the table.', function (done) {
+        fetchVisibleCellHeight('common_schema_2', 'table_1_schema_2', 'table_1_text', 'detailed', done, function (val) {
+          expect(val).toBe(300);
+        });
+      });
+
+      it('should return `false` when the column-level annotation disables the feature.', function (done) {
+        fetchVisibleCellHeight('common_schema_2', 'table_1_schema_2', 'table_1_longtext', 'detailed', done, function (val) {
+          expect(val).toBe(false);
+        });
+      });
+
+      it('should ignore invalid values even when a parent level defines a valid one.', function (done) {
+        fetchVisibleCellHeight('common_schema_2', 'table_1_schema_2', 'table_1_markdown', 'detailed', done, function (val) {
+          expect(val).toBeFalsy();
+        });
+      });
+
+      afterAll(function (done) {
+        // remove the catalog annotation
+        utils.setCatalogAnnotations(options, {}).then(function () {
+          done();
+        }).catch(function (err) {
+          done.fail(err);
+        });
+      });
+    });
+  });
+};


### PR DESCRIPTION
Adds a new `visible_cell_height` property so data modelers can limit the height of displayed cells in the record page main section. Exposed to clients as `column.display.visibleCellHeight` on all reference column types (normal, key, foreign key, and general pseudo-columns).

Chaise PR: https://github.com/informatics-isi-edu/chaise/pull/2772