### PR TITLE
fix: url length chunking and the failed row comparison in update()

### DIFF
--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1233,7 +1233,7 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
 
         var result = []; // computed, keyData
 
-        var keyData = [], filter = '', currentPath = '', keyColName, keyColVal, keyColumnsData;
+        var keyData = [], filter, currentPath = '', keyColName, keyColVal, keyColumnsData;
         for (var rowIndex = 0; rowIndex < data.length; rowIndex++) {
             var rowData = data[rowIndex];
             if (canUseQuantified) {

--- a/js/utils/helpers.js
+++ b/js/utils/helpers.js
@@ -1288,8 +1288,10 @@ import AuthnService from '@isrd-isi-edu/ermrestjs/src/services/authn';
                 filter += keyColumns.length > 1 ? ')' : '';
 
                 // check url length limit if not first one;
+                // +1 is for the `;` that we're going to add
+                // <pathOffset/><filter>;<filter>
                 if (rowIndex != 0 && pathOffsetLength >= 0 &&
-                    (pathOffsetLength + currentPath.length + (rowIndex != 0 ? ';' : '') + filter).length > pathLimit) {
+                    (pathOffsetLength + currentPath.length + 1 + filter.length) > pathLimit) {
                     // any more filters will go over the url length limit so save the current path and count
                     // then clear both to start creating a new path
                     result.push({

--- a/src/models/reference/reference.ts
+++ b/src/models/reference/reference.ts
@@ -2529,7 +2529,7 @@ export class Reference {
 
           for (let k = 0; k < shortestKeyNames.length; k++) {
             keyName = shortestKeyNames[k];
-            if (tuples[i].data[keyName] === successfulPage.tuples[j].data[keyName]) {
+            if (tuples[i].data[keyName] !== successfulPage.tuples[j].data[keyName]) {
               // these keys don't match, go for the next tuple
               keyMatch = false;
               break;


### PR DESCRIPTION
This PR fixes two bugs:

- `generateKeyValueFilters` never splits in the non-quantified branch. The length check adds a number to a string before taking `.length`:

  ```js
  (pathOffsetLength + currentPath.length + ';' + filter).length
  // 120 + 3800 -> "3920;(ida=x&idb=y)" -> 18, never > 4000
  ```
  Not reachable today, since any single column key takes the quantified branch, which is correct. You would need a table with no RID and a composite shortest key.

- The failed row comparison in `update()` is inverted. `keyMatch` clears when the key values are equal, so it means "every key column differs" rather than "same key". Failed rows get matched against successful ones and treated as successful, leaving the failed page empty under an "N failed updates" header (or holding the successful row when only one succeeded).
