### PR TITLE
fix: condition request dedup

### DIFF
--- a/.claude/rules/unit-test.md
+++ b/.claude/rules/unit-test.md
@@ -8,3 +8,14 @@ paths:
 ## Notes for Claude
 
 Unit tests require a running ERMrest backend (`ERMREST_URL`, `AUTH_COOKIE`, `RESTRICTED_AUTH_COOKIE` env vars) and import schemas into a real catalog. Do not run `make test` or `make test-single` without explicit user approval — they make external HTTP calls and mutate catalog state.
+
+### Test descriptions
+
+Keep `describe()` and `it()` descriptions short so the run logs stay easy to scan. Describe the action or
+the expectation in a few words; don't restate the assertion or explain the "why" (put rationale in a code
+comment if needed).
+
+```javascript
+it('folds the condition source onto the display', function () { ... });   // ✅ concise
+it('should put the entity_set_i8 display in main requests with a condition object so it is read once instead of twice', function () { ... });  // ❌ too long
+```

--- a/docs/user-docs/column-directive.md
+++ b/docs/user-docs/column-directive.md
@@ -677,6 +677,10 @@ Visibility is a two-step decision: first determine whether the condition result 
 
 For example, a no-source `condition_pattern` of `{{#if (isUserInAcl "admin")}}show{{/if}}` renders non-empty for admins and empty for everyone else. With `on_empty: "hide"` (default), admins see the column; with `on_empty: "show"`, the visibility is inverted (everyone except admins sees it).
 
+**Entity-set sources see only the first page:**
+
+When a with-source condition's source is an entity set (an inbound path in entity mode, no aggregate), the condition is evaluated against the first page of that entity set, and it is evaluated once on load (it is not re-evaluated when the user paginates the related table). This is fine for a "does it have any rows" check, because the first page is empty exactly when the table is empty. It is **not** reliable for a `condition_pattern` that iterates `$self` looking for a specific row (for example "is there a row where `term=one`") once the table can have more rows than the page size, because rows beyond the first page are not visible to the template. For a condition that must consider the whole table, use an [`aggregate`](#aggregate) source (for example a `cnt` with a filter) instead. The entity-set condition source exists to reuse the read that already happens to display the related table, so it does not widen the page or perform an unbounded read.
+
 <a name="condition_key"></a>
 #### condition_key
 

