### PR TITLE
fix(error): map postgres 18 RESTRICT fkey violation message

### DIFF
--- a/src/services/error.ts
+++ b/src/services/error.ts
@@ -139,7 +139,8 @@ export default class ErrorService {
       const newMessage = `The requested snapshot time ${formattedTime ? '(' + formattedTime + ') ' : ''}is older than any available history.`;
 
       return new SnapshotNotFoundError(errorStatusText, newMessage);
-    } else if (generatedErrMessage.indexOf('violates foreign key constraint') > -1 && actionFlag === _operationsFlag.DELETE) {
+      /* postgres 18+ says "violates RESTRICT setting of foreign key constraint" for ON DELETE RESTRICT fkeys */
+    } else if (/violates (RESTRICT setting of )?foreign key constraint/.test(generatedErrMessage) && actionFlag === _operationsFlag.DELETE) {
       let referenceTable: any = '';
 
       let detail: string | number = generatedErrMessage.search(/DETAIL:/g);

--- a/test/specs/errors/tests/07.http_409_error.js
+++ b/test/specs/errors/tests/07.http_409_error.js
@@ -20,6 +20,9 @@ exports.execute = function (options) {
             'The request conflicts with the state of the server. update or delete on table "dataset" violates foreign key constraint "dataset_human_age_dataset_id_fkey" on table "dataset_human_age" DETAIL:  Key (id)=(269) is still referenced from table "dataset_human_age".';
         var integrityErrorServerResponseArb = '409 Conflict\nThe request conflicts with the state of the server. ' +
                 'The request conflicts with the state of the server. update or delete on table "1dataset" violates foreign key constraint "1dataset_human_age_dataset_id_fkey" on table "1dataset_human_age" DETAIL:  Key (id)=(269) is still referenced from table "1dataset_human_age".';
+        /* postgres 18+ wording for ON DELETE RESTRICT fkeys: mentions the RESTRICT setting and drops "still" from the detail */
+        const integrityErrorServerResponseArbRestrict = '409 Conflict\nThe request conflicts with the state of the server. ' +
+            'The request conflicts with the state of the server. update or delete on table "1dataset" violates RESTRICT setting of foreign key constraint "1dataset_human_age_dataset_id_fkey" on table "1dataset_human_age" DETAIL:  Key (id)=(269) is referenced from table "1dataset_human_age".';
         var duplicateErrorServerResponse = '409 Conflict\nThe request conflicts with the state of the server. ' +
             'Input data violates model. ERROR:  duplicate key value violates unique constraint "dataset_pkey" DETAIL:  Key (id)=(269) already exists.';
 
@@ -158,22 +161,29 @@ exports.execute = function (options) {
               done.fail();
           });
         });
-        it("if it's an integrity error and no displayName was found then use table name passed by ermrest using mock", function (done) {
-          var mockUri = "/ermrest/catalog/"+catalog_id+"/entity/M:=" + schemaName + ":" + tableNameWithoutDisplayName;
+        /* both wordings must map to the same message, since the server's postgres version dictates which one we get */
+        [
+            { desc: 'pre-18 postgres message', response: integrityErrorServerResponseArb },
+            { desc: 'postgres 18+ RESTRICT message', response: integrityErrorServerResponseArbRestrict },
+        ].forEach(({ desc, response }) => {
+            it(`if it's an integrity error and no displayName was found then use table name passed by ermrest (${desc})`, (done) => {
+                const mockUri = `/ermrest/catalog/${catalog_id}/entity/M:=${schemaName}:${tableNameWithoutDisplayName}`;
 
-          nock(url, ops)
-              .delete(mockUri)
-              .reply(409, integrityErrorServerResponseArb)
-              .persist();
-          reference2.delete().then(null, function (err) {
-              expect(err.status).toBe("Conflict", "invalid error status message");
-              expect(err.message).toBe(integrityErrorMappedSiteAdminMessage, "invalid error message");
-              done();
-          }).catch(function(err) {
-              console.log(err);
-              done.fail();
-          });
+                nock.cleanAll();
+                nock(url, ops)
+                    .delete(mockUri)
+                    .reply(409, response)
+                    .persist();
 
+                reference2.delete().then(null, (err) => {
+                    expect(err.status).toBe("Conflict", "invalid error status message");
+                    expect(err.message).toBe(integrityErrorMappedSiteAdminMessage, "invalid error message");
+                    done();
+                }).catch((err) => {
+                    console.log(err);
+                    done.fail();
+                });
+            });
         });
 
         it("if it's an integrity error without deletion flag passed then we should allow the ermrest error to the client.", function (done) {


### PR DESCRIPTION
In our code, we were looking for `violates foreign key constraint` text to see a 409 response from ermrest is due to foreign key violation or not. Postgres 18 has changed it to  `violates RESTRICT setting of foreign key constraint` .

So In this PR I modified our error handling to support both versions.