### PR TITLE
feat(handlebars): add overlaps helper for array intersection

### DIFF
--- a/docs/user-docs/handlebars.md
+++ b/docs/user-docs/handlebars.md
@@ -75,6 +75,7 @@ This document summarizes the key concepts of Handlebars that are relevant to Der
     - [List Membership](#list-membership)
       - [memberOf](#memberof)
       - [hasMember](#hasmember)
+      - [overlaps](#overlaps)
     - [Access Control (ACL) check](#access-control-acl-check)
     - [Logical Helpers](#logical-helpers)
 
@@ -1459,6 +1460,20 @@ Membership test helpers.
 {{#if (hasMember tags "active")}}
   ...
 {{/if}}
+```
+
+#### overlaps
+
+`overlaps` returns `true` if the given array shares at least one element with a list of candidates (a non-empty intersection). It is the array-vs-list counterpart to [`hasMember`](#hasmember) (array contains a single scalar). `overlaps` is variadic, pass the array column first, then any number of candidate args. Array arguments are flattened one level, so the same helper covers a fixed list, another array column, or the result of [`pluck`](#pluck). If the first argument is not an array, it returns `false`.
+
+```
+{{#if (overlaps tags "active" "featured")}}...{{/if}}
+
+{{#if (overlaps tags allowedArray)}}...{{/if}}
+
+{{#if (overlaps tags allowedArray "extra")}}...{{/if}}
+
+{{#if (overlaps tags (pluck $self "values.type"))}}...{{/if}}
 ```
 
 ### Access Control (ACL) check

--- a/src/services/handlebars.ts
+++ b/src/services/handlebars.ts
@@ -648,6 +648,20 @@ export default class HandlebarsService {
       },
 
       /**
+       * {{#if (overlaps arrayCol "a" "b")}}
+       * {{#if (overlaps arrayCol someArray)}}
+       * {{#if (overlaps arrayCol (pluck $self "values.type"))}}
+       *
+       * Variadic candidate args; any array argument is flattened one level.
+       * @returns true if `array` shares at least one element with the candidates
+       */
+      overlaps: function (array: unknown, ...args: unknown[]) {
+        if (!Array.isArray(array)) return false;
+        const candidates = flattenVariadicArgs(args);
+        return array.some((v) => candidates.includes(v));
+      },
+
+      /**
        * {{pluck $self "values.type"}}
        *
        * Preserves length and order; missing paths resolve to undefined.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -298,6 +298,7 @@ export const _handlebarsHelpersList = [
   // list/array helpers
   'memberOf',
   'hasMember',
+  'overlaps',
   'pluck',
 ];
 

--- a/test/specs/print_utils/tests/01.print_utils.js
+++ b/test/specs/print_utils/tests/01.print_utils.js
@@ -1356,6 +1356,32 @@ export function execute (options) {
         expect(render('{{#if (hasMember missing "x")}}yes{{else}}no{{/if}}', {})).toBe('no');
       });
 
+      it('overlaps helper', function () {
+        const render = (t, v) => module.renderHandlebarsTemplate(t, v);
+        // variadic candidates
+        expect(render('{{#if (overlaps tags "active" "draft")}}yes{{else}}no{{/if}}', { tags: ['active', 'public'] })).toBe('yes');
+        expect(render('{{#if (overlaps tags "draft" "archived")}}yes{{else}}no{{/if}}', { tags: ['active', 'public'] })).toBe('no');
+        // array candidate is flattened
+        expect(render('{{#if (overlaps tags allowed)}}yes{{else}}no{{/if}}', { tags: ['active', 'public'], allowed: ['draft', 'public'] })).toBe('yes');
+        expect(render('{{#if (overlaps tags allowed)}}yes{{else}}no{{/if}}', { tags: ['active', 'public'], allowed: ['draft', 'archived'] })).toBe('no');
+        // mix array candidate with extra scalar
+        expect(render('{{#if (overlaps tags allowed "active")}}yes{{else}}no{{/if}}', { tags: ['active'], allowed: ['draft'] })).toBe('yes');
+        // numeric members
+        expect(render('{{#if (overlaps values 4 2)}}yes{{else}}no{{/if}}', { values: [1, 2, 3] })).toBe('yes');
+        // composes with pluck
+        expect(
+          render('{{#if (overlaps (pluck items "values.type") "b")}}yes{{else}}no{{/if}}', {
+            items: [{ values: { type: 'a' } }, { values: { type: 'b' } }],
+          }),
+        ).toBe('yes');
+        // no candidates -> false
+        expect(render('{{#if (overlaps tags)}}yes{{else}}no{{/if}}', { tags: ['active'] })).toBe('no');
+        // non-array input -> false (no throw)
+        expect(render('{{#if (overlaps tags "x")}}yes{{else}}no{{/if}}', { tags: 'not-an-array' })).toBe('no');
+        // missing variable -> false
+        expect(render('{{#if (overlaps missing "x")}}yes{{else}}no{{/if}}', {})).toBe('no');
+      });
+
       it('pluck helper', function () {
         const render = (t, v) => module.renderHandlebarsTemplate(t, v);
         // basic path


### PR DESCRIPTION
This PR adds the `overlaps` handlebar function so we can avoid using multiple `hasMember`s with an `or`.

```
{{overlaps values "1" "2" "3"}}
{{or (hasMember values "1") (hasMember values "2") (hasMember values "3")}}
```