--- a/src/models/reference/reference.ts
+++ b/src/models/reference/reference.ts
@@ -930,18 +930,22 @@ export class Reference {
     if (isDetailed) {
       this.generateRelatedList(tuple).forEach((rel, i) => {
         const rc = rel.pseudoColumn?.resolvedCondition;
+        // source hash of this related entity, used by the consolidation pass to match
+        // data consumers (wait_fors, citation, condition sources) of the same source.
+        // Mirrors how generateRelatedList computes fkName.
+        const relSourceName = rel.pseudoColumn ? rel.pseudoColumn.name : (_sourceColumnHelpers.generateForeignKeyName(rel.origFKR, true) as string);
         /**
          * if there's a condition, we have to capture the requests generated for the related entity as its dependencies.
          * So when the condition is evaludated, we can decide whether to run those requests or not.
          */
         const addRelatedToDeps = (deps: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => {
-          deps.push({ related: true, index: i });
+          deps.push({ related: true, index: i, entitysetSourceName: relSourceName });
           rel.pseudoColumn?.waitFor.forEach((wf) => {
             builder.addColToDependent(deps, wf, true, ActiveListRequestTypes.RELATED, i);
           });
         };
         if (tryCondition(rc, { related: true, index: i }, addRelatedToDeps)) return;
-        builder.requests.push({ related: true, index: i });
+        builder.requests.push({ related: true, index: i, entitysetSourceName: relSourceName });
         rel.pseudoColumn?.waitFor.forEach((wf) => {
           builder.addCol(wf, true, ActiveListRequestTypes.RELATED, i);
         });

--- a/src/models/reference/reference.ts
+++ b/src/models/reference/reference.ts
@@ -936,7 +936,7 @@ export class Reference {
         const relSourceName = rel.pseudoColumn ? rel.pseudoColumn.name : (_sourceColumnHelpers.generateForeignKeyName(rel.origFKR, true) as string);
         /**
          * if there's a condition, we have to capture the requests generated for the related entity as its dependencies.
-         * So when the condition is evaludated, we can decide whether to run those requests or not.
+         * So when the condition is evaluated, we can decide whether to run those requests or not.
          */
         const addRelatedToDeps = (deps: Array<ActiveListRequest | ActiveListRelatedEntityRequest>) => {
           deps.push({ related: true, index: i, entitysetSourceName: relSourceName });

--- a/src/services/active-list.ts
+++ b/src/services/active-list.ts
@@ -436,76 +436,79 @@ export class ActiveListBuilder {
   }
 
   /**
-   * One read per source. After the whole active list is built, fold every set of
-   * requests that share the same source hash — across the main `requests` list and
-   * every conditional group's `dependentRequests` — onto a single canonical request,
-   * merging their consumer objects. This covers entitysets, aggregates, and
-   * inline/related displays uniformly, so a source that is both displayed and
-   * consumed (or whose gated value equals its condition source / an unconditional
-   * wait_for) is read only once.
+   * consolidates the requests in this.requests and this.conditionalGroups.dependentRequests
+   * to avoid duplicate reads for the same source.
    *
-   * - The canonical is a display when one exists (it renders the table AND yields the
-   *   rows the data consumers need); otherwise the unconditional (main) data request.
-   * - A canonical that lives in a group's `dependentRequests` is promoted into the main
-   *   `requests` when any consumer of the same source is unconditional (lives in main),
-   *   so the read happens once on load; visibility is still gated by `conditionHide`.
-   * - Aggregates only ever share a hash with other aggregates of the same source (the
-   *   hash encodes the aggregate function), so they never fold into a display.
-   * - Dependents of two different conditional groups are never folded into each other
-   *   (that would mis-gate one group's consumer behind the other's condition).
-   *
-   * Runs after the whole list is built (columns, inline, related, citation, conditions),
-   * because related displays are registered after the consumers that may reference them.
+   * - Uses similar dedup logic as `consideredSets` / `consideredAggregates`
+   * (group by source hash, first request wins, the rest attach their `objects`),
+   * plus one clause: a display (visible inline or related entities) wins when one exists,
+   * so a source that is both displayed and consumed is read once.
+   * - Runs as a final pass rather than an inline map because related displays are registered
+   * after the consumers that reference them, so at consumer time the display does not exist yet.
+   * - A fold removes the duplicate from wherever it lives (`requests` or a group's
+   * `dependentRequests`); a deferred merge target is promoted into `requests` when any
+   * request for its source is unconditional, so the read happens on load. Nothing is ever
+   * added to a group's `dependentRequests`.
    */
   private consolidateRequests(): void {
     if (!this.isDetailed) return;
 
-    type Entry = {
+    type LocatedRequest = {
       requestList: Array<ActiveListRequest | ActiveListRelatedEntityRequest>;
       req: ActiveListRequest & ActiveListRelatedEntityRequest;
-      isDisplay: boolean;
-      isMain: boolean;
+      isRelatedOrInline: boolean;
+      isUnconditional: boolean;
     };
-    const byHash: { [hash: string]: Entry[] } = {};
-    const collect = (requestList: Array<ActiveListRequest | ActiveListRelatedEntityRequest>, isMain: boolean) => {
+
+    // capture all the requests that we have (conditioned + unconditioned)
+    const requestsBySource: { [hash: string]: LocatedRequest[] } = {};
+    const collect = (requestList: Array<ActiveListRequest | ActiveListRelatedEntityRequest>, isUnconditional: boolean) => {
       requestList.forEach((r) => {
         const req = r as ActiveListRequest & ActiveListRelatedEntityRequest;
-        const isDisplay = !!(req.inline || req.related);
-        const hash = isDisplay ? req.entitysetSourceName : req.column?.name;
+        const isRelatedOrInline = !!(req.inline || req.related);
+        const hash = isRelatedOrInline ? req.entitysetSourceName : req.column?.name;
         if (typeof hash !== 'string') return;
-        (byHash[hash] = byHash[hash] || []).push({ requestList, req, isDisplay, isMain });
+        if (!(hash in requestsBySource)) requestsBySource[hash] = [];
+        requestsBySource[hash].push({ requestList, req, isRelatedOrInline, isUnconditional });
       });
     };
     collect(this.requests, true);
     this.conditionalGroups.forEach((group) => collect(group.dependentRequests, false));
 
-    Object.keys(byHash).forEach((hash) => {
-      const entries = byHash[hash];
+    Object.keys(requestsBySource).forEach((hash) => {
+      const entries = requestsBySource[hash];
       if (entries.length < 2) return;
 
-      // canonical: a display if any (prefer a main display), else a main data request.
-      // if neither exists (only dependent data requests), leave them gated as-is.
-      const displays = entries.filter((e) => e.isDisplay);
-      const canonical = displays.find((e) => e.isMain) || displays[0] || entries.find((e) => e.isMain);
-      if (!canonical) return;
+      /**
+       * Prefer a display as the merge target (even a conditional one): it renders the
+       * table AND yields the rows the data consumers need, so everyone reuses its read.
+       * A conditional display is promoted to run on load below when needed. With no
+       * display and no unconditional consumer there is no safe target, so skip: e.g.
+       * condition A gates column X and condition B gates column Y, both X and Y valued
+       * from the same entity set `H`. Folding B's `H` onto A would gate Y behind A, so
+       * if A is false but B is true, Y loses its data. Leave them as two reads.
+       */
+      const displays = entries.filter((e) => e.isRelatedOrInline);
+      const mergeTarget = displays.find((e) => e.isUnconditional) || displays[0] || entries.find((e) => e.isUnconditional);
+      if (!mergeTarget) return;
 
-      const anyMain = entries.some((e) => e.isMain);
+      const anyUnconditional = entries.some((e) => e.isUnconditional);
       entries.forEach((e) => {
-        if (e === canonical) return;
-        // when the canonical is deferred, only fold unconditional consumers or ones in
-        // the canonical's own list — never another group's dependent.
-        if (!canonical.isMain && !e.isMain && e.requestList !== canonical.requestList) return;
-        if (!canonical.req.objects) canonical.req.objects = [];
-        if (Array.isArray(e.req.objects)) canonical.req.objects.push(...e.req.objects);
+        if (e === mergeTarget) return;
+        // when the merge target is deferred, only fold unconditional requests or ones in
+        // the merge target's own list (never another group's dependent)
+        if (!mergeTarget.isUnconditional && !e.isUnconditional && e.requestList !== mergeTarget.requestList) return;
+        if (!mergeTarget.req.objects) mergeTarget.req.objects = [];
+        if (Array.isArray(e.req.objects)) mergeTarget.req.objects.push(...e.req.objects);
         const idx = e.requestList.indexOf(e.req);
         if (idx !== -1) e.requestList.splice(idx, 1);
       });
 
-      // a deferred canonical that has an unconditional consumer must run on load.
-      if (!canonical.isMain && anyMain) {
-        const idx = canonical.requestList.indexOf(canonical.req);
-        if (idx !== -1) canonical.requestList.splice(idx, 1);
-        this.requests.push(canonical.req);
+      // a deferred merge target that has an unconditional request must run on load.
+      if (!mergeTarget.isUnconditional && anyUnconditional) {
+        const idx = mergeTarget.requestList.indexOf(mergeTarget.req);
+        if (idx !== -1) mergeTarget.requestList.splice(idx, 1);
+        this.requests.push(mergeTarget.req);
       }
     });
   }

--- a/src/services/active-list.ts
+++ b/src/services/active-list.ts
@@ -68,6 +68,18 @@ export type ActiveListRelatedEntityRequest = {
   related?: boolean;
   /** the index of the related entity in the reference.related array */
   index: number;
+  /**
+   * the source hash (pseudo-column name) of the displayed entity set. Set so the
+   * consolidation pass can match data consumers (values, wait_fors, citation,
+   * condition sources) of the same source onto this display request.
+   */
+  entitysetSourceName?: string;
+  /**
+   * consumers folded onto this display request by the consolidation pass. When
+   * present, chaise routes the display read's page to these consumers instead of
+   * issuing a separate fetch. Mirrors `ActiveListRequest.objects`.
+   */
+  objects?: Array<ActiveListRequestObject>;
 };
 
 /**
@@ -333,7 +345,7 @@ export class ActiveListBuilder {
    */
   addInline(col: VisibleColumn, i: number): void {
     if (isRelatedColumn(col)) {
-      this.requests.push({ inline: true, index: i });
+      this.requests.push({ inline: true, index: i, entitysetSourceName: col.name });
     } else {
       this.addCol(col, false, ActiveListRequestTypes.COLUMN, i);
     }
@@ -346,7 +358,7 @@ export class ActiveListBuilder {
   /** Same as addInline but adds to dependent requests in a conditional group */
   addInlineToDependent(dependentRequests: Array<ActiveListRequest | ActiveListRelatedEntityRequest>, col: VisibleColumn, i: number): void {
     if (isRelatedColumn(col)) {
-      dependentRequests.push({ inline: true, index: i });
+      dependentRequests.push({ inline: true, index: i, entitysetSourceName: col.name });
     } else {
       this.addColToDependent(dependentRequests, col, false, ActiveListRequestTypes.COLUMN, i);
     }
@@ -424,9 +436,85 @@ export class ActiveListBuilder {
   }
 
   /**
+   * One read per source. After the whole active list is built, fold every set of
+   * requests that share the same source hash — across the main `requests` list and
+   * every conditional group's `dependentRequests` — onto a single canonical request,
+   * merging their consumer objects. This covers entitysets, aggregates, and
+   * inline/related displays uniformly, so a source that is both displayed and
+   * consumed (or whose gated value equals its condition source / an unconditional
+   * wait_for) is read only once.
+   *
+   * - The canonical is a display when one exists (it renders the table AND yields the
+   *   rows the data consumers need); otherwise the unconditional (main) data request.
+   * - A canonical that lives in a group's `dependentRequests` is promoted into the main
+   *   `requests` when any consumer of the same source is unconditional (lives in main),
+   *   so the read happens once on load; visibility is still gated by `conditionHide`.
+   * - Aggregates only ever share a hash with other aggregates of the same source (the
+   *   hash encodes the aggregate function), so they never fold into a display.
+   * - Dependents of two different conditional groups are never folded into each other
+   *   (that would mis-gate one group's consumer behind the other's condition).
+   *
+   * Runs after the whole list is built (columns, inline, related, citation, conditions),
+   * because related displays are registered after the consumers that may reference them.
+   */
+  private consolidateRequests(): void {
+    if (!this.isDetailed) return;
+
+    type Entry = {
+      requestList: Array<ActiveListRequest | ActiveListRelatedEntityRequest>;
+      req: ActiveListRequest & ActiveListRelatedEntityRequest;
+      isDisplay: boolean;
+      isMain: boolean;
+    };
+    const byHash: { [hash: string]: Entry[] } = {};
+    const collect = (requestList: Array<ActiveListRequest | ActiveListRelatedEntityRequest>, isMain: boolean) => {
+      requestList.forEach((r) => {
+        const req = r as ActiveListRequest & ActiveListRelatedEntityRequest;
+        const isDisplay = !!(req.inline || req.related);
+        const hash = isDisplay ? req.entitysetSourceName : req.column?.name;
+        if (typeof hash !== 'string') return;
+        (byHash[hash] = byHash[hash] || []).push({ requestList, req, isDisplay, isMain });
+      });
+    };
+    collect(this.requests, true);
+    this.conditionalGroups.forEach((group) => collect(group.dependentRequests, false));
+
+    Object.keys(byHash).forEach((hash) => {
+      const entries = byHash[hash];
+      if (entries.length < 2) return;
+
+      // canonical: a display if any (prefer a main display), else a main data request.
+      // if neither exists (only dependent data requests), leave them gated as-is.
+      const displays = entries.filter((e) => e.isDisplay);
+      const canonical = displays.find((e) => e.isMain) || displays[0] || entries.find((e) => e.isMain);
+      if (!canonical) return;
+
+      const anyMain = entries.some((e) => e.isMain);
+      entries.forEach((e) => {
+        if (e === canonical) return;
+        // when the canonical is deferred, only fold unconditional consumers or ones in
+        // the canonical's own list — never another group's dependent.
+        if (!canonical.isMain && !e.isMain && e.requestList !== canonical.requestList) return;
+        if (!canonical.req.objects) canonical.req.objects = [];
+        if (Array.isArray(e.req.objects)) canonical.req.objects.push(...e.req.objects);
+        const idx = e.requestList.indexOf(e.req);
+        if (idx !== -1) e.requestList.splice(idx, 1);
+      });
+
+      // a deferred canonical that has an unconditional consumer must run on load.
+      if (!canonical.isMain && anyMain) {
+        const idx = canonical.requestList.indexOf(canonical.req);
+        if (idx !== -1) canonical.requestList.splice(idx, 1);
+        this.requests.push(canonical.req);
+      }
+    });
+  }
+
+  /**
    * Return the built ActiveList object. After calling this method, the builder should not be used anymore.
    */
   build(): ActiveList {
+    this.consolidateRequests();
     return {
       requests: this.requests,
       conditionalGroups: this.conditionalGroups,

--- a/src/services/active-list.ts
+++ b/src/services/active-list.ts
@@ -460,8 +460,9 @@ export class ActiveListBuilder {
       isUnconditional: boolean;
     };
 
-    // capture all the requests that we have (conditioned + unconditioned)
-    const requestsBySource: { [hash: string]: LocatedRequest[] } = {};
+    // capture all the requests that we have (conditioned + unconditioned).
+    // null-prototype so a schema-controlled source hash like `__proto__` is a plain key.
+    const requestsBySource: { [hash: string]: LocatedRequest[] } = Object.create(null);
     const collect = (requestList: Array<ActiveListRequest | ActiveListRelatedEntityRequest>, isUnconditional: boolean) => {
       requestList.forEach((r) => {
         const req = r as ActiveListRequest & ActiveListRelatedEntityRequest;

--- a/test/specs/column/conf/active_list_schema/data/inbound8.json
+++ b/test/specs/column/conf/active_list_schema/data/inbound8.json
@@ -1,0 +1,7 @@
+[
+    {"inbound8_id": "i01", "rowname_col": "inbound8 one", "int_col": 12345281, "fk1_col1": "01"},
+    {"inbound8_id": "i02", "rowname_col": "inbound8 two", "int_col": 12345282, "fk1_col1": "01"},
+    {"inbound8_id": "i03", "rowname_col": "inbound8 three", "int_col": 12345283, "fk1_col1": "01"},
+    {"inbound8_id": "i04", "rowname_col": "inbound8 four", "int_col": 12345284, "fk1_col1": "01"},
+    {"inbound8_id": "i05", "rowname_col": "inbound8 five", "int_col": 12345285, "fk1_col1": "01"}
+]

--- a/test/specs/column/conf/active_list_schema/schema.json
+++ b/test/specs/column/conf/active_list_schema/schema.json
@@ -479,6 +479,10 @@
                         {
                             "sourcekey": "entity_set_i5",
                             "condition_key": "cond_has_inbound1"
+                        },
+                        {
+                            "sourcekey": "entity_set_i8",
+                            "condition_key": "cond_self_i8"
                         }
                     ]
                 },
@@ -715,6 +719,9 @@
                         "entity_set_i7": {
                             "source": [{"inbound": ["active_list_schema", "inbound7_fk1"]}, "inbound7_id"]
                         },
+                        "entity_set_i8": {
+                            "source": [{"inbound": ["active_list_schema", "inbound8_fk1"]}, "inbound8_id"]
+                        },
                         "all_outbound_entity_o1_o1_o1": {
                             "source": [
                                 {"outbound": ["active_list_schema", "main_fk1"]},
@@ -782,6 +789,12 @@
                         },
                         "cond_no_source_show": {
                             "condition_pattern": "show"
+                        },
+                        "cond_self_i8": {
+                            "sourcekey": "entity_set_i8",
+                            "on_empty": "hide",
+                            "condition_pattern": "{{#if (gt $self.length 0)}}show{{/if}}",
+                            "template_engine": "handlebars"
                         }
                     }
                 }
@@ -2005,6 +2018,68 @@
             "column_definitions": [
                 {
                     "name": "inbound7_id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "rowname_col",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "fk1_col1",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "int_col",
+                    "type": {
+                        "typename": "int4"
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2016:table-display": {
+                    "row_name": {
+                        "row_markdown_pattern": "{{{rowname_col}}}"
+                    }
+                }
+            }
+        },
+        "inbound8": {
+            "kind": "table",
+            "table_name": "inbound8",
+            "schema_name": "active_list_schema",
+            "keys": [
+                {"unique_columns": ["inbound8_id"]},
+                {"unique_columns": ["rowname_col"]}
+            ],
+            "foreign_keys": [
+                {
+                    "names": [["active_list_schema", "inbound8_fk1"]],
+                    "foreign_key_columns": [
+                        {
+                            "column_name": "fk1_col1",
+                            "table_name": "inbound8",
+                            "schema_name": "active_list_schema"
+                        }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "column_name": "main_id",
+                            "table_name": "main",
+                            "schema_name": "active_list_schema"
+                        }
+                    ]
+                }
+            ],
+            "column_definitions": [
+                {
+                    "name": "inbound8_id",
                     "nullok": false,
                     "type": {
                         "typename": "text"

--- a/test/specs/column/tests/05.active_list.js
+++ b/test/specs/column/tests/05.active_list.js
@@ -508,7 +508,7 @@ exports.execute = function (options) {
             });
 
             describe("consolidation (one read per source), ", function () {
-                it ("should not leave any standalone entityset request for a displayed source.", function () {
+                it ("no standalone entityset request for a displayed source", function () {
                     // every entity set in this schema is displayed (inline or vis-fk), so the data
                     // consumers (values, wait_fors, citation, condition) are folded onto the matching
                     // display request and no standalone entityset request remains.
@@ -519,7 +519,7 @@ exports.execute = function (options) {
                         "no standalone entityset requests should remain after consolidation");
                 });
 
-                it ("should not have two top-level requests sharing the same source hash.", function () {
+                it ("no two top-level requests share a source hash", function () {
                     // a display (entitysetSourceName) and a data request (column.name) must never both
                     // exist for the same source — that pair was the duplicate read this change removes.
                     var seen = {};
@@ -533,7 +533,7 @@ exports.execute = function (options) {
                     });
                 });
 
-                it ("should promote a self-referential conditioned display into main requests (read once).", function () {
+                it ("promotes a self-referential conditioned display to main requests", function () {
                     // entity_set_i8 vis-fk is gated by cond_self_i8 whose source IS entity_set_i8. The
                     // condition source folds onto the display and the display is promoted to a main
                     // request tagged with a condition object — so it is read once, not twice.

--- a/test/specs/column/tests/05.active_list.js
+++ b/test/specs/column/tests/05.active_list.js
@@ -101,6 +101,7 @@ exports.execute = function (options) {
         "entity_set_i5": "F9KkhBV_Qkaw20GzvIMAjQ",
         "entity_set_i6": "FZPDS1yFBJ1mdyr_Q",
         "entity_set_i7": "VEu1Crxy0bkExWQzrm6vvA",
+        "entity_set_i8": "zp5su_u3gOQ6FHT2DZY8uQ",
         "all_outbound_entity_o1_o1_o1": "nTVhVgmnwDAdAScCUP5qwA",
         "path_to_outbound1_inbound1_array_d": "foYSV-qV86Kqb62X9sZlbQ",
         "min_i3": "cVT7HCiuMShqBDIm54k-JA",
@@ -297,6 +298,8 @@ exports.execute = function (options) {
                     {"waitFor": ["array_d_entity_i4", "array_d_entity_i5"], "hasWaitFor": true},
                     {"waitFor": ["entity_set_i5", "all_outbound_entity_o3_o1_o1"], "hasWaitFor": true},
                     {"waitFor": [], "hasWaitFor": false},
+                    {"waitFor": [], "hasWaitFor": false},
+                    // entity_set_i8 (self-ref condition, no display wait_for)
                     {"waitFor": [], "hasWaitFor": false}
                 ];
                 var related = mainRefDetailed.related;
@@ -384,8 +387,9 @@ exports.execute = function (options) {
                     //   group 2: conditioned_col_key      (async, condition_key=cond_has_inbound1_show)
                     //   group 3: conditioned_col_pattern  (async, source=cnt_i1, inline pattern + wait_for)
                     //   group 4: entity_set_i5 vis-fk     (async, condition_key=cond_has_inbound1)
-                    expect(detailedActiveList.conditionalGroups.length).toBe(5,
-                        "should have 5 conditional groups (4 columns + 1 related)");
+                    //   group 5: entity_set_i8 vis-fk     (async, condition_key=cond_self_i8 — source is itself)
+                    expect(detailedActiveList.conditionalGroups.length).toBe(6,
+                        "should have 6 conditional groups (4 columns + 2 related)");
                 });
 
                 it ("each group should have a condition with the expected source column.", function () {
@@ -397,7 +401,9 @@ exports.execute = function (options) {
                         columnMapping["cnt_i1"],
                         columnMapping["cnt_i1"],
                         columnMapping["cnt_i1"],
-                        columnMapping["cnt_i1"]
+                        columnMapping["cnt_i1"],
+                        // group 5: cond_self_i8 — its source is the entity_set_i8 it gates
+                        columnMapping["entity_set_i8"]
                     ];
                     groups.forEach(function (g, i) {
                         expect(g.condition).toBeDefined("condition not defined for group index=" + i);
@@ -422,11 +428,20 @@ exports.execute = function (options) {
                     });
                     expect(groups[0].dependentRequests.length).toBe(0,
                         "group 0 (sync outbound on plain column) should have empty deps");
-                    // groups 1-3 wrap aggregate columns, group 4 wraps a related entity, all
-                    // need at least one dependent request to fetch their data.
-                    [1, 2, 3, 4].forEach(function (i) {
+                    // groups 1-3 wrap aggregate columns whose sources are exclusively conditional,
+                    // so they keep a deferred dependent fetch.
+                    [1, 2, 3].forEach(function (i) {
                         expect(groups[i].dependentRequests.length).toBeGreaterThan(0,
                             "dependentRequests should not be empty for group index=" + i);
+                    });
+                    // group 4 (cond_has_inbound1) gates the entity_set_i5 vis-fk and the
+                    // conditioned_col_shared_w_fk column, but both their sources are ALSO needed
+                    // unconditionally elsewhere, so consolidation folds them into main requests
+                    // and the group keeps no deferred fetch. group 5 (cond_self_i8) is the same:
+                    // its display is promoted to main, leaving no deps.
+                    [4, 5].forEach(function (i) {
+                        expect(groups[i].dependentRequests.length).toBe(0,
+                            "deps should be empty for group index=" + i + " (sources folded to main)");
                     });
                 });
 
@@ -489,6 +504,67 @@ exports.execute = function (options) {
                     expect(condObjects.length).toBe(2, "cnt_i2 should have 2 condition objects");
                     expect(condObjects[0].index).toBe(2, "first condition object should be for group 2");
                     expect(condObjects[1].index).toBe(3, "second condition object should be for group 3");
+                });
+            });
+
+            describe("consolidation (one read per source), ", function () {
+                it ("should not leave any standalone entityset request for a displayed source.", function () {
+                    // every entity set in this schema is displayed (inline or vis-fk), so the data
+                    // consumers (values, wait_fors, citation, condition) are folded onto the matching
+                    // display request and no standalone entityset request remains.
+                    var standalone = detailedActiveList.requests.filter(function (r) {
+                        return r.entityset === true;
+                    });
+                    expect(standalone.length).toBe(0,
+                        "no standalone entityset requests should remain after consolidation");
+                });
+
+                it ("should not have two top-level requests sharing the same source hash.", function () {
+                    // a display (entitysetSourceName) and a data request (column.name) must never both
+                    // exist for the same source — that pair was the duplicate read this change removes.
+                    var seen = {};
+                    detailedActiveList.requests.forEach(function (r, i) {
+                        var hash = (r.inline || r.related) ? r.entitysetSourceName : (r.column && r.column.name);
+                        if (!hash) return;
+                        expect(hash in seen).toBe(false,
+                            "duplicate source hash `" + (reverseColumnMapping[hash] || hash) +
+                            "` at requests index " + i + " (also at " + seen[hash] + ")");
+                        seen[hash] = i;
+                    });
+                });
+
+                it ("should promote a self-referential conditioned display into main requests (read once).", function () {
+                    // entity_set_i8 vis-fk is gated by cond_self_i8 whose source IS entity_set_i8. The
+                    // condition source folds onto the display and the display is promoted to a main
+                    // request tagged with a condition object — so it is read once, not twice.
+                    var i8Hash = columnMapping["entity_set_i8"];
+                    var display = detailedActiveList.requests.find(function (r) {
+                        return r.related === true && r.entitysetSourceName === i8Hash;
+                    });
+                    expect(display).toBeDefined("entity_set_i8 display should be a main request");
+                    expect(Array.isArray(display.objects)).toBe(true, "i8 display should carry folded consumers");
+                    var condObj = (display.objects || []).find(function (o) { return o.condition === true; });
+                    expect(condObj).toBeDefined("i8 display should carry a condition consumer object");
+
+                    // the self-ref group must NOT also keep the display in its dependentRequests
+                    var group = detailedActiveList.conditionalGroups.find(function (g) {
+                        return g.condition.conditionKey === "cond_self_i8";
+                    });
+                    expect(group).toBeDefined("cond_self_i8 group should exist");
+                    expect(condObj.index).toBe(
+                        detailedActiveList.conditionalGroups.indexOf(group),
+                        "condition object index should point at the cond_self_i8 group"
+                    );
+                    var depDisplay = group.dependentRequests.find(function (r) {
+                        return r.related === true && r.index === display.index;
+                    });
+                    expect(depDisplay).toBeUndefined("self-ref display should not be duplicated in dependentRequests");
+
+                    // and no standalone entityset request for entity_set_i8
+                    var standalone = detailedActiveList.requests.find(function (r) {
+                        return r.entityset === true && r.column && r.column.name === i8Hash;
+                    });
+                    expect(standalone).toBeUndefined("entity_set_i8 should not have a standalone entityset request");
                 });
             });
         });
@@ -670,10 +746,11 @@ exports.execute = function (options) {
             });
 
             it ("should be true for async condition sources (inbound aggregate).", function () {
-                // groups 1-4 all use cnt_i1 (inbound + cnt aggregate → async)
-                [1, 2, 3, 4].forEach(function (i) {
+                // groups 1-4 all use cnt_i1 (inbound + cnt aggregate → async);
+                // group 5 (cond_self_i8) uses the entity_set_i8 inbound entityset → also async.
+                [1, 2, 3, 4, 5].forEach(function (i) {
                     expect(detailedActiveList.conditionalGroups[i].condition.isAsync).toBe(true,
-                        "group " + i + " (cnt_i1 source) should be async");
+                        "group " + i + " should be async");
                 });
             });
         });
@@ -789,12 +866,43 @@ exports.execute = function (options) {
             });
         });
 
+        describe("ActiveListCondition.evaluateCondition ($self over a single-inbound-FK entityset), ", function () {
+            // cond_self_i8's source is entity_set_i8 — a single inbound FK, which ERMrestJS
+            // represents as an InboundForeignKeyPseudoColumn (NOT a path-based PseudoColumn).
+            // Its condition_pattern reads `$self.length`, so buildSelfTemplateVariables must
+            // expose the page's row array as `$self` (the `{ $self: page.templateVariables }`
+            // wrapping) rather than falling through to the scalar/base-column branch.
+            var selfCondition;
+            beforeAll(function () {
+                var group = detailedActiveList.conditionalGroups.find(function (g) {
+                    return g.condition.conditionKey === "cond_self_i8";
+                });
+                selfCondition = group ? group.condition : null;
+            });
+
+            it ("should show when the entityset $self has rows.", function () {
+                expect(selfCondition).toBeTruthy("cond_self_i8 condition should exist");
+                // page-shaped value: templateVariables is the bare row array (Page.templateVariables)
+                var pageWithRows = { length: 2, templateVariables: [{}, {}] };
+                var result = selfCondition.evaluateCondition({}, pageWithRows, null);
+                expect(result.shouldShow).toBe(true, "$self.length > 0 → pattern renders show");
+            });
+
+            it ("should hide when the entityset $self has no rows.", function () {
+                expect(selfCondition).toBeTruthy("cond_self_i8 condition should exist");
+                var emptyPage = { length: 0, templateVariables: [] };
+                var result = selfCondition.evaluateCondition({}, emptyPage, null);
+                expect(result.shouldShow).toBe(false, "$self.length === 0 → pattern renders empty");
+            });
+        });
+
         describe("processConditionedItem dedup (shared condition_key), ", function () {
             it ("should NOT create a separate group when two items share the same condition_key.", function () {
-                // 4 conditioned vis-cols + 1 conditioned vis-fk + 1 NEW conditioned vis-col sharing
-                // cond_has_inbound1 with the vis-fk = 6 conditioned items but only 5 groups (dedup).
-                expect(detailedActiveList.conditionalGroups.length).toBe(5,
-                    "should still be 5 groups even with 6 conditioned items");
+                // 4 conditioned vis-cols (groups 0-3) + 1 conditioned vis-fk (entity_set_i5) sharing
+                // cond_has_inbound1 with 1 NEW conditioned vis-col = group 4 (the shared column does
+                // NOT add its own group) + entity_set_i8 self-ref vis-fk (group 5) = 6 groups.
+                expect(detailedActiveList.conditionalGroups.length).toBe(6,
+                    "shared condition_key still collapses to one group; total is 6 with the self-ref group");
             });
 
             it ("should add both items to the same group's conditionedItems list.", function () {
@@ -813,26 +921,28 @@ exports.execute = function (options) {
                 expect(byType.column).toBeDefined("new column item should be added");
             });
 
-            it ("should add the new column's secondary fetch to the group dependentRequests, not main requests.", function () {
+            it ("should fold the new column's secondary fetch onto the unconditional main request (one read per source).", function () {
+                // the new column's source is array_d_entity_i3 (an aggregate) which is ALSO an
+                // unconditional wait_for elsewhere, so it is already fetched on load. The
+                // consolidation pass folds the conditioned column's value onto that main request
+                // instead of issuing a second (gated) read — group 4 keeps no aggregate dep.
                 var group = detailedActiveList.conditionalGroups[4];
-                // the new column's source is array_d_entity_i3 (an aggregate) — it should land
-                // in the group's deps so chaise only fires it after the condition resolves true.
                 var depForNewCol = group.dependentRequests.find(function (r) {
                     return r.column && r.column.name === columnMapping["array_d_entity_i3"] && r.aggregate;
                 });
-                expect(depForNewCol).toBeDefined("group 4 deps should include array_d_entity_i3");
+                expect(depForNewCol).toBeUndefined("group 4 deps should NOT hold a duplicate array_d_entity_i3");
 
-                // and the main detailed requests for array_d_entity_i3 should NOT have a new
-                // top-level entry from the conditioned column (only the existing wait_for entry)
+                // the main array_d_entity_i3 request now carries the conditioned column (index 35)
+                // as a folded consumer, so it is read once and serves both uses.
                 var mainReq = detailedActiveList.requests.find(function (r) {
                     return r.column && r.column.name === columnMapping["array_d_entity_i3"] && r.aggregate;
                 });
-                expect(mainReq).toBeDefined("array_d_entity_i3 should still be in main requests (used as wait_for of cnt_i2)");
-                var fromConditionedCol = mainReq.objects.filter(function (obj) {
-                    return obj.column && !obj.isWaitFor && obj.index >= 35;
+                expect(mainReq).toBeDefined("array_d_entity_i3 should be in main requests (unconditional wait_for)");
+                var foldedConditionedCol = mainReq.objects.filter(function (obj) {
+                    return obj.column && obj.index === 35;
                 });
-                expect(fromConditionedCol.length).toBe(0,
-                    "main detailed requests should NOT pick up the conditioned column directly");
+                expect(foldedConditionedCol.length).toBe(1,
+                    "the conditioned column's value should be folded onto the main array_d_entity_i3 request");
             });
         });
 
@@ -861,15 +971,34 @@ exports.execute = function (options) {
         });
     }
 
+    function assertRequestObjects (objects, expectedObjects, message) {
+        objects = objects || [];
+        expectedObjects = expectedObjects || [];
+        expect(objects.length).toBe(expectedObjects.length, "objects length missmatch" + message);
+        objects.forEach(function (obj, objIndex) {
+            var expObj = expectedObjects[objIndex] || {};
+            var m = message + " obj index=" + objIndex;
+            expect(obj.index).toBe(expObj.index, "index missmatch" + m);
+            expect(obj.isWaitFor).toBe(expObj.isWaitFor, "isWaitFor missmatch" + m);
+            expect(obj.column).toBe(expObj.column, "column missmatch" + m);
+            expect(obj.condition).toBe(expObj.condition, "condition missmatch" + m);
+            expect(obj.inline).toBe(expObj.inline, "obj.inline missmatch" + m);
+            expect(obj.related).toBe(expObj.related, "obj.related missmatch" + m);
+            expect(obj.citation).toBe(expObj.citation, "obj.citation missmatch" + m);
+        });
+    }
+
     function testRequestList (requests, expected) {
         expect(requests.length).toBe(expected.length, "length missmatch.");
         requests.forEach(function (req, reqIndex) {
-            var expReq = expected[reqIndex];
+            var expReq = expected[reqIndex] || {};
 
-            if (req.inline) {
-                expect(req.inline).toBe(expReq.inline, "inline missmatch for index=" + reqIndex);
-            } else if (req.related) {
-                expect(req.related).toBe(expReq.related, "related missmatch for index=" + reqIndex);
+            if (req.inline || req.related) {
+                var typeKey = req.inline ? "inline" : "related";
+                expect(req[typeKey]).toBe(expReq[typeKey], typeKey + " missmatch for index=" + reqIndex);
+                expect(req.index).toBe(expReq.index, "display index missmatch for reqIndex=" + reqIndex);
+                // consumers folded onto the display request by the consolidation pass
+                assertRequestObjects(req.objects, expReq.objects, " for display reqIndex=" + reqIndex);
             } else {
                 // entityset/aggregate/firstOutbound
                 var message = " for index= " + reqIndex + "(expected column= `"+ reverseColumnMapping[req.column.name] +"`)";
@@ -877,18 +1006,8 @@ exports.execute = function (options) {
                 expect(req.entityset).toBe(expReq.entityset, "entityset missmatch" + message);
                 expect(req.aggregate).toBe(expReq.aggregate, "aggregate missmatch" + message);
                 expect(req.firstOutbound).toBe(expReq.firstOutbound, "firstOutbound missmatch" + message);
-                expect(req.objects.length).toBe(expReq.objects.length, "objects length missmatch" + message);
-
-
-                req.objects.forEach(function (obj, objIndex) {
-                    var expObj = expReq.objects[objIndex];
-                    expect(obj.index).toBe(expObj.index, "index missmatch" + message + " obj index=" + objIndex);
-                    expect(obj.isWaitFor).toBe(expObj.isWaitFor, "isWaitFor missmatch" + message + " obj index=" + objIndex);
-                    expect(obj.column).toBe(expObj.column, "column missmatch" + message + " obj index=" + objIndex);
-                    expect(obj.condition).toBe(expObj.condition, "condition missmatch" + message + " obj index=" + objIndex);
-                });
+                assertRequestObjects(req.objects, expReq.objects, message);
             }
-
         });
     }
 
@@ -1510,204 +1629,390 @@ exports.execute = function (options) {
         expectedDetailedActiveList = {
             requests: [
                 {
-                    "column": "array_d_entity_i5",
-                    "aggregate": true,
-                    "objects": [
-                        {"citation": true, "isWaitFor": true},
-                        {"inline": true, "index": 4, "isWaitFor": true},
-                        {"related": true, "index": 0, "isWaitFor": true}
-                    ]
+                  "column": "array_d_entity_i5",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "citation": true,
+                      "isWaitFor": true
+                    },
+                    {
+                      "inline": true,
+                      "index": 4,
+                      "isWaitFor": true
+                    },
+                    {
+                      "related": true,
+                      "index": 0,
+                      "isWaitFor": true
+                    }
+                  ]
                 },
                 {
-                    "column": "entity_set_i4",
-                    "entityset": true,
-                    "objects": [
-                        {"citaiton": true, "isWaitFor": true}
-                    ]
+                  "inline": true,
+                  "index": 8,
+                  "objects": [
+                    {
+                      "inline": true,
+                      "index": 4,
+                      "isWaitFor": true
+                    }
+                  ]
                 },
                 {
-                    "inline": true,
-                    "index": 8
+                  "inline": true,
+                  "index": 14,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 28,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 29,
+                      "isWaitFor": true
+                    }
+                  ]
                 },
                 {
-                    "column": "entity_set_i5",
-                    "entityset": true,
-                    "objects": [
-                        {"inline": true, "index": 8, "isWaitFor": true},
-                        {"related": true, "index": 1, "isWaitFor": true}
-                    ]
+                  "column": "array_d_scalar_i1",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 2,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 18,
+                      "isWaitFor": false
+                    }
+                  ]
                 },
                 {
-                    "inline": true,
-                    "index": 14
+                  "inline": true,
+                  "index": 4
                 },
                 {
-                    "column": "array_d_scalar_i1",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 2, "isWaitFor": true, "column": true},
-                        { "index": 18, "isWaitFor": false, "column": true}
-                    ]
+                  "column": "cnt_i1",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 5,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 7,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 20,
+                      "isWaitFor": false
+                    },
+                    {
+                      "column": true,
+                      "index": 21,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 23,
+                      "isWaitFor": true
+                    },
+                    {
+                      "condition": true,
+                      "index": 1,
+                      "isWaitFor": false
+                    },
+                    {
+                      "condition": true,
+                      "index": 2,
+                      "isWaitFor": false
+                    },
+                    {
+                      "condition": true,
+                      "index": 3,
+                      "isWaitFor": false
+                    },
+                    {
+                      "condition": true,
+                      "index": 4,
+                      "isWaitFor": false
+                    }
+                  ]
                 },
                 {
-                    "inline": true,
-                    "index": 4
+                  "column": "array_d_entity_i1",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 10,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 16,
+                      "isWaitFor": false
+                    },
+                    {
+                      "column": true,
+                      "index": 27,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 30,
+                      "isWaitFor": true
+                    }
+                  ]
                 },
                 {
-                    "column": "entity_set_i2",
-                    "entityset": true,
-                    "objects": [
-                        {"inline": true, "index": 4, "isWaitFor": true}
-                    ]
+                  "column": "max_i1",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 10,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 26,
+                      "isWaitFor": false
+                    }
+                  ]
                 },
                 {
-                    "column": "cnt_i1",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 5, "isWaitFor": true, "column": true},
-                        {"index": 7, "isWaitFor": true, "column": true},
-                        {"index": 20, "isWaitFor": false, "column": true},
-                        {"index": 21, "isWaitFor": true, "column": true},
-                        {"index": 23, "isWaitFor": true, "column": true},
-                        // condition source for groups 1, 2, 3, 4. group 0 belongs to the
-                        // sync outbound_entity_o1 condition on conditioned_col_outbound,
-                        // which is processed first (non-aggregate pass) and doesn't fetch
-                        // anything. condition sources are isWaitFor:false (they ARE the
-                        // condition, not a prerequisite of it).
-                        {"isWaitFor": false, "condition": true, "index": 1},
-                        {"isWaitFor": false, "condition": true, "index": 2},
-                        {"isWaitFor": false, "condition": true, "index": 3},
-                        {"isWaitFor": false, "condition": true, "index": 4}
-                    ]
+                  "column": "array_d_scalar_i2",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 12,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 19,
+                      "isWaitFor": false
+                    }
+                  ]
                 },
                 {
-                    "column": "array_d_entity_i1",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 10, "isWaitFor": true, "column": true},
-                        {"index": 16, "isWaitFor": false, "column": true},
-                        {"index": 27, "isWaitFor": true, "column": true},
-                        {"index": 30, "isWaitFor": true, "column": true},
-                    ]
+                  "column": "array_d_entity_i2",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 17,
+                      "isWaitFor": false
+                    }
+                  ]
                 },
                 {
-                    "column": "max_i1",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 10, "isWaitFor": true, "column": true},
-                        {"index": 26, "isWaitFor": false, "column": true}
-                    ]
+                  "column": "cnt_d_i2",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 17,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 23,
+                      "isWaitFor": false
+                    }
+                  ]
                 },
                 {
-                    "column": "array_d_scalar_i2",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 12, "isWaitFor": true, "column": true},
-                        {"index": 19, "isWaitFor": false, "column": true}
-                    ]
+                  "column": "max_i2",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 19,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 27,
+                      "isWaitFor": false
+                    },
+                    {
+                      "column": true,
+                      "index": 28,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 29,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 30,
+                      "isWaitFor": true
+                    }
+                  ]
                 },
                 {
-                    "column": "array_d_entity_i2",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 17, "isWaitFor": false, "column": true}
-                    ]
+                  "column": "cnt_i2",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 21,
+                      "isWaitFor": false
+                    },
+                    {
+                      "column": true,
+                      "index": 23,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 25,
+                      "isWaitFor": true
+                    },
+                    {
+                      "condition": true,
+                      "index": 2,
+                      "isWaitFor": true
+                    },
+                    {
+                      "condition": true,
+                      "index": 3,
+                      "isWaitFor": true
+                    }
+                  ]
                 },
                 {
-                    "column": "cnt_d_i2",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 17, "isWaitFor": true, "column": true},
-                        {"index": 23, "isWaitFor": false, "column": true}
-                    ]
+                  "column": "array_d_entity_i3",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 21,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 35,
+                      "isWaitFor": false
+                    }
+                  ]
                 },
                 {
-                    "column": "max_i2",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 19, "isWaitFor": true, "column": true},
-                        {"index": 27, "isWaitFor": false, "column": true},
-                        {"index": 28, "isWaitFor": true, "column": true},
-                        {"index": 29, "isWaitFor": true, "column": true},
-                        {"index": 30, "isWaitFor": true, "column": true}
-                    ]
+                  "column": "cnt_d_i1",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 22,
+                      "isWaitFor": false
+                    }
+                  ]
                 },
                 {
-                    "column": "cnt_i2",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 21, "isWaitFor": false,"column": true},
-                        {"index": 23, "isWaitFor": true, "column": true},
-                        {"index": 25, "isWaitFor": true, "column": true},
-                        // wait_for of conditions on groups 2 (cond_has_inbound1_show on col 32)
-                        // and 3 (inline cnt_i1 + condition_pattern on col 33). still isWaitFor:true
-                        // — wait_fors of conditions ARE prerequisites.
-                        {"isWaitFor": true, "condition": true, "index": 2},
-                        {"isWaitFor": true, "condition": true, "index": 3}
-                    ]
+                  "column": "array_d_scalar_i4",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 23,
+                      "isWaitFor": true
+                    },
+                    {
+                      "column": true,
+                      "index": 27,
+                      "isWaitFor": true
+                    }
+                  ]
                 },
                 {
-                    "column": "array_d_entity_i3",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 21, "isWaitFor": true, "column": true}
-                    ]
+                  "column": "min_i1",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 24,
+                      "isWaitFor": false
+                    }
+                  ]
                 },
                 {
-                    "column": "cnt_d_i1",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 22, "isWaitFor": false, "column": true}
-                    ]
+                  "column": "min_i2",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "column": true,
+                      "index": 25,
+                      "isWaitFor": false
+                    }
+                  ]
                 },
                 {
-                    "column": "array_d_scalar_i4",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 23, "isWaitFor": true, "column": true},
-                        {"index": 27, "isWaitFor": true, "column": true}
-                    ]
+                  "related": true,
+                  "index": 0,
+                  "objects": [
+                    {
+                      "citation": true,
+                      "isWaitFor": true
+                    }
+                  ]
                 },
                 {
-                    "column": "min_i1",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 24, "isWaitFor": false,"column": true}
-                    ]
+                  "column": "array_d_entity_i4",
+                  "aggregate": true,
+                  "objects": [
+                    {
+                      "related": true,
+                      "index": 0,
+                      "isWaitFor": true
+                    }
+                  ]
                 },
                 {
-                    "column": "min_i2",
-                    "aggregate": true,
-                    "objects": [
-                        {"index": 25, "isWaitFor": false, "column": true}
-                    ]
+                  "related": true,
+                  "index": 1
                 },
                 {
-                    "column": "entity_set_i3",
-                    "entityset": true,
-                    "objects": [
-                        {"column": true, "isWaitFor": true, "index": 28},
-                        {"column": true, "isWaitFor": true, "index": 29}
-                    ]
+                  "related": true,
+                  "index": 2
                 },
                 {
-                    "related": true,
-                    "index": 0
+                  "related": true,
+                  "index": 3,
+                  "objects": [
+                    {
+                      "inline": true,
+                      "index": 8,
+                      "isWaitFor": true
+                    },
+                    {
+                      "related": true,
+                      "index": 1,
+                      "isWaitFor": true
+                    }
+                  ]
                 },
                 {
-                    "column": "array_d_entity_i4",
-                    "aggregate": true,
-                    "objects": [
-                        {"related": true, "isWaitFor": true, "index": 0}
-                    ]
-                },
-                {
-                    "related": true,
-                    "index": 1
-                },
-                {
-                    "related": true,
-                    "index": 2
+                  "related": true,
+                  "index": 4,
+                  "objects": [
+                    {
+                      "condition": true,
+                      "index": 5,
+                      "isWaitFor": false
+                    }
+                  ]
                 }
             ],
             allOutBounds: [


### PR DESCRIPTION
This PR will ensure the active list creates one read per source. So if a source is both displayed (as a related or inline table) and consumed (as a value, wait_for, citation, or condition), it will only be read once instead of twice.

Prior to this PR, the duplication logic only handles the following:

- aggregate requests.
- entity requests that are not displayed (i.e. not inline or related).

To implement this, I had to add a new pass to the `ActiveList` that runs after the duplication pass. It groups every non-aggregate request by source hash and folds the consumers onto the matching displayed inline or related table. A inline or related table display always wins as the target, since it renders the table and gives the consumers their rows. A conditioned display gets promoted to load when something needs the source unconditionally, but stays visually gated. Aggregates are left alone since their hash already keeps them separate